### PR TITLE
fixed JP2 flipping

### DIFF
--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -37,7 +37,8 @@ def read(filepath):
     header = get_header(filepath)
     data = Jp2k(filepath).read()
     
-    return [(data, header[0])]
+    # Data is read in north-south flipped, so flip it around.
+    return [(data[::-1], header[0])]
 
 def get_header(filepath):
     """


### PR DESCRIPTION
Jp2k module reads in Helioviewer JP2 files with north-south flipped.  This PR applies the necessary flip.  Fixes #707
