### PR TITLE
Add a pre-commit hook to check tests and docs where appropriate.

### DIFF
--- a/doc/source/dev.rst
+++ b/doc/source/dev.rst
@@ -710,6 +710,17 @@ When to write unit tests
 A rule of thumb for unit testing is to have at least one unit test per public
 function.
 
+Testing Your Code Before Commiting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+When you commit your changes and make a Pull Request to the main SunPy repo on
+GitHub, your code will be tested by Travis CI to make sure that all the tests
+pass and the documentation builds without any warnings. Before you commit your
+code you should check that this is the case. There is a helper script in
+`sunpy/tools/pre-commit.sh` that is designed to run these tests automatically
+everytime you run `git commit` to install it copy the file from
+`sunpy/tools/pre-commit.sh` to `sunpy/.git/hooks/pre-commit`, you should also
+check the script to make sure that it is configured properly for your system.
+
 Continuous Intergration
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+PY_TEST=py.test
+SPHINX=sphinx-build
+BASE_DIR="$(git rev-parse --show-toplevel)"
+
+NUM_SUNPY=$(git diff --name-only --stat HEAD $BASE_DIR/sunpy | wc -l)
+NUM_DOCS=$(git diff --name-only --stat HEAD $BASE_DIR/doc | wc -l)
+#IF code has changed run the tests:
+if [ $NUM_SUNPY -gt  0 ]; then
+    $PY_TEST $BASE_DIR
+fi
+
+#If the code OR the docs have changed run the docs
+if  [ $NUM_SUNPY -gt 0 -o  $NUM_DOCS -gt  0 ]; then
+    
+    CWD="$(pwd)"
+    DOC_DIR=$BASE_DIR/doc/source
+    rm -r $DOC_DIR/_build
+    rm -r $DOC_DIR/api
+    rm -r $DOC_DIR/_generated
+
+    cd $DOC_DIR
+    $SPHINX -W -b html -d ./_build/doctrees . ./_build/html
+    cd $CWD
+fi


### PR DESCRIPTION
This is to help with the commit process and increase the chance that Travis will pass when you commit.
