### PR TITLE
Opting in the container based Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,21 @@ os:
     - linux
     - osx
 
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
+# The apt packages below are needed but can no longer be installed with
+# sudo apt-get.
+addons:
+    apt:
+        packages:
+            - libatlas-dev
+            - liblapack-dev
+            - gfortran
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
+
 # These are currently not used, but we want to cache the packages dir
 # to reduce the number of packages to download.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ addons:
 
 # These are currently not used, but we want to cache the packages dir
 # to reduce the number of packages to download.
-cache:
-    directories:
-       - $HOME/miniconda/pkgs
-       - $HOME/miniconda3/pkgs
+# cache:
+#    directories:
+#       - $HOME/miniconda/pkgs
+#       - $HOME/miniconda3/pkgs
 
 # Configure the build environment. Global varibles are defined for all configurations.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ addons:
 # to reduce the number of packages to download.
 cache:
     directories:
-        $HOME/miniconda/pkgs
-        /Users/travis/miniconda3/pkgs
+       - $HOME/miniconda/pkgs
+       - $HOME/miniconda3/pkgs
 
 # Configure the build environment. Global varibles are defined for all configurations.
 env:

--- a/continuous-integration/travis/install_linux.sh
+++ b/continuous-integration/travis/install_linux.sh
@@ -15,9 +15,9 @@ tar xvzf openjpeg-1.5.0-Linux-x86_64.tar.gz --strip-components=1
 MINICONDA_URL="http://repo.continuum.io/miniconda"
 MINICONDA_FILE="Miniconda-3.5.5-Linux-x86_64.sh"
 wget "${MINICONDA_URL}/${MINICONDA_FILE}"
-bash $MINICONDA_FILE -b -f
+bash $MINICONDA_FILE -b
 
-export PATH=/home/travis/miniconda/bin:$PATH
+export PATH=$HOME/miniconda/bin:$PATH
 
 conda update --yes conda
 conda install -q --yes binstar conda-build

--- a/continuous-integration/travis/install_linux.sh
+++ b/continuous-integration/travis/install_linux.sh
@@ -7,7 +7,8 @@
 
 # Install more upto date openjpeg library.
 wget http://openjpeg.googlecode.com/files/openjpeg-1.5.0-Linux-x86_64.tar.gz
-tar xvzf openjpeg-1.5.0-Linux-x86_64.tar.gz --strip-components=1
+tar xvzf openjpeg-1.5.0-Linux-x86_64.tar.gz
+export PATH=$HOME/openjpeg-1.5.0-Linux-x86_64:$PATH
 
 ###############################################################################
 # Install miniconda

--- a/continuous-integration/travis/install_linux.sh
+++ b/continuous-integration/travis/install_linux.sh
@@ -7,8 +7,8 @@
 
 # Install more upto date openjpeg library.
 wget http://openjpeg.googlecode.com/files/openjpeg-1.5.0-Linux-x86_64.tar.gz
-tar xvzf openjpeg-1.5.0-Linux-x86_64.tar.gz
-export PATH=$HOME/openjpeg-1.5.0-Linux-x86_64:$PATH
+tar xvzf openjpeg-1.5.0-Linux-x86_64.tar.gz --strip-components=1
+export PATH=$HOME:$PATH
 
 ###############################################################################
 # Install miniconda

--- a/continuous-integration/travis/install_linux.sh
+++ b/continuous-integration/travis/install_linux.sh
@@ -10,6 +10,9 @@ wget http://openjpeg.googlecode.com/files/openjpeg-1.5.0-Linux-x86_64.tar.gz
 tar xvzf openjpeg-1.5.0-Linux-x86_64.tar.gz --strip-components=1
 export PATH=$HOME:$PATH
 
+export LIBRARY_PATH=$(pwd)/lib
+export LD_LIBRARY_PATH=$(pwd)/lib
+
 ###############################################################################
 # Install miniconda
 ###############################################################################

--- a/continuous-integration/travis/install_linux.sh
+++ b/continuous-integration/travis/install_linux.sh
@@ -1,9 +1,9 @@
 ###############################################################################
 # Install Linux Packages
 ###############################################################################
-sudo apt-get -y update
-sudo apt-get -yqq install libatlas-dev liblapack-dev gfortran
-if [[ $TEST_MODE == 'sphinx' ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
+
+# Installation of non-Python dependencies that are in the travis approved
+# packages list is now in .travis.yml
 
 # Install more upto date openjpeg library.
 wget http://openjpeg.googlecode.com/files/openjpeg-1.5.0-Linux-x86_64.tar.gz

--- a/continuous-integration/travis/install_linux.sh
+++ b/continuous-integration/travis/install_linux.sh
@@ -15,7 +15,7 @@ tar xvzf openjpeg-1.5.0-Linux-x86_64.tar.gz --strip-components=1
 MINICONDA_URL="http://repo.continuum.io/miniconda"
 MINICONDA_FILE="Miniconda-3.5.5-Linux-x86_64.sh"
 wget "${MINICONDA_URL}/${MINICONDA_FILE}"
-bash $MINICONDA_FILE -b
+bash $MINICONDA_FILE -b -f
 
 export PATH=/home/travis/miniconda/bin:$PATH
 

--- a/continuous-integration/travis/install_linux.sh
+++ b/continuous-integration/travis/install_linux.sh
@@ -7,7 +7,7 @@
 
 # Install more upto date openjpeg library.
 wget http://openjpeg.googlecode.com/files/openjpeg-1.5.0-Linux-x86_64.tar.gz
-sudo tar -xvf openjpeg-1.5.0-Linux-x86_64.tar.gz --strip-components=1 -C /
+tar xvzf openjpeg-1.5.0-Linux-x86_64.tar.gz --strip-components=1
 
 ###############################################################################
 # Install miniconda
@@ -17,7 +17,7 @@ MINICONDA_FILE="Miniconda-3.5.5-Linux-x86_64.sh"
 wget "${MINICONDA_URL}/${MINICONDA_FILE}"
 bash $MINICONDA_FILE -b
 
-export PATH=$HOME/miniconda/bin:$PATH
+export PATH=/home/travis/miniconda/bin:$PATH
 
 conda update --yes conda
 conda install -q --yes binstar conda-build


### PR DESCRIPTION
This is to address #1494. 
However installing the ``openjpeg`` dependency still requires ``sudo`` as that is not in the travis apt package list. Thus this needs a workaround.