### PR TITLE
Updated SWPC/NOAA links 

### DIFF
--- a/sunpy/lightcurve/sources/noaa.py
+++ b/sunpy/lightcurve/sources/noaa.py
@@ -33,10 +33,10 @@ class NOAAIndicesLightCurve(LightCurve):
 
     References
     ----------
-    | http://www.swpc.noaa.gov/Data/index.html#indices
-    | http://www.swpc.noaa.gov/ftpdir/weekly/README3
-    | http://www.swpc.noaa.gov/ftpdir/weekly/RecentIndices.txt
-    | http://www.swpc.noaa.gov/SolarCycle/
+    | http://legacy-www.swpc.noaa.gov/Data/index.html#indices
+    | ftp://ftp.swpc.noaa.gov/pub/weekly/README3
+    | ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt
+    | http://www.swpc.noaa.gov/products/solar-cycle-progression
     """
 
     def peek(self, axes=None, type='sunspot SWO', **plot_args):
@@ -78,7 +78,7 @@ class NOAAIndicesLightCurve(LightCurve):
     @classmethod
     def _get_default_uri(cls):
         """Return the url to download indices"""
-        return "http://www.swpc.noaa.gov/ftpdir/weekly/RecentIndices.txt"
+        return "ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt"
 
     @staticmethod
     def _get_url_for_date_range(*args, **kwargs):
@@ -125,9 +125,10 @@ class NOAAPredictIndicesLightCurve(LightCurve):
 
     References
     ----------
-    | http://www.swpc.noaa.gov/Data/index.html#indices
-    | http://www.swpc.noaa.gov/ftpdir/weekly/Predict.txt
-    | http://www.swpc.noaa.gov/SolarCycle/
+    | http://legacy-www.swpc.noaa.gov/Data/index.html#indices
+    | http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt
+    | http://www.swpc.noaa.gov/products/solar-cycle-progression
+    | http://www.swpc.noaa.gov/products-and-data
     """
 
     def peek(self, axes=None, **plot_args):
@@ -154,7 +155,7 @@ class NOAAPredictIndicesLightCurve(LightCurve):
     @classmethod
     def _get_default_uri(cls):
         """Return the url to download indices"""
-        return "http://www.swpc.noaa.gov/ftpdir/weekly/Predict.txt"
+        return "http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt"
 
     @staticmethod
     def _get_url_for_date_range(*args, **kwargs):

--- a/sunpy/lightcurve/tests/test_noaa.py
+++ b/sunpy/lightcurve/tests/test_noaa.py
@@ -24,7 +24,7 @@ class TestNOAAIndicesLightCurve(object):
     @pytest.mark.online
     def test_url(self):
         """Test creation with url"""
-        url = 'http://www.swpc.noaa.gov/ftpdir/weekly/RecentIndices.txt'
+        url = 'ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt'
         lc1 = sunpy.lightcurve.NOAAIndicesLightCurve.create(url)
         assert isinstance(lc1, sunpy.lightcurve.NOAAIndicesLightCurve)
 
@@ -37,7 +37,7 @@ class TestNOAAIndicesLightCurve(object):
     def test_get_url(self):
         """Test the getting of url"""
         g = sunpy.lightcurve.NOAAIndicesLightCurve
-        assert g._get_url_for_date_range(timerange_a) == 'http://www.swpc.noaa.gov/ftpdir/weekly/RecentIndices.txt'
+        assert g._get_url_for_date_range(timerange_a) == 'ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt'
 
     @pytest.mark.online
     def test_header(self):
@@ -69,14 +69,14 @@ class TestNOAAPredictIndicesLightCurve(object):
     @pytest.mark.online
     def test_url(self):
         """Test creation with url"""
-        url = 'http://www.swpc.noaa.gov/ftpdir/weekly/Predict.txt'
+        url = 'http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt'
         lc1 = sunpy.lightcurve.NOAAPredictIndicesLightCurve.create(url)
         assert isinstance(lc1, sunpy.lightcurve.NOAAPredictIndicesLightCurve)
 
     def test_get_url(self):
         """Test the getting of url"""
         g = sunpy.lightcurve.NOAAPredictIndicesLightCurve
-        assert g._get_url_for_date_range(timerange_a) == 'http://www.swpc.noaa.gov/ftpdir/weekly/Predict.txt'
+        assert g._get_url_for_date_range(timerange_a) == 'http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt'
 
     @pytest.mark.online
     def test_header(self):


### PR DESCRIPTION
[SWPC](http://www.swpc.noaa.gov/news/new-website-qa) has updated their page a few weeks ago, changing most of the links to their real-time data.

This pull-request updates all these links, however there are some references in the documentation which I didn't find the equivalent in the new site, therefore I used the `legacy` url.  These urls will be deprecated some time in the future. 