### PR TITLE
Make all the imports in sunpy.io.file_tools optional

### DIFF
--- a/sunpy/io/file_tools.py
+++ b/sunpy/io/file_tools.py
@@ -23,7 +23,7 @@ __all__ = ['read_file', 'read_file_header', 'write_file']
 _known_extensions = {
     ('fts', 'fits'): 'fits',
     ('jp2', 'j2k', 'jpc', 'jpt'): 'jp2',
-    ('fz', 'f0'): 'fz'
+    ('fz', 'f0'): 'ana'
 }
 
 #Define a dict which raises a custom error message if the value is None
@@ -41,7 +41,7 @@ class Readers(dict):
 _readers = Readers({
             'fits':fits,
             'jp2':jp2,
-		  'fz':ana
+		  'ana':ana
 })
 
 print _readers
@@ -188,6 +188,9 @@ class UnrecognizedFileTypeError(IOError):
     """Exception to raise when an unknown file type is encountered"""
     pass
 
-class ReaderError(IOError):
+class ReaderError(ImportError):
     """Exception to raise when an unknown file type is encountered"""
+    pass
+
+class InvalidJPEG2000FileExtension(IOError):
     pass


### PR DESCRIPTION
I have made this in such a way that it will not fail until it tries to
read a file with an unsupported filetype and then it raises a nice error.
