### PR TITLE
Sphinx 1.2.2 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
    - pip install $PIP_WHEEL_COMMAND scikit-image
    - pip install $PIP_WHEEL_COMMAND sqlalchemy
 # Install sphinx if needed
-   - if [[ $TEST_MODE == 'sphinx' ]]; then pip install $PIP_WHEEL_COMMAND sphinx>=1.2; fi 
+   - if [[ $TEST_MODE == 'sphinx' ]]; then pip install $PIP_WHEEL_COMMAND sphinx==1.2.2; fi 
 
 # Install SunPy and run tests.
 script:


### PR DESCRIPTION
As mentioned in astropy/astropy#2914 sphinx v1.2.3 is incompatible with the current astropy-sphinx plugin.  This PR makes Travis to run on 1.2.2 till the problem is solved upstream.
