### PR TITLE
Removed findpeaks from SunPy

### DIFF
--- a/sunpy/util/tests/test_util.py
+++ b/sunpy/util/tests/test_util.py
@@ -56,14 +56,6 @@ def test_print_table():
                '3|1.732  |9  ')
     assert util.print_table(lst, colsep='|') == expected
 
-def test_findpeaks():
-    """
-    This should return the indices of the local maxima of numpy array
-    data (relative to index 1).
-    """
-    data = np.array([1.0, 3.5, 3.0, 4.0, -9.0, 0.0, 0.5, 0.3, 9.5])
-    assert np.array_equal(util.findpeaks(data), np.array([0, 2, 5]))
-
 def test_polyfun_at():
     """
     This should evaluate the polynomial x^3 + 5x^2 - 6x + 3 at x = 5.

--- a/sunpy/util/util.py
+++ b/sunpy/util/util.py
@@ -124,23 +124,6 @@ def print_table(lst, colsep=' ', linesep='\n'):
     )
 
 
-def findpeaks(a):
-    """Find local maxima in 1D. Use findpeaks(-a) for minima.
-
-    Parameters
-    ----------
-    a : `~numpy.ndarray`
-        a one dimensional `~numpy.ndarray` array.
-
-    Returns
-    -------
-    `~numpy.ndarray`
-        indices of all the local maxima
-
-    """
-    return np.nonzero((a[1:-1] > a[:-2]) & (a[1:-1] > a[2:]))[0]
-
-
 def polyfun_at(coeff, p):
     """ Return value of polynomial with coefficients (highest first) at
     point (can also be an np.ndarray for more than one point) p.


### PR DESCRIPTION
The function findpeaks occurs in two places in SunPy.  The first place is its definition in util/util.py.  The second place is its test util/tests/test_util.py.  It is not used in any other place in SunPy.  Also, although the findpeaks passes its test, it does not work correctly in that it does not identify the index of the local peaks.  This PR removes findpeaks from SunPy since (a) it is not used by SunPy, and (b) it is wrong.  This PR is a reply to #1511.