### PR TITLE
DocSprint: citation up to date 

### DIFF
--- a/doc/source/sunpy/cite.rst
+++ b/doc/source/sunpy/cite.rst
@@ -2,17 +2,23 @@
 Citing SunPy
 ============
 
-If you have used SunPy in your scientific work we would appreciate it if you would cite SunPy in the resulting paper or presentation. The following is 
-recommended:
+If you have used SunPy in your scientific work we would appreciate 
+it if you would cite SunPy in the resulting paper or presentation. 
+The following is recommended:
 
 - Author: Stuart Mumford, David Pérez-Suárez, Steven Christe, Florian Mayer and Russell J. Hewett
 - Title: SunPy: Open Source Solar Data Analysis Tools for Python
 - Year 2013
 - URL: `http:///www.sunpy.org <http:///www.sunpy.org>`_
 
-This `paper <http://conference.scipy.org/proceedings/scipy2013/mumford.html>`_  is the result of the `presentation <http://www.youtube.com/watch?v=bXPPTCkaVu8>`_ hold during the `12th Python in Science conference (SciPy 2013) <http://conference.scipy.org/proceedings/scipy2013/>`_ in Austin, Texas (US).  The `notebook is also available <nbviewer.ipython.org/url/sunpy.cadair.com/presentations/scipy_2013/SunPy_Presentation.ipynb>`_.
+This `paper <http://conference.scipy.org/proceedings/scipy2013/mumford.html>`_  
+is the result of the `presentation <http://www.youtube.com/watch?v=bXPPTCkaVu8>`_ 
+hold during the `12th Python in Science conference (SciPy 2013) <http://conference.scipy.org/proceedings/scipy2013/>`_ 
+in Austin, Texas (US).  
+The `notebook is also available <nbviewer.ipython.org/url/sunpy.cadair.com/presentations/scipy_2013/SunPy_Presentation.ipynb>`_.
 
-The `paper is open access <http://conference.scipy.org/proceedings/scipy2013/pdfs/mumford.pdf>`_ and its BibTex entry is as follows: ::
+The `paper is open access <http://conference.scipy.org/proceedings/scipy2013/pdfs/mumford.pdf>`_ 
+and its BibTex entry is as follows: ::
 
   @InProceedings{ mumford-proc-scipy-2013,
      author    = { Stuart Mumford and David P\'erez-Su\'arez and Steven Christe and Florian Mayer and Russell J. Hewett },
@@ -28,10 +34,13 @@ Thank you for using SunPy!
 Other References
 ----------------
 
-A list of previous publications/presentations can be found in `figshare.com <http://figshare.com/articles/search?q=tag%3A+sunpy&quick=1>`_ and in the `github SunPy Presentations repository <https://github.com/sunpy/presentations>`_
+A list of previous publications/presentations can be found in 
+`figshare.com <http://figshare.com/articles/search?q=tag%3A+sunpy&quick=1>`_ 
+and in the `github SunPy Presentations repository <https://github.com/sunpy/presentations>`_
 
 
 Useful references
 -----------------
 
-SunPy maintains a list of references related with the code as a `public group in Zotero <https://www.zotero.org/groups/sunpy_-_python_for_solar_physicists>`_.
+SunPy maintains a list of references related with the code as a 
+`public group in Zotero <https://www.zotero.org/groups/sunpy_-_python_for_solar_physicists>`_.


### PR DESCRIPTION
New citation and sections added pointing towards the figshare material and the zotero library.

resolves #693
