### PR TITLE
Fixed memory leak in Crotate

### DIFF
--- a/sunpy/image/src/rot_extn.c
+++ b/sunpy/image/src/rot_extn.c
@@ -70,7 +70,8 @@ static PyObject *rot_shift_scale_args(PyObject *dummy, PyObject *args, PyObject 
   int ndim;
   int i;
   INTYPE *in_arr;
-  
+
+  int result;
   PyObject *out1;  
   OUTTYPE *out_arr;
 
@@ -118,13 +119,18 @@ static PyObject *rot_shift_scale_args(PyObject *dummy, PyObject *args, PyObject 
    
 //##  printf("E: ktype (interp type) %d\n", ktype);
 /* Call to function that does the actual work.  This one is external. */ 
-  if (affine_transform_kc(
+  result = affine_transform_kc(
         dims, out_arr, in_arr, 
         rotscale, 
         offset,
         ktype, interp_param, 
         mode, cval
-        ) != 0)
+        );
+
+  Py_DECREF(arr1);
+  Py_DECREF(arr2);
+
+  if (result != 0)
     return NULL;
 
   return Py_BuildValue("N", out1);


### PR DESCRIPTION
There was a memory leak in Crotate because references were not being decremented (see http://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html#reference-counting).  The input arguments are converted using `PyArray_FROM_OTF`, but that actually creates new references (PyObject class).  After the data has been used, these references need to be decremented using `Py_DECREF`.
