### PR TITLE
Fix for GOES lightcurve range-based queries

### DIFF
--- a/sunpy/lightcurve/lightcurve.py
+++ b/sunpy/lightcurve/lightcurve.py
@@ -102,7 +102,7 @@ for compatability with map, please use meta instead""", Warning)
             err = "Unable to download data for specified date range"
         )
         result = cls.from_file(filepath)
-        result.data = result.data.ix[result.data.index.searchsorted(start):result.data.index.searchsorted(end)]
+        result.data = result.data.truncate(start,end)
         return result
 
     @classmethod
@@ -113,7 +113,7 @@ for compatability with map, please use meta instead""", Warning)
             err = "Unable to download data for specified date range"
         )
         result = cls.from_file(filepath)
-        result.data = result.data.ix[ts.index.indexer_between_time(timerange.start(), timerange.end())]
+        result.data = result.data.truncate(timerange.start(), timerange.end())
         return result
 
     @classmethod


### PR DESCRIPTION
This fix addresses issues found in #658, #881 and #890. When constructing a GOES lightcurve based on a time query, slicing was being handled incorrectly, leading to buggy behaviour, e.g.

```
lc = lightcurve.GOESLightCurve.create('2013-06-01','2013-06-02')
```

The date portion of the start and end times was being ignored during the data slicing, leading to strange behaviour.
