### PR TITLE
Tweaking of LYRA peek visualization and patch for big-endian bug

### DIFF
--- a/sunpy/lightcurve/sources/lyra.py
+++ b/sunpy/lightcurve/sources/lyra.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import datetime
 import urlparse
+import sys
 
 from matplotlib import pyplot as plt
 from astropy.io import fits
@@ -124,7 +125,7 @@ class LYRALightCurve(LightCurve):
 
         for i, col in enumerate(fits_record.columns[1:-1]):
             #temporary patch for big-endian data bug on pandas 0.13
-            if fits_record.field(i+1).dtype.byteorder == '>':
+            if fits_record.field(i+1).dtype.byteorder == '>' and sys.byteorder =='little':
                 table[col.name] = fits_record.field(i + 1).byteswap().newbyteorder()
             else:
                 table[col.name] = fits_record.field(i + 1)


### PR DESCRIPTION
Some cleanup to make the LYRA peek plot look a little nicer:
- y labels changed to span multiple lines to prevent overlap
- shrank y label fontsize
- reduced number of y-ticks to prevent overcrowding
