### PR TITLE
Add a 'period' keyword to apply time interval between SDO data from JSOC

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,12 +5,14 @@ Albert Y. Shih <ayshih@gmail.com> ayshih <ayshih@gmail.com>
 Jack Ireland <jack.ireland@nasa.gov> wafels <jackireland@gmail.com>
 Jack Ireland <jack.ireland@nasa.gov> Jack Ireland <jackireland@gmail.com>
 Jack Ireland <jack.ireland@nasa.gov> Jack Ireland <ireland@Ganymede.(none)>
-Stuart Mumford <stuart@mumford.me.uk> Stuart Mumford <stuartmumford@physics.org>
-Stuart Mumford <stuart@mumford.me.uk> Stuart Mumford <s.mumford@sheffield.ac.uk>
-Stuart Mumford <stuart@mumford.me.uk> U-Cadair-Core\stuart <stuart@Cadair-Core.(none)>
+Stuart Mumford <stuart@cadair.com> Stuart Mumford <stuartmumford@physics.org>
+Stuart Mumford <stuart@cadair.com> Stuart Mumford <stuart@mumford.me.uk>
+Stuart Mumford <stuart@cadair.com> Stuart Mumford <s.mumford@sheffield.ac.uk>
+Stuart Mumford <stuart@cadair.com> U-Cadair-Core\stuart <stuart@Cadair-Core.(none)>
 Florian Mayer <florian.mayer@bitsrc.org> Florian Mayer <flormayer@aim.com>
 David Perez-Suarez <dps.helio@gmail.com> dpshelio <dps.helio@gmail.com>
 David Perez-Suarez <dps.helio@gmail.com> DavidPS <dps.helio@gmail.com>
+David Perez-Suarez <dps.helio@gmail.com> David PS <dps.helio@gmail.com>
 Nabil Freij <nabil.freij@gmail.com> Nabobalis <nabil.freij@gmail.com>
 Nabil Freij <nabil.freij@gmail.com> Nabil <nabil.freij@gmail.com>
 Russell Hewett <rhewett@mit.edu> rhewett <russell.j.hewett@gmail.com>
@@ -27,5 +29,15 @@ Mateo Inchaurrandieta <mateo.inchaurrandieta@gmail.com> Mateo Inchaurrandieta <m
 Rishabh Sharma <rishabh.sharma@students.iiit.ac.in> rishabh <rishabh.sharma@students.iiit.ac.in>
 Rishabh Sharma <rishabh.sharma@students.iiit.ac.in>  gunner272 <rishabh.sharma@students.iiit.ac.in>
 Andrew Inglis <a.r.inglis@gmail.com> aringlis <a.r.inglis@gmail.com>
+Andrew Inglis <a.r.inglis@gmail.com> Andrew Inglis <Inglis@scapa.local>
 Asish Panda <asishrocks95@gmail.com> kaichogami <asishrocks95@gmail.com>
 Rajul Srivastava <rajul.iitkgp@gmail.com> Rajul <rajul.iitkgp@gmail.com>
+Rajul Srivastava <rajul.iitkgp@gmail.com> Rajul <rajul09@gmail.com>
+Rajul Srivastava <rajul.iitkgp@gmail.com> Rajul Srivastava <rajul09@gmail.com>
+John Evans <john.g.evans.ne@gmail.com> quintusdias <john.g.evans.ne@gmail.com>
+John Evans <john.g.evans.ne@gmail.com> jevans <john.g.evans.ne@gmail.com>
+Ruben De Visscher <ruben.de.visscher@gmail.com> Ruben De Visscher <ruben.devisscher@observatory.be>
+Tiago Pereira <tiago.pereira@astro.uio.no>  tiagopereira <tiago@1x-193-157-254-255.uio.no>
+Dumindu Buddhika <dumindukarunathilaka@gmail.com> dumindux <dumindukarunathilaka@gmail.com>
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
     - if [[ $TEST_MODE != 'astropy-dev' ]]; then conda install -q --yes astropy>=0.4.0; fi 
     - if [[ $TEST_MODE == 'astropy-dev' ]]; then pip install git+git://github.com/astropy/astropy.git; fi 
     # Install sphinx if needed
