### PR TITLE
Added documentation section for MacPorts

### DIFF
--- a/doc/source/guide/installation/mac.rst
+++ b/doc/source/guide/installation/mac.rst
@@ -90,7 +90,12 @@ e.g.::
     sudo port install py27-sunpy
 
 to install SunPy. This will automatically install all of the required
-dependencies. You may also install SunPy for Python 2.6 (``py26-sunpy``).
+dependencies. You may also install SunPy for Python 2.6 (``py26-sunpy``). If
+a new version of SunPy is released, you can update your installation using
+e.g::
+
+    sudo port selfupdate
+    sudo port upgrade py27-sunpy
 
 For more information on using MacPorts to manage your Python installation,
 see the following `page <http://astrofrog.github.com/macports-python/>`_.


### PR DESCRIPTION
SunPy is now available in MacPorts:

```
$ port info py27-sunpy
py27-sunpy @0.1, Revision 1 (python, science)
Variants:             universal

Description:          The SunPy project is an effort to create an open-source
                      software library for solar physics using the Python
                      programming language.
Homepage:             http://www.sunpy.org

Build Dependencies:   py27-numpy, py27-scipy, py27-matplotlib, py27-pyfits,
                      py27-pyqt4, py27-suds, py27-pandas, py27-beautifulsoup4,
                      py27-configobj, py27-distribute, py27-py
Library Dependencies: python27
Platforms:            darwin
License:              BSD
Maintainers:          robitaille@macports.org
```

This minor PR adds some text to the MacPorts section of the installation. I'd like to make sure I have set up the dependencies correctly (c.f. #309) before this is merged. In particular, maybe the package is Python 3 compatible (though one of the dependencies, configobj, doesn't appear to be, hence why I am waiting on #309). Also, maybe some of the listed dependencies are not really needed and can be removed.

In addition, for people not at academic institutions and where EPD (full) is not available, MacPorts is actually much better than EPD Free, so maybe it deserves a top-level heading? I actually now recommend it over EPD in any case, as it allows people to have concurrent Python installations (e.g. I have 2.6, 2.7, 3.1, and 3.2), and it allows packages to be easily updated.
