### PR TITLE
Mark broken GOES API tests as xfail

### DIFF
--- a/sunpy/lightcurve/tests/test_goes.py
+++ b/sunpy/lightcurve/tests/test_goes.py
@@ -8,6 +8,7 @@ import sunpy.lightcurve
 
 
 class TestGOESLightCurve():
+    #Temporary fix for disabled GOES API
     @pytest.mark.xfail
     @pytest.mark.online
     def test_goes_range(self):


### PR DESCRIPTION
This is a fix for the fact that the GOES API has gone dead.
