### PR TITLE
Add a 'sample' keyword to apply time interval between SDO data from JSOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Latest
    x first.
  * map.rsun_arcseconds is now map.rsun_obs as it returns a quantity.
  * Map properties are now named tuples rather than dictionaries.
+ * net.jsoc can query data series with time sampling by a Sample attribute implemented in vso.
 
 0.5.0
 -----

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -3,17 +3,22 @@ from __future__ import absolute_import
 import astropy.units as u
 
 from sunpy.net.attr import (Attr, AttrWalker, AttrAnd, AttrOr)
-from sunpy.net.vso.attrs import Time, _VSOSimpleAttr
+from sunpy.net.vso.attrs import Time,Sample,_VSOSimpleAttr
 
 __all__ = ['Series', 'Protocol', 'Notify', 'Compression', 'Wavelength', 'Time',
-           'Segment']
+           'Segment','Sample']
 
 
 class Time(Time):
     """
     Time range to download
     """
-
+    
+class Sample(Sample):
+    """
+    Time interval as seconds
+    """
+    pass
 
 class Series(_VSOSimpleAttr):
     """

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -13,12 +13,6 @@ class Time(Time):
     """
     Time range to download
     """
-    
-class Sample(Sample):
-    """
-    Time interval as seconds
-    """
-    pass
 
 class Series(_VSOSimpleAttr):
     """

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -479,10 +479,15 @@ class JSOCClient(object):
         # Extract and format segment
         if segment != '':
             segment = '{{{segment}}}'.format(segment=segment)
-
-        dataset = '{series}[{start}-{end}]{wavelength}{segment}'.format(
+        
+        sample = kwargs.get('sample', '')
+        if sample:
+            sample = '@{}s'.format(sample)
+        
+        dataset = '{series}[{start}-{end}{sample}]{wavelength}{segment}'.format(
                    series=series, start=start_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
                    end=end_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
+                   sample=sample,
                    wavelength=wavelength, segment=segment)
 
         return dataset
@@ -506,6 +511,7 @@ class JSOCClient(object):
 
         dataset = self._make_recordset(start_time, end_time, series, **kwargs)
         kwargs.pop('wavelength', None)
+        kwargs.pop('sample',None)
 
         # Build full POST payload
         payload = {'ds': dataset,

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -290,7 +290,7 @@ class JSOCClient(object):
         return allstatus
 
     def get(self, jsoc_response, path=None, overwrite=False, progress=True,
-            max_conn=5, sleep=10):
+            max_conn=5, downloader=None,sleep=10):
         """
         Make the request for the data in jsoc_response and wait for it to be
         staged and then download the data.
@@ -341,7 +341,7 @@ class JSOCClient(object):
                 if u.status_code == 200 and u.json()['status'] == '0':
                     rID = requestIDs.pop(i)
                     r = self.get_request(rID, path=path, overwrite=overwrite,
-                                         progress=progress)
+                                         progress=progress,downloader=downloader)
 
                 else:
                     time.sleep(sleep)

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -470,11 +470,11 @@ class JSOCClient(object):
             if not series.startswith('aia'):
                 raise TypeError("This series does not support the wavelength attribute.")
             else:
-               if isinstance(wavelength, list):
-                   wavelength = [int(np.ceil(wave.to(u.AA).value)) for wave in wavelength]
-                   wavelength = str(wavelength)
-               else:
-                   wavelength = '[{0}]'.format(int(np.ceil(wavelength.to(u.AA).value)))
+                if isinstance(wavelength, list):
+                    wavelength = [int(np.ceil(wave.to(u.AA).value)) for wave in wavelength]
+                    wavelength = str(wavelength)
+                else:
+                    wavelength = '[{0}]'.format(int(np.ceil(wavelength.to(u.AA).value)))
 
         # Extract and format segment
         if segment != '':
@@ -482,7 +482,7 @@ class JSOCClient(object):
         
         sample = kwargs.get('sample', '')
         if sample:
-            sample = '@{}s'.format(sample)
+            sample = '@{}s'.format(sample.to(u.s).value)
         
         dataset = '{series}[{start}-{end}{sample}]{wavelength}{segment}'.format(
                    series=series, start=start_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -41,7 +41,7 @@ def test_payload():
     start = parse_time('2012/1/1T00:00:00')
     end = parse_time('2012/1/1T00:00:45')
 
-    payload = client._make_query_payload(start, end, 'hmi.M_42s', notify='@')
+    payload = client._make_query_payload(start, end, 'hmi.M_42s', notify='@',sample=90)
 
     payload_expected = {
        'ds': '{0}[{1}-{2}]'.format('hmi.M_42s',

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -136,8 +136,8 @@ def  test_empty_jsoc_response():
 
 @pytest.mark.online
 def test_query():
-    Jresp = client.query(attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
-                         attrs.Series('hmi.M_45s'))
+    Jresp = client.query(attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:01:30'),
+                         attrs.Series('hmi.M_45s'),attrs.Sample(90*u.second))
     assert isinstance(Jresp, JSOCResponse)
     assert len(Jresp) == 2
 

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -41,7 +41,7 @@ def test_payload():
     start = parse_time('2012/1/1T00:00:00')
     end = parse_time('2012/1/1T00:00:45')
 
-    payload = client._make_query_payload(start, end, 'hmi.M_42s', notify='@',sample=90)
+    payload = client._make_query_payload(start, end, 'hmi.M_42s', notify='@')
 
     payload_expected = {
        'ds': '{0}[{1}-{2}]'.format('hmi.M_42s',

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -198,7 +198,7 @@ class Sample(_VSOSimpleAttr):
     """
     @u.quantity_input(value=u.s)
     def __init__(self, value):
-        super(Sample,self).__init__(self,value)
+        super(Sample,self).__init__(value)
 
 
 class Quicklook(_VSOSimpleAttr):

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -193,7 +193,12 @@ class Filter(_VSOSimpleAttr):
 
 
 class Sample(_VSOSimpleAttr):
-    pass
+    """
+    Time interval for data sampling
+    """
+    @u.quantity_input(value=u.s)
+    def __init__(self, value):
+        super(Sample,self).__init__(self,value)
 
 
 class Quicklook(_VSOSimpleAttr):


### PR DESCRIPTION
From #1421 

The hash of last commit was changed after a cherry-picking, so #1421 was automatically closed.

This commit reflects suggestions of @Cadair. I didn't recognize the Sample class in VSO.

Now the sample class has a input as only seconds.
The class may be enhanced by parsing time period string like 00h, 00m, and 00s.

Thanks many helps,
Jongyeob



