### PR TITLE
Make Travis to don't use the latest version of Sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
    - pip install $PIP_WHEEL_COMMAND scikit-image
    - pip install $PIP_WHEEL_COMMAND sqlalchemy
 # Install sphinx if needed
-   - if [[ $TEST_MODE == 'sphinx' ]]; then pip install $PIP_WHEEL_COMMAND sphinx>=1.2; fi 
+   - if [[ $TEST_MODE == 'sphinx' ]]; then pip install $PIP_WHEEL_COMMAND sphinx==1.2.2; fi 
 
 # Install SunPy and run tests.
 script:


### PR DESCRIPTION
make travis to install sphinx 1.2.2 to avoid the new conflict produced by the not-updatd sphinx module in astropy.
Same than #1167 but for 0.5
