### PR TITLE
added pytest.ini.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+norecursedirs = build *.egg-info
+python_files = test_?*.py
+addopts = -p no:doctest


### PR DESCRIPTION
ignores the build and *.egg-info dirs and does not test doctest text files. Previously, also the text file "test_table.txt" in the test directory for the database package was recognized as a test file (and somehow 3 tests were found there). This PR fixes this.
