### PR TITLE
Fix a memory leak in BaseMap.submap()

### DIFF
--- a/sunpy/map/basemap.py
+++ b/sunpy/map/basemap.py
@@ -406,7 +406,7 @@ class BaseMap(np.ndarray):
         data = np.asarray(self)[y_pixels[0]:y_pixels[1], 
                                 x_pixels[0]:x_pixels[1]]
 
-        return self.__class__(data, header)
+        return self.__class__(data.copy(), header)
    
     @toggle_pylab
     def plot(self, overlays=None, draw_limb=True, gamma=None, draw_grid=False, 


### PR DESCRIPTION
There is a memory leak when calling BaseMap.submap(). The submap method returns a region of the image, but the memory allocating for the original array isn't release.
