### PR TITLE
JP2s now flipped the correct way

### DIFF
--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -36,7 +36,7 @@ def read(filepath):
     """
     header = get_header(filepath)
 
-    data = Jp2k(filepath).read()
+    data = Jp2k(filepath).read()[::-1]
 
     return [(data, header[0])]
 


### PR DESCRIPTION
The test JP2 image read in by sunpy was flipped the wrong way.  After this fix, the test JP2 image has the same orientation as the image in the helioviewer link below.

http://helioviewer.org/?date=2013-06-24T17:31:30.000Z&imageScale=4.8408818&centerX=229.6999005027954&centerY=143.77417468680116&imageLayers=%5BSDO,AIA,AIA,193,1,100%5D&eventLayers=%5BAR,all,1%5D,%5BCC,all,1%5D,%5BCD,all,1%5D,%5BCH,all,1%5D,%5BCJ,all,1%5D,%5BCE,all,1%5D,%5BCR,all,1%5D,%5BCW,all,1%5D,%5BEF,all,1%5D,%5BER,all,1%5D,%5BFI,all,1%5D,%5BFA,all,1%5D,%5BFE,all,1%5D,%5BFL,all,1%5D,%5BLP,all,1%5D,%5BOS,all,1%5D,%5BPG,all,1%5D,%5BSG,all,1%5D,%5BSP,all,1%5D,%5BSS,all,1%5D&eventLabels=true
