### PR TITLE
Make CROTA2 default to 0.

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -396,7 +396,7 @@ Dimension:\t [%d, %d]
         conversion.
         """
         lam = self.scale['y'] / self.scale['x']
-        p = np.deg2rad(self.meta['CROTA2'])
+        p = np.deg2rad(self.meta.get('CROTA2', 0))
 
         return np.matrix([[np.cos(p), -1 * lam * np.sin(p)],
                           [1/lam * np.sin(p), np.cos(p)]])


### PR DESCRIPTION
If no rotation information in the header, the default is 0.

closes #1141
