### PR TITLE
Make no waveunit in database non-fatal.

### DIFF
--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -489,7 +489,8 @@ def entries_from_file(file, default_waveunit=None):
                 entry.instrument = value
             elif key == 'WAVELNTH':
                 if unit is None:
-                    raise WaveunitNotFoundError(file)
+                    warnings.warn("No wavelength unit information was found for this file.",
+                                  Warning)
                 # use the value of `unit` to convert the wavelength to nm
                 entry.wavemin = entry.wavemax = unit.to(
                     nm, value, equivalencies.spectral())


### PR DESCRIPTION
Currently the default behavior if a wavelength is present but a wavelength unit can not be found adding that file to the database will error. This behaviour is causing problems for the ginga project where it is (currently) not possible to override the default waveunit when graphically adding a file to the database.

I am not convinced this is the best solution to this problem. The other option I can think of is  defaulting to Angstroms, or we leave it as-is and work around it in the GUI. Any suggestions?
