### PR TITLE
Fix for issue #432

### DIFF
--- a/sunpy/image/rescale.py
+++ b/sunpy/image/rescale.py
@@ -90,15 +90,17 @@ def _resample_nearest_linear(orig, dimensions, method, offset, m1):
     old_coords = [np.arange(i, dtype=np.float) for i in orig.shape]
 
     # first interpolation - for ndims = any
-    mint = scipy.interpolate.interp1d(old_coords[-1], orig, kind=method)
+    mint = scipy.interpolate.interp1d(old_coords[-1], orig, bounds_error=False,
+                                      fill_value=min(old_coords[-1]), kind=method)
+
     new_data = mint(dimlist[-1])
 
     trorder = [orig.ndim - 1] + range(orig.ndim - 1)
     for i in xrange(orig.ndim - 2, -1, -1):
         new_data = new_data.transpose(trorder)
 
-        mint = scipy.interpolate.interp1d(old_coords[i], new_data, 
-                                          kind=method)
+        mint = scipy.interpolate.interp1d(old_coords[i], new_data,
+            bounds_error=False, fill_value=min(old_coords[i]), kind=method)
         new_data = mint(dimlist[i])
 
     if orig.ndim > 1:


### PR DESCRIPTION
This pull request fixes issue #432 by defining `fill_value` for the `interp1d`, so values that are outside of the original `mint` range are set to the value of `fill_value`. I'm not sure if this is the perfect solution for this issue, but it seems to solve problem.
