### PR TITLE
fix submap so that it works for HMI images.

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -934,8 +934,14 @@ scale:\t\t [{dx}, {dy}]
             raise ValueError(
                 "Invalid unit. Must be one of 'data' or 'pixels'")
 
+
+        # Sort the pixel values so we are always slicing in the correct direction
+        x_pixels.sort()
+        y_pixels.sort()
+
         x_pixels = np.array(x_pixels)
         y_pixels = np.array(y_pixels)
+
         # Clip pixel values to max of array, prevents negative
         # indexing
         x_pixels[np.less(x_pixels, 0)] = 0


### PR DESCRIPTION
HMI images are upside down, which leads to the wcs giving the submap
pixel coords in the wrong order, this fixes it.