-    - if [[ $TEST_MODE == 'sphinx' ]]; then conda install -q --yes sphinx==1.2; fi 
+    - if [[ $TEST_MODE == 'sphinx' ]]; then conda install -q --yes sphinx=1.2; fi 
 
 script:
     - if [[ $TEST_MODE == 'sphinx' ]]; then python setup.py build_sphinx -w; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,34 @@
 Latest
 ------
 
+ * Enforced the use of Astropy Quantities through out most of SunPy.
+ * Dropped Support for Python 2.6.
+ * Remove old style string formatting and other 2.6 compatibility lines.
  * Added vso like querying feature to JSOC Client.
- * Update to TimeRange API, removed t1 and t0, start and end are now read-only attributes
+ * Refactor the JSOC client so that it follows the .query() .get() interface of VSOClient and UnifedDownloader.
+ * Provide `__str__` and `__repr__` methods on vso `QueryResponse` deprecate `.show()`.
+ * Downloaded files now keep file extensions rather than replacing all periods with underscores.
+ * Update to TimeRange API, removed t1 and t0, start and end are now read-only attributes.
  * Added ability to download level3 data for lyra Light Curve along with corresponding tests.
  * Added support for gzipped FITS files.
  * Add STEREO HI Map subclass and color maps.
  * Map.rotate() no longer crops any image data.
  * For accuracy, default Map.rotate() transformation is set to bi-quartic.
  * `sunpy.image.transform.affine_transform` now casts integer data to float64 and sets NaN values to 0 for all transformations except scikit-image rotation with order <= 3.
- * Refactor the JSOC client so that it follows the .query() .get() interface of VSOClient and UnifedDownloader
- * Remove old style string formatting and other 2.6 compatibility lines.
  * CD matrix now updated, if present, when Map pixel size is changed.
- * Removed now-redundant method for rotating IRIS maps since the functionality exists in Map.rotate()
- * Provide `__str__` and `__repr__` methods on vso `QueryResponse` deprecate `.show()`
- * SunPy colormaps are now registered with matplotlib on import of `sunpy.cm`
- * `sunpy.cm.get_cmap` no longer defaults to 'sdoaia94'
- * Added database url config setting to be setup by default as a sqlite database in the sunpy working directory
- * Added a few tests for the sunpy.roi module
+ * Removed now-redundant method for rotating IRIS maps since the functionality exists in Map.rotate().
+ * SunPy colormaps are now registered with matplotlib on import of `sunpy.cm`.
+ * `sunpy.cm.get_cmap` no longer defaults to 'sdoaia94'.
+ * Added database url config setting to be setup by default as a sqlite database in the sunpy working directory.
+ * Added a few tests for the sunpy.roi module.
  * Refactored mapcube co-alignment functionality.
  * Removed sample data from distribution and added ability to download sample files
  * Require JSOC request data calls have an email address attached.
  * Calculation of the solar rotation of a point on the Sun as seen from Earth, and its application to the de-rotation of mapcubes.
  * Downloaded files now keep file extensions rather than replacing all periods with underscores
  * Fixed the downloading of files with duplicate names in sunpy.database
+ * Removed sample data from distribution and added ability to download sample files.
+ * Added the calculation of the solar rotation of a point on the Sun as seen from Earth, and its application to the de-rotation of mapcubes.
  * Changed default for GOESLightCurve.create() so that it gets the data from the most recent existing GOES fits file.
  * Map plot functionality now uses the mask property if it is present, allowing the plotting of masked map data
  * Map Expects Quantities and returns quantities for most parameters.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,62 +1,56 @@
-The SunPy project is happy to announce the release of SunPy 0.5.0.
-This release consists of x commits from y people, including the ability to
-co-align map cubes via template matching in scikit image, massive improvements
-to Map.rotate() including an implementation of an aiaprep calibration routine for
-SDO/AIA data and the ability to calculate GOES temperature and emission
-measure from GOES fluxes.
+The SunPy project is happy to announce the release of SunPy 0.6.0.
+This is a major SunPy release with lots of changes that will make SunPy even
+better than it was before.
+This release consists of 1,139 commits from 23 different people and
+8 new contributors!
 
-Special mentions to Daniel Ryan and Andrew Leonard who have both contributed
-their first major features to SunPy for this release. They contributed the
-GOES temperature and aiaprep code respectively.
+The major changes in this release are:
 
