### PR TITLE
Fix file names when downloading multiple files using database.download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Latest
  * Removed sample data from distribution and added ability to download sample files
  * Calculation of the solar rotation of a point on the Sun as seen from Earth, and its application to the de-rotation of mapcubes.
  * Downloaded files now keep file extensions rather than replacing all periods with underscores
+ * Fixed the downloading of files with duplicate names in sunpy.database
 
 0.5.0
 -----

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -9,6 +9,7 @@ import itertools
 import operator
 from datetime import datetime
 from contextlib import contextmanager
+import os.path
 
 from sqlalchemy import create_engine, exists
 from sqlalchemy.orm import sessionmaker
@@ -22,6 +23,11 @@ from sunpy.net.hek2vso import H2VClient
 from sunpy.net.attr import and_
 from sunpy.net.vso import VSOClient
 
+__authors__ = ['Simon Liedtke', 'Rajul Srivastava']
+__emails__ = [
+    'liedtke.simon@googlemail.com',
+    'rajul09@gmail.com'
+]
 
 class EntryNotFoundError(Exception):
     """This exception is raised if a database entry cannot be found by its
@@ -301,27 +307,34 @@ class Database(object):
             path=None, progress=False):
         if client is None:
             client = VSOClient()
-        for block in query_result:
-            paths = client.get([block], path).wait(progress=progress)
-            for path in paths:
-                qr_entry = tables.DatabaseEntry._from_query_result_block(block)
-                file_entries = list(
-                    tables.entries_from_file(path, self.default_waveunit))
-                for entry in file_entries:
-                    entry.source = qr_entry.source
-                    entry.provider = qr_entry.provider
-                    entry.physobs = qr_entry.physobs
-                    entry.fileid = qr_entry.fileid
-                    entry.observation_time_start =\
-                        qr_entry.observation_time_start
-                    entry.observation_time_end = qr_entry.observation_time_end
-                    entry.instrument = qr_entry.instrument
-                    entry.size = qr_entry.size
-                    entry.wavemin = qr_entry.wavemin
-                    entry.wavemax = qr_entry.wavemax
-                    entry.path = path
-                    entry.download_time = datetime.utcnow()
-                    yield entry
+
+        paths = client.get(query_result, path).wait(progress=progress)
+
+        for (path, block) in zip(paths, query_result):
+            qr_entry = tables.DatabaseEntry._from_query_result_block(block)
+
+            if os.path.isfile(path):
+                entries = tables.entries_from_file(path, self.default_waveunit)
+            elif os.path.isdir(path):
+                entries = tables.entries_from_dir(path, self.default_waveunit)
+            else:
+                raise ValueError('The path is neither a file nor directory')
+
+            for entry in entries:
+                entry.source = qr_entry.source
+                entry.provider = qr_entry.provider
+                entry.physobs = qr_entry.physobs
+                entry.fileid = qr_entry.fileid
+                entry.observation_time_start = \
+                qr_entry.observation_time_start
+                entry.observation_time_end = qr_entry.observation_time_end
+                entry.instrument = qr_entry.instrument
+                entry.size = qr_entry.size
+                entry.wavemin = qr_entry.wavemin
+                entry.wavemax = qr_entry.wavemax
+                entry.path = path
+                entry.download_time = datetime.utcnow()
+                yield entry
 
     def download(self, *query, **kwargs):
         """download(*query, client=sunpy.net.vso.VSOClient(), path=None, progress=False)

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -325,8 +325,7 @@ class Database(object):
                 entry.provider = qr_entry.provider
                 entry.physobs = qr_entry.physobs
                 entry.fileid = qr_entry.fileid
-                entry.observation_time_start = \
-                qr_entry.observation_time_start
+                entry.observation_time_start = qr_entry.observation_time_start
                 entry.observation_time_end = qr_entry.observation_time_end
                 entry.instrument = qr_entry.instrument
                 entry.size = qr_entry.size

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -7,7 +7,9 @@ from __future__ import absolute_import
 
 import glob
 import ConfigParser
+import os
 import os.path
+import shutil
 import sys
 
 import pytest
