### PR TITLE
Quick fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ Latest
  * Provide `__str__` and `__repr__` methods on vso `QueryResponse` deprecate `.show()`
  * SunPy colormaps are now registered with matplotlib on import of `sunpy.cm`
  * `sunpy.cm.get_cmap` no longer defaults to 'sdoaia94'
-* Added database url config setting to be setup by default as a sqlite database in the sunpy working directory
-* Added a few tests for the sunpy.roi module
+ * Added database url config setting to be setup by default as a sqlite database in the sunpy working directory
  * Added a few tests for the sunpy.roi module
 
 0.5.0

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -228,7 +228,7 @@ class QueryResponse(list):
                 return ['N/A']
 
         for record in self:
-            record_items['Start Time'].appennd(validate_time(record.time.start))
+            record_items['Start Time'].append(validate_time(record.time.start))
             record_items['End Time'].append(validate_time(record.time.end))
             record_items['Source'].append(str(record.source))
             record_items['Instrument'].append(str(record.instrument))


### PR DESCRIPTION
* Long-standing typo in `net/vso/vso.py`
* Duplicate line and bad formatting in the changelog