### PR TITLE
Fix apply shift function for mapcubes

### DIFF
--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -371,8 +371,7 @@ def apply_shifts(mc, yshift, xshift, clip=True):
         A `~sunpy.map.MapCube` of the same shape as the input.  All layers in
         the `~sunpy.map.MapCube` have been shifted according the input shifts.
     """
-
-    # new mapcube will be constructed from this list
+    # New mapcube will be constructed from this list
     new_mc = []
 
     # Calculate the clipping
@@ -389,9 +388,8 @@ def apply_shifts(mc, yshift, xshift, clip=True):
             shifted_data = clip_edges(shifted_data, yclips, xclips)
             new_meta['naxis1'] = shifted_data.shape[1]
             new_meta['naxis2'] = shifted_data.shape[0]
-            #print i, new_meta['crpix1'], new_meta['crpix2'], xshift[i].value, yshift[i].value, np.mean(m.data)
-            new_meta['crval1'] = new_meta['crval1'] - xshift[i].value * m.scale.x.value
-            new_meta['crval2'] = new_meta['crval2'] - yshift[i].value * m.scale.y.value
+            new_meta['crpix1'] = m.reference_pixel.x.value + xshift[i].value - xshift[0].value
+            new_meta['crpix2'] = m.reference_pixel.y.value + yshift[i].value - yshift[0].value
 
         new_map = sunpy.map.Map(shifted_data, new_meta)
 

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -584,4 +584,4 @@ def mapcube_coalign_by_match_template(mc, template=None, layer_index=0,
         yshift_keep[i] = (yshift_arcseconds[i] / m.scale.y)
 
     # Apply the shifts and return the coaligned mapcube
-    return apply_shifts(mc, yshift_keep, xshift_keep, clip=clip)
+    return apply_shifts(mc, -yshift_keep, -xshift_keep, clip=clip)

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -260,6 +260,9 @@ def test_mapcube_coalign_by_match_template(aia171_test_mc,
     assert(test_mc[0].data.shape == (ny - number_of_pixels_clipped[0].value, nx - number_of_pixels_clipped[1].value))
     assert(test_mc[1].data.shape == (ny - number_of_pixels_clipped[0].value, nx - number_of_pixels_clipped[1].value))
 
+    # Test that the reference pixels of each map in the coaligned mapcube is
+    # correct
+    assert(False)
 
 def test_apply_shifts(aia171_test_map):
     # take two copies of the AIA image and create a test mapcube.

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -110,12 +110,12 @@ def test_get_correlation_shifts():
     # Input array is too big in either direction
     test_array = np.zeros((4, 3))
     y_test, x_test = get_correlation_shifts(test_array)
-    assert(y_test == None)
-    assert(x_test == None)
+    assert(y_test is None)
+    assert(x_test is None)
     test_array = np.zeros((3, 4))
     y_test, x_test = get_correlation_shifts(test_array)
-    assert(y_test == None)
-    assert(x_test == None)
+    assert(y_test is None)
+    assert(x_test is None)
 
 
 def test_find_best_match_location(aia171_test_map_layer, aia171_test_template,
@@ -201,13 +201,13 @@ def test_calculate_match_template_shift(aia171_test_mc,
     template_ndarray = aia171_test_map_layer[ny / 4: 3 * ny / 4, nx / 4: 3 * nx / 4]
     test_displacements = calculate_match_template_shift(aia171_test_mc, template=template_ndarray)
     assert_allclose(test_displacements['x'], aia171_mc_arcsec_displacements['x'], rtol=5e-2, atol=0)
-    assert_allclose(test_displacements['y'], aia171_mc_arcsec_displacements['y'], rtol=5e-2, atol=0 )
+    assert_allclose(test_displacements['y'], aia171_mc_arcsec_displacements['y'], rtol=5e-2, atol=0)
 
     # Test setting the template as GenericMap
     submap = aia171_test_map.submap([nx / 4, 3 * nx / 4]*u.pix, [ny / 4, 3 * ny / 4]*u.pix)
     test_displacements = calculate_match_template_shift(aia171_test_mc, template=submap)
     assert_allclose(test_displacements['x'], aia171_mc_arcsec_displacements['x'], rtol=5e-2, atol=0)
-    assert_allclose(test_displacements['y'], aia171_mc_arcsec_displacements['y'], rtol=5e-2, atol=0 )
+    assert_allclose(test_displacements['y'], aia171_mc_arcsec_displacements['y'], rtol=5e-2, atol=0)
 
     # Test setting the template as something other than a ndarray and a
     # GenericMap.  This should throw a ValueError.
@@ -221,7 +221,7 @@ def test_mapcube_coalign_by_match_template(aia171_test_mc,
     ny = aia171_test_map_layer_shape[0]
     nx = aia171_test_map_layer_shape[1]
 
-    # Get the test displacements
+    # Get the calculated test displacements
     test_displacements = calculate_match_template_shift(aia171_test_mc)
 
     # Test passing in displacements
@@ -260,9 +260,13 @@ def test_mapcube_coalign_by_match_template(aia171_test_mc,
     assert(test_mc[0].data.shape == (ny - number_of_pixels_clipped[0].value, nx - number_of_pixels_clipped[1].value))
     assert(test_mc[1].data.shape == (ny - number_of_pixels_clipped[0].value, nx - number_of_pixels_clipped[1].value))
 
-    # Test that the reference pixels of each map in the coaligned mapcube is
-    # correct
-    assert(False)
+    # Test that the reference pixel of each map in the coaligned mapcube is
+    # correct.
+    for im, m in enumerate(aia171_test_mc):
+        for i_s, s in enumerate(['x', 'y']):
+            assert_allclose(aia171_test_mc[im].reference_pixel[i_s] - test_mc[im].reference_pixel[i_s],
+                            test_displacements[s][im] / m.scale[i_s],
+                            rtol=5e-2, atol=0)
 
 def test_apply_shifts(aia171_test_map):
     # take two copies of the AIA image and create a test mapcube.

--- a/sunpy/physics/transforms/solar_rotation.py
+++ b/sunpy/physics/transforms/solar_rotation.py
@@ -131,12 +131,9 @@ def mapcube_solar_derotate(mc, layer_index=0, clip=True, shift=None, **kwargs):
     # If no shifts are passed in, calculate them.  Otherwise,
     # use the shifts passed in.
     if shift is None:
-        shifts = calculate_solar_rotate_shift(mc, layer_index=layer_index, **kwargs)
-        xshift_arcseconds = shifts['x']
-        yshift_arcseconds = shifts['y']
-    else:
-        xshift_arcseconds = shift[0]
-        yshift_arcseconds = shift[1]
+        shift = calculate_solar_rotate_shift(mc, layer_index=layer_index, **kwargs)
+    xshift_arcseconds = shift['x']
+    yshift_arcseconds = shift['y']
 
     # Calculate the pixel shifts
     for i, m in enumerate(mc):
@@ -144,4 +141,4 @@ def mapcube_solar_derotate(mc, layer_index=0, clip=True, shift=None, **kwargs):
         yshift_keep[i] = yshift_arcseconds[i] / m.scale.y
 
     # Apply the pixel shifts and return the mapcube
-    return apply_shifts(mc, yshift_keep, xshift_keep , clip=clip)
+    return apply_shifts(mc, yshift_keep, xshift_keep, clip=clip)

--- a/sunpy/physics/transforms/tests/test_solar_rotation.py
+++ b/sunpy/physics/transforms/tests/test_solar_rotation.py
@@ -74,14 +74,16 @@ def test_mapcube_solar_derotate(aia171_test_mapcube, aia171_test_submap):
     for m in tmc:
         assert(m.data.shape == aia171_test_submap.data.shape)
 
-    # Test that the returned centers are correctly displaced.
+    # Test that the returned reference pixels are correctly displaced.
     tmc = mapcube_solar_derotate(aia171_test_mapcube, clip=True)
-    tshift = calculate_solar_rotate_shift(aia171_test_mapcube)
-    print tshift
+    tshift = calculate_solar_rotate_shift(aia171_test_mapcube, layer_index=1)
     for im, m in enumerate(tmc):
         for i_s, s in enumerate(['x', 'y']):
-            print im, i_s, s, m.center[i_s], aia171_test_submap.center[i_s], tshift[s][im]
-            #assert_allclose(m.center[i_s], aia171_test_submap.center[i_s] + tshift[s][im], rtol=5e-2, atol=0)
+            assert_allclose(m.reference_pixel[i_s],
+                            aia171_test_submap.reference_pixel[i_s] +
+                            tshift[s][im] / m.scale[i_s] -
+                            tshift[s][0] / m.scale[i_s],
+                            rtol=5e-2, atol=0)
 
     # Test that a mapcube is returned on default clipping (clipping is True)
     tmc = mapcube_solar_derotate(aia171_test_mapcube)
@@ -91,4 +93,3 @@ def test_mapcube_solar_derotate(aia171_test_mapcube, aia171_test_submap):
     clipped_shape = (24, 20)
     for m in tmc:
         assert(m.data.shape == clipped_shape)
-    assert(False)

--- a/sunpy/physics/transforms/tests/test_solar_rotation.py
+++ b/sunpy/physics/transforms/tests/test_solar_rotation.py
@@ -75,11 +75,13 @@ def test_mapcube_solar_derotate(aia171_test_mapcube, aia171_test_submap):
         assert(m.data.shape == aia171_test_submap.data.shape)
 
     # Test that the returned centers are correctly displaced.
+    tmc = mapcube_solar_derotate(aia171_test_mapcube, clip=True)
     tshift = calculate_solar_rotate_shift(aia171_test_mapcube)
+    print tshift
     for im, m in enumerate(tmc):
         for i_s, s in enumerate(['x', 'y']):
-            assert_allclose(m.center[i_s], aia171_test_submap.center[i_s] -
-                            tshift[s][im], rtol=5e-2, atol=0)
+            print im, i_s, s, m.center[i_s], aia171_test_submap.center[i_s], tshift[s][im]
+            #assert_allclose(m.center[i_s], aia171_test_submap.center[i_s] + tshift[s][im], rtol=5e-2, atol=0)
 
     # Test that a mapcube is returned on default clipping (clipping is True)
     tmc = mapcube_solar_derotate(aia171_test_mapcube)
@@ -89,9 +91,4 @@ def test_mapcube_solar_derotate(aia171_test_mapcube, aia171_test_submap):
     clipped_shape = (24, 20)
     for m in tmc:
         assert(m.data.shape == clipped_shape)
-
-
-
-
-
-
+    assert(False)


### PR DESCRIPTION
Fixes #1533.  See that issue for a full description of the problem.

This PR produces maps that have the correct positioning information when using mapcube_coalign_by_match_template and mapcube_solar_derotate, both of which use the apply_shifts function.

