### PR TITLE
Update CONTRIBUTING about PRs to non-master branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,11 @@ For the code to be accepted into SunPy it must meet the following criteria:
 * Contain an entry in the CHANGELOG.md file.
 * Be approved by at least two SunPy contributors.
 
+
+## Pull Requests to non-master Branches
+
+From time to time, large feature development work may occur in branches other than master, and all maintained releases currently have a branch i.e. `0.6`. When making a PR to one of these branches, please put the name of the branch in square brackets at the beginning of the PR, i.e. `[0.6] My bug fix`. This makes it easier to filter and review these PRs.
+
 ## More Information
 
 For more information on contributing to SunPy check out the following:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,10 @@ For the code to be accepted into SunPy it must meet the following criteria:
 
 ## Pull Requests to non-master Branches
 
-From time to time, large feature development work may occur in branches other than master, and all maintained releases currently have a branch i.e. `0.6`. When making a PR to one of these branches, please put the name of the branch in square brackets at the beginning of the PR, i.e. `[0.6] My bug fix`. This makes it easier to filter and review these PRs.
+From time to time, large feature development work may occur in branches other than master, and all 
+maintained releases currently have a branch i.e. `0.6`.
+When making a PR to one of these branches, please put the name of the branch in square brackets at 
+the beginning of the PR, i.e. `[0.6] My bug fix`. This makes it easier to filter and review these PRs.
 
 ## More Information
 


### PR DESCRIPTION
This is an idea I have had to try and make releasing bug fixes easier, as well as making it clear when PRs are not destined for `master` (as GitHub does not make this exceedingly obvious).

I have also added this text to the wiki page: https://github.com/sunpy/sunpy/wiki/Pull-Request-Review-Procedure

A list of correctly labelled PRs that either need backporting, or have been backported can be found by the following search: https://github.com/sunpy/sunpy/pulls?q=is%3Apr+label%3A0.6.x+label%3Aaffects-released