### PR TITLE
Fix issue #85

### DIFF
--- a/sunpy/map/basemap.py
+++ b/sunpy/map/basemap.py
@@ -17,6 +17,8 @@ import matplotlib.colors as colors
 import matplotlib.cm as cm
 from datetime import datetime
 from sunpy.solwcs import solwcs as wcs
+from sunpy.util.util import toggle_pylab
+        
 
 """
 Questions
@@ -294,6 +296,7 @@ class BaseMap(np.ndarray):
 
         return self.__class__(data, header)
    
+    @toggle_pylab
     def plot(self, overlays=[], draw_limb=False, gamma=None, **matplot_args):
         """Plots the map object using matplotlib
         

--- a/sunpy/util/util.py
+++ b/sunpy/util/util.py
@@ -18,6 +18,24 @@ from __future__ import absolute_import
 from datetime import datetime
 import numpy as np
 
+def toggle_pylab(fn):
+    """ A decorator to prevent functions from opening matplotlib windows
+        unexpectedly when sunpy is run in interactive shells like ipython --pylab. 
+
+        Toggles the value of matplotlib.pyplot.isinteractive() to preserve the
+        users' expections of pylab's behaviour in general. """
+
+    from matplotlib import pyplot
+    if pyplot.isinteractive():
+        def fn_itoggle(*args, **kwargs):
+            pyplot.ioff()
+            ret = fn(*args, **kwargs)
+            pyplot.ion()
+            return ret
+        return fn_itoggle
+    else:
+        return fn
+
 def anytim(time_string=None):
     """Given a time string will parse and return a datetime object.
     If no string is given then returns the datetime object for the current time.


### PR DESCRIPTION
Methods that make calls to matplotlib.pyplot functions should use the decorator @toggle_pylab to prevent matplotlib windows from being opened.
