### PR TITLE
Indentation error fixed and xfail removed from test_results_filenames

### DIFF
--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -423,8 +423,8 @@ class JSOCClient(object):
         else:
             #Make Results think it has finished.
             results.require([])
+            results.poke()
 
-        results.poke()
         return results
 
     def _process_time(self, time):

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -212,7 +212,6 @@ def test_get_request():
     assert isinstance(aa, Results)
 
 @pytest.mark.online
-@pytest.mark.xfail
 def test_results_filenames():
     responses = client.query(attrs.Time('2014/1/1T1:00:36', '2014/1/1T01:01:38'),
                              attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'))


### PR DESCRIPTION
PR for "JSOC download skips first file in Results object" #1357