### PR TITLE
 Changed default grid spacing to 15 degrees

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -815,7 +815,7 @@ installed, falling back to the interpolation='spline' of order=3""" ,Warning)
 
 # #### Visualization #### #
 
-    def draw_grid(self, axes=None, grid_spacing=20, **kwargs):
+    def draw_grid(self, axes=None, grid_spacing=15, **kwargs):
         """Draws a grid over the surface of the Sun
 
         Parameters


### PR DESCRIPTION
A very short PR.  The current default grid spacing of 20 degrees means that the recent update to `draw_grid` (#1048) will draw latitude lines at +/-10 degrees and not the equator.  15 degrees is a better default (for other reasons too).
