### PR TITLE
Reworked map plotting, made map.imshow and map.quick_plot

### DIFF
--- a/sunpy/map/map.py
+++ b/sunpy/map/map.py
@@ -824,7 +824,7 @@ Dimension:\t [%d, %d]
         return ret
         
     @toggle_pylab
-    def view(self, draw_limb=True, draw_grid=False, gamma=None,
+    def peek(self, draw_limb=True, draw_grid=False, gamma=None,
                    colorbar=True, basic_plot=False, **matplot_args):
         """Displays the map in a new figure
 


### PR DESCRIPTION
As discussed in the last two weeks G+ meetings here is my take on how plotting should work.

Commit:
quick_plot is functionally the same as previous map.plot
map.imshow() works like plt.imshow()

Also changed _draw_limb to draw_limb and _draw_grid to draw_grid so can be used independently of map.imshow()
