### PR TITLE
Add a coordinate type check when plotting the wcsaxes grid

### DIFF
--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -84,6 +84,11 @@ def default_wcs_grid(axes):
     x.set_ticks_position('bl')
     y.set_ticks_position('bl')
 
+    if x.coord_type != 'longitude':
+        x.set_coord_type('longitude', coord_wrap=180.)
+    if y.coord_type != 'latitude':
+        y.set_coord_type('latitude')
+
     x.set_major_formatter('s.s')
     y.set_major_formatter('s.s')
 


### PR DESCRIPTION
This will fix #1478 as long as you have a version of wcsaxes that has the patch from astrofrog/wcsaxes#171.