### PR TITLE
Fix SOHO maps co-ordinate systems

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -209,10 +209,10 @@ scale:\t\t {scale}
         # "solar-y" ctypes.  This overrides the default assignment and
         # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
         # 449, 791.
-        if w2.wcs.ctype[0] == "solar-x":
+        if w2.wcs.ctype[0].lower() == "solar-x":
             w2.wcs.ctype[0] = 'HPLN-TAN'
 
-        if w2.wcs.ctype[1] == "solar-y":
+        if w2.wcs.ctype[1].lower() == "solar-y":
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
         return w2

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -205,6 +205,16 @@ scale:\t\t {scale}
         w2.wcs.pc = self.rotation_matrix
         w2.wcs.cunit = self.units
 
+        # Astropy WCS does not understand the SOHO default of "solar-x" and
+        # "solar-y" ctypes.  This overrides the default assignment and
+        # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
+        # 449, 791.
+        if w2.wcs.ctype[0] == "solar-x":
+            w2.wcs.ctype[0] = 'HPLN-TAN'
+
+        if w2.wcs.ctype[1] == "solar-y":
+            w2.wcs.ctype[1] = 'HPLT-TAN'
+
         return w2
 
     # Some numpy extraction

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -69,6 +69,12 @@ class EITMap(GenericMap):
         self.plot_settings['cmap'] = cm.get_cmap(self._get_cmap_name())
         self.plot_settings['norm'] = ImageNormalize(stretch=PowerStretch(0.5))
 
+        # Astropy WCS has an issue with the MDI default of "solar-x" and
+        # "solar-y" as the ctypes.  This overrides the default assignment and
+        # changes it to a ctype that is understood.
+        self.meta['ctype1'] = 'HPLN-TAN'
+        self.meta['ctype2'] = 'HPLT-TAN'
+
     @property
     def rsun_obs(self):
         """
@@ -131,6 +137,12 @@ class LASCOMap(GenericMap):
         self._nickname = self.instrument + "-" + self.detector
         self.plot_settings['cmap'] = cm.get_cmap('soholasco{det!s}'.format(det=self.detector[1]))
         self.plot_settings['norm'] = ImageNormalize(stretch=PowerStretch(0.5))
+
+        # Astropy WCS has an issue with the MDI default of "solar-x" and
+        # "solar-y" as the ctypes.  This overrides the default assignment and
+        # changes it to a ctype that is understood.
+        self.meta['ctype1'] = 'HPLN-TAN'
+        self.meta['ctype2'] = 'HPLT-TAN'
 
     @property
     def measurement(self):

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -188,6 +188,12 @@ class MDIMap(GenericMap):
         else:
             self.plot_settings['norm'] = colors.Normalize(-vmax, vmax)
 
+        # Astropy WCS has an issue with the MDI default of "solar-x" and
+        # "solar-y" as the ctypes.  This overrides the default assignment and
+        # changes it to a ctype that is understood.
+        self.meta['ctype1'] = 'HPLN-TAN'
+        self.meta['ctype2'] = 'HPLT-TAN'
+
     @property
     def measurement(self):
         """

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -71,7 +71,8 @@ class EITMap(GenericMap):
 
         # Astropy WCS has an issue with the MDI default of "solar-x" and
         # "solar-y" as the ctypes.  This overrides the default assignment and
-        # changes it to a ctype that is understood.
+        # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
+        # 449, 791.
         self.meta['ctype1'] = 'HPLN-TAN'
         self.meta['ctype2'] = 'HPLT-TAN'
 
@@ -140,7 +141,8 @@ class LASCOMap(GenericMap):
 
         # Astropy WCS has an issue with the MDI default of "solar-x" and
         # "solar-y" as the ctypes.  This overrides the default assignment and
-        # changes it to a ctype that is understood.
+        # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
+        # 449, 791.
         self.meta['ctype1'] = 'HPLN-TAN'
         self.meta['ctype2'] = 'HPLT-TAN'
 
@@ -202,7 +204,8 @@ class MDIMap(GenericMap):
 
         # Astropy WCS has an issue with the MDI default of "solar-x" and
         # "solar-y" as the ctypes.  This overrides the default assignment and
-        # changes it to a ctype that is understood.
+        # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
+        # 449, 791.
         self.meta['ctype1'] = 'HPLN-TAN'
         self.meta['ctype2'] = 'HPLT-TAN'
 

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -69,13 +69,6 @@ class EITMap(GenericMap):
         self.plot_settings['cmap'] = cm.get_cmap(self._get_cmap_name())
         self.plot_settings['norm'] = ImageNormalize(stretch=PowerStretch(0.5))
 
-        # Astropy WCS has an issue with the MDI default of "solar-x" and
-        # "solar-y" as the ctypes.  This overrides the default assignment and
-        # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
-        # 449, 791.
-        self.meta['ctype1'] = 'HPLN-TAN'
-        self.meta['ctype2'] = 'HPLT-TAN'
-
     @property
     def rsun_obs(self):
         """
@@ -139,13 +132,6 @@ class LASCOMap(GenericMap):
         self.plot_settings['cmap'] = cm.get_cmap('soholasco{det!s}'.format(det=self.detector[1]))
         self.plot_settings['norm'] = ImageNormalize(stretch=PowerStretch(0.5))
 
-        # Astropy WCS has an issue with the MDI default of "solar-x" and
-        # "solar-y" as the ctypes.  This overrides the default assignment and
-        # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
-        # 449, 791.
-        self.meta['ctype1'] = 'HPLN-TAN'
-        self.meta['ctype2'] = 'HPLT-TAN'
-
     @property
     def measurement(self):
         """
@@ -202,12 +188,6 @@ class MDIMap(GenericMap):
         else:
             self.plot_settings['norm'] = colors.Normalize(-vmax, vmax)
 
-        # Astropy WCS has an issue with the MDI default of "solar-x" and
-        # "solar-y" as the ctypes.  This overrides the default assignment and
-        # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
-        # 449, 791.
-        self.meta['ctype1'] = 'HPLN-TAN'
-        self.meta['ctype2'] = 'HPLT-TAN'
 
     @property
     def measurement(self):


### PR DESCRIPTION
The SOHO maps - EIT, MDI and LASCO - all have their ctypes as "solar-x", "solar-y".  This ctype does not seem to be recognized by the current WCS implementation.  Thompson, 2006, A&A, 449, 791, (http://fits.gsfc.nasa.gov/wcs/coordinates.pdf), Table 2 shows that the SOHO "solar-x" and "solar-y" type ctypes can be converted to the WCS-compliant HPLN-TAN and HPLT-TAN respectively.  This pull request implements that conversion.  This fix solves #1523. 