### PR TITLE
[Review]: switching draw_limb to False as the default

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -902,7 +902,7 @@ installed, falling back to the interpolation='spline' of order=3""" ,Warning)
         return axes
 
     @toggle_pylab
-    def peek(self, draw_limb=True, draw_grid=False, gamma=None,
+    def peek(self, draw_limb=False, draw_grid=False, gamma=None,
                    colorbar=True, basic_plot=False, **matplot_args):
         """Displays the map in a new figure
 


### PR DESCRIPTION
The limb should not be on by default when displaying Maps when using map.peek().

First, the limb that is drawn is based on the value of the solar radius in the map, which has no guarantee of being correct.  Also, the default solar radius is the photospheric radius, which is not the same as the estimated solar radius for other wavebands, for example, coronal wavebands.  This means that for most datasets, the limb that is drawn is not at the same location as the limb estimated by eye.  This is confusing to the user.

Second, having the limb on by default assumes that the user wants to see the photospheric limb at the same time as the data.    The user may not be interested in the limb, or anything happening close to it.  I submit that plotting a limb is therefore a larger and more intrusive assumption than assuming that the user does not want to see the photospheric limb at the same time as the data.  Most users will want to see the data, and just the data, when viewing some data for the first time.

Third, displaying the limb shows inconsistent reasoning compared with the settings for the other defaults - for example, why not have the grid on by default too?  If you are going to assume that the user wants the photospheric limb, why not assume that the user wants to see a grid too, since that is also informative and useful?

Fourth, users may assume that the plotted limb is actually part of the data they have read in.  

Fifth, using the '.plot(...)' functionality is not a substitute.  In order to use this, an extra command has to be issued to tell matplotlib to execute the plot.  This can be extremely inconvenient.

Sixth, the default plotting in other commonly used tools that deal with full disk images such as SSWIDL maps (use fits2map.pro and plot_map.pro to read in an AIA file) and the Helioviewer project clients, do not have limb plotting on by default.  SunPy's behavior is therefore inconsistent with the behavior of other software.

Seventh, most images of the Sun shown in talks, posters, web pages, etc do not have the limb on them, typically because there is no need to have it for most purposes.  SunPy's map.peek() behavior is inconsistent with the common usage by the majority of the solar physics community.
