### PR TITLE
small fix to allow sunpy 0.2 to read in SWAP JP2 files

### DIFF
--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -41,7 +41,7 @@ def get_data(filepath, j2k_to_image="j2k_to_image"):
     
     Uses the OpenJPEG j2k_to_image command, if available, to extract the data
     portion of a JPEG 2000 image. The image is first converted to a temporary
-    intermediate file (PGM) and then read back in and stored an as ndarray.
+    intermediate file (PNG) and then read back in and stored an as ndarray.
     
     NOTE: PIL is also required for Matplotlib to read in PGM images.
     """
@@ -55,7 +55,7 @@ def get_data(filepath, j2k_to_image="j2k_to_image"):
     
     jp2filename = os.path.basename(filepath)
     
-    tmpname = "".join(os.path.splitext(jp2filename)[0:-1]) + ".pgm"
+    tmpname = "".join(os.path.splitext(jp2filename)[0:-1]) + ".png"
     tmpfile = os.path.join(tempfile.mkdtemp(), tmpname)
     
     with open(os.devnull, 'w') as fnull:


### PR DESCRIPTION
SWAP JP2 files do not have a 'comment' key in header.  Sunpy 0.2 was failing in reading SWAP JP2 files.  This patch tests for the existence of the 'comment' key.
