### PR TITLE
Adding the capability to query JSOC for SHARP numbers by kwargs

### DIFF
--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -100,7 +100,7 @@ class PrimaryKey(_VSOSimpleAttr):
     """
     def __init__(self, key, value):
         Attr.__init__(self)
-        self.__class__.__name__ += '_{}'.format(key)
+        self.__class__.__name__ = 'PrimaryKey_{}'.format(key)
         self.value = value
 
 

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -94,6 +94,16 @@ class Wavelength(_VSOSimpleAttr):
     __ror__ = __or__
 
 
+class PrimaryKey(_VSOSimpleAttr):
+    """
+    Extra key,values pair produced by the user to query jsoc
+    """
+    def __init__(self, key, value):
+        Attr.__init__(self)
+        self.__class__.__name__ += '_{}'.format(key)
+        self.value = value
+
+
 walker = AttrWalker()
 
 

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -493,16 +493,23 @@ class JSOCClient(object):
         if sample:
             sample = '@{}s'.format(sample)
 
+        if 'harp' in series:
+            if kwargs:
+                series += '[{0}]'.format(kwargs.get('primarykey_harpnum',''))
+            else:
+                series += '[]'
+
         dataset = '{series}[{start}-{end}{sample}]{wavelength}{segment}'.format(
                    series=series, start=start_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
                    end=end_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
                    sample=sample,
                    wavelength=wavelength, segment=segment)
 
-        if kwargs:
-            for key in kwargs.keys():
-                if 'primarykey' in key:
-                    dataset += '[{k}={value}]'.format(k=key.replace('primarykey_',''),value=kwargs[key])
+        # Which other primarykeys we want? it seems that harpnum=XXXX does not work anymore
+        # if kwargs:
+        #     for key in kwargs.keys():
+        #         if 'primarykey' in key:
+        #             dataset += '[{k}={value}]'.format(k=key.replace('primarykey_',''),value=kwargs[key])
 
         return dataset
 
@@ -528,6 +535,9 @@ class JSOCClient(object):
         kwargs.pop('sample',None)
 
         # Build full POST payload
+        filename_ext = '{T_REC:A}.{CAMERA}.{segment}'
+        if 'harp' in series:
+            filename_ext = '{HARPNUM}.' + filename_ext
         payload = {'ds': dataset,
                    'format': 'json',
                    'method': 'url',
@@ -536,7 +546,7 @@ class JSOCClient(object):
                    'process': 'n=0|no_op',
                    'protocol': jprotocol,
                    'requestor': 'none',
-                   'filenamefmt': '{0}.{{T_REC:A}}.{{CAMERA}}.{{segment}}'.format(series)}
+                   'filenamefmt': '{0}.{1}'.format(series, filename_ext)}
 
         payload.update(self._clean_primarykey(kwargs))
         return payload
@@ -573,8 +583,10 @@ class JSOCClient(object):
         """
         Do a LookData request to JSOC to workout what results the query returns
         """
-        keywords = ['DATE', 'TELESCOP', 'INSTRUME', 'T_OBS', 'WAVELNTH',
+        keywords = ['T_OBS', 'TELESCOP', 'INSTRUME', 'WAVELNTH',
                     'WAVEUNIT']
+        # note waveunit returns "Invalid KeyLink" for HMI,
+        # eg:  http://jsoc.stanford.edu/cgi-bin/ajax/jsoc_info?&op=rs_list&ds=hmi.sharp_cea_720s[637][2011.05.31_23:59:00_TAI-2011.06.01_00:01:00_TAI]{Bp}&key=DATE,TELESCOP,INSTRUME,T_OBS,WAVELNTH,WAVEUNIT
 
         if not all([k in iargs for k in ('start_time', 'end_time', 'series')]):
             error_message = "Both Time and Series must be specified for a "\
@@ -584,7 +596,7 @@ class JSOCClient(object):
         postthis = {'ds': self._make_recordset(**iargs),
                     'op': 'rs_list',
                     'key': str(keywords)[1:-1].replace(' ', '').replace("'", ''),
-                    'seg': '**NONE**',
+                    'seg': '**NONE**', # TODO: segments would give an idea of files (eg: Bp,Bt)
                     'link': '**NONE**'}
 
         r = requests.get(JSOC_INFO_URL, params=postthis)

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -228,3 +228,23 @@ def test_results_filenames():
 def test_invalid_query():
     with pytest.raises(ValueError):
         resp = client.query(attrs.Time('2012/1/1T01:00:00', '2012/1/1T01:00:45'))
+
+@pytest.mark.online
+def test_harp_none():
+    response = client.query(attrs.Time('2011-05-31T23:59:00', '2011-06-01T00:01:00'),
+                            attrs.Series('hmi.sharp_cea_720s'), attrs.Segment('Bp'))
+    assert len(response) == 10
+
+@pytest.mark.online
+def test_harp_one():
+    response = client.query(attrs.Time('2011-05-31T23:59:00', '2011-06-01T00:01:00'),
+                            attrs.Series('hmi.sharp_cea_720s'), attrs.Segment('Bp'),
+                            attrs.PrimaryKey('HARPNUM', '637'))
+    assert len(response) == 1
+
+@pytest.mark.online
+def test_harp_multi():
+    response = client.query(attrs.Time('2011-05-31T23:59:00', '2011-06-01T00:01:00'),
+                            attrs.Series('hmi.sharp_cea_720s'), attrs.Segment('Bp'),
+                            attrs.PrimaryKey('HARPNUM', '622, 633, 637'))
+    assert len(response) == 3


### PR DESCRIPTION
This PR should help towards solving the problems explained in #1399 
It does at the moment by ading **kwargs on the query as [key=value] packages.  To avoid the position dependency it has been added the `'T_REC'` and `'WAVELNTH'` to the built ones.

This PR as it is can solve this query without any `HARPNUM`:

``` python
response = client.query(jsoc.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'), jsoc.Series('hmi.sharp_720s'))
```

or if it's known:

``` python
response = client.query(jsoc.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'), jsoc.Series('hmi.sharp_720s'), HARPNUM=3535)
```

things still to add:
- [ ] Tests
- [ ] Check whether the keyword,value pair is one of the allowed ones
  This can be obtained by:

``` python
r = requests.get('http://jsoc.stanford.edu/cgi-bin/ajax/jsoc_info', params={'seg': '**NONE**', 'link': '**NONE**', 'ds':'hmi.sharp_720s','key':'Interval','op':'series_struct'})
```
