### PR TITLE
Add plot_function argument to MapCubeAnimator

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1122,8 +1122,9 @@ scale:\t\t [{dx}, {dy}]
 
             Returns
             -------
-            circ: `matplotlib.patches.Circle`
-                The circle object that has been added to the axes.
+            circ: list
+                A list containing the `matplotlib.patches.Circle` object that
+                has been added to the axes.
 
             Notes
             -----
@@ -1151,7 +1152,7 @@ scale:\t\t [{dx}, {dy}]
         circ = patches.Circle([0, 0], **c_kw)
         axes.add_artist(circ)
 
-        return circ
+        return [circ]
 
     @toggle_pylab
     def peek(self, draw_limb=False, draw_grid=False, gamma=None,

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1239,14 +1239,14 @@ scale:\t\t [{dx}, {dy}]
         Examples
         --------
         #Simple Plot with color bar
-        plt.figure()
-        aiamap.plot()
-        plt.colorbar()
+        >>> aiamap.plot()
+        >>> plt.colorbar()
 
         #Add a limb line and grid
-        aia.plot()
-        aia.draw_limb()
-        aia.draw_grid()
+        >>> aia.plot()
+        >>> aia.draw_limb()
+        >>> aia.draw_grid()
+
         """
 
         #Get current axes

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1042,7 +1042,8 @@ scale:\t\t [{dx}, {dy}]
 
         Returns
         -------
-        matplotlib.axes object
+        lines: list
+            A list of `matplotlib.lines.Line2D` objects that have been plotted.
 
         Notes
         -----
@@ -1051,6 +1052,8 @@ scale:\t\t [{dx}, {dy}]
 
         if not axes:
             axes = wcsaxes_compat.gca_wcs(self.wcs)
+
+        lines = []
 
         # Do not automatically rescale axes when plotting the overlay
         axes.set_autoscale_on(False)
@@ -1087,7 +1090,7 @@ scale:\t\t [{dx}, {dy}]
             if wcsaxes_compat.is_wcsaxes(axes):
                 x = (x*u.arcsec).to(u.deg).value
                 y = (y*u.arcsec).to(u.deg).value
-            axes.plot(x, y, **plot_kw)
+            lines += axes.plot(x, y, **plot_kw)
 
         hg_longitude_deg = np.arange(-180, 180, grid_spacing.to(u.deg).value) + l0
         hg_latitude_deg = np.linspace(-90, 90, num=181)
@@ -1103,11 +1106,11 @@ scale:\t\t [{dx}, {dy}]
             if wcsaxes_compat.is_wcsaxes(axes):
                 x = (x*u.arcsec).to(u.deg).value
                 y = (y*u.arcsec).to(u.deg).value
-            axes.plot(x, y, **plot_kw)
+            lines += axes.plot(x, y, **plot_kw)
 
         # Turn autoscaling back on.
         axes.set_autoscale_on(True)
-        return axes
+        return lines
 
     def draw_limb(self, axes=None, **kwargs):
         """Draws a circle representing the solar limb
@@ -1119,7 +1122,8 @@ scale:\t\t [{dx}, {dy}]
 
             Returns
             -------
-            matplotlib.axes object
+            circ: `matplotlib.patches.Circle`
+                The circle object that has been added to the axes.
 
             Notes
             -----
@@ -1147,7 +1151,7 @@ scale:\t\t [{dx}, {dy}]
         circ = patches.Circle([0, 0], **c_kw)
         axes.add_artist(circ)
 
-        return axes
+        return circ
 
     @toggle_pylab
     def peek(self, draw_limb=False, draw_grid=False, gamma=None,

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -237,13 +237,13 @@ class MapCube(object):
         Examples
         --------
         >>> cube = sunpy.Map(files, cube=True)
-        >>> ani = cube.plot(colorbar=True)
+        >>> ani = cube.peek(colorbar=True)
         >>> plt.show()
 
         Plot the map at 1/2 original resolution
 
         >>> cube = sunpy.Map(files, cube=True)
-        >>> ani = cube.plot(resample=[0.5, 0.5], colorbar=True)
+        >>> ani = cube.peek(resample=[0.5, 0.5], colorbar=True)
         >>> plt.show()
 
         Plot the map with the limb at each time step
@@ -252,13 +252,13 @@ class MapCube(object):
         ...    p = map.draw_limb()
         ...    return p
         >>> cube = sunpy.Map(files, cube=True)
-        >>> ani = cube.plot(plot_function=myplot)
+        >>> ani = cube.peek(plot_function=myplot)
         >>> plt.show()
 
         Decide you want an animation:
 
         >>> cube = sunpy.Map(files, cube=True)
-        >>> ani = cube.plot(resample=[0.5, 0.5], colorbar=True)
+        >>> ani = cube.peek(resample=[0.5, 0.5], colorbar=True)
         >>> mplani = ani.get_animation()
         """
 

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -252,7 +252,7 @@ class MapCube(object):
         ...    p = map.draw_limb()
         ...    return p
         >>> cube = sunpy.Map(files, cube=True)
-        >>> ani = cube.plot(resample=[0.5, 0.5], colorbar=True)
+        >>> ani = cube.plot(plot_function=myplot)
         >>> plt.show()
 
         Decide you want an animation:

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -221,9 +221,14 @@ class MapCube(object):
         colorbar: bool
             Plot colorbar
 
+        plot_function : function
+            A function to call to overplot extra items on the map plot.
+            For more information see `sunpy.visualization.MapCubeAnimator`.
+
         Returns
         -------
-        Returns a MapCubeAnimator object
+        mapcubeanim : `sunpy.visualization.MapCubeAnimator`
+            A mapcube animator instance.
 
         See Also
         --------
@@ -237,6 +242,15 @@ class MapCube(object):
 
         Plot the map at 1/2 original resolution
 
+        >>> cube = sunpy.Map(files, cube=True)
+        >>> ani = cube.plot(resample=[0.5, 0.5], colorbar=True)
+        >>> plt.show()
+
+        Plot the map with the limb at each time step
+
+        >>> def myplot(fig, ax, map):
+        ...    p = map.draw_limb()
+        ...    return p
         >>> cube = sunpy.Map(files, cube=True)
         >>> ani = cube.plot(resample=[0.5, 0.5], colorbar=True)
         >>> plt.show()

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -144,6 +144,16 @@ class MapCube(object):
         >>> writer = Writer(fps=10, metadata=dict(artist='SunPy'), bitrate=1800)
 
         >>> ani.save('mapcube_animation.mp4', writer=writer)
+
+        Save an animation with the limb at each time step
+
+        >>> def myplot(fig, ax, map):
+        ...    p = map.draw_limb()
+        ...    return p
+        >>> cube = sunpy.Map(files, cube=True)
+        >>> ani = cube.peek(plot_function=myplot)
+        >>> plt.show()
+
         """
         if not axes:
             axes = plt.gca()

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -147,8 +147,8 @@ class MapCube(object):
 
         Save an animation with the limb at each time step
 
-        >>> def myplot(fig, ax, map):
-        ...    p = map.draw_limb()
+        >>> def myplot(fig, ax, sunpy_map):
+        ...    p = sunpy_map.draw_limb()
         ...    return p
         >>> cube = sunpy.Map(files, cube=True)
         >>> ani = cube.peek(plot_function=myplot)
@@ -269,8 +269,8 @@ class MapCube(object):
 
         Plot the map with the limb at each time step
 
-        >>> def myplot(fig, ax, map):
-        ...    p = map.draw_limb()
+        >>> def myplot(fig, ax, sunpy_map):
+        ...    p = sunpy_map.draw_limb()
         ...    return p
         >>> cube = sunpy.Map(files, cube=True)
         >>> ani = cube.peek(plot_function=myplot)

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -118,9 +118,9 @@ class MapCube(object):
             Animation interval in ms
 
         plot_function : function
-            A function to be called as each map is plotted. Any varibles
+            A function to be called as each map is plotted. Any variables
             returned from the function will have their ``remove()`` method called
-            at he start of the next frame so that they are removed from the plot.
+            at the start of the next frame so that they are removed from the plot.
 
         Examples
         --------

--- a/sunpy/visualization/mapcubeanimator.py
+++ b/sunpy/visualization/mapcubeanimator.py
@@ -50,7 +50,7 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
         self.mapcube = mapcube
         self.annotate = annotate
         self.user_plot_function = kwargs.pop('plot_function',
-                                             lambda fig, ax, map: None)
+                                             lambda fig, ax, map: [])
         # List of object to remove at the start of each plot step
         self.remove_obj = []
         slider_functions = [self.updatefig]

--- a/sunpy/visualization/mapcubeanimator.py
+++ b/sunpy/visualization/mapcubeanimator.py
@@ -35,8 +35,8 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
 
     plot_function: function
         A function to call when each map is plotted, the function must have
-        the signature `(fig, axes, map)` where fig and axes are the figure and
-        axes objects of the plot and map is the current frames Map object.
+        the signature `(fig, axes, smap)` where fig and axes are the figure and
+        axes objects of the plot and smap is the current frames Map object.
         Any objects returned from this function will have their `remove()` method
         called at the start of the next frame to clear them from the plot.
 
@@ -50,7 +50,7 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
         self.mapcube = mapcube
         self.annotate = annotate
         self.user_plot_function = kwargs.pop('plot_function',
-                                             lambda fig, ax, map: [])
+                                             lambda fig, ax, smap: [])
         # List of object to remove at the start of each plot step
         self.remove_obj = []
         slider_functions = [self.updatefig]

--- a/sunpy/visualization/mapcubeanimator.py
+++ b/sunpy/visualization/mapcubeanimator.py
@@ -34,7 +34,7 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
         Plot colorbar
 
     plot_function: function
-        A function to call when each frame is plotted, the function must have
+        A function to call when each map is plotted, the function must have
         the signature `(fig, axes, map)` where fig and axes are the figure and
         axes objects of the plot and map is the current frames Map object.
         Any objects returned from this function will have their `remove()` method


### PR DESCRIPTION
This allows the user to pass a custom plotting function to MapCubeAnimator which will be called for each animation step. It allows the following:

```python
mapc = sunpy.map.Map('/home/stuart/sunpy/data/aia_lev1_*fits', cube=True)
def my_plot(fig, ax, smap):
    l = smap.draw_grid()
    return l
mapc.peek(plot_function=my_plot)
```

Associated with this change, is something that I have wanted to do for a while but not had need to, it makes `draw_grid` and `draw_limb` return sensible things, `draw_grid` now returns in a consistent way with `pyplot.plot()` and `draw_limb` returns the patch object.

This sprung out of #1412 