### PR TITLE
Fix for Issue #1307

### DIFF
--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -67,7 +67,7 @@ from sunpy.time import parse_time
 from sunpy import config
 from sunpy import lightcurve
 from sunpy.util.net import check_download_file
-from sunpy.sun import sun
+from sunpy import sun
 
 __all__ = ['get_goes_event_list', 'calculate_temperature_em',
            'calculate_radiative_loss_rate', 'calculate_xray_luminosity']
@@ -1095,7 +1095,9 @@ def _goes_lx(longflux, shortflux, obstime=None, date=None):
         were taken simultaneously.
 
     date : (optional) datetime object or valid date string.
-        Date at which measurements were taken.
+        Date at which measurements were taken.  This is used to
+        calculate the Sun-Earth distance.
+        Default=None implies mean Sun-Earth distance used.
 
     Returns
     -------
@@ -1211,7 +1213,7 @@ def _calc_xraylum(flux, date=None):
 
     date : (optional) datetime object or valid date string
         Used to calculate a more accurate Sun-Earth distance based on
-        Earth's orbit at that date.  If date is not set, standard value
+        Earth's orbit at that date.  If date is not set, mean value
         for 1AU used.
 
     Returns
@@ -1231,7 +1233,7 @@ def _calc_xraylum(flux, date=None):
     """
     if date is not None:
         date = parse_time(date)
-        xraylum = 4 * np.pi * sun.sunearth_distance(t=date).to("m")**2 * flux
+        xraylum = 4 * np.pi * sun.sun.sunearth_distance(t=date).to("m")**2 * flux
     else:
-        xraylum = 4 * np.pi * sun.sunearth_distance().to("m")**2 * flux
+        xraylum = 4 * np.pi * sun.constants.au.to("m")**2 * flux
     return xraylum

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -1097,7 +1097,7 @@ def _goes_lx(longflux, shortflux, obstime=None, date=None):
     date : (optional) datetime object or valid date string.
         Date at which measurements were taken.  This is used to
         calculate the Sun-Earth distance.
-        Default=None implies mean Sun-Earth distance used.
+        Default=None implies Sun-Earth distance is set to 1AU.
 
     Returns
     -------
@@ -1213,8 +1213,8 @@ def _calc_xraylum(flux, date=None):
 
     date : (optional) datetime object or valid date string
         Used to calculate a more accurate Sun-Earth distance based on
-        Earth's orbit at that date.  If date is not set, mean value
-        for 1AU used.
+        Earth's orbit at that date.  If date is None, Sun-Earth
+        distance is set to 1AU.
 
     Returns
     -------

--- a/sunpy/instr/tests/test_goes.py
+++ b/sunpy/instr/tests/test_goes.py
@@ -377,10 +377,10 @@ def test_goes_lx_nokwargs():
     shortflux = Quantity([7e-7, 7e-7, 7e-7, 7e-7, 7e-7, 7e-7], unit="W/m**2")
     # Test output when no kwargs are set.
     lx_test = goes._goes_lx(longflux[:2], shortflux[:2])
-    lx_expected = {"longlum": Quantity([1.91013779e+18, 1.91013779e+18],
+    lx_expected = {"longlum": Quantity([1.98649103e+18, 1.98649103e+18],
                                        unit="W"),
-                   "shortlum": Quantity([1.91013779e+17, 1.91013779e+17],
-                                       unit="W")}
+                   "shortlum": Quantity([1.98649103e+17, 1.98649103e+17],
+                                        unit="W")}
     assert sorted(lx_test.keys()) == sorted(lx_expected.keys())
     assert np.allclose(lx_test["longlum"], lx_expected["longlum"], rtol=0.01)
     assert np.allclose(lx_test["shortlum"], lx_expected["shortlum"],
@@ -414,16 +414,16 @@ def test_goes_lx_obstime():
     # Test output when obstime and cumulative kwargs are set.
     lx_test = goes._goes_lx(longflux, shortflux, obstime)
     lx_expected = {
-        "longlum": 1.91013779e+18 * Quantity(np.ones(6), unit='W'),
-        "shortlum": 1.91013779e+17 * Quantity(np.ones(6), unit='W'),
-        "longlum_int": Quantity([1.9101360630079373e+19], unit="J"),
-        "shortlum_int": Quantity([1.9101360630079373e+18], unit="J"),
-        "longlum_cumul": Quantity([3.82027213e+18, 7.64054425e+18,
-                                  1.14608164e+19, 1.52810885e+19,
-                                  1.91013606e+19], unit="J"),
-        "shortlum_cumul": Quantity([3.82027213e+17, 7.64054425e+17,
-                                    1.14608164e+18, 1.52810885e+18,
-                                    1.91013606e+18], unit="J")}
+        "longlum": 1.96860565e+18 * Quantity(np.ones(6), unit='W'),
+        "shortlum": 1.96860565e+17 * Quantity(np.ones(6), unit='W'),
+        "longlum_int": Quantity([1.96860565e+19], unit="J"),
+        "shortlum_int": Quantity([1.96860565e+18], unit="J"),
+        "longlum_cumul": Quantity([3.93721131e+18, 7.87442262e+18,
+                                   1.18116339e+19, 1.57488452e+19,
+                                   1.96860565e+19], unit="J"),
+        "shortlum_cumul": Quantity([3.93721131e+17, 7.87442262e+17,
+                                    1.18116339e+18, 1.57488452e+18,
+                                    1.96860565e+18], unit="J")}
     assert sorted(lx_test.keys()) == sorted(lx_expected.keys())
     assert np.allclose(lx_test["longlum"], lx_expected["longlum"], rtol=0.01)
     assert np.allclose(lx_test["shortlum"], lx_expected["shortlum"],


### PR DESCRIPTION
Hi guys,
Here's the fix to Issue #1307.  When a date keyword is not supplied, the mean 1AU distance is used in calc_xraylum() rather than the Sun-Earth distance at the time the code is run.  This means the test_goes_lx_nokwargs() and test_goes_lx_obstime() are no longer time dependent and now pass.
I made a small adjustment to the docstring of _goes_lx() to make it clear what the default value is.