### PR TITLE
Fixed MapCube animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Latest
 
 * Added IRIS SJI color maps.
 * Updated `show_colormaps()` with new string filter to show a subset of color maps.
+* Fixed MapCube animations by working around a bug in Astropy's ImageNormalize
 
 0.6.0
 -----

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import
 #pylint: disable=W0401,W0614,W0201,W0212,W0404
 
+from copy import deepcopy
+
 import numpy as np
 import matplotlib.animation
 
@@ -203,7 +205,11 @@ class MapCube(object):
 
             im.set_array(ani_data[i].data)
             im.set_cmap(self.maps[i].plot_settings['cmap'])
-            im.set_norm(self.maps[i].plot_settings['norm'])
+
+            norm = deepcopy(self.maps[i].plot_settings['norm'])
+            # The following explicit call is for bugged versions of Astropy's ImageNormalize
+            norm.autoscale_None(ani_data[i].data)
+            im.set_norm(norm)
 
             if wcsaxes_compat.is_wcsaxes(axes):
                 im.axes.reset_wcs(self.maps[i].wcs)

--- a/sunpy/visualization/mapcubeanimator.py
+++ b/sunpy/visualization/mapcubeanimator.py
@@ -2,6 +2,8 @@
 
 __all__ = ['MapCubeAnimator']
 
+from copy import deepcopy
+
 from sunpy.visualization import imageanimator, wcsaxes_compat
 from sunpy.visualization.wcsaxes_compat import HAVE_WCSAXES, FORCE_NO_WCSAXES
 
@@ -88,7 +90,12 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
         i = int(val)
         im.set_array(self.data[i].data)
         im.set_cmap(self.mapcube[i].plot_settings['cmap'])
-        im.set_norm(self.mapcube[i].plot_settings['norm'])
+
+        norm = deepcopy(self.mapcube[i].plot_settings['norm'])
+        # The following explicit call is for bugged versions of Astropy's ImageNormalize
+        norm.autoscale_None(self.data[i].data)
+        im.set_norm(norm)
+
         if wcsaxes_compat.is_wcsaxes(im.axes):
             im.axes.reset_wcs(self.mapcube[i].wcs)
             wcsaxes_compat.default_wcs_grid(im.axes)


### PR DESCRIPTION
Fixes #1532: the broken MapCube animations when using maps with Astropy's normalizers.  The underlying issue is actually a bug in Astropy (yet to be reported), but even after that bug is fixed, I think it would still be good to have this explicit call to `autoscale_None()` as a protective measure.