### PR TITLE
got rid of the need to create a whole new datacube to store the shifted ...

### DIFF
--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -7,7 +7,7 @@ import numpy as np
 try:
     from skimage.feature import match_template
 except ImportError:
-   pass
+   match_template = None
 
 
 def default_fmap_function(data):
@@ -132,7 +132,10 @@ def match_template_to_layer(layer, template):
     This function requires the "match_template" function in scikit image.
 
     """
-    return match_template(layer, template)
+    if match_template is None:
+        raise ImportError("Can't import 'match_template' from skimage.feature.  Please install the scikit-image package.")
+    else:
+        return match_template(layer, template)
 
 
 def find_best_match_location(corr):

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 #pylint: disable=W0401,W0614,W0201,W0212,W0404
 
-import sys
 import numpy as np
 import matplotlib.animation
 import matplotlib.pyplot as plt
@@ -134,11 +133,6 @@ class MapCube(object):
                                arcseconds.
 
         """
-        # Check to make sure that match_template has been loaded
-        if not("skimage.feature.template") in sys.modules:
-             print('Warning: the mapcube "coalign" method will not work. Please install scikit-image >= 0.9.3 to enable the coalign method of mapcube.')
-             return self
-
         # Size of the data
         ny = self.maps[layer_index].shape[0]
         nx = self.maps[layer_index].shape[1]


### PR DESCRIPTION
...data.  This should be more efficient in memory. 

Added in the option to return the arcsecond shifts required to coalign the data.  This is useful as a sanity check.  it is good to compare the shifts that were calculated against what you see in the final mapcube, and against what you thought expected.  Anyone have any better ideas about how to store/return this information?
