### PR TITLE
internal database package refactor

### DIFF
--- a/sunpy/database/commands.py
+++ b/sunpy/database/commands.py
@@ -74,6 +74,38 @@ class DatabaseOperation(object):
         return  # pragma: no cover
 
 
+class CompositeOperation(DatabaseOperation):
+    def __init__(self, operations=None):
+        if operations is None:
+            self._operations = []
+        else:
+            self._operations = operations
+
+    @property
+    def operations(self):
+        return self._operations
+
+    def add(self, operation):
+        self._operations.append(operation)
+
+    def remove(self, operation):
+        self._operations.remove(operation)
+
+    def __call__(self):
+        for operation in self._operations:
+            # FIXME: What follows is the worst hack of my life. Enjoy.
+            # Without it, the test test_clear_database would fail.
+            f = open(os.devnull, 'w'); f.write(repr(operation)); f.flush()
+            operation()
+
+    def undo(self):
+        for operation in self._operations:
+            operation.undo()
+
+    def __len__(self):
+        return len(self._operations)
+
+
 class AddEntry(DatabaseOperation):
     """Add a new database entry to this session. It is not checked whether an
     equivalent entry is already saved in the session; this has to be checked by
@@ -236,8 +268,14 @@ class RemoveTag(DatabaseOperation):
         except InvalidRequestError:
             # self.tag cannot be added because it was just removed
             # -> put it back to transient state
-            make_transient(self.tag)
-            self.database_entry.tags.append(self.tag)
+            try:
+                make_transient(self.tag)
+                self.database_entry.tags.append(self.tag)
+            except InvalidRequestError:
+                # self.database_entry has been removed
+                # -> put it back to transient state
+                make_transient(self.database_entry)
+                self.database_entry.tags.append(self.tag)
 
     def __repr__(self):
         return "<RemoveTag(tag '{0}', session {1!r}, entry id {2})>".format(
@@ -304,14 +342,7 @@ class CommandManager(object):
         iterable is executed and only one entry is saved in the undo history.
 
         """
-        if isinstance(command, collections.Iterable):
-            for cmd in command:
-                # FIXME: What follows is the worst hack of my life. Enjoy.
-                # Without it, the test test_clear_database would fail.
-                f = open(os.devnull, 'w'); f.write(repr(cmd)); f.flush()
-                cmd()
-        else:
-            command()
+        command()
         self.push_undo_command(command)
         # clear the redo stack when a new command was executed
         self.redo_commands[:] = []
@@ -325,11 +356,7 @@ class CommandManager(object):
         """
         for _ in xrange(n):
             command = self.pop_undo_command()
-            if isinstance(command, collections.Iterable):
-                for cmd in reversed(command):
-                    cmd.undo()
-            else:
-                command.undo()
+            command.undo()
             self.push_redo_command(command)
 
     def redo(self, n=1):
@@ -342,9 +369,5 @@ class CommandManager(object):
         """
         for _ in xrange(n):
             command = self.pop_redo_command()
-            if isinstance(command, collections.Iterable):
-                for cmd in command:
-                    cmd()
-            else:
-                command()
+            command()
             self.push_undo_command(command)

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import sessionmaker
 import sunpy
 from sunpy.database import commands, tables, serialize
 from sunpy.database.caching import LRUCache
+from sunpy.database.commands import CompositeOperation
 from sunpy.database.attrs import walker
 from sunpy.net.hek2vso import H2VClient
 from sunpy.net.attr import and_
@@ -263,7 +264,7 @@ class Database(object):
         :class:`sunpy.database.caching.LFUCache`).
 
         """
-        cmds = []
+        cmds = CompositeOperation()
         # remove items from the cache if the given argument is lower than the
         # current cache size
         while cache_size < self.cache_size:
@@ -272,7 +273,7 @@ class Database(object):
             entry_id, entry = self._cache.to_be_removed
             cmd = commands.RemoveEntry(self.session, entry)
             if self._enable_history:
-                cmds.append(cmd)
+                cmds.add(cmd)
             else:
                 cmd()
             del self._cache[entry_id]
@@ -504,7 +505,7 @@ class Database(object):
             raise TypeError('at least one tag must be given')
         # avoid duplicates
         tag_names = set(tags)
-        cmds = []
+        cmds = CompositeOperation()
         for tag_name in tag_names:
             try:
                 tag = self.get_tag(tag_name)
@@ -515,7 +516,7 @@ class Database(object):
                 tag = tables.Tag(tag_name)
             cmd = commands.AddTag(self.session, database_entry, tag)
             if self._enable_history:
-                cmds.append(cmd)
+                cmds.add(cmd)
             else:
                 cmd()
         if cmds:
@@ -533,16 +534,16 @@ class Database(object):
 
         """
         tag = self.get_tag(tag_name)
-        cmds = []
+        cmds = CompositeOperation()
         remove_tag_cmd = commands.RemoveTag(self.session, database_entry, tag)
         remove_tag_cmd()
         if self._enable_history:
