### PR TITLE
Fixes a regression bug on masked map data plotting

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1283,7 +1283,10 @@ scale:\t\t [{dx}, {dy}]
         kwargs = self._mpl_imshow_kwargs(axes, cmap)
         kwargs.update(imshow_args)
 
-        ret = axes.imshow(self.data, **kwargs)
+        if self.mask is None:
+            ret = axes.imshow(self.data, **kwargs)
+        else:
+            ret = axes.imshow(np.ma.array(np.asarray(self.data), mask=self.mask), **kwargs)
 
         if wcsaxes_compat.is_wcsaxes(axes):
             wcsaxes_compat.default_wcs_grid(axes)
@@ -1297,17 +1300,17 @@ scale:\t\t [{dx}, {dy}]
         Return the keyword arguments for imshow to display this map
         """
         if wcsaxes_compat.is_wcsaxes(axes):
-            kwargs = {'cmap':cmap,
+            kwargs = {'cmap': cmap,
                       'origin': 'lower',
-                      'norm':self.mpl_color_normalizer,
-                      'interpolation':'nearest'}
+                      'norm': self.mpl_color_normalizer,
+                      'interpolation': 'nearest'}
         else:
             # make imshow kwargs a dict
-            kwargs = {'origin':'lower',
-                      'cmap':cmap,
-                      'norm':self.mpl_color_normalizer,
-                      'extent':list(self.xrange.value) + list(self.yrange.value),
-                      'interpolation':'nearest'}
+            kwargs = {'origin': 'lower',
+                      'cmap': cmap,
+                      'norm': self.mpl_color_normalizer,
+                      'extent': list(self.xrange.value) + list(self.yrange.value),
+                      'interpolation': 'nearest'}
 
         return kwargs
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -412,3 +412,13 @@ def test_rotate_invalid_order(generic_map):
 @figure_test
 def test_plot_aia171(aia171_test_map):
     aia171_test_map.plot()
+
+
+@figure_test
+def test_plot_masked_aia171(aia171_test_map):
+    shape = aia171_test_map.shape
+    mask = np.zeros_like(aia171_test_map.data, dtype=bool)
+    mask[0:shape[0]/2, 0:shape[1]/2] = True
+    masked_map = sunpy.map.Map(np.ma.array(aia171_test_map.data, mask=mask), aia171_test_map.meta)
+    masked_map.plot()
+

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -416,7 +416,7 @@ def test_plot_aia171(aia171_test_map):
 
 @figure_test
 def test_plot_masked_aia171(aia171_test_map):
-    shape = aia171_test_map.shape
+    shape = aia171_test_map.data.shape
     mask = np.zeros_like(aia171_test_map.data, dtype=bool)
     mask[0:shape[0]/2, 0:shape[1]/2] = True
     masked_map = sunpy.map.Map(np.ma.array(aia171_test_map.data, mask=mask), aia171_test_map.meta)

--- a/sunpy/tests/figure_hashes.json
+++ b/sunpy/tests/figure_hashes.json
@@ -1,3 +1,4 @@
 {
-    "sunpy.map.tests.test_mapbase.test_plot_aia171": "62b5b9fc1a423e3cbeeea85d3b8daf1a7877099fdeda2ce9352746be1dd451fc"
+    "sunpy.map.tests.test_mapbase.test_plot_aia171": "62b5b9fc1a423e3cbeeea85d3b8daf1a7877099fdeda2ce9352746be1dd451fc",
+    "sunpy.map.tests.test_mapbase.test_plot_masked_aia171": "d70f0e5797fc864498e0bed5326afdba1e6400aa8c7aa81729f33007b4663157"
 }


### PR DESCRIPTION
Somehow the fix #1392 regressed in master, so I'm putting it back.  The fix makes map.plot respect masked data.