### PR TITLE
Map attributes are now named tuples instead of dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Latest
  * map.shape has been replaced with map.dimensions, which is ordered
    x first.
  * map.rsun_arcseconds is now map.rsun_obs as it returns a quantity.
+ * Map properties are now named tuples rather than dictionaries.
 
 0.5.0
 -----

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -385,8 +385,8 @@ def apply_shifts(mc, yshift, xshift, clip=True):
         new_meta = deepcopy(m.meta)
 
         # Adjust the positioning information accordingly.
-        new_meta['crval1'] = new_meta['crval1'] - xshift[i].value * m.scale['x'].value
-        new_meta['crval2'] = new_meta['crval2'] - yshift[i].value * m.scale['y'].value
+        new_meta['crval1'] = new_meta['crval1'] - xshift[i].value * m.scale.x.value
+        new_meta['crval2'] = new_meta['crval2'] - yshift[i].value * m.scale.y.value
 
         # Append to the list
         newmc_list.append(sunpy.map.Map(shifted_data, new_meta))
@@ -478,8 +478,8 @@ def calculate_match_template_shift(mc, template=None, layer_index=0,
     for i, m in enumerate(mc.maps):
         # Calculate the shifts required in physical units, which are
         # presumed to be arcseconds.
-        xshift_arcseconds[i] = xshift_keep[i] * m.scale['x']
-        yshift_arcseconds[i] = yshift_keep[i] * m.scale['y']
+        xshift_arcseconds[i] = xshift_keep[i] * m.scale.x
+        yshift_arcseconds[i] = yshift_keep[i] * m.scale.y
 
     return {"x": xshift_arcseconds, "y": yshift_arcseconds}
 
@@ -571,8 +571,8 @@ def mapcube_coalign_by_match_template(mc, template=None, layer_index=0,
 
     # Calculate the pixel shifts
     for i, m in enumerate(mc):
-        xshift_keep[i] = (xshift_arcseconds[i] / m.scale['x'])
-        yshift_keep[i] = (yshift_arcseconds[i] / m.scale['y'])
+        xshift_keep[i] = (xshift_arcseconds[i] / m.scale.x)
+        yshift_keep[i] = (yshift_arcseconds[i] / m.scale.y)
 
     # Apply the shifts and return the coaligned mapcube
     return apply_shifts(mc, -yshift_keep, -xshift_keep, clip=clip)

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -170,8 +170,8 @@ def aia171_test_mc_pixel_displacements():
 
 @pytest.fixture
 def aia171_mc_arcsec_displacements(aia171_test_mc_pixel_displacements, aia171_test_map):
-    return {'x': np.asarray([0.0, aia171_test_mc_pixel_displacements[1] * aia171_test_map.scale['x'].value]) * u.arcsec,
-            'y': np.asarray([0.0, aia171_test_mc_pixel_displacements[0] * aia171_test_map.scale['y'].value]) * u.arcsec}
+    return {'x': np.asarray([0.0, aia171_test_mc_pixel_displacements[1] * aia171_test_map.scale.x.value]) * u.arcsec,
+            'y': np.asarray([0.0, aia171_test_mc_pixel_displacements[0] * aia171_test_map.scale.y.value]) * u.arcsec}
 
 
 @pytest.fixture
@@ -241,8 +241,8 @@ def test_mapcube_coalign_by_match_template(aia171_test_mc,
     # All output layers should have the same size
     # which is smaller than the input by a known amount
     test_mc = mapcube_coalign_by_match_template(aia171_test_mc)
-    x_displacement_pixels = test_displacements['x'] / test_mc[0].scale['x']
-    y_displacement_pixels = test_displacements['y'] / test_mc[0].scale['y']
+    x_displacement_pixels = test_displacements['x'] / test_mc[0].scale.x
+    y_displacement_pixels = test_displacements['y'] / test_mc[0].scale.y
     expected_clipping = calculate_clipping(y_displacement_pixels, x_displacement_pixels)
     number_of_pixels_clipped = [np.sum(np.abs(expected_clipping[0])), np.sum(np.abs(expected_clipping[1]))]
 
@@ -253,8 +253,8 @@ def test_mapcube_coalign_by_match_template(aia171_test_mc,
     # All output layers should have the same size
     # which is smaller than the input by a known amount
     test_mc = mapcube_coalign_by_match_template(aia171_test_mc, clip=True)
-    x_displacement_pixels = test_displacements['x'] / test_mc[0].scale['x']
-    y_displacement_pixels = test_displacements['y'] / test_mc[0].scale['y']
+    x_displacement_pixels = test_displacements['x'] / test_mc[0].scale.x
+    y_displacement_pixels = test_displacements['y'] / test_mc[0].scale.y
     expected_clipping = calculate_clipping(y_displacement_pixels, x_displacement_pixels)
     number_of_pixels_clipped = [np.sum(np.abs(expected_clipping[0])), np.sum(np.abs(expected_clipping[1]))]
 

--- a/sunpy/instr/aia.py
+++ b/sunpy/instr/aia.py
@@ -42,11 +42,11 @@ def aiaprep(aiamap):
 
     # Taget scale is 0.6 arcsec/pixel, but this needs to be adjusted if the map
     # has already been rescaled.
-    if (aiamap.scale['x']/0.6).round() != 1.0*u.arcsec and aiamap.data.shape != (4096, 4096):
-        scale = (aiamap.scale['x']/0.6).round() * 0.6*u.arcsec
+    if (aiamap.scale.x/0.6).round() != 1.0*u.arcsec and aiamap.data.shape != (4096, 4096):
+        scale = (aiamap.scale.x/0.6).round() * 0.6*u.arcsec
     else:
         scale = 0.6*u.arcsec # pragma: no cover # can't test this because it needs a full res image
-    scale_factor = aiamap.scale['x'] / scale
+    scale_factor = aiamap.scale.x / scale
 
     newmap = aiamap.rotate(recenter=True, scale=scale_factor.value, missing=aiamap.min())
     newmap.meta['lvl_num'] = 1.5

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -301,16 +301,16 @@ class CompositeMap(object):
 
         if annotate:
             # x-axis label
-            if self._maps[0].coordinate_system['x'] == 'HG':
-                xlabel = 'Longitude [{lon}]'.format(lon=self._maps[0].units['x'])
+            if self._maps[0].coordinate_system.x == 'HG':
+                xlabel = 'Longitude [{lon}]'.format(lon=self._maps[0].units.x)
             else:
-                xlabel = 'X-position [{solx}]'.format(solx=self._maps[0].units['x'])
+                xlabel = 'X-position [{solx}]'.format(solx=self._maps[0].units.x)
 
             # y-axis label
-            if self._maps[0].coordinate_system['y'] == 'HG':
-                ylabel = 'Latitude [{lat}]'.format(lat=self._maps[0].units['y'])
+            if self._maps[0].coordinate_system.y == 'HG':
+                ylabel = 'Latitude [{lat}]'.format(lat=self._maps[0].units.y)
             else:
-                ylabel = 'Y-position [{soly}]'.format(soly=self._maps[0].units['y'])
+                ylabel = 'Y-position [{soly}]'.format(soly=self._maps[0].units.y)
 
             axes.set_xlabel(xlabel)
             axes.set_ylabel(ylabel)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -93,6 +93,12 @@ class GenericMap(NDData):
     Notes
     -----
 
+    A number of the properties of this class are returned as two-value named
+    tuples that can either be indexed by position ([0] or [1]) or be accessed by
+    name (.x or .y).  The names "x" and "y" here refer to the first and second
+    axes of the map, and may not necessarily correspond to any similarly named
+    axes in the coordinate system.
+
     This class makes some assumptions about the WCS information contained in
     the meta data. The first and most extensive assumption is that it is
     FITS-like WCS information as defined in the FITS WCS papers.

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -149,16 +149,16 @@ class MapCube(object):
             axes.set_title("{s.name} {s.date!s}".format(s=self[i]))
 
             # x-axis label
-            if self[0].coordinate_system['x'] == 'HG':
-                xlabel = 'Longitude [{lon}'.format(lon=self[i].units['x'])
+            if self[0].coordinate_system.x == 'HG':
+                xlabel = 'Longitude [{lon}'.format(lon=self[i].units.x)
             else:
-                xlabel = 'X-position [{xpos}]'.format(xpos=self[i].units['x'])
+                xlabel = 'X-position [{xpos}]'.format(xpos=self[i].units.x)
 
             # y-axis label
-            if self[0].coordinate_system['y'] == 'HG':
-                ylabel = 'Latitude [{lat}]'.format(lat=self[i].units['y'])
+            if self[0].coordinate_system.y == 'HG':
+                ylabel = 'Latitude [{lat}]'.format(lat=self[i].units.y)
             else:
-                ylabel = 'Y-position [{ypos}]'.format(ypos=self[i].units['y'])
+                ylabel = 'Y-position [{ypos}]'.format(ypos=self[i].units.y)
 
             axes.set_xlabel(xlabel)
             axes.set_ylabel(ylabel)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -74,17 +74,16 @@ def test_wcs(aia171_test_map):
     wcs = aia171_test_map.wcs
     assert isinstance(wcs, astropy.wcs.WCS)
 
-    assert all(wcs.wcs.crpix == [aia171_test_map.reference_pixel['x'].value,
-                                 aia171_test_map.reference_pixel['y'].value])
-    assert all(wcs.wcs.cdelt == [aia171_test_map.scale['x'].value,
-                                 aia171_test_map.scale['y'].value])
-    assert all(wcs.wcs.crval == [aia171_test_map.reference_coordinate['x'].value,
-                                 aia171_test_map.reference_coordinate['y'].value])
-    assert set(wcs.wcs.ctype) == set([aia171_test_map.coordinate_system['x'],
-                             aia171_test_map.coordinate_system['y']])
+    assert all(wcs.wcs.crpix == [aia171_test_map.reference_pixel.x.value,
+                                 aia171_test_map.reference_pixel.y.value])
+    assert all(wcs.wcs.cdelt == [aia171_test_map.scale.x.value,
+                                 aia171_test_map.scale.y.value])
+    assert all(wcs.wcs.crval == [aia171_test_map.reference_coordinate.x.value,
+                                 aia171_test_map.reference_coordinate.y.value])
+    assert set(wcs.wcs.ctype) == set([aia171_test_map.coordinate_system.x,
+                             aia171_test_map.coordinate_system.y])
     np.testing.assert_allclose(wcs.wcs.pc, aia171_test_map.rotation_matrix)
-    assert set(wcs.wcs.cunit) == set([u.Unit(a) for a in [aia171_test_map.units['x'],
-                                                          aia171_test_map.units['y']]])
+    assert set(wcs.wcs.cunit) == set([u.Unit(a) for a in aia171_test_map.units])
 
 def test_dtype(generic_map):
     assert generic_map.dtype == np.float64
@@ -158,7 +157,7 @@ def test_rsun_obs(generic_map):
 
 
 def test_coordinate_system(generic_map):
-    assert generic_map.coordinate_system == {'x':'HPLN-TAN', 'y': 'HPLT-TAN'}
+    assert generic_map.coordinate_system == ('HPLN-TAN', 'HPLT-TAN')
 
 
 def test_carrington_longitude(generic_map):
@@ -174,7 +173,7 @@ def test_heliographic_longitude(generic_map):
 
 
 def test_units(generic_map):
-    generic_map.units == {'x': 'arcsec', 'y': 'arcsec'}
+    generic_map.units == ('arcsec', 'arcsec')
 
 
 #==============================================================================
@@ -200,8 +199,8 @@ def test_rotation_matrix_cd_cdelt():
               'CDELT1': 10,
               'CDELT2': 9,
               'CD1_1': 0,
-              'CD1_2': -10,
-              'CD2_1': 9,
+              'CD1_2': -9,
+              'CD2_1': 10,
               'CD2_2': 0,
               'NAXIS1': 6,
               'NAXIS2': 6}
@@ -235,17 +234,16 @@ def test_data_range(generic_map):
     assert generic_map.xrange[1].value - generic_map.xrange[0].value == generic_map.meta['cdelt1'] * generic_map.meta['naxis1']
     assert generic_map.yrange[1].value - generic_map.yrange[0].value == generic_map.meta['cdelt2'] * generic_map.meta['naxis2']
 
-    assert np.average(generic_map.xrange.value) == generic_map.center['x'].value
-    assert np.average(generic_map.yrange.value) == generic_map.center['y'].value
+    assert np.average(generic_map.xrange.value) == generic_map.center.x.value
+    assert np.average(generic_map.yrange.value) == generic_map.center.y.value
 
 
 def test_data_to_pixel(generic_map):
     """Make sure conversion from data units to pixels is internally consistent"""
     # Note: FITS pixels start from 1,1
-    test_pixel = generic_map.data_to_pixel(*generic_map.reference_coordinate.values(),
-                                           origin=1)
-    assert_quantity_allclose(test_pixel,
-                             generic_map.reference_pixel.values())
+    test_pixel = generic_map.data_to_pixel(*generic_map.reference_coordinate, origin=1)
+    assert_quantity_allclose(test_pixel, generic_map.reference_pixel)
+
 
 def test_submap(generic_map):
     """Check data and header information for a submap"""
@@ -253,19 +251,13 @@ def test_submap(generic_map):
     height = generic_map.data.shape[0]
 
     # Create a submap of the top-right quadrant of the image
-    submap = generic_map.submap([height/2.,height]*u.pix, [width/2.,width]*u.pix)
-
-    # Expected offset for center
-    offset = {
-        "x": generic_map.meta['crpix1'] - width / 2.,
-        "y": generic_map.meta['crpix2'] - height / 2.,
-    }
+    submap = generic_map.submap([width/2.,width]*u.pix, [height/2.,height]*u.pix)
 
     # Check to see if submap properties were updated properly
-    assert submap.reference_pixel['x'].value == offset['x']
-    assert submap.reference_pixel['y'].value == offset['y']
-    assert submap.data.shape[0] == width / 2.
-    assert submap.data.shape[1] == height / 2.
+    assert submap.reference_pixel.x.value == generic_map.meta['crpix1'] - width / 2.
+    assert submap.reference_pixel.y.value == generic_map.meta['crpix2'] - height / 2.
+    assert submap.data.shape[1] == width / 2.
+    assert submap.data.shape[0] == height / 2.
 
     # Check to see if header was updated
     assert submap.meta['naxis1'] == width / 2.
@@ -301,8 +293,8 @@ def test_resample_metadata(generic_map, sample_method, new_dimensions):
         == float(generic_map.data.shape[0]) / resampled_map.data.shape[0]
     assert resampled_map.meta['crpix1'] == (resampled_map.data.shape[1] + 1) / 2.
     assert resampled_map.meta['crpix2'] == (resampled_map.data.shape[0] + 1) / 2.
-    assert resampled_map.meta['crval1'] == generic_map.center['x'].value
-    assert resampled_map.meta['crval2'] == generic_map.center['y'].value
+    assert resampled_map.meta['crval1'] == generic_map.center.x.value
+    assert resampled_map.meta['crval2'] == generic_map.center.y.value
     for key in generic_map.meta:
         if key not in ('cdelt1', 'cdelt2', 'crpix1', 'crpix2',
                        'crval1', 'crval2'):
@@ -383,7 +375,7 @@ def test_rotate_recenter(generic_map):
     pixel_array_center = (np.flipud(rotated_map.data.shape) - 1) / 2.0
 
     assert_quantity_allclose((pixel_array_center + 1) * u.pix, # FITS indexes from 1
-                             u.Quantity(rotated_map.reference_pixel.values()))
+                             u.Quantity(rotated_map.reference_pixel))
 
 
 def test_rotate_crota_remove(aia171_test_map):

--- a/sunpy/physics/transforms/solar_rotation.py
+++ b/sunpy/physics/transforms/solar_rotation.py
@@ -63,14 +63,14 @@ def calculate_solar_rotate_shift(mc, layer_index=0, **kwargs):
         # Calculate the rotation of the center of the map 'm' at its
         # observation time to the observation time of the reference layer
         # indicated by "layer_index".
-        newx, newy = rot_hpc(m.center['x'],
-                             m.center['y'],
+        newx, newy = rot_hpc(m.center.x,
+                             m.center.y,
                              m.date,
                              mc.maps[layer_index].date, **kwargs)
 
         # Calculate the shift in arcseconds
-        xshift_arcseconds[i] = newx - mc.maps[layer_index].center['x']
-        yshift_arcseconds[i] = newy - mc.maps[layer_index].center['y']
+        xshift_arcseconds[i] = newx - mc.maps[layer_index].center.x
+        yshift_arcseconds[i] = newy - mc.maps[layer_index].center.y
 
     return {"x": xshift_arcseconds, "y": yshift_arcseconds}
 
@@ -136,8 +136,8 @@ def mapcube_solar_derotate(mc, layer_index=0, clip=True, shift=None, **kwargs):
 
     # Calculate the pixel shifts
     for i, m in enumerate(mc):
-        xshift_keep[i] = xshift_arcseconds[i] / m.scale['x']
-        yshift_keep[i] = yshift_arcseconds[i] / m.scale['y']
+        xshift_keep[i] = xshift_arcseconds[i] / m.scale.x
+        yshift_keep[i] = yshift_arcseconds[i] / m.scale.y
 
     # Apply the pixel shifts and return the mapcube
     return apply_shifts(mc, yshift_keep, xshift_keep , clip=clip)

--- a/sunpy/physics/transforms/tests/test_solar_rotation.py
+++ b/sunpy/physics/transforms/tests/test_solar_rotation.py
@@ -77,8 +77,8 @@ def test_mapcube_solar_derotate(aia171_test_mapcube, aia171_test_submap):
     # Test that the returned centers are correctly displaced.
     tshift = calculate_solar_rotate_shift(aia171_test_mapcube)
     for im, m in enumerate(tmc):
-        for s in ['x', 'y']:
-            assert_allclose(m.center[s], aia171_test_submap.center[s] -
+        for i_s, s in enumerate(['x', 'y']):
+            assert_allclose(m.center[i_s], aia171_test_submap.center[i_s] -
                             tshift[s][im], rtol=5e-2, atol=0)
 
     # Test that a mapcube is returned on default clipping (clipping is True)

--- a/sunpy/visualization/mapcubeanimator.py
+++ b/sunpy/visualization/mapcubeanimator.py
@@ -73,16 +73,16 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
         self.axes.set_title("{s.name} {s.date!s}".format(s=self.data[ind]))
 
         # x-axis label
-        if self.data[ind].coordinate_system['x'] == 'HG':
-            xlabel = 'Longitude [{lon}]'.format(lon=self.data[ind].units['x'])
+        if self.data[ind].coordinate_system.x == 'HG':
+            xlabel = 'Longitude [{lon}]'.format(lon=self.data[ind].units.x)
         else:
-            xlabel = 'X-position [{xpos}]'.format(xpos=self.data[ind].units['x'])
+            xlabel = 'X-position [{xpos}]'.format(xpos=self.data[ind].units.x)
 
         # y-axis label
-        if self.data[ind].coordinate_system['y'] == 'HG':
-            ylabel = 'Latitude [{lat}]'.format(lat=self.data[ind].units['y'])
+        if self.data[ind].coordinate_system.y == 'HG':
+            ylabel = 'Latitude [{lat}]'.format(lat=self.data[ind].units.y)
         else:
-            ylabel = 'Y-position [{ypos}]'.format(ypos=self.data[ind].units['y'])
+            ylabel = 'Y-position [{ypos}]'.format(ypos=self.data[ind].units.y)
 
         self.axes.set_xlabel(xlabel)
         self.axes.set_ylabel(ylabel)

--- a/sunpy/wcs/tests/test_wcs.py
+++ b/sunpy/wcs/tests/test_wcs.py
@@ -29,12 +29,6 @@ def l0():
 # the following known_answers come from equivalent queries to IDL
 # WCS implementation (http://hesperia.gsfc.nasa.gov/ssw/gen/idl/wcs/)
 
-#def test_convert_pixel_to_data():
-#    actual =
-#    reference_pixel = [img.reference_pixel['x'], img.reference_pixel['y']]
-#    reference_coordinate = [img.reference_coordinate['x'], img.reference_coordinate['y']]
-#    scale = [img.scale['x'], img.scale['y']]
-#    actual = wcs.convert_pixel_to_data(scale,img.shape, reference_pixel, reference_coordinate, 0, 0)
 
 def test_convert_angle_units():
     actual = np.array([wcs._convert_angle_units(), wcs._convert_angle_units('arcsec'),


### PR DESCRIPTION
During the May 18th developer discussion, the consensus was that the Map attributes currently return dictionaries (e.g., `scale` or `reference_coordinate`) should instead return named tuples (#1414).  This allows expressions such as:
```python
>>> map.scale.x
>>> map.scale[0]
>>> u.Quantity(map.scale)
>>> function_with_two_input_arguments(*map.scale)
>>> map.scale._asdict()
```
The cost, of course, is that it is a breaking change to our API because the one call that doesn't work is `map.scale['x']`.  But, since lots of existing code is likely to break anyway with 0.6 because of the Quantity changes, the time to make this switch is now.

This PR makes the switch using a named tuple called `Pair`.  Comment away!

Needs:
- [x] Documentation
- [x] Changelog