-            cmds.append(remove_tag_cmd)
+            cmds.add(remove_tag_cmd)
         if not tag.data:
             remove_entry_cmd = commands.RemoveEntry(self.session, tag)
             remove_entry_cmd()
             if self._enable_history:
-                cmds.append(remove_entry_cmd)
+                cmds.add(remove_entry_cmd)
         if self._enable_history:
             self._command_manager.push_undo_command(cmds)
 
@@ -583,7 +584,7 @@ class Database(object):
             See Database.add
 
         """
-        cmds = []
+        cmds = CompositeOperation()
         for database_entry in database_entries:
             # use list(self) instead of simply self because __contains__ checks
             # for existence in the database and not only all attributes except
@@ -592,7 +593,7 @@ class Database(object):
                 raise EntryAlreadyAddedError(database_entry)
             cmd = commands.AddEntry(self.session, database_entry)
             if self._enable_history:
-                cmds.append(cmd)
+                cmds.add(cmd)
             else:
                 cmd()
             if database_entry.id is None:
@@ -722,7 +723,7 @@ class Database(object):
             See :meth:`sunpy.database.Database.add`.
 
         """
-        cmds = []
+        cmds = CompositeOperation()
         entries = tables.entries_from_dir(
             path, recursive, pattern, self.default_waveunit)
         for database_entry, filepath in entries:
@@ -730,7 +731,7 @@ class Database(object):
                 raise EntryAlreadyAddedError(database_entry)
             cmd = commands.AddEntry(self.session, database_entry)
             if self._enable_history:
-                cmds.append(cmd)
+                cmds.add(cmd)
             else:
                 cmd()
             self._cache.append(database_entry)
@@ -779,11 +780,11 @@ class Database(object):
         database_entries : iterable of sunpy.database.tables.DatabaseEntry
             The database entries that will be removed from the database.
         """
-        cmds = []
+        cmds = CompositeOperation()
         for database_entry in database_entries:
             cmd = commands.RemoveEntry(self.session, database_entry)
             if self._enable_history:
-                cmds.append(cmd)
+                cmds.add(cmd)
             else:
                 cmd()
             try:
@@ -814,10 +815,10 @@ class Database(object):
         using the :meth:`undo` method.
 
         """
-        cmds = []
+        cmds = CompositeOperation()
         for entry in self:
             for tag in entry.tags:
-                cmds.append(commands.RemoveTag(self.session, entry, tag))
+                cmds.add(commands.RemoveTag(self.session, entry, tag))
             # TODO: also remove all FITS header entries and all FITS header
             # comments from each entry before removing the entry itself!
         # remove all entries from all helper tables
@@ -826,15 +827,14 @@ class Database(object):
             tables.FitsKeyComment]
         for table in database_tables:
             for entry in self.session.query(table):
-                cmds.append(commands.RemoveEntry(self.session, entry))
+                cmds.add(commands.RemoveEntry(self.session, entry))
         for entry in self:
-            cmds.append(commands.RemoveEntry(self.session, entry))
+            cmds.add(commands.RemoveEntry(self.session, entry))
             del self._cache[entry.id]
         if self._enable_history:
             self._command_manager.do(cmds)
         else:
-            for cmd in cmds:
-                cmd()
+            cmds()
 
     def clear_histories(self):
         """Clears all entries from the undo and redo history.

--- a/sunpy/database/tests/test_commands.py
+++ b/sunpy/database/tests/test_commands.py
@@ -13,7 +13,7 @@ import pytest
 
 from sunpy.database.commands import AddEntry, RemoveEntry, EditEntry,\
     AddTag, RemoveTag, NoSuchEntryError, NonRemovableTagError,\
-    EmptyCommandStackError, CommandManager
+    EmptyCommandStackError, CommandManager, CompositeOperation
 from sunpy.database.tables import DatabaseEntry, Tag
 
 
@@ -280,10 +280,10 @@ def test_cmd_manager_redo(session, command_manager):
 
 def test_undo_redo_multiple_cmds_at_once(session, command_manager):
     assert command_manager.undo_commands == []
-    command_manager.do([
+    command_manager.do(CompositeOperation([
         AddEntry(session, DatabaseEntry()),
         AddEntry(session, DatabaseEntry()),
-        AddEntry(session, DatabaseEntry())])
+        AddEntry(session, DatabaseEntry())]))
     assert len(command_manager.undo_commands) == 1
     assert session.query(DatabaseEntry).count() == 3
     command_manager.undo()


### PR DESCRIPTION
I added a new class `CompositeOperation` so that from the user's point of view the `__call__` of a sequence of operation works the same as just one operation. Nothing will change for the average user of SunPy, it's mainly a refactor to improve maintainability and code style in general. Unfortunately, the ugly hack couldn't be removed, only moved to a new location :(
