### PR TITLE
Fixing: parse_time does not always return a datetime object #1191

### DIFF
--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -169,6 +169,7 @@ def parse_time(time_string, time_format=''):
     Add ability to parse tai (International Atomic Time seconds since
     Jan 1, 1958)
     """
+    time_string = str(time_string)
     if isinstance(time_string, datetime) or time_format == 'datetime':
         return time_string
     elif isinstance(time_string, tuple):


### PR DESCRIPTION
Issue: https://github.com/sunpy/sunpy/issues/1191

I am getting this Output for the above input, 

```
In [1]: import sunpy.lightcurve
In [2]: from sunpy.time import parse_time

In [3]: glc = sunpy.lightcurve.GOESLightCurve.create("2014-01-01", "2014-01-02")
In [4]: lc_time = parse_time(glc.data.index[0])
In [5]: lc_time
Out[5]: datetime.datetime(2014, 1, 1, 0, 0, 0, 421999)
```

and for normal string input:

```
In [6]: str_time = parse_time("2014-01-01")
In [7]: str_time
Out[7]: datetime.datetime(2014, 1, 1, 0, 0)
```
