### PR TITLE
[DocFix]: remove redundant exception docs from database.rst

### DIFF
--- a/doc/source/code_ref/database.rst
+++ b/doc/source/code_ref/database.rst
@@ -10,39 +10,6 @@ SunPy database
 .. automodapi:: sunpy.database
     :no-inheritance-diagram:
 
-Exceptions
-^^^^^^^^^^
-.. class:: sunpy.database.EntryAlreadyAddedError(database_entry)
-
-    This exception is raised if a database entry is attempted to be added
-    to the database although it was already saved in it.
-
-.. class:: sunpy.database.EntryAlreadyStarredError(database_entry)
-
-    This exception is raised if a database entry is marked as starred
-    using :meth:`Database.star` although it was already starred before
-    this operation.
-
-.. class:: sunpy.database.EntryAlreadyUnstarredError(database_entry)
-
-    This exception is raised if the star mark from a database entry is
-    attempted to be removed although the entry is not starred.
-
-.. class:: sunpy.database.EntryNotFoundError(entry_id)
-
-    This exception is raised if a database entry cannot be found by its
-    unique ID.
-
-.. class:: sunpy.database.TagAlreadyAssignedError(database_entry, tag_name)
-
-    This exception is raised if it is attempted to assign a tag to a
-    database entry but the database entry already has this tag assigned.
-
-.. class:: sunpy.database.NoSuchTagError(tag_name)
-
-    This exception is raised if a tag cannot be found in a database by its
-    name.
-
 Submodules
 ----------
 


### PR DESCRIPTION
This works-around a werid doc bug. see astropy/astropy_helpers#37
