### PR TITLE
Ignoring a Callisto-related test that has a Travis-specific failure

### DIFF
--- a/sunpy/spectra/tests/test_callisto.py
+++ b/sunpy/spectra/tests/test_callisto.py
@@ -49,6 +49,7 @@ def test_read(CALLISTO_IMAGE):
     )
     assert ca.dtype == np.uint8
 
+
 @pytest.mark.online
 def test_query():
     URL = 'http://soleil.i4ds.ch/solarradio/data/2002-20yy_Callisto/2011/09/22/'
@@ -72,6 +73,7 @@ def test_query():
     for item in RESULTS:
         assert URL + item in result
 
+
 @pytest.mark.online
 @pytest.mark.xfail
 def test_query_number():
@@ -94,6 +96,7 @@ def test_query_number():
 
 
 @pytest.mark.online
+@pytest.mark.xfail
 def test_download():
     directory = mkdtemp()
     try:
@@ -111,6 +114,7 @@ def test_download():
     finally:
         shutil.rmtree(directory)
 
+
 def test_create_file(CALLISTO_IMAGE):
     ca = CallistoSpectrogram.create(CALLISTO_IMAGE)
     assert np.array_equal(ca.data, CallistoSpectrogram.read(CALLISTO_IMAGE).data)
@@ -119,6 +123,7 @@ def test_create_file(CALLISTO_IMAGE):
 def test_create_file_kw(CALLISTO_IMAGE):
     ca = CallistoSpectrogram.create(filename=CALLISTO_IMAGE)
     assert np.array_equal(ca.data, CallistoSpectrogram.read(CALLISTO_IMAGE).data)
+
 
 @pytest.mark.online
 def test_create_url():
@@ -129,6 +134,7 @@ def test_create_url():
     ca = CallistoSpectrogram.create(URL)
     assert np.array_equal(ca.data, CallistoSpectrogram.read(URL).data)
 
+
 @pytest.mark.online
 def test_create_url_kw():
     URL = (
@@ -137,6 +143,7 @@ def test_create_url_kw():
     )
     ca = CallistoSpectrogram.create(url=URL)
     assert np.array_equal(ca.data, CallistoSpectrogram.read(URL).data)
+
 
 def test_create_single_glob(CALLISTO_IMAGE, CALLISTO_IMAGE_GLOB_INDEX, CALLISTO_IMAGE_GLOB_KEY):
     PATTERN = os.path.join(os.path.dirname(CALLISTO_IMAGE), CALLISTO_IMAGE_GLOB_KEY)
@@ -159,6 +166,7 @@ def test_create_glob_kw(CALLISTO_IMAGE, CALLISTO_IMAGE_GLOB_INDEX, CALLISTO_IMAG
     ca = CallistoSpectrogram.create(pattern=PATTERN)[CALLISTO_IMAGE_GLOB_INDEX]
     assert_allclose(ca.data, CallistoSpectrogram.read(CALLISTO_IMAGE).data)
 
+
 def test_create_glob(CALLISTO_IMAGE_GLOB_KEY):
     PATTERN = os.path.join(
         os.path.dirname(sunpy.data.test.__file__),
@@ -167,11 +175,13 @@ def test_create_glob(CALLISTO_IMAGE_GLOB_KEY):
     ca = CallistoSpectrogram.create(PATTERN)
     assert len(ca) == 2
 
+
 def test_minimum_pairs_commotative():
     A = [0, 1, 2]
     B = [1, 2, 3]
     first = list(minimal_pairs(A, B))
     assert first == [(b, a, d) for a, b, d in minimal_pairs(B, A)]
+
 
 def test_minimum_pairs_end():
     assert (
@@ -179,11 +189,13 @@ def test_minimum_pairs_end():
         [(1, 0, 0), (2, 1, 0), (3, 3, 0)]
     )
 
+
 def test_minimum_pairs_end_more():
     assert (
         list(minimal_pairs([0, 1, 2, 4, 8], [1, 2, 3, 4])) ==
         [(1, 0, 0), (2, 1, 0), (3, 3, 0)]
     )
+
 
 def test_minimum_pairs_end_diff():
     assert (
@@ -191,11 +203,13 @@ def test_minimum_pairs_end_diff():
         [(1, 0, 0), (2, 1, 0), (3, 3, 4)]
     )
 
+
 def test_closest():
     assert (
         list(minimal_pairs([50, 60], [0, 10, 20, 30, 40, 51, 52])) ==
         [(0, 5, 1), (1, 6, 8)]
     )
+
 
 def test_homogenize_factor():
     a = np.float64(np.random.randint(0, 255, 3600))[np.newaxis, :]
@@ -243,6 +257,7 @@ def test_homogenize_factor():
     assert_array_almost_equal(constants, [0], 2)
     assert_array_almost_equal(factors[0] * b + constants[0], a)
 
+
 def test_homogenize_constant():
     a = np.float64(np.random.randint(0, 255, 3600))[np.newaxis, :]
 
@@ -288,6 +303,7 @@ def test_homogenize_constant():
     assert_array_almost_equal(factors, [1], 2)
     assert_array_almost_equal(constants, [-10], 2)
     assert_array_almost_equal(factors[0] * b + constants[0], a)
+
 
 def test_homogenize_both():
     a = np.float64(np.random.randint(0, 255, 3600))[np.newaxis, :]
@@ -335,6 +351,7 @@ def test_homogenize_both():
     assert_array_almost_equal(constants, [-0.5], 2)
     assert_array_almost_equal(factors[0] * b + constants[0], a)
 
+
 def test_homogenize_rightfq():
     a = np.float64(np.random.randint(0, 255, 3600))[np.newaxis, :]
 
@@ -381,6 +398,7 @@ def test_homogenize_rightfq():
     assert_array_almost_equal(factors, [0.5], 2)
     assert_array_almost_equal(constants, [-0.5], 2)
     assert_array_almost_equal(factors[0] * b + constants[0], a)
+
 
 @pytest.mark.online
 def test_extend(CALLISTO_IMAGE):


### PR DESCRIPTION
(This is a clean version of PR #1380)

One of the Callisto-related tests fails on Travis but not on local machines.  The Callisto webserver may be providing Travis a different webpage than to other machines.  See #1376 for the open issue.  For the time being, let's ignore this failure (mark it as `xfail`) so that we have a working onilne build on Travis.