### PR TITLE
submap now respects the mask property

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1031,6 +1031,9 @@ scale:\t\t {scale}
 
         # Create new map instance
         new_map.data = new_data
+        if self.mask is not None:
+            new_map.mask = self.mask[yslice, xslice].copy()
+
         return new_map
 
     @u.quantity_input(dimensions=u.pixel)


### PR DESCRIPTION
The submap method did not respect the mask property.  This PR implements the submapping of the mask when present.