### PR TITLE
Allow the overriding of the databases value of default_waveunit in add_from_file.

### DIFF
--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -737,7 +737,8 @@ class Database(object):
         if cmds:
             self._command_manager.do(cmds)
 
-    def add_from_file(self, file, ignore_already_added=False):
+    def add_from_file(self, file, ignore_already_added=False,
+                      default_waveunit=None):
         """Generate as many database entries as there are FITS headers in the
         given file and add them to the database.
 
@@ -751,9 +752,15 @@ class Database(object):
         ignore_already_added : bool, optional
             See :meth:`sunpy.database.Database.add`.
 
+        default_waveunit : str
+            The default waveunti to assume for this file only, if not specified
+            uses the Databases default value.
         """
+        if not default_waveunit:
+            default_waveunit = self.default_waveunit
+
         self.add_many(
-            tables.entries_from_file(file, self.default_waveunit),
+            tables.entries_from_file(file, default_waveunit),
             ignore_already_added)
 
     def edit(self, database_entry, **kwargs):


### PR DESCRIPTION
The logic behind this is that sometimes you might be adding a file
with a odd waveunit that is not in the header, and you don't want
a global default but a file-by-file one.