### PR TITLE
Add overwrite option to sample download to avoid unnecessary downloads

### DIFF
--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -43,7 +43,7 @@ for key in _files:
     sample_files[key] = os.path.abspath(os.path.join(sampledata_dir, _files[key][0]))
 
 
-def download_sample_data(progress=True):
+def download_sample_data(progress=True, overwrite=True):
     """
     Download the sample data.
 
@@ -51,6 +51,8 @@ def download_sample_data(progress=True):
     ----------
     progress: bool
         Show a progress bar during download
+    overwrite: bool
+        If exist overwrites the downloaded sample data.
 
     Returns
     -------
@@ -59,6 +61,12 @@ def download_sample_data(progress=True):
     number_of_files_fetched = 0
     print("Downloading sample files to " + sampledata_dir)
     for file_name in _files.itervalues():
+        if not overwrite:
+            if os.path.isfile(os.path.join(sampledata_dir,
+                                           file_name[0])):
+                number_of_files_fetched += 1
+                continue
+
         for base_url in _base_urls:
             full_file_name = file_name[0] + file_name[1]
             if url_exists(os.path.join(base_url, full_file_name)):


### PR DESCRIPTION
Yesterday I tried to run tests and doctests (and was shocked how many were failing, and thus fixed a few in a separate PR) and it was a bit annoying that ``download_sample_data()`` didn't check whether the files had already been downloaded and it was always downloading all of them again.

This PR adds an overwrite option, set to True to keep the original behaviour.