### PR TITLE
Rename lightcurve.header to lightcurve.meta

### DIFF
--- a/sunpy/lightcurve/lightcurve.py
+++ b/sunpy/lightcurve/lightcurve.py
@@ -75,7 +75,13 @@ class LightCurve(object):
     
     @property
     def header(self):
-        warnings.warn("""lightcurve.header has been renamed to map.meta
+        """
+        Return the lightcurves metadata
+
+        .. deprecated:: 0.4.0
+            Use .meta instead
+        """
+        warnings.warn("""lightcurve.header has been renamed to lightcurve.meta
 for compatability with map, please use meta instead""", Warning)
         return self.meta
 


### PR DESCRIPTION
Also added a warning when .header is used.
