### PR TITLE
Added new url for sample data

### DIFF
--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -22,7 +22,8 @@ sampledata_dir = config.get("downloads", "sample_dir")
 # urls to search for the sample data
 _base_urls = (
     'http://data.sunpy.org/sample-data/',
-    'http://hesperia.gsfc.nasa.gov/~schriste/sunpy-sample-data/')
+    'http://hesperia.gsfc.nasa.gov/~schriste/sunpy-sample-data/',
+    'https://github.com/ehsteve/sunpy-sample-data/raw/master/')
 
 # keys are file shortcuts
 # values consist of filename as well as optional file extension if files are


### PR DESCRIPTION
Recently got early access to github’s new large file tracking system (see https://github.com/github/git-lfs) so I added the sample files to a new github repo (see https://github.com/ehsteve/sunpy-sample-data). Once this rolls out across all of github we can move this repo to SunPy.