### PR TITLE
fixed download_sample_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [SunPy](http://sunpy.org) 
+# [SunPy](http://sunpy.org)
 [![Downloads](https://pypip.in/d/sunpy/badge.png)](https://pypi.python.org/pypi/sunpy/) [![Latest Version](https://pypip.in/v/sunpy/badge.png)](https://pypi.python.org/pypi/sunpy/) [![Build Status](https://secure.travis-ci.org/sunpy/sunpy.png)] (http://travis-ci.org/sunpy/sunpy)[![Build status](https://ci.appveyor.com/api/projects/status/xow461iejsjvp9vl?svg=true)](https://ci.appveyor.com/project/sunpy/sunpy)[![Coverage Status](https://coveralls.io/repos/sunpy/sunpy/badge.png?branch=master)](https://coveralls.io/r/sunpy/sunpy?branch=master) [![Code Health](https://landscape.io/github/sunpy/sunpy/master/landscape.png)](https://landscape.io/github/sunpy/sunpy/master)
 
 SunPy is an open-source Python library for solar physics data analysis.
@@ -26,7 +26,7 @@ Next, use git to grab the latest version of SunPy:
 
 Done!
 
-For detailed installation instructions, see the [installation guide](http://sunpy.readthedocs.org/en/latest/guide/installation/index.html) 
+For detailed installation instructions, see the [installation guide](http://sunpy.readthedocs.org/en/latest/guide/installation/index.html)
 in the SunPy docs.
 
 Usage
@@ -36,8 +36,9 @@ Here is a quick example of plotting an AIA image:
 
 ```python
 >>> import sunpy.map
+>>> import sunpy.data.sample
 >>> import matplotlib.cm as cm
->>> aia = sunpy.map.Map(sunpy.AIA_171_IMAGE)
+>>> aia = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 >>> aia.peek(cmap=cm.hot)
 ```
 
@@ -53,12 +54,12 @@ For more information or to ask questions about SunPy, check out:
 Contributing
 ------------
 
-If you would like to get involved, start by joining the 
+If you would like to get involved, start by joining the
 [SunPy mailing list](https://groups.google.com/forum/#!forum/sunpy)
-and check out the [Developer's Guide](http://sunpy.readthedocs.org/en/latest/dev.html) section 
-of the SunPy docs. Stop by our IRC chat room named #sunpy on irc.freenode.net 
-if you have any questions. Help is always welcome so let us know what you like 
-to work on, or check out the [issues page](https://github.com/sunpy/sunpy/issues) 
+and check out the [Developer's Guide](http://sunpy.readthedocs.org/en/latest/dev.html) section
+of the SunPy docs. Stop by our IRC chat room named #sunpy on irc.freenode.net
+if you have any questions. Help is always welcome so let us know what you like
+to work on, or check out the [issues page](https://github.com/sunpy/sunpy/issues)
 for a list of some known outstanding items.
 
 

--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -2,19 +2,21 @@
 """SunPy sample data files"""
 from __future__ import absolute_import
 
-from sunpy.util.net import url_exists
 from os import remove
-from astropy.utils.data import download_file
+import os.path
 from zipfile import ZipFile
 from urllib2 import URLError
 from shutil import move
 
-import os.path
+from astropy.utils.data import download_file
+
+from sunpy.util.net import url_exists
+from sunpy import config
 
 __author__ = "Steven Christe"
 __email__ = "steven.christe@nasa.gov"
 
-from sunpy import config
+
 sampledata_dir = config.get("downloads", "sample_dir")
 
 # urls to search for the sample data

--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -3,10 +3,11 @@
 from __future__ import absolute_import
 
 from sunpy.util.net import url_exists
-from os import rename, remove
+from os import remove
 from astropy.utils.data import download_file
 from zipfile import ZipFile
 from urllib2 import URLError
+from shutil import move
 
 import os.path
 
@@ -17,33 +18,37 @@ from sunpy import config
 sampledata_dir = config.get("downloads", "sample_dir")
 
 # urls to search for the sample data
-_base_urls = ('http://data.sunpy.org/sample-data/', 'http://hesperia.gsfc.nasa.gov/~schriste/sunpy-sample-data/')
+_base_urls = (
+    'http://data.sunpy.org/sample-data/',
+    'http://hesperia.gsfc.nasa.gov/~schriste/sunpy-sample-data/')
 
 # keys are file shortcuts
 # values consist of filename as well as optional file extension if files are
 # hosted compressed. This extension is removed after download.
-_files = {"AIA_171_IMAGE": ("AIA20110319_105400_0171.fits", ""),
-          "RHESSI_IMAGE": ("hsi_image_20101016_191218.fits", ""),
-          "EIT_195_IMAGE": ("eit_l1_20020625_100011.fits", ""),
-          "CALLISTO_IMAGE": ("BIR_20110922_103000_01.fit", ""),
-          "RHESSI_EVENT_LIST": ("hsi_calib_ev_20020220_1106_20020220_1106_25_40.fits", ""),
-          "SWAP_LEVEL1_IMAGE": ("swap_lv1_20120101_001607.fits", ""),
-          "AIA_193_IMAGE": ("aia.lev1.193A_2013-09-21T16_00_06.84Z.image_lev1.fits", ".zip")
+_files = {
+    "AIA_171_IMAGE": ("AIA20110319_105400_0171.fits", ""),
+    "RHESSI_IMAGE": ("hsi_image_20101016_191218.fits", ""),
+    "EIT_195_IMAGE": ("eit_l1_20020625_100011.fits", ""),
+    "CALLISTO_IMAGE": ("BIR_20110922_103000_01.fit", ""),
+    "RHESSI_EVENT_LIST": ("hsi_calib_ev_20020220_1106_20020220_1106_25_40.fits", ""),
+    "SWAP_LEVEL1_IMAGE": ("swap_lv1_20120101_001607.fits", ""),
+    "AIA_193_IMAGE": ("aia.lev1.193A_2013-09-21T16_00_06.84Z.image_lev1.fits", ".zip")
 }
 
 sample_files = {}
 for key in _files:
     sample_files[key] = os.path.abspath(os.path.join(sampledata_dir, _files[key][0]))
 
+
 def download_sample_data(progress=True):
     """
     Download the sample data.
-    
+
     Parameters
     ----------
     progress: bool
         Show a progress bar during download
-    
+
     Returns
     -------
     None
@@ -56,7 +61,7 @@ def download_sample_data(progress=True):
             if url_exists(os.path.join(base_url, full_file_name)):
                 f = download_file(os.path.join(base_url, full_file_name))
                 real_name, ext = os.path.splitext(full_file_name)
-                
+
                 if file_name[1] == '.zip':
                     print("Unpacking: %s" % real_name)
                     with ZipFile(f, 'r') as zip_file:
@@ -64,9 +69,9 @@ def download_sample_data(progress=True):
                     remove(f)
                 else:
                     # move files to the data directory
-                    rename(f, os.path.join(sampledata_dir, file_name[0]))
+                    move(f, os.path.join(sampledata_dir, file_name[0]))
                 # increment the number of files obtained to check later
-                number_of_files_fetched+=1
-    
+                number_of_files_fetched += 1
+
     if number_of_files_fetched < len(_files.keys()):
         raise URLError("Could not download all samples files. Problem with accessing sample data servers.")


### PR DESCRIPTION
Importing sunpy.data.sample notifies that no sample data is available and should be downloaded with download_sample_data but once you try that is fails when calling rename with 'invalid cross-device link' when using rename, probably because of different partitions of files. Also, the readme doesn't work because sample image that gets called by matplolib has moved to sunpy.data.sample and minor PEP8 fixes.