### PR TITLE
made sure the measurement in SWAP is truly a string as required

### DIFF
--- a/sunpy/map/sources/proba2.py
+++ b/sunpy/map/sources/proba2.py
@@ -28,7 +28,7 @@ class SWAPMap(GenericMap):
 #        self.meta['instrme'] = "SWAP"
         self.meta['obsrvtry'] = "PROBA2"
         
-        self._name = self.detector + " " + self.measurement
+        self._name = self.detector + " " + str(self.measurement)
         self._nickname = self.detector
         
         self.cmap = cm.get_cmap(name='sdoaia171')


### PR DESCRIPTION
This bug meant that PROBA2 JP2 files could not be read in as a map.
