### PR TITLE
Goes peek fix

### DIFF
--- a/sunpy/lightcurve/sources/goes.py
+++ b/sunpy/lightcurve/sources/goes.py
@@ -38,7 +38,7 @@ class GOESLightCurve(LightCurve):
         figure = plt.figure()
         axes = plt.gca()
 
-        dates = matplotlib.dates.date2num(self.data.index)
+        dates = matplotlib.dates.date2num(parse_time(self.data.index))
 
         axes.plot_date(dates, self.data['xrsa'], '-',
                      label='0.5--4.0 $\AA$', color='blue', lw=2)

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -5,6 +5,9 @@ from datetime import datetime
 from sunpy import time
 from sunpy.time import parse_time
 
+import numpy as np
+import pandas
+
 LANDING = datetime(1966, 2, 3)
 
 
@@ -29,8 +32,42 @@ def test_parse_time_int():
     assert parse_time(765548612.0,'utime') == datetime(2003, 4, 5, 12, 23, 32)
     assert parse_time(1009685652.0,'utime') == datetime(2010, 12, 30, 4, 14, 12)
 
+def test_parse_time_pandas_timestamp():
+    ts = pandas.Timestamp(LANDING)
+    
+    dt = parse_time(ts)
+    
+    assert isinstance(dt, datetime)
+    assert dt == LANDING
 
-def test_parse_time_ISO():
+def test_parse_time_pandas_index():
+    inputs = [datetime(2012, 1, i) for i in range(1,13)]
+    ind = pandas.tseries.index.DatetimeIndex(inputs)
+
+    dts = parse_time(ind)
+    
+    assert isinstance(dts, np.ndarray)
+    assert all([isinstance(dt, datetime) for dt in dts])
+    assert list(dts) == inputs
+
+
+def test_parse_time_numpy_date():
+    inputs = np.arange('2005-02', '2005-03', dtype='datetime64[D]')
+    
+    dts = parse_time(inputs)
+    
+    assert isinstance(dts, np.ndarray)
+    assert all([isinstance(dt, datetime) for dt in dts])
+  
+def test_parse_time_numpy_datetime():
+    inputs = np.arange('2005-02-01T00', '2005-02-01T10', dtype='datetime64')
+    
+    dts = parse_time(inputs)
+    
+    assert isinstance(dts, np.ndarray)
+    assert all([isinstance(dt, datetime) for dt in dts])  
+
+def test_ISO():
     assert parse_time('1966-02-03') == LANDING
     assert (
         parse_time('1966-02-03T20:17:40') == datetime(1966, 2, 3, 20, 17, 40)
@@ -93,3 +130,4 @@ def test_day_of_year():
     assert time.day_of_year('2012/04/10') == 101
     assert time.day_of_year('2012/01/31') == 31
     assert time.day_of_year('2012/09/30') == 274
+

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from datetime import timedelta
 
+import numpy as np
 import pandas
 
 __all__ = ['find_time', 'extract_time', 'parse_time', 'is_time', 'day_of_year', 'break_time', 'get_day', 'is_time_in_given_format']
@@ -181,6 +182,8 @@ def parse_time(time_string, time_format=''):
         return datetime(1979, 1, 1) + timedelta(0, time_string)
     elif isinstance(time_string, pandas.tseries.index.DatetimeIndex):
     	return time_string._mpl_repr()
+    elif isinstance(time_string, np.ndarray) and 'datetime64' in str(time_string.dtype):
+        return np.array([ss.astype(datetime) for ss in time_string])
     elif time_string is 'now':
         return datetime.utcnow()
     else:

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -168,9 +168,6 @@ def parse_time(time_string, time_format=''):
     >>> sunpy.time.parse_time('2012/08/01')
     >>> sunpy.time.parse_time('2005-08-04T00:01:02.000Z')
 
-    Todo:
-    Add ability to parse tai (International Atomic Time seconds since
-    Jan 1, 1958)
     """
     if isinstance(time_string, pandas.tslib.Timestamp):
     	return time_string.to_datetime()
@@ -183,7 +180,9 @@ def parse_time(time_string, time_format=''):
     elif isinstance(time_string, pandas.tseries.index.DatetimeIndex):
     	return time_string._mpl_repr()
     elif isinstance(time_string, np.ndarray) and 'datetime64' in str(time_string.dtype):
-        return np.array([ss.astype(datetime) for ss in time_string])
+        ii = [ss.astype(datetime) for ss in time_string]
+        # Validate (in an agnostic way) that we are getting a datetime rather than a date
+        return np.array([datetime(*(dt.timetuple()[:6])) for dt in ii])
     elif time_string is 'now':
         return datetime.utcnow()
     else:

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -2,6 +2,8 @@ import re
 from datetime import datetime
 from datetime import timedelta
 
+import pandas
+
 __all__ = ['find_time', 'extract_time', 'parse_time', 'is_time', 'day_of_year', 'break_time', 'get_day', 'is_time_in_given_format']
 
 # Mapping of time format codes to regular expressions.

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -169,12 +169,16 @@ def parse_time(time_string, time_format=''):
     Add ability to parse tai (International Atomic Time seconds since
     Jan 1, 1958)
     """
-    if isinstance(time_string, datetime) or time_format == 'datetime':
+    if isinstance(time_string, pandas.tslib.Timestamp):
+    	return time_string.to_datetime()
+    elif isinstance(time_string, datetime) or time_format == 'datetime':
         return time_string
     elif isinstance(time_string, tuple):
         return datetime(*time_string)
     elif time_format == 'utime' or  isinstance(time_string, (int, float))  :
         return datetime(1979, 1, 1) + timedelta(0, time_string)
+    elif isinstance(time_string, pandas.tseries.index.DatetimeIndex):
+    	return time_string._mpl_repr()
     elif time_string is 'now':
         return datetime.utcnow()
     else:


### PR DESCRIPTION
This adds the ability to convert pandas TimeStamp, DateTimeIndex and np.datetime64 objects through `parse_time`, in the process fixing the goes peek issue.