### PR TITLE
MapCube Plotting BugFixes

### DIFF
--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -161,6 +161,7 @@ class MapCube(object):
 
         """
         if not axes:
+            #axes = wcsaxes_helpers.gca_wcs(self.maps[0].wcs)
             axes = plt.gca()
         fig = axes.get_figure()
 
@@ -201,8 +202,8 @@ class MapCube(object):
             while removes:
                 removes.pop(0).remove()
             im.set_array(ani_data[i].data)
-            im.set_cmap(self.maps[i].cmap)
-            im.set_norm(self.maps[i].mpl_color_normalizer)
+            im.set_cmap(self.maps[i].plot_settings['cmap'])
+            im.set_norm(self.maps[i].plot_settings['norm'])
             im.set_extent(np.concatenate((self.maps[i].xrange.value, self.maps[i].yrange.value)))
             if annotate:
                 annotate_frame(i)

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -201,14 +201,12 @@ class MapCube(object):
             while removes:
                 removes.pop(0).remove()
 
-            if wcsaxes_compat.is_wcsaxes(im.axes):
-                im.axes.reset_wcs(self.maps[i].wcs)
-
             im.set_array(ani_data[i].data)
             im.set_cmap(self.maps[i].plot_settings['cmap'])
             im.set_norm(self.maps[i].plot_settings['norm'])
 
             if wcsaxes_compat.is_wcsaxes(axes):
+                im.axes.reset_wcs(self.maps[i].wcs)
                 wcsaxes_compat.default_wcs_grid(axes)
             else:
                 im.set_extent(np.concatenate((self.maps[i].xrange.value,

--- a/sunpy/visualization/mapcubeanimator.py
+++ b/sunpy/visualization/mapcubeanimator.py
@@ -2,7 +2,8 @@
 
 __all__ = ['MapCubeAnimator']
 
-from sunpy.visualization import imageanimator
+from sunpy.visualization import imageanimator, wcsaxes_compat
+from sunpy.visualization.wcsaxes_compat import HAVE_WCSAXES, FORCE_NO_WCSAXES
 
 class MapCubeAnimator(imageanimator.BaseFuncAnimator):
     """
@@ -72,6 +73,10 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
         im.set_array(self.data[i].data)
         im.set_cmap(self.mapcube[i].plot_settings['cmap'])
         im.set_norm(self.mapcube[i].plot_settings['norm'])
+        if wcsaxes_compat.is_wcsaxes(im.axes):
+            im.axes.reset_wcs(self.mapcube[i].wcs)
+            wcsaxes_compat.default_wcs_grid(im.axes)
+
         # Having this line in means the plot will resize for non-homogenous
         # maps. However it also means that if you zoom in on the plot bad
         # things happen.
@@ -104,6 +109,15 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
 
         self.axes.set_xlabel(xlabel)
         self.axes.set_ylabel(ylabel)
+
+    def _get_main_axes(self):
+        """
+        Create an axes which is wcsaxes if we have that...
+        """
+        if HAVE_WCSAXES and not FORCE_NO_WCSAXES:
+            return self.fig.add_subplot(111, projection=self.mapcube[0].wcs)
+        else:
+            return self.fig.add_subplot(111)
 
     def plot_start_image(self, ax):
         im = self.mapcube[0].plot(annotate=self.annotate, axes=ax,


### PR DESCRIPTION
This fixes a bug in mapcube.plot which was that it had not been updated since the `plot_settings` dictionary had been introduced.

Also this pulls `mapcube.plot` up to using wcsaxes by default (same as map.plot).