### PR TITLE
update development version number to 0.6.dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ LONG_DESCRIPTION = "SunPy is a Python library for solar physics data analysis."
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.5.dev'
+VERSION = '0.6.dev'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
To be compatible with PEP440, upon a major release we are developing the next major version. http://legacy.python.org/dev/peps/pep-0440/#developmental-releases
