### PR TITLE
Move import absolute_import to setup_package in the io module

### DIFF
--- a/sunpy/io/__init__.py
+++ b/sunpy/io/__init__.py
@@ -1,4 +1,3 @@
 """File input and output functions"""
-from __future__ import absolute_import
 
 from sunpy.io.file_tools import *

--- a/sunpy/io/ana.py
+++ b/sunpy/io/ana.py
@@ -16,7 +16,6 @@ Created by Tim van Werkhoven (t.i.m.vanwerkhoven@gmail.com) on 2009-02-11.
 Copyright (c) 2009--2011 Tim van Werkhoven.
 """
 
-from __future__ import absolute_import
 import os
 
 try:

--- a/sunpy/io/file_tools.py
+++ b/sunpy/io/file_tools.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 import os
 

--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -30,8 +30,6 @@ References
 | http://stsdas.stsci.edu/download/wikidocs/The_PyFITS_Handbook.pdf
 
 """
-from __future__ import absolute_import
-
 import os
 import re
 import itertools

--- a/sunpy/io/header.py
+++ b/sunpy/io/header.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 from collections import OrderedDict
 
 __all__ = ['FileHeader']

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -1,5 +1,4 @@
 """JPEG 2000 File Reader"""
-from __future__ import absolute_import
 
 __author__ = "Keith Hughitt"
 __email__ = "keith.hughitt@nasa.gov"

--- a/sunpy/io/setup_package.py
+++ b/sunpy/io/setup_package.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import platform
 


### PR DESCRIPTION
I got the usual ``RuntimeWarning``, thus moved the ``from __future__ import absolute_import`` to the setup_package, and removed it from the individual files in the ``sunpy.io`` module.

```
sunpy/io/setup_package.py:1: RuntimeWarning: Parent module 'sunpy.io' not found while handling absolute import
  import os
sunpy/io/setup_package.py:2: RuntimeWarning: Parent module 'sunpy.io' not found while handling absolute import
  import platform
sunpy/io/setup_package.py:4: RuntimeWarning: Parent module 'sunpy.io' not found while handling absolute import
  from distutils.core import Extension
sunpy/io/setup_package.py:5: RuntimeWarning: Parent module 'sunpy.io' not found while handling absolute import
  from glob import glob
sunpy/io/setup_package.py:7: RuntimeWarning: Parent module 'sunpy.io' not found while handling absolute import
  from astropy_helpers import setup_helpers
sunpy/io/setup_package.py:8: RuntimeWarning: Parent module 'sunpy.io' not found while handling absolute import
  from astropy.extern import six
```