### PR TITLE
Checking filenames matches with jsoc filenames

### DIFF
--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -4,6 +4,7 @@ Created on Wed Mar 26 20:17:06 2014
 
 @author: stuart
 """
+import os
 import time
 import tempfile
 import datetime
@@ -220,6 +221,8 @@ def test_results_filenames():
     assert isinstance(aa, Results)
     files = aa.wait()
     assert len(files) == len(responses)
+    for hmiurl in aa.map_:
+        assert os.path.basename(hmiurl) == os.path.basename(aa.map_[hmiurl]['path'])
 
 @pytest.mark.online
 def test_invalid_query():


### PR DESCRIPTION
This adds to #1365
By adding a new text to check whether the filename locally matches the one remotely, and not just the number of files.