### PR TITLE
"fixed" MapCube.coalign

### DIFF
--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -78,7 +78,7 @@ class MapCube(object):
     def coalign(self, method="diff"):
         """ Fine coalign the data"""
         if method == 'diff':
-            return _coalign_diff(self)
+            return self._coalign_diff(self)
 
     # Coalignment methods
     def _coalign_diff(self):


### PR DESCRIPTION
This _may_ call the `_coalign_diff` method (if the passed argument is
`"diff"`) which raises NotImplementedError. Otherwise, `None` is
returned. Seems kinda not-finished-yet to me. At least MapCube.coalign won't raise a NameError anymore, yay.