-New Features:
-
-    * map.rotate() improvements and the additon of a aiaprep routine.
-    * GOES temperature and emission measure calculation.
-    * Added functions that implement image coalignment with support for MapCubes.
-    * MapCube._maps changed to MapCube.maps.
-    * Added Nobeyama Radioheliograph data support to Lightcurve object.
-    * Added support for NOAA solar cycle prediction in lightcurves.
-    * Improved line quality and performances issues with map.draw_grid().
-    * Most tests should pass on windows and on installed versions of SunPy.
-    * Added a window/split method to time range.
-    * Updates to spectrogram documentation.
-    * Added method Database.add_from_hek_query_result to HEK database.
-    * Added method Database.download_from_vso_query_result.
-    * GOES Lightcurve now makes use of a new source of GOES data, provides metadata, and data back to 1981.
-    * Fix algorithm in sunpy.sun.equation_of_center.
-    * Added contains functionality to TimeRange module
-    * Added t='now' to parse_time to privide utcnow datetime.
-    * Fixed time dependant functions (.sun) to default to t='now'
-    * Fixed solar_semidiameter_angular_size
-    * Removed sqlalchemy as a requirement for SunPy
-    * Some basic tests for GenericLightCurve on types of expected input.
-    * Added Docstrings to LightCurve methods.
-    * Added tests for classes in sunpy.map.sources.
-    * Cleaned up the sunpy namespace, removed .units, /ssw and .sphinx. Also moved .coords .physics.transforms.
+    * Most functions throughout the SunPy code base expect Astropy
+      Quantity objects, and return Astropy Quantity objects.
+    * Python 2.6 support has ended, we do not expect this release to
+      work under Python 2.6.
+    * Sample data has been removed from SunPy but helpers for
+      downloading sample data have been added to sunpy.data.
+    * TimeRange has a new property based API, e.g. start and end are
+      now properties.
+    * Map.rotate() now pads arrays to prevent loss of data under
+      rotation.
+    * Map.rotate() now defaults to the slower but more accurate
+      bi-quartic interpolation method (order=4).
+    * SunPy colormaps are now registered with matplotlib, allowing
+      their use from imshow and similar functions after the import
+      of sunpy.cm.
+    * JSOC client export calls now checks for an email address.
+    * Solar rotation calculation functionality has been added, along
+      with functionality to de-rotate MapCubes.
+    * Files downloaded through the VSO now keep their file
+      extension.
 
 The people who have contributed to this release are:
 
     Stuart Mumford
-    Daniel Ryan *
-    Andrew Leonard
-    Steven Christe
-    Pritish Chakraborty
+    Daniel Ryan
     Jack Ireland
-    David Pérez-Suárez
-    Andrew Inglis
-    Michael Mueller *
-    Rishabh Sharma *
+    Steven Christe
     Albert Y. Shih
-    Jose Ivan Campos Rozo
-    Simon Liedtke
-    Rajul Srivastava *
-    Larry Manley *
-    Mateo Inchaurrandieta *
-    Asish Panda *
-    Daniel Williams *
+    Asish Panda
+    Andrew Inglis
+    Rishabh Sharma
+    David Perez-Suarez
+    Rajul Srivastava
+    Ruben De Visscher *
+    Dumindu Buddhika *
+    Andrew Leonard
+    Goran Cetusic *
+    Ishtyaq Habib *
     Nabil Freij
-    Russell Hewett
-    freekv *
+    Simon Liedtke
+    Abigail Stevens *
+    Ambar Mehrotra *
+    Jaylen Wimbish *
+    Larry Manley
+    Norbert Gyenge
+    Rishabh Mishra *
 
 Where a * indicates their first contribution.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 The SunPy project is happy to announce the release of SunPy 0.6.0.
 This is a major SunPy release with lots of changes that will make SunPy even
 better than it was before.
-This release consists of 1,139 commits from 23 different people and
-8 new contributors!
+This release consists of 1,139 commits from 24 different people and
+9 new contributors!
 
 The major changes in this release are:
 
@@ -48,6 +48,7 @@ The people who have contributed to this release are:
     Simon Liedtke
     Abigail Stevens *
     Ambar Mehrotra *
