### PR TITLE
[DocFix]: Fixed broken link for Matplotlib in Documentation

### DIFF
--- a/doc/source/guide/installation/index.rst
+++ b/doc/source/guide/installation/index.rst
@@ -23,7 +23,7 @@ SunPy also depends on other packages for optional features.
 However, note that these only need to be installed if those particular features
 are needed. SunPy will import even if these dependencies are not installed.
 
-- `Matplotlib <http://http://matplotlib.org/>`_ [*Highly Recommended*] 1.3.0 or later: For `lightcurve`, `map`, `spectra`, `instr` and `vizualisation`.
+- `Matplotlib <http://matplotlib.org/>`_ [*Highly Recommended*] 1.3.0 or later: For `lightcurve`, `map`, `spectra`, `instr` and `vizualisation`.
 
 - `pandas <http://pandas.pydata.org/>`_ 0.10 or later: For `lightcurve`.
 


### PR DESCRIPTION
Matplotlib link was broken.  Removed the double http:// to fix it.
