### PR TITLE
Fixed bug with missing call to parse_time

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1083,8 +1083,9 @@ Dimension:\t [{xdim:d}, {ydim:d}]
 
         # Normal plot
         if annotate:
-            axes.set_title("{s.name} {s.date:{tmf}}".format(s=self, 
-                                                            tmf=TIME_FORMAT))
+            axes.set_title("{name} {date:{tmf}}".format(name=self.name,
+                                                        date=parse_time(self.date),
+                                                        tmf=TIME_FORMAT))
 
             # x-axis label
             if self.coordinate_system['x'] == 'HG':


### PR DESCRIPTION
PR #1073 introduced a bug where SunPy now crashes when trying to plot a Map.  For the construction of the title of Map plots, `self.date` is a string and needs to be converted to a `datetime` object first before it can be formatted.

Please review so this PR can be merged as soon as possible.
