### PR TITLE
Manifest updates for licenses

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ recursive-include sunpy *.txt
 include README.md
 include RELEASE.md
 include CHANGELOG.md
-include LICENSE.txt
+include licenses/*.rst
 include sunpy/data/sunpyrc
 include setup.py
 include ah_bootstrap.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,6 @@ include sunpy/data/sunpyrc
 include setup.py
 include ah_bootstrap.py
 include ez_setup.py
+
+recursive-include astropy_helpers *
+exclude astropy_helpers/.*


### PR DESCRIPTION
The manifest was still looking for `LICENSE.txt`, which has been renamed in #1233.  This produced warnings when installing SunPy.

Should `astropy_helpers` also be included in the manifest?