### PR TITLE
Change default hek spatial region

### DIFF
--- a/sunpy/net/hek/attrs.py
+++ b/sunpy/net/hek/attrs.py
@@ -11,7 +11,7 @@
 """
 Attributes that can be used to construct HEK queries. They are different to
 the VSO ones in that a lot of them are wrappers that conveniently expose
-the comparisions by overloading Python operators. So, e.g., you are able
+the comparisons by overloading Python operators. So, e.g., you are able
 to say AR & AR.NumSpots < 5 to find all active regions with less than 5 spots.
 As with the VSO query, you can use the fundamental logic operators AND and OR
 to construct queries of almost arbitrary complexity. Note that complex queries
@@ -33,7 +33,7 @@ class _ParamAttr(attr.Attr):
         self.name = name
         self.op = op
         self.value = value
-
+    
     def collides(self, other):
         if not isinstance(other, self.__class__):
             return False
@@ -44,13 +44,13 @@ class _ParamAttr(attr.Attr):
 class _BoolParamAttr(_ParamAttr):
     def __init__(self, name, value='true'):
         _ParamAttr.__init__(self, name, '=', value)
-
+    
     def __neg__(self):
         if self.value == 'true':
             return _BoolParamAttr(self.name, 'false')
         else:
             return _BoolParamAttr(self.name)
-
+    
     def __pos__(self):
         return _BoolParamAttr(self.name)
 
@@ -61,18 +61,18 @@ class _ListAttr(attr.Attr):
     item is added to that list. """
     def __init__(self, key, item):
         attr.Attr.__init__(self)
-
+        
         self.key = key
         self.item = item
-
+    
     def collides(self, other):
         return False
-
+    
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
         return vars(self) == vars(other)
-
+    
     def __hash__(self):
         return hash(tuple(vars(self).itervalues()))
 
@@ -81,10 +81,10 @@ class EventType(attr.Attr):
     def __init__(self, item):
         attr.Attr.__init__(self)
         self.item = item
-
+    
     def collides(self, other):
         return isinstance(other, EventType)
-
+    
     def __or__(self, other):
         if isinstance(other, EventType):
             return EventType(self.item + ',' + other.item)
@@ -99,18 +99,18 @@ class Time(attr.Attr):
         attr.Attr.__init__(self)
         self.start = start
         self.end = end
-
+    
     def collides(self, other):
         return isinstance(other, Time)
-
+    
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
         return vars(self) == vars(other)
-
+    
     def __hash__(self):
         return hash(tuple(vars(self).itervalues()))
-
+    
     @classmethod
     def dt(cls, start, end):
         return cls(datetime(*start), datetime(*end))
@@ -119,23 +119,23 @@ class Time(attr.Attr):
 # pylint: disable=R0913
 class SpatialRegion(attr.Attr):
     def __init__(
-        self, x1=-1200, y1=-1200, x2=1200, y2=1200, sys='helioprojective'):
+        self, x1=-5000, y1=-5000, x2=5000, y2=5000, sys='helioprojective'):
         attr.Attr.__init__(self)
-
+        
         self.x1 = x1
         self.y1 = y1
         self.x2 = x2
         self.y2 = y2
         self.sys = sys
-
+    
     def collides(self, other):
         return isinstance(other, SpatialRegion)
-
+    
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
         return vars(self) == vars(other)
-
+    
     def __hash__(self):
         return hash(tuple(vars(self).itervalues()))
 
@@ -144,15 +144,15 @@ class Contains(attr.Attr):
     def __init__(self, *types):
         attr.Attr.__init__(self)
         self.types = types
-
+    
     def collides(self, other):
         return False
-
+    
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
         return vars(self) == vars(other)
-
+    
     def __hash__(self):
         return hash(tuple(vars(self).itervalues()))
 
@@ -160,22 +160,22 @@ class Contains(attr.Attr):
 class _ComparisonParamAttrWrapper(object):
     def __init__(self, name):
         self.name = name
-
+    
     def __lt__(self, other):
         return _ParamAttr(self.name, '<', other)
-
+    
     def __le__(self, other):
         return _ParamAttr(self.name, '<=', other)
-
+    
     def __gt__(self, other):
         return _ParamAttr(self.name, '>', other)
-
+    
     def __ge__(self, other):
         return _ParamAttr(self.name, '>=', other)
-
+    
     def __eq__(self, other):
         return _ParamAttr(self.name, '=', other)
-
+    
     def __ne__(self, other):
         return _ParamAttr(self.name, '!=', other)
 
@@ -200,11 +200,11 @@ def _a(wlk, root, state, dct):
     dct['type'] = 'contains'
     if not Contains in state:
         state[Contains] = 1
-
+    
     nid = state[Contains]
     n = 0
     for n, type_ in enumerate(root.types):
-        dct['event_type{num:d}'.format(num=(nid + n))] = type_
+        dct['event_type%d' % (nid + n)] = type_
     state[Contains] += n
     return dct
 
@@ -246,11 +246,11 @@ def _a(wlk, root, state, dct):
 def _a(wlk, root, state, dct):
     if not _ParamAttr in state:
         state[_ParamAttr] = 0
-
+    
     nid = state[_ParamAttr]
-    dct['param{num:d}'.format(num=nid)] = root.name
-    dct['op{num:d}'.format(num=nid)] = root.op
-    dct['value{num:d}'.format(num=nid)] = root.value
+    dct['param%d' % nid] = root.name
+    dct['op%d' % nid] = root.op
+    dct['value%d' % nid] = root.value
     state[_ParamAttr] += 1
     return dct
 

--- a/sunpy/net/hek/attrs.py
+++ b/sunpy/net/hek/attrs.py
@@ -204,7 +204,7 @@ def _a(wlk, root, state, dct):
     nid = state[Contains]
     n = 0
     for n, type_ in enumerate(root.types):
-        dct['event_type%d' % (nid + n)] = type_
+        dct['event_type{num:d}'.format(num=(nid + n))] = type_
     state[Contains] += n
     return dct
 
@@ -248,9 +248,9 @@ def _a(wlk, root, state, dct):
         state[_ParamAttr] = 0
     
     nid = state[_ParamAttr]
-    dct['param%d' % nid] = root.name
-    dct['op%d' % nid] = root.op
-    dct['value%d' % nid] = root.value
+    dct['param{num:d}'.format(num=nid)] = root.name
+    dct['op{num:d}'.format(num=nid)] = root.op
+    dct['value{num:d}'.format(num=nid)] = root.value
     state[_ParamAttr] += 1
     return dct
 

--- a/tools/hektemplate.py
+++ b/tools/hektemplate.py
@@ -11,7 +11,7 @@
 """
 Attributes that can be used to construct HEK queries. They are different to
 the VSO ones in that a lot of them are wrappers that conveniently expose
-the comparisions by overloading Python operators. So, e.g., you are able
+the comparisons by overloading Python operators. So, e.g., you are able
 to say AR & AR.NumSpots < 5 to find all active regions with less than 5 spots.
 As with the VSO query, you can use the fundamental logic operators AND and OR
 to construct queries of almost arbitrary complexity. Note that complex queries
@@ -119,7 +119,7 @@ class Time(attr.Attr):
 # pylint: disable=R0913
 class SpatialRegion(attr.Attr):
     def __init__(
-        self, x1=-1200, y1=-1200, x2=1200, y2=1200, sys='helioprojective'):
+        self, x1=-5000, y1=-5000, x2=5000, y2=5000, sys='helioprojective'):
         attr.Attr.__init__(self)
         
         self.x1 = x1

--- a/tools/hektemplate.py
+++ b/tools/hektemplate.py
@@ -204,7 +204,7 @@ def _a(wlk, root, state, dct):
     nid = state[Contains]
     n = 0
     for n, type_ in enumerate(root.types):
-        dct['event_type%d' % (nid + n)] = type_
+        dct['event_type{num:d}'.format(num=(nid + n))] = type_
     state[Contains] += n
     return dct
 
@@ -248,9 +248,9 @@ def _a(wlk, root, state, dct):
         state[_ParamAttr] = 0
     
     nid = state[_ParamAttr]
-    dct['param%d' % nid] = root.name
-    dct['op%d' % nid] = root.op
-    dct['value%d' % nid] = root.value
+    dct['param{num:d}'.format(num=nid)] = root.name
+    dct['op{num:d}'.format(num=nid)] = root.op
+    dct['value{num:d}'.format(num=nid)] = root.value
     state[_ParamAttr] += 1
     return dct
 


### PR DESCRIPTION
Changed the hektemplate file to expand the default search region for the HEK (so that CMEs show up without having to manually extend the spatial search), and to put the new number formatting style in the template file.  Used the hek_mkcls.py file to implement the changes.