### PR TITLE
fixed Map imports in tutorial

### DIFF
--- a/doc/source/guide/tutorial.rst
+++ b/doc/source/guide/tutorial.rst
@@ -22,7 +22,7 @@ SunPy supports many different data products from various sources 'out of the box
 shall use SDO's AIA instrument as an example in this tutorial. The general way to create
 a map from one of the supported data products is with the `Map()` class from the `map` submodule.
 
-`Map()` takes either a filename, list of filenames data array and header. We can test map with::
+`Map()` takes either a filename, a list of filenames or a data array and header pair. We can test map with::
 
     import sunpy
     from sunpy.map import Map


### PR DESCRIPTION
The general tutorial still had the old-style (Map) imports in it. I fixed the imports, together with the explanations that are linked to the respective code examples. Also the sentence

> `Map()` takes either a filename, list of filenames data array and header.

sounds weird to me, but I wasn't sure whether it was wrong grammar or not. Shouldn't it be of the form "… either an x, y or z."?
