### PR TITLE
Small fix for LYRA utility function in instr.lyra

### DIFF
--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -118,7 +118,7 @@ def split_series_using_lytaf(timearray,data,lar):
 
     if len(disc) == 0:
         print 'No events found within time series interval. Returning original series.'
-        return {'subtimes':datetime_array,'subdata':data}
+        return [{'subtimes':datetime_array,'subdata':data}]
     
     #-1 in diffmask means went from good data to bad
     #+1 means went from bad data to good


### PR DESCRIPTION
One-line fix for LYRA utility function. Now, if lyra.split_series_using_lytaf does not need to modify the input time series then it is returned unmodified in a list, consistent with what's returned when the series is modified.
