### PR TITLE
make the queryreposonse repr test less specific.

### DIFF
--- a/sunpy/net/tests/test_vso.py
+++ b/sunpy/net/tests/test_vso.py
@@ -207,5 +207,4 @@ def test_str():
 
 def test_repr():
     qr = QueryResponse([])
-    assert repr(qr) in ('<Table masked=False length=0>\nStart Time End Time  Source Instrument   Type \n float64   float64  float64  float64   float64\n---------- -------- ------- ---------- -------', # astropy >1.0
-                        "<Table rows=0 names=('Start Time','End Time','Source','Instrument','Type')>\narray([], \n      dtype=[('Start Time', '<f8'), ('End Time', '<f8'), ('Source', '<f8'), ('Instrument', '<f8'), ('Type', '<f8')])") # astropy 0.4.x
+    assert "Start Time End Time  Source Instrument   Type" in repr(qr)


### PR DESCRIPTION
Astropy keeps iterating on the table repr, so this just checks to see if
the header values are in the repr. This will fix the astropy-dev travis
build.