### PR TITLE
Trying to solve SUDS connections through proxy

### DIFF
--- a/sunpy/net/__init__.py
+++ b/sunpy/net/__init__.py
@@ -2,34 +2,3 @@ from __future__ import absolute_import
 
 from sunpy.net.helioviewer import *
 
-from suds.transport.http import HttpTransport as SudsHttpTransport 
-
-__all__ = ['WellBehavedHttpTransport']
-
-
-class WellBehavedHttpTransport(SudsHttpTransport): 
-    """HttpTransport which properly obeys the ``*_proxy`` environment variables.""" 
-
-    def u2handlers(self): 
-        """Return a list of specific handlers to add. 
-
-        The urllib2 logic regarding ``build_opener(*handlers)`` is: 
-
-        - It has a list of default handlers to use 
-
-        - If a subclass or an instance of one of those default handlers is given 
-            in ``*handlers``, it overrides the default one. 
-
-        Suds uses a custom {'protocol': 'proxy'} mapping in self.proxy, and adds 
-        a ProxyHandler(self.proxy) to that list of handlers. 
-        This overrides the default behaviour of urllib2, which would otherwise 
-        use the system configuration (environment variables on Linux, System 
-        Configuration on Mac OS, ...) to determine which proxies to use for 
-        the current protocol, and when not to use a proxy (no_proxy). 
-
-        Thus, passing an empty list will use the default ProxyHandler which 
-        behaves correctly. 
-
-        This method comes from http://stackoverflow.com/a/12433606/1087595
-        """ 
-        return []

--- a/sunpy/net/helio/hec.py
+++ b/sunpy/net/helio/hec.py
@@ -9,7 +9,7 @@
 This module is meant to be an interface with the HELIO webservice, providing
 it's support through the use of a WSDL file.
 """
-from sunpy.net import WellBehavedHttpTransport
+from sunpy.net.proxyfix import WellBehavedHttpTransport
 from sunpy.net.helio import parser
 from sunpy.time import time as T
 from suds.client import Client as C

--- a/sunpy/net/proxyfix.py
+++ b/sunpy/net/proxyfix.py
@@ -1,0 +1,28 @@
+from suds.transport.http import HttpTransport as SudsHttpTransport 
+
+class WellBehavedHttpTransport(SudsHttpTransport): 
+    """HttpTransport which properly obeys the ``*_proxy`` environment variables.""" 
+
+    def u2handlers(self): 
+        """Return a list of specific handlers to add. 
+
+        The urllib2 logic regarding ``build_opener(*handlers)`` is: 
+
+        - It has a list of default handlers to use 
+
+        - If a subclass or an instance of one of those default handlers is given 
+            in ``*handlers``, it overrides the default one. 
+
+        Suds uses a custom {'protocol': 'proxy'} mapping in self.proxy, and adds 
+        a ProxyHandler(self.proxy) to that list of handlers. 
+        This overrides the default behaviour of urllib2, which would otherwise 
+        use the system configuration (environment variables on Linux, System 
+        Configuration on Mac OS, ...) to determine which proxies to use for 
+        the current protocol, and when not to use a proxy (no_proxy). 
+
+        Thus, passing an empty list will use the default ProxyHandler which 
+        behaves correctly. 
+
+        This method comes from http://stackoverflow.com/a/12433606/1087595
+        """ 
+        return []

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -28,7 +28,8 @@ from string import ascii_lowercase
 from suds import client, TypeNotFound
 
 from sunpy import config
-from sunpy.net import download, WellBehavedHttpTransport
+from sunpy.net import download
+from sunpy.net.proxyfix import WellBehavedHttpTransport
 from sunpy.util.progressbar import TTYProgressBar as ProgressBar
 from sunpy.util.net import get_filename, slugify
 from sunpy.net.attr import and_, Attr


### PR DESCRIPTION
This workaround is an attempt to solve Issue #702.  However, it needs to be tested on free-proxy systems.

On my side I can connect now to VSO, but the HELIO module seems to fail because the `last_received` attribute of the suds request is not created anymore.  This issue need to be also tested on a machine free of proxy servers.
