### PR TITLE
[BugFix]: Truncated lightcurves should remember their sub-class

### DIFF
--- a/sunpy/lightcurve/lightcurve.py
+++ b/sunpy/lightcurve/lightcurve.py
@@ -302,7 +302,7 @@ for compatability with map, please use meta instead""", Warning)
             time_range = TimeRange(a,b)
 
         truncated = self.data.truncate(time_range.start(), time_range.end())
-        return self.create(truncated, self.meta.copy())
+        return self.__class__.create(truncated, self.meta.copy())
 
     def extract(self, a):
         """Extract a set of particular columns from the DataFrame"""


### PR DESCRIPTION
A one-line PR!

Truncated lightcurves should remember what type of lightcurve they are (e.g. NoRH, LYRA), instead of falling back to the generic lightcurve class.
