### PR TITLE
Fixes for more rotation bugs!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Latest
  * Add STEREO HI Map subclass and color maps.
  * Map.rotate() no longer crops any image data.
  * For accuracy, default Map.rotate() transformation is set to bi-quartic.
+ * `sunpy.image.transform.affine_transform` now casts integer data to float64 and sets NaN values to 0 for all transformations except scikit-image rotation with order <= 3.
  * Refactor the JSOC client so that it follows the .query() .get() interface of VSOClient and UnifedDownloader
  * Remove old style string formatting and other 2.6 compatibility lines.
  * CD matrix now updated, if present, when Map pixel size is changed.

--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -12,6 +12,12 @@ original = images.camera().astype('float')
 # Tolerance for tests
 rtol = 1.0e-15
 
+
+@pytest.fixture
+def identity():
+    return np.array([[1, 0], [0, 1]])
+
+
 def compare_results(expect, result, allclose=True):
     """
     Function to check that the obtained results are what was expected, to
@@ -179,3 +185,38 @@ def test_all(angle, dx, dy, scale_factor):
     ymin, ymax = max([0, -dy]), min([original.shape[1], original.shape[1]-dy])
     xmin, xmax = max([0, -dx]), min([original.shape[0], original.shape[0]-dx])
     compare_results(original[ymin:ymax, xmin:xmax], inverse[ymin:ymax, xmin:xmax])
+
+
+def test_flat(identity):
+    # Test that a flat array can be rotated using scikit-image
+    in_arr = np.array([[100]])
+    out_arr = affine_transform(in_arr, rmatrix=identity)
+    assert np.allclose(in_arr, out_arr, rtol=rtol)
+
+
+def test_nan_skimage_low(identity):
+    # Test non-replacement of NaN values for scikit-image rotation with order <= 3
+    in_arr = np.array([[np.nan]])
+    out_arr = affine_transform(in_arr, rmatrix=identity, order=3)
+    assert np.all(np.isnan(out_arr))
+
+
+def test_nan_skimage_high(identity):
+    # Test replacement of NaN values for scikit-image rotation with order >=4
+    in_arr = np.array([[np.nan]])
+    out_arr = affine_transform(in_arr, rmatrix=identity, order=4)
+    assert not np.all(np.isnan(out_arr))
+
+
+def test_nan_scipy(identity):
+    # Test replacement of NaN values for scipy rotation
+    in_arr = np.array([[np.nan]])
+    out_arr = affine_transform(in_arr, rmatrix=identity, use_scipy=True)
+    assert not np.all(np.isnan(out_arr))
+
+
+def test_int(identity):
+    # Test casting of integer array to float array
+    in_arr = np.array([[100]], dtype=int)
+    out_arr = affine_transform(in_arr, rmatrix=identity)
+    assert np.issubdtype(out_arr.dtype, np.float)

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -118,16 +118,23 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         # Transform the image using the skimage function
         # Image data is normalised because warp() requires an array of values
         # between -1 and 1.
-        adjusted_image = np.copy(image)
+        if np.issubdtype(image.dtype, np.integer):
+            adjusted_image = image.astype(np.float64)
+        else:
+            adjusted_image = image.copy()
         im_min = np.nanmin(adjusted_image)
         adjusted_image -= im_min
         im_max = np.nanmax(adjusted_image)
         adjusted_image /= im_max
         adjusted_missing = (missing - im_min) / im_max
+
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)
 
-
         rotated_image *= im_max
         rotated_image += im_min
+
+        if rotated_image.dtype != image.dtype:
+            rotated_image = rotated_image.astype(image.dtype)
+
     return rotated_image

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -122,12 +122,15 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
             adjusted_image = image.astype(np.float64)
         else:
             adjusted_image = image.copy()
+        if np.any(np.isnan(adjusted_image)) and order >= 4:
+            warnings.warn("Setting NaNs to 0 for higher-order scikit-image rotation", Warning)
+            adjusted_image = np.nan_to_num(adjusted_image)
+
         im_min = np.nanmin(adjusted_image)
         adjusted_image -= im_min
         im_max = np.nanmax(adjusted_image)
         adjusted_image /= im_max
         adjusted_missing = (missing - im_min) / im_max
-
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)
 

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -134,7 +134,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
             adjusted_image /= im_max
             adjusted_missing = (missing - im_min) / im_max
         else:
-            adjusted_missing = missing
+            adjusted_missing = missing - im_min
 
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -130,12 +130,17 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         im_min = np.nanmin(adjusted_image)
         adjusted_image -= im_min
         im_max = np.nanmax(adjusted_image)
-        adjusted_image /= im_max
-        adjusted_missing = (missing - im_min) / im_max
+        if im_max > 0:
+            adjusted_image /= im_max
+            adjusted_missing = (missing - im_min) / im_max
+        else:
+            adjusted_missing = missing
+
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)
 
-        rotated_image *= im_max
+        if im_max > 0:
+            rotated_image *= im_max
         rotated_image += im_min
 
     return rotated_image

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -119,6 +119,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         # Image data is normalised because warp() requires an array of values
         # between -1 and 1.
         if np.issubdtype(image.dtype, np.integer):
+            warnings.warn("Input integer data has been cast to float64", RuntimeWarning)
             adjusted_image = image.astype(np.float64)
         else:
             adjusted_image = image.copy()
@@ -136,8 +137,5 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
 
         rotated_image *= im_max
         rotated_image += im_min
-
-        if rotated_image.dtype != image.dtype:
-            rotated_image = rotated_image.astype(image.dtype)
 
     return rotated_image

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -612,12 +612,8 @@ Dimension:\t [{xdim:d}, {ydim:d}]
         use_scipy : bool
             If True, forces the rotation to use
             :func:`scipy.ndimage.interpolation.affine_transform`, otherwise it
-            uses the :class:`skimage.transform.AffineTransform` class and
-            :func:`skimage.transform.warp`.
-            The function will also automatically fall back to
-            :func:`scipy.ndimage.interpolation.affine_transform` if scikit-image
-            can't be imported.
-            Default: False
+            uses the :func:`skimage.transform.warp`.
+            Default: False, unless scikit-image can't be imported
 
         Returns
         -------
@@ -634,12 +630,9 @@ Dimension:\t [{xdim:d}, {ydim:d}]
         This function will remove old CROTA keywords from the header.
         This function will also convert a CDi_j matrix to a PCi_j matrix.
 
-        The scikit-image and scipy affine_transform routines do not use the same algorithm,
-        see :func:`sunpy.image.transform.affine_transform` for details.
-
-        This function is not numerically equalivalent to IDL's rot() see the
-        :func:`sunpy.image.transform.affine_transform` documentation for a
-        detailed description of the differences.
+        See :func:`sunpy.image.transform.affine_transform` for details on the
+        transformations, situations when the underlying data is modified prior to rotation,
+        and differences from IDL's rot().
         """
         if angle is not None and rmatrix is not None:
             raise ValueError("You cannot specify both an angle and a matrix")


### PR DESCRIPTION
I fixed three more bugs with (Map) rotation:
* We normalize the image to feed into scikit-image's warp, but we didn't check for integer arrays (as opposed to float arrays).  Now, the array is cast to a float64 pre-rotation and then cast back post-rotation.
* When we switched the default warp order from 3 to 4 (when called through `Map.rotate()`), we didn't notice that warp apparently returns crap on arrays containing NaNs for orders >=4.  Now, NaNs are set to 0.
* When feeding in a completely flat array (i.e., all the same value), the normalization code would try to divide by zero.  Now fixed.

- [x] Remove back-casting and output a warning
- [x] Docstring explanations, including about casting
- [x] Changelog entry
- [x] Add tests