### PR TITLE
Add an offline build to the Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
    - python setup.py develop
    - if [[ $TEST_MODE == 'sphinx' ]]; then cd doc/source && sphinx-build -W -b html -d _build/doctrees   . _build/html; fi
    - if [[ $TEST_MODE == 'tests' ]]; then py.test -cov-report html --cov sunpy; fi
-   - if [[ $TEST_MODE == 'offline' ]]; then py.test --cov-report html --cov sunpy -k-offline; fi
+   - if [[ $TEST_MODE == 'offline' ]]; then py.test --cov-report html --cov sunpy -k-online; fi
 
 after_success:
    - coveralls


### PR DESCRIPTION
This bumps a minor version or two and adds a test run with the `-k-online` flag set, so no online tests are run.
