### PR TITLE
[BugFix]: Change default FITS file fixing settings.

### DIFF
--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -76,7 +76,7 @@ def read(filepath, hdus=None):
         elif isinstance(hdus, collections.Iterable):
             hdulist = [hdulist[i] for i in hdus]
     try:
-        hdulist.verify('silentfix')
+        hdulist.verify('fix+warn')
 
         headers = get_header(hdulist)
         pairs = []


### PR DESCRIPTION
This should allow bad fits files to be read and fixed without raising an
exception.
