### PR TITLE
added missing import for TRACEMap implementation

### DIFF
--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -7,6 +7,7 @@ __email__ = "jack.ireland@nasa.gov"
 from sunpy.map import GenericMap
 from sunpy.cm import cm
 import numpy as np
+from matplotlib import colors
 
 __all__ = ['TRACEMap']
 


### PR DESCRIPTION
The method `_get_norm` calls `LogNorm` but didn't import it.
