### PR TITLE
[BugFix]: fixed the units on the solar_semidiameter_angular_size function

### DIFF
--- a/sunpy/sun/sun.py
+++ b/sunpy/sun/sun.py
@@ -79,7 +79,7 @@ def solar_semidiameter_angular_size(t=None):
 
     """
     solar_semidiameter_rad = constants.radius / (sunearth_distance(t) * constants.au)
-    return np.rad2deg(solar_semidiameter_rad * u.degree) * 60. * 60.
+    return (np.rad2deg(solar_semidiameter_rad * u.rad)).to(u.arcsec)
  
 def position(t=None):
     """Returns the position of the Sun (right ascension and declination)


### PR DESCRIPTION
fixed the units on the `sun.solar_semidiameter_angular_size()` function as it was not being converted to radians properly.

On the same, I've changed the `time_parse` to accept None, and defaulting to `utcnow` when it is empty
