### PR TITLE
adding sort argument to display_entries to avoid doctest failures

### DIFF
--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -579,7 +579,7 @@ def entries_from_dir(fitsdir, recursive=False, pattern='*',
             break
 
 
-def display_entries(database_entries, columns):
+def display_entries(database_entries, columns, sort=False):
     """Generate a table to display the database entries.
 
     Parameters
@@ -590,6 +590,9 @@ def display_entries(database_entries, columns):
     columns : iterable of str
         The columns that will be displayed in the resulting table. Possible
         values for the strings are all attributes of :class:`DatabaseEntry`.
+
+    sort : bool (optional)
+        If True, sorts the entries before displaying them.
 
     Returns
     -------
@@ -626,4 +629,6 @@ def display_entries(database_entries, columns):
         data.append(row)
     if not data:
         raise TypeError('given iterable is empty')
+    if sort:
+        data.sort()
     return print_table(header + rulers + data)


### PR DESCRIPTION
Fixing some of the doctests in the database examples are difficult as it contains results from DB queries and thus the order of them may change between consecutive doctest runs. This PR adds a ``sort`` option to ``display_entries()``.