### PR TITLE
Add rotation angle attribute to Map object

### DIFF
--- a/sunpy/map/map.py
+++ b/sunpy/map/map.py
@@ -222,7 +222,7 @@ class Map(np.ndarray):
                 'x': header.get('cunit1', 'arcsec'),
                 'y': header.get('cunit2', 'arcsec')
             },
-            "angle": {
+            "rotation_angle": {
                 'x': header.get('crota1', 0.),
                 'y': header.get('crota2', 0.)
             }
@@ -240,7 +240,7 @@ class Map(np.ndarray):
                           'scale', 'units', 'reference_coordinate',
                           'reference_pixel', 'coordinate_system',
                           'heliographic_latitude', 'heliographic_longitude',
-                          'carrington_longitude','angle']
+                          'carrington_longitude','rotation_angle']
 
             for attr in properties:
                 setattr(self, attr, getattr(obj, attr))


### PR DESCRIPTION
This version only supports the 'CROTA' standard, but should be general enough to cope with any variant on that.
