### PR TITLE
adding in GSOC acknowledgement to the documentation

### DIFF
--- a/doc/source/guide/acquiring_data/hek.rst
+++ b/doc/source/guide/acquiring_data/hek.rst
@@ -341,3 +341,6 @@ HEK results and create the corresponding VSO query attributes.
 
 This function allows users finer-grained control of VSO queries
 generated from HEK results.
+
+The 'hek2vso' module was developed with support from the 2013 Google
+Summer of Code.


### PR DESCRIPTION
This is an edit to the pull request I made last night.  It adds in a GSOC acknowledgement to the hek2vso guide.  I wonder if we should have another section to the guide that includes these acknowledgements in one place?  We also need a place to put a SunPy citation.
