### PR TITLE
Issue #866: Added a note on Python C headers

### DIFF
--- a/doc/source/guide/installation/index.rst
+++ b/doc/source/guide/installation/index.rst
@@ -31,6 +31,11 @@ To install the Anaconda Python distribution follow the instructions
 select the correct download for your platform and follow the install procedure.
 
 .. note::
+    If you are using Linux, it is required to have a package such as 
+    ``python-dev`` installed (or similar name, depending on the linux distro)
+    to provide the Python development headers.
+    
+.. note::
 
     On OS/X you need to install XCode so you can build SunPy's extensions.
     see :ref:`xcode`

--- a/doc/source/guide/installation/index.rst
+++ b/doc/source/guide/installation/index.rst
@@ -31,11 +31,6 @@ To install the Anaconda Python distribution follow the instructions
 select the correct download for your platform and follow the install procedure.
 
 .. note::
-    If you are using Linux, it is required to have a package such as 
-    ``python-dev`` installed (or similar name, depending on the linux distro)
-    to provide the Python development headers.
-    
-.. note::
 
     On OS/X you need to install XCode so you can build SunPy's extensions.
     see :ref:`xcode`

--- a/doc/source/guide/installation/linux.rst
+++ b/doc/source/guide/installation/linux.rst
@@ -7,6 +7,10 @@ Overview
 
 Almost all versions of Linux ship with a recent enough version
 of Python, so it is unlikely that you will need to install Python yourself.
+If you do not have python you can find the source at the 
+`Python Software Foundation <https://www.python.org/downloads/source/>`_. 
+Install using ``sudo apt-get install python2.7-dev`` or a similar command, 
+depending on your linux distro.
 
 Ubuntu
 ------

--- a/doc/source/guide/installation/linux.rst
+++ b/doc/source/guide/installation/linux.rst
@@ -8,9 +8,10 @@ Overview
 Almost all versions of Linux ship with a recent enough version
 of Python, so it is unlikely that you will need to install Python yourself.
 If you do not have python you can find the source at the 
-`Python Software Foundation <https://www.python.org/downloads/source/>`_. 
-Install using ``sudo apt-get install python2.7-dev`` or a similar command, 
+`Python official site <https://www.python.org/downloads/source/>`_. 
+Install using `sudo apt-get install python2.7-dev` or a similar command, 
 depending on your linux distro.
+Anything like `python-dev` provides you the required Python development headers.
 
 Ubuntu
 ------


### PR DESCRIPTION
Explicitly tells Linux users to make sure the development headers are
installed. As the Python installer for Windows installs the C headers
automatically, and the pre-installed Python on OS X also has those
headers.