### PR TITLE
make the py.test mark `online` Python 2.6 compatible

### DIFF
--- a/sunpy/tests/conftest.py
+++ b/sunpy/tests/conftest.py
@@ -26,5 +26,5 @@ def pytest_runtest_setup(item):
     """
     if isinstance(item, item.Function):
         if 'online' in item.keywords and not is_online():
-            msg = 'skipping test {} (reason: client seems to be offline)'
+            msg = 'skipping test {0} (reason: client seems to be offline)'
             pytest.skip(msg.format(item.name))


### PR DESCRIPTION
When my PR with the `@pytest.mark.online`  functionality was merged into master, I introduced a ValueError for Python 2.6 because of the format of the string-formatting. This PR fixes this.
