### PR TITLE
Created a MapHeader class

### DIFF
--- a/sunpy/map/__init__.py
+++ b/sunpy/map/__init__.py
@@ -13,15 +13,16 @@ which deals with a specific type of data, e.g. :class:`AIAMap` or
 """
 #pylint: disable=W0401
 
-__all__ = ["sources", "mapcube"]
+__all__ = ["header", "mapcube", "sources"]
 __author__ = "Keith Hughitt"
 __email__ = "keith.hughitt@nasa.gov"
 
 import sys
 import pyfits
-from sunpy.map.sources import *
 from sunpy.map.basemap import BaseMap
 from sunpy.map.basemap import UnrecognizedDataSouceError
+from sunpy.map.header import MapHeader
+from sunpy.map.sources import *
 
 #pylint: disable=C0103,E1101
 def Map(input_):
@@ -64,10 +65,11 @@ def Map(input_):
     | http://stsdas.stsci.edu/download/wikidocs/The_PyFITS_Handbook.pdf
     """
     if isinstance(input_, basestring):
+        # TODO: Add logic to determine filetype instead of assuming FITS
         fits = pyfits.open(input_)
         fits.verify('silentfix')        
         data = fits[0].data
-        header = fits[0].header
+        header = MapHeader(fits[0].header)
 
         for cls in BaseMap.__subclasses__():
             if cls.is_datasource_for(header):

--- a/sunpy/map/header.py
+++ b/sunpy/map/header.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+"""
+MapHeader is a generalized header class that deals with header parsing and
+normalization.
+"""
+
+class MapHeader(dict):
+    """
+    MapHeader(header)
+    
+    A dictionary-like class for working with FITS, etc headers
+    
+    Parameters
+    ----------
+    header : pyfits.core.Header, dict
+        Header tags associated with the data
+        
+    Attributes
+    ----------
+    
+    """
+    def __init__(self, *args, **kwargs):
+        """Creates a new MapHeader instance"""
+        dict.__init__(self, *args, **kwargs)
+        
+    def __getitem__(self, key):
+        """Overide [] indexing"""
+        return dict.__getitem__(self, key.upper())
+    
+    def get(self, key, default=None):
+        """Overide .get() indexing"""
+        return dict.get(self, key.upper(), default)
+        


### PR DESCRIPTION
I created a separate MapHeader class to use in place of pyfits.core.Header class.

**Reasoning:**
1) Having something more general provides us with a more natural way to add support for other (non-FITS) types of data such as JPEG 2000.

2) Header-parsing logic (including WCS handling) can go here to avoid isolate it from other code.

**Question:**
Currently normalization of header tags is done both in the source-specific modules (e.g. sdo.py) and in solwcs. Each approach has it's advantages: by handling it in the source-specific files the logic is generally much shorter since you already know what the tag should look like. By handling it elsewhere (e.g. in MapHeader), you can avoid redundant code in the source-specific files, but have to check for many more different variations of each tag.

Should we continue using both approaches or just choose one? If both, which tags should be handled in the source-specific files and which ones should be handled more generally?
