### PR TITLE
Make self_test default to offline only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,8 @@ install:
 
 script:
     - if [[ $TEST_MODE == 'sphinx' ]]; then python setup.py build_sphinx -w; fi
-    - if [[ $TEST_MODE == 'offline' || $TEST_MODE == 'astropy-dev' ]]; then python setup.py test --offline-only; fi
-    - if [[ $TEST_MODE == 'online' ]]; then python setup.py test --coverage --cov-report=html; fi
+    - if [[ $TEST_MODE == 'offline' || $TEST_MODE == 'astropy-dev' ]]; then python setup.py test; fi
+    - if [[ $TEST_MODE == 'online' ]]; then python setup.py test --online --coverage --cov-report=html; fi
     - if [[ $TEST_MODE == 'skip' ]]; then coveralls --rcfile='./sunpy/tests/coveragerc'; fi
 
 # Notify the IRC channel of build status

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,5 +42,5 @@ install:
 build: false
 
 test_script:
-    - "%CMD_IN_ENV% python setup.py test --offline-only"
+    - "%CMD_IN_ENV% python setup.py test"
 

--- a/sunpy/tests/__init__.py
+++ b/sunpy/tests/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
 
 
 def main(modulename='', coverage=False, cov_report=False,
-         online=True, offline=True, verbose=False, parallel=0, args=None):
+         online=False, offline=True, verbose=False, parallel=0, args=None):
     """
     Execute the test suite of the sunpy package. The parameters may be
     used to restrict the number of tests that will be executed or to
@@ -31,7 +31,7 @@ def main(modulename='', coverage=False, cov_report=False,
 
     online : bool
         Run the tests that require an internet connection.
-    
+
     offline: bool
         Run the tests that don't require an internet connection.
 
@@ -52,7 +52,7 @@ def main(modulename='', coverage=False, cov_report=False,
         raise ImportError(
             'No module named {0!r} in the sunpy package'.format(modulename))
     assert path is not None
-    
+
     all_args = []
     if coverage:
         print path, modulename
@@ -66,15 +66,15 @@ def main(modulename='', coverage=False, cov_report=False,
     if not offline:
         all_args.append('-k online')
     all_args.append(path)
-    
+
     if args:
         all_args.append(args)
-    
+
     if verbose:
         all_args.append('-v')
-    
+
     if parallel != 0:
-        try:    
+        try:
             import xdist
         except ImportError:
             raise ImportError(

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -26,10 +26,10 @@ class SunPyTest(AstropyTest):
         # plugins to enable
         ('plugins=', 'p',
          'Plugins to enable when running pytest.'),
-        # Run only offline tests?
-        ('offline-only', None,
-         'Only run test that do not require a internet connection.'),
-        # Run only offline tests?
+        # Run online tests?
+        ('online', None,
+         'Also run tests that do require a internet connection.'),
+        # Run only online tests?
         ('online-only', None,
          'Only run test that do require a internet connection.'),
         # Calculate test coverage
@@ -57,8 +57,8 @@ class SunPyTest(AstropyTest):
         self.verbose_results = False
         self.plugins = None
         self.args = None
+        self.online = False
         self.online_only = False
-        self.offline_only = False
         self.coverage = False
         self.cov_report = 'term' if self.coverage else None
         self.docs_path = None
@@ -84,7 +84,7 @@ class SunPyTest(AstropyTest):
         cmd_pre = ''  # Commands to run before the test function
         cmd_post = ''  # Commands to run after the test function
 
-        online = not self.offline_only
+        online = self.online
         offline = not self.online_only
 
         cmd = ('{cmd_pre}{0}; import {1.package_name}, sys; result = ('

--- a/sunpy/tests/tests/test_main.py
+++ b/sunpy/tests/tests/test_main.py
@@ -23,14 +23,14 @@ def test_main_stdlib_module():
 def test_main_noargs(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main()
-    assert args in (['sunpy'], [root_dir])
+    assert args in (['-k-online', 'sunpy'], [root_dir])
 
 
 def test_main_submodule(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map')
-    assert args in ([os.path.join('sunpy', 'map', 'tests')],
-                    [os.path.join(root_dir, 'map', 'tests')])
+    assert args in (['-k-online'] + [os.path.join('sunpy', 'map', 'tests')],
+                    ['-k-online'] + [os.path.join(root_dir, 'map', 'tests')])
 
 
 def test_main_with_cover(monkeypatch):
@@ -38,16 +38,16 @@ def test_main_with_cover(monkeypatch):
     args = sunpy.tests.main('map', coverage=True)
     covpath = os.path.abspath(
         os.path.join(sunpy.tests.testdir, os.path.join(os.pardir, 'map')))
-    assert args in (['--cov', covpath, os.path.join('sunpy', 'map', 'tests')],
-                    ['--cov', covpath, os.path.join(root_dir, 'map', 'tests')])
+    assert args in (['--cov', covpath, '-k-online', os.path.join('sunpy', 'map', 'tests')],
+                    ['--cov', covpath, '-k-online', os.path.join(root_dir, 'map', 'tests')])
 
 
 def test_main_with_show_uncovered_lines(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map', cov_report='term-missing')
-    assert args in (['--cov-report', 'term-missing',
+    assert args in (['--cov-report', 'term-missing', '-k-online',
                      os.path.join('sunpy', 'map', 'tests')],
-                    ['--cov-report', 'term-missing',
+                    ['--cov-report', 'term-missing', '-k-online',
                      os.path.join(root_dir, 'map', 'tests')])
 
 
@@ -60,7 +60,7 @@ def test_main_exclude_online(monkeypatch):
 
 def test_main_only_online(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
-    args = sunpy.tests.main('map', offline=False)
+    args = sunpy.tests.main('map', offline=False, online=True)
     assert args in (['-k online', os.path.join('sunpy', 'map', 'tests')],
                     ['-k online', os.path.join(root_dir, 'map', 'tests')])
 


### PR DESCRIPTION
This makes the test much faster for a user to validate their sunpy install.