### PR TITLE
Backport of rotation fixes (#1275 and part of #1185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.5.4
+-----
+Bug Fixes:
+`
+ * `sunpy.image.transform.affine_transform` now casts integer data to float64 and sets NaN values to 0 for all transformations except scikit-image rotation with order <= 3.
+
 0.5.3
 -----
 Bug Fixes:

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -118,16 +118,23 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         # Transform the image using the skimage function
         # Image data is normalised because warp() requires an array of values
         # between -1 and 1.
-        adjusted_image = np.copy(image)
+        if np.issubdtype(image.dtype, np.integer):
+            adjusted_image = image.astype(np.float64)
+        else:
+            adjusted_image = image.copy()
         im_min = np.nanmin(adjusted_image)
         adjusted_image -= im_min
         im_max = np.nanmax(adjusted_image)
         adjusted_image /= im_max
         adjusted_missing = (missing - im_min) / im_max
+
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)
 
-
         rotated_image *= im_max
         rotated_image += im_min
+
+        if rotated_image.dtype != image.dtype:
+            rotated_image = rotated_image.astype(image.dtype)
+
     return rotated_image

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -122,12 +122,15 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
             adjusted_image = image.astype(np.float64)
         else:
             adjusted_image = image.copy()
+        if np.any(np.isnan(adjusted_image)) and order >= 4:
+            warnings.warn("Setting NaNs to 0 for higher-order scikit-image rotation", Warning)
+            adjusted_image = np.nan_to_num(adjusted_image)
+
         im_min = np.nanmin(adjusted_image)
         adjusted_image -= im_min
         im_max = np.nanmax(adjusted_image)
         adjusted_image /= im_max
         adjusted_missing = (missing - im_min) / im_max
-
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)
 

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -31,13 +31,12 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         Linear transformation rotation matrix.
     order : int 0-5
         Interpolation order to be used. When using scikit-image this parameter
-        is passed into :func:`skimage.transform.warp`.
-        The default value of order 3 is a bicubic interpolation when using
-        :func:`skimage.transform.warp` and a cubic spline interpolation
-        when using :func:`scipy.ndimage.interpolation.affine_transform`.
+        is passed into :func:`skimage.transform.warp` (e.g., 3 corresponds to
+        bi-cubic interpolation).
         When using scipy it is passed into
         :func:`scipy.ndimage.interpolation.affine_transform` where it controls
         the order of the spline.
+        Default: 3
     scale : float
         A scale factor for the image. Default is no scaling.
     image_center : tuple

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -134,7 +134,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
             adjusted_image /= im_max
             adjusted_missing = (missing - im_min) / im_max
         else:
-            adjusted_missing = missing
+            adjusted_missing = missing - im_min
 
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -130,12 +130,17 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         im_min = np.nanmin(adjusted_image)
         adjusted_image -= im_min
         im_max = np.nanmax(adjusted_image)
-        adjusted_image /= im_max
-        adjusted_missing = (missing - im_min) / im_max
+        if im_max > 0:
+            adjusted_image /= im_max
+            adjusted_missing = (missing - im_min) / im_max
+        else:
+            adjusted_missing = missing
+
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)
 
-        rotated_image *= im_max
+        if im_max > 0:
+            rotated_image *= im_max
         rotated_image += im_min
 
     return rotated_image

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -124,8 +124,9 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         adjusted_image -= im_min
         im_max = np.nanmax(adjusted_image)
         adjusted_image /= im_max
+        adjusted_missing = (missing - im_min) / im_max
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
-                                               mode='constant', cval=missing)
+                                               mode='constant', cval=adjusted_missing)
 
 
         rotated_image *= im_max

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -119,6 +119,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         # Image data is normalised because warp() requires an array of values
         # between -1 and 1.
         if np.issubdtype(image.dtype, np.integer):
+            warnings.warn("Input integer data has been cast to float64", RuntimeWarning)
             adjusted_image = image.astype(np.float64)
         else:
             adjusted_image = image.copy()
@@ -136,8 +137,5 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
 
         rotated_image *= im_max
         rotated_image += im_min
-
-        if rotated_image.dtype != image.dtype:
-            rotated_image = rotated_image.astype(image.dtype)
 
     return rotated_image

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -599,12 +599,8 @@ Dimension:\t [%d, %d]
         use_scipy : bool
             If True, forces the rotation to use
             :func:`scipy.ndimage.interpolation.affine_transform`, otherwise it
-            uses the :class:`skimage.transform.AffineTransform` class and
-            :func:`skimage.transform.warp`.
-            The function will also automatically fall back to
-            :func:`scipy.ndimage.interpolation.affine_transform` if scikit-image
-            can't be imported.
-            Default: False
+            uses the :func:`skimage.transform.warp`.
+            Default: False, unless scikit-image can't be imported
 
         Returns
         -------
@@ -621,12 +617,9 @@ Dimension:\t [%d, %d]
         This function will remove old CROTA keywords from the header.
         This function will also convert a CDi_j matrix to a PCi_j matrix.
 
-        The scikit-image and scipy affine_transform routines do not use the same algorithm,
-        see :func:`sunpy.image.transform.affine_transform` for details.
-
-        This function is not numerically equalivalent to IDL's rot() see the
-        :func:`sunpy.image.transform.affine_transform` documentation for a
-        detailed description of the differences.
+        See :func:`sunpy.image.transform.affine_transform` for details on the
+        transformations, situations when the underlying data is modified prior to rotation,
+        and differences from IDL's rot().
         """
         if angle is not None and rmatrix is not None:
             raise ValueError("You cannot specify both an angle and a matrix")

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -578,12 +578,13 @@ Dimension:\t [%d, %d]
             Linear transformation rotation matrix.
         order : int 0-5
             Interpolation order to be used. When using scikit-image this parameter
-            is passed into :func:`skimage.transform.warp`.
+            is passed into :func:`skimage.transform.warp` (e.g., 4 corresponds to
+            bi-quartic interpolation).
             When using scipy it is passed into
             :func:`scipy.ndimage.interpolation.affine_transform` where it controls
             the order of the spline.
-            Higher accuracy may be obtained at the cost of performance by using
-            higher values.
+            Faster performance may be obtained at the cost of accuracy by using lower values.
+            Default: 4
         scale : float
             A scale factor for the image, default is no scaling
         image_center : tuple


### PR DESCRIPTION
See #1275 for the specific rotation fixes.

The part of #1185 that is backported is the bugfix for when a value other than 0 is specified for missing data.