### PR TITLE
Fix for doc build when Glymur is present but OpenJPEG is not

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,7 +44,7 @@ except ImportError:
 try:
     import glymur
     _, OJP2 = glymur.lib.config.glymur_config()
-except ImportError:
+except IOError:
     from mock import Mock
     mock = Mock()
     modules.update({'glymur':mock})


### PR DESCRIPTION
Read the Docs is unhappy because it installs Glymur, but not OpenJPEG.  This issue was noted and attempted to be fixed in PR #1180, but the exception that Glymur throws is actually `IOError`, not `ImportError`.

Incidentally, the change in Glymur of throwing an exception instead of a warning was introduced just a month ago with with this commit (https://github.com/quintusdias/glymur/commit/4ac5b575d20c2ccdd8b0901d8cb1d2a0442a70e6) for Glymur 0.7.0.
