### PR TITLE
Silence warnings for any fixable FITS violations

### DIFF
--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -76,7 +76,7 @@ def read(filepath, hdus=None):
         elif isinstance(hdus, collections.Iterable):
             hdulist = [hdulist[i] for i in hdus]
     try:
-        hdulist.verify('fix+warn')
+        hdulist.verify('silentfix+warn')
 
         headers = get_header(hdulist)
         pairs = []


### PR DESCRIPTION
Because `fix` is used instead of `silentfix` when verifying a FITS file, all of the fixable FITS violations in a typical solar FITS file produce a whole bunch of warnings, even though these "violations" are not relevant (e.g., tags that we don't use are not present).  This behavior can give users the impression that that something is fundamentally broken.  This proposed change silences those warnings for fixable violations, while unfixable violations will still produce warnings.

Note that `get_header()` already uses `silentfix`.