### PR TITLE
Use union merge strategy for the changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Git has the capability of specifying a different merge strategy (or driver) for different files.  To avoid PRs from being blocked by merge conflicts on `CHANGELOG.md`, the file should use the "union" merge driver rather than the default "text" merge driver.  See:

http://git-scm.com/docs/gitattributes
http://stackoverflow.com/questions/13263902/git-merge-keep-both

The changelog will then always have a successful merge, although the product may need to be edited afterwards if the resulting order doesn't make sense.
