### PR TITLE
fix for extract_waveunit

### DIFF
--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -243,7 +243,7 @@ def extract_waveunit(header):
             -15: 'fm',
             -18: 'am',
             -21: 'zm',
-            -24: 'zm'}
+            -24: 'ym'}
         waveunit = metre_submultiples.get(waveunit, str(waveunit).lower())
     elif waveunit_comment is not None:
         waveunit = parse_waveunit_comment(waveunit_comment)


### PR DESCRIPTION
Previously, both the exponent -21 and -24 have been converted to "zm" (zeptometre). This fix ensures that -21 is converted to "zm" and -24 to "ym" (yoctometre).