@@ -27,7 +29,7 @@ from sunpy.data.test.waveunit import waveunitdir
 from sunpy.io import fits
 
 import sunpy.data.test
-import os
+
 testpath = sunpy.data.test.rootdir
 RHESSI_IMAGE = os.path.join(testpath, 'hsi_image_20101016_191218.fits')
 
@@ -782,6 +784,40 @@ def test_fetch(database, download_query, tmpdir):
     database.fetch(*download_query, path=str(tmpdir.join('{file}.fits')))
     assert len(database) == 4
     assert database[0].download_time == download_time
+
+
+@pytest.mark.online
+def test_fetch_separate_filenames():
+    # Setup
+    db = Database('sqlite:///')
+
+    download_query = [
+        vso.attrs.Time('2012-08-05', '2012-08-05 00:00:05'),
+        vso.attrs.Instrument('AIA')
+    ]
+
+    tmp_test_dir = os.path.join(
+        sunpy.config.get('downloads', 'download_dir'),
+        'tmp_test_dir/'
+    )
+
+    if not os.path.isdir(tmp_test_dir):
+        os.mkdir(tmp_test_dir)
+
+    path = tmp_test_dir + '{file}.fits'
+
+    db.fetch(*download_query, path=path)
+    
+    # Test
+    assert len(db) == 2
+    
+    dir_contents = os.listdir(tmp_test_dir)
+    assert dir_contents[-2] == 'aia_lev1_335a_2012_08_05t00_00_02_62z_image_lev1_fits.fits'
+    assert dir_contents[-1] == 'aia_lev1_94a_2012_08_05t00_00_01_12z_image_lev1_fits.fits'
+    assert dir_contents[-1].split('.')[0] != dir_contents[-2].split('.')[1]
+    
+    # Teardown
+    shutil.rmtree(tmp_test_dir)
 
 
 @pytest.mark.online

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -804,18 +804,19 @@ def test_fetch_separate_filenames():
     if not os.path.isdir(tmp_test_dir):
         os.mkdir(tmp_test_dir)
 
-    path = tmp_test_dir + '{file}.fits'
+    path = tmp_test_dir + '{file}'
 
     db.fetch(*download_query, path=path)
-    
+
     # Test
     assert len(db) == 2
-    
+
     dir_contents = os.listdir(tmp_test_dir)
-    assert dir_contents[-2] == 'aia_lev1_335a_2012_08_05t00_00_02_62z_image_lev1_fits.fits'
-    assert dir_contents[-1] == 'aia_lev1_94a_2012_08_05t00_00_01_12z_image_lev1_fits.fits'
-    assert dir_contents[-1].split('.')[0] != dir_contents[-2].split('.')[1]
-    
+    assert 'aia_lev1_335a_2012_08_05t00_00_02_62z_image_lev1.fits' in dir_contents
+    assert 'aia_lev1_94a_2012_08_05t00_00_01_12z_image_lev1.fits' in dir_contents
+    assert os.path.isfile(os.path.join(tmp_test_dir, 'aia_lev1_335a_2012_08_05t00_00_02_62z_image_lev1.fits'))
+    assert os.path.isfile(os.path.join(tmp_test_dir, 'aia_lev1_94a_2012_08_05t00_00_01_12z_image_lev1.fits'))
+
     # Teardown
     shutil.rmtree(tmp_test_dir)
 

--- a/sunpy/net/download.py
+++ b/sunpy/net/download.py
@@ -58,6 +58,7 @@ class Downloader(object):
                         else:
                             fd.write(rec)
         except Exception, e:
+            # TODO: Fix the silent failing
             if errback is not None:
                 with self.mutex:
                     self._close(errback, [e], server)

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -600,6 +600,8 @@ class VSOClient(object):
         if path is None:
             path = os.path.join(config.get('downloads','download_dir'),
                                 '{file}')
+        path = os.path.expanduser(path)
+
         fileids = VSOClient.by_fileid(query_response)
         if not fileids:
             res.poke()


### PR DESCRIPTION
This fixes the outstanding problem in #1336 for speedy 0.6 merge.

closes #1336 

closes #1164 