### PR TITLE
Fix for Issue #1320 for version 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Latest
  * Fixed solar_semidiameter_angular_size
  * Improved line quality and performances issues with map.draw_grid()
  * Remove deprecated make_map command.
+ * Changed default for GOESLightCurve.create() so that it gets the data from the most recent existing GOES fits file.
 
 0.4.1
 -----

--- a/sunpy/lightcurve/sources/goes.py
+++ b/sunpy/lightcurve/sources/goes.py
@@ -12,6 +12,7 @@ from pandas import DataFrame
 
 from sunpy.lightcurve import LightCurve
 from sunpy.time import parse_time, TimeRange, is_time_in_given_format
+from sunpy.util import net
 
 __all__ = ['GOESLightCurve']
 
@@ -74,10 +75,13 @@ class GOESLightCurve(LightCurve):
     @classmethod
     def _get_default_uri(cls):
         """Retrieve latest GOES data if no other data is specified"""
-        today = datetime.datetime.today()
-        days_back = 3
-        time_range = TimeRange(today - datetime.timedelta(days=days_back),
-                               today - datetime.timedelta(days=days_back - 1))
+        now = datetime.datetime.utcnow()
+        time_range = TimeRange(datetime.datetime(now.year, now.month, now.day), now)
+        url_does_exist = net.url_exists(cls._get_url_for_date_range(time_range))
+        while not url_does_exist:
+            time_range = TimeRange(time_range.start-datetime.timedelta(days=1),
+                                   time_range.start)
+            url_does_exist = net.url_exists(cls._get_url_for_date_range(time_range))
         return cls._get_url_for_date_range(time_range)
 
     @classmethod


### PR DESCRIPTION
Hi guys,
Here is the new PR to fix Issue #1320 but for backporting to 0.5.  sunpy/lightcurve/sources/goes._get_default_uri() has been changed so that it now finds data from the most recent existing GOES FITS file. Previously it looked for data from 3 days ago and crashed if the file didn't exist. Now it doesn't crash but just find the next most recent that does. It also looks for the most recent data first and not just 3 days ago.