### PR TITLE
Sorted the KeyError in issue #1371

### DIFF
--- a/sunpy/lightcurve/sources/goes.py
+++ b/sunpy/lightcurve/sources/goes.py
@@ -186,5 +186,5 @@ class GOESLightCurve(LightCurve):
         newxrsb = xrsb.byteswap().newbyteorder()
 
         data = DataFrame({'xrsa': newxrsa, 'xrsb': newxrsb}, index=times)
-
+        data.sort(inplace=True)
         return header, data

--- a/sunpy/lightcurve/sources/lyra.py
+++ b/sunpy/lightcurve/sources/lyra.py
@@ -144,4 +144,6 @@ class LYRALightCurve(LightCurve):
                 table[col.name] = fits_record.field(i + 1)
 
         # Return the header and the data
-        return OrderedDict(hdulist[0].header), pandas.DataFrame(table, index=times)
+        data = pandas.DataFrame(table, index=times)
+        data.sort(inplace=True)
+        return OrderedDict(hdulist[0].header), data


### PR DESCRIPTION
The data no longer shows KeyError. However, GOES data is missing for 1984-01-16 and LYRA data is available for only 2010-03-14.