### PR TITLE
number of maps now an attribute of the mapcube object

### DIFF
--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -36,6 +36,9 @@ class MapCube(object):
     maps : {List}
         This attribute holds the list of Map instances obtained from parameter args.
 
+    nmaps : int
+        A convenience attribute to expose the number of maps in the mapcube.
+
     Examples
     --------
     >>> mapcube = sunpy.map.Map('images/*.fits', mapcube=True)
@@ -51,6 +54,9 @@ class MapCube(object):
         derotate = kwargs.pop('derotate', False)
 
         self.maps = expand_list(args)
+
+        # Convenience attribute to expose the number of maps in the mapcube
+        self.nmaps = len(self.maps)
 
         for m in self.maps:
             if not isinstance(m, GenericMap):


### PR DESCRIPTION
A small addition to mapcube - a convenience property that exposes the number of maps in a mapcube.