+    Erik M. Bray *
     Jaylen Wimbish *
     Larry Manley
     Norbert Gyenge

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ LONG_DESCRIPTION = "SunPy is a Python library for solar physics data analysis."
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.7.dev'
+VERSION = '0.6rc1'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ LONG_DESCRIPTION = "SunPy is a Python library for solar physics data analysis."
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.6rc1'
+VERSION = '0.6a1'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/sunpy/database/setup_package.py
+++ b/sunpy/database/setup_package.py
@@ -1,0 +1,2 @@
+def get_package_data():
+    return {'sunpy.database.tests': ['test_table.txt']}

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -290,7 +290,7 @@ class JSOCClient(object):
         return allstatus
 
     def get(self, jsoc_response, path=None, overwrite=False, progress=True,
-            max_conn=5, sleep=10):
+            max_conn=5, downloader=None,sleep=10):
         """
         Make the request for the data in jsoc_response and wait for it to be
         staged and then download the data.
@@ -341,7 +341,7 @@ class JSOCClient(object):
                 if u.status_code == 200 and u.json()['status'] == '0':
                     rID = requestIDs.pop(i)
                     r = self.get_request(rID, path=path, overwrite=overwrite,
-                                         progress=progress)
+                                         progress=progress,downloader=downloader)
 
                 else:
                     time.sleep(sleep)

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -466,23 +466,31 @@ class JSOCClient(object):
                         segment='', **kwargs):
         # Build the dataset string
         # Extract and format Wavelength
+        
         if wavelength:
             if not series.startswith('aia'):
                 raise TypeError("This series does not support the wavelength attribute.")
             else:
-               if isinstance(wavelength, list):
-                   wavelength = [int(np.ceil(wave.to(u.AA).value)) for wave in wavelength]
-                   wavelength = str(wavelength)
-               else:
-                   wavelength = '[{0}]'.format(int(np.ceil(wavelength.to(u.AA).value)))
+                if isinstance(wavelength, list):
+                    wavelength = [int(np.ceil(wave.to(u.AA).value)) for wave in wavelength]
+                    wavelength = str(wavelength)
+                else:
+                    wavelength = '[{0}]'.format(int(np.ceil(wavelength.to(u.AA).value)))
 
         # Extract and format segment
         if segment != '':
             segment = '{{{segment}}}'.format(segment=segment)
-
-        dataset = '{series}[{start}-{end}]{wavelength}{segment}'.format(
+        
+        period = ''
+        try :
+            period = '@%ds'%(int(kwargs.pop('period'))) # seconds
+        except KeyError: 
+            pass
+        
+        dataset = '{series}[{start}-{end}{period}]{wavelength}{segment}'.format(
                    series=series, start=start_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
                    end=end_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
+                   period=period,
                    wavelength=wavelength, segment=segment)
 
         return dataset
@@ -506,6 +514,7 @@ class JSOCClient(object):
 
         dataset = self._make_recordset(start_time, end_time, series, **kwargs)
         kwargs.pop('wavelength', None)
+        kwargs.pop('period',None)
 
         # Build full POST payload
         payload = {'ds': dataset,

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -41,12 +41,13 @@ def test_payload():
     start = parse_time('2012/1/1T00:00:00')
     end = parse_time('2012/1/1T00:00:45')
 
-    payload = client._make_query_payload(start, end, 'hmi.M_42s', notify='@')
+    payload = client._make_query_payload(start, end, 'hmi.M_42s', notify='@',period=90)
 
     payload_expected = {
-       'ds': '{0}[{1}-{2}]'.format('hmi.M_42s',
+       'ds': '{0}[{1}-{2}{3}]'.format('hmi.M_42s',
                                    start.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
-                                   end.strftime("%Y.%m.%d_%H:%M:%S_TAI")),
+                                   end.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
+                                   '@90s'),
        'format': 'json',
        'method': 'url',
        'notify': '@',


### PR DESCRIPTION
Hello

I add a 'period' keyword to query SDO data from JSOC.

as-is : every data fetched from start_time to end_time. (It may make JSOC exhausted)
to-be : the data statisfied to keep time interval.

For examples,

query = hmi.m_45s[2015.04.01T00:00:00_TAI-2015.04.01T01:00:00]
It will download 81 files (1268MB) because a default interval of HMI is 45 seconds.

but
query = hmi.m_45s[2015.04.01T00:00:00_TAI-2015.04.01T01:00:00@90s]
It will download only 41 files (642MB) keeping the interval as 90s.

It was a simple modification using JSOC query sentences.

Thanks,

Jongyeob