### PR TITLE
Miscellaneous updates to the Windows installation instructions

### DIFF
--- a/doc/source/guide/installation/win.rst
+++ b/doc/source/guide/installation/win.rst
@@ -8,8 +8,8 @@ Overview
 
 For its basic functioning, SunPy requires several libraries:
 
-* `NumPy <http://numpy.scipy.org/>`__
-* `Matplotlib <http://matplotlib.sourceforge.net/>`__
+* `NumPy <http://numpy.scipy.org/>`_
+* `Matplotlib <http://matplotlib.sourceforge.net/>`_
 * `PyFITS <http://www.stsci.edu/resources/software_hardware/pyfits>`_
 
 **Optional**
@@ -17,8 +17,8 @@ For its basic functioning, SunPy requires several libraries:
 In addition to the required libraries listed above, there are a couple other
 optional dependencies which are only needed for certain features.
 
-* `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`__ (SunPy Plotman)
-* `Suds <https://fedorahosted.org/suds/>`__ (VSO/HEK support)
+* `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_ (SunPy Plotman)
+* `Suds <https://fedorahosted.org/suds/>`_ (VSO/HEK support)
 
 There are many ways to get SunPy up and running on Windows, and we describe the 
 recommended method and an alternate method below.  Lines in text boxes should 
@@ -33,26 +33,28 @@ Recommended method
 Download and install `Python(x,y) <https://code.google.com/p/pythonxy/wiki/Downloads>`_.
 Python(x,y) is a distribution that include not only Python, but also a large 
 variety of Python modules and development tools.  Please note that this 
-installer is rather large (>500 MB) and thus may take a while to download.
+installer is rather large (~400 MB) and thus may take a while to download.
 
-**2. Install additional modules**
+**2. Install PyFITS**
+
+Download and install `PyFITS <http://pypi.python.org/packages/2.7/p/pyfits/pyfits-3.0.1.win32-py2.7.exe>`_, which is used to read FITS files.
+
+**3. Install additional modules**
 
 Install additional modules: ::
 
-    easy_install pyfits
     easy_install paver
     easy_install suds
 
-* PyFITS is used to read and write FITS files
 * Paver is used to link symbolically to the SunPy code
 * Suds is used for web-based requests (e.g., for VSO interactions)
 
-**3. Install Git**
+**4. Install Git**
 
 Download and install `Git <https://code.google.com/p/msysgit/downloads/list?can=3>`_ 
 (choose the first file listed).  Git is used to retrieve the SunPy code.
 
-**4. Download and install SunPy**
+**5. Download and install SunPy**
 
 The following will download SunPy to ``C:\sunpy``.  If you wish to download 
 SunPy elsewhere, modify these and later commands accordingly. ::
@@ -112,10 +114,12 @@ Download and install `SciPy <http://sourceforge.net/projects/scipy/files/scipy/0
 
 Download and install `matplotlib <http://sourceforge.net/projects/matplotlib/files/matplotlib/matplotlib-1.0.1/matplotlib-1.0.1.win32-py2.7.exe/download>`_.
 
+Download and install `PyQt4 <http://www.riverbankcomputing.co.uk/static/Downloads/PyQt4/PyQt-Py2.7-x86-gpl-4.8.5-1.exe>`_.
+
 Download and install `setuptools 
 <http://pypi.python.org/packages/2.7/s/setuptools/setuptools-0.6c11.win32-py2.7.exe>`_.
 
-**2-4. The remaining steps**
+**2-5. The remaining steps**
 
 You have now performed the required elements of step 1 of the recommended 
-method.  Now perform steps 2-4 of that method to complete your installation.
+method.  Now perform steps 2-5 of that method to complete your installation.


### PR DESCRIPTION
Python(x,y) is now using Python 2.7!  This simplifies the PyFITS installation instructions, although we still need to use the Windows installer since we don't want to deal with the hassle of instructions for setting up a build environment.  I also added PyQt4 to the instructions.
