### PR TITLE
Remove previous version pandas testing from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     matrix:
         - NUMPY_VERSION=1.8.0 PANDAS_VERSION=0.12.0
         - NUMPY_VERSION=1.7.1 PANDAS_VERSION=0.12.0
-        - NUMPY_VERSION=1.8.0 PANDAS_VERSION=0.11.0
 matrix:
      include:
         - python: 2.7


### PR DESCRIPTION
As sent out to the mailing list for opinions this would implement that change.
