### PR TITLE
Indexing a mapcube returns a mapcube (except when returning a single layer).

### DIFF
--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -68,8 +68,8 @@ class MapCube(object):
             self._derotate()
 
     def __getitem__(self, key):
-        """Overiding indexing operation"""
-        return self.maps[key]
+        """Overiding indexing operation.  Returns a mapcube."""
+        return MapCube(self.maps[key])
 
     def __len__(self):
         """Return the number of maps in a mapcube."""

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -68,8 +68,14 @@ class MapCube(object):
             self._derotate()
 
     def __getitem__(self, key):
-        """Overriding indexing operation.  Returns a mapcube."""
-        return MapCube(self.maps[key])
+        """Overriding indexing operation.  If the key results in a single map,
+        then a map object is returned.  This allows functions like enumerate to
+        work.  Otherwise, a mapcube is returned."""
+
+        if isinstance(self.maps[key], GenericMap):
+            return self.maps[key]
+        else:
+            return MapCube(self.maps[key])
 
     def __len__(self):
         """Return the number of maps in a mapcube."""

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -68,7 +68,7 @@ class MapCube(object):
             self._derotate()
 
     def __getitem__(self, key):
-        """Overiding indexing operation.  Returns a mapcube."""
+        """Overriding indexing operation.  Returns a mapcube."""
         return MapCube(self.maps[key])
 
     def __len__(self):


### PR DESCRIPTION
This small fix creates mapcubes when indexing mapcubes.

Previously, if you had a mapcube then doing index operations such as

mapcube[10:20]

would return a list, and not a mapcube, which is the expected behavior.  Note that

mapcube[10:11]

returns a map.  Although this changes the type of object returned when indexing, it does seem like the more natural behavior.


