### PR TITLE
Proposed patch to allow specifying the site keyword in vso_get

### DIFF
--- a/sunpy/net/vso/__init__.py
+++ b/sunpy/net/vso/__init__.py
@@ -513,6 +513,18 @@ class VSOClient(object):
             Methods acceptable to user.
         downloader : sunpy.net.downloader.Downloader
             Downloader used to download the data.
+        site: str
+            There are a number of caching mirrors for SDO and other
+            instruments, some available ones are listed below.
+                NSO   : National Solar Observatory, Tucson (US)
+                SAO  (aka CFA)  : Smithonian Astronomical Observatory, Harvard U. (US)
+                SDAC (aka GSFC) : Solar Data Analysis Center, NASA/GSFC (US)
+                ROB   : Royal Observatory of Belgium (Belgium)
+                MPS   : Max Planck Institute for Solar System Research (Germany)
+                UCLan : University of Central Lancashire (UK)
+                IAS   : Institut Aeronautique et Spatial (France)
+                KIS   : Kiepenheuer-Institut fur Sonnenphysik Germany)
+                NMSU  : New Mexico State University (US)
         
         Returns
         -------


### PR DESCRIPTION
The site keyword allows to select from which institute you desire to get the data. For example specifying site='rob' allows to download SDO data from the Royal Observatory of Belgium.

Not specifying the keyword will download the data from the regular location.

The site keyword will be added to the Info part of the request to the VSO. This required a change in http://docs.virtualsolar.org/WSDL/VSOi_rpc_literal.wsdl that has already been done by Joe Hourcle.
