### PR TITLE
Warning on failed skimage import

### DIFF
--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -12,6 +12,8 @@ try:
     import skimage.transform
     scikit_image_not_found = False
 except ImportError:  # pragma: no cover
+    warnings.warn("scikit-image could not be imported. Map rotation will use scipy",
+                  ImportWarning)
     scikit_image_not_found = True  # pragma: no cover
 
 __all__ = ['affine_transform']

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -12,7 +12,7 @@ try:
     import skimage.transform
     scikit_image_not_found = False
 except ImportError:  # pragma: no cover
-    warnings.warn("scikit-image could not be imported. Map rotation will use scipy",
+    warnings.warn("scikit-image could not be imported. Image rotation will use scipy",
                   ImportWarning)
     scikit_image_not_found = True  # pragma: no cover
 


### PR DESCRIPTION
I found that using the scipy affine transform instead of the scikit-image made a big difference to the results of my work, and it took me a long time to track down the bug because I didn't know scikit-image wasn't installed. So now there's a warning. Errors should never pass silently