### PR TITLE
small fix of the map.plot example for the documentation

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1309,11 +1309,11 @@ scale:\t\t {scale}
 
         Examples
         --------
-        #Simple Plot with color bar
-        >>> aiamap.plot()   # doctest: +SKIP
+        >>> # Simple Plot with color bar
+        >>> aia.plot()   # doctest: +SKIP
         >>> plt.colorbar()   # doctest: +SKIP
 
-        #Add a limb line and grid
+        >>> # Add a limb line and grid
         >>> aia.plot()   # doctest: +SKIP
         >>> aia.draw_limb()   # doctest: +SKIP
         >>> aia.draw_grid()   # doctest: +SKIP


### PR DESCRIPTION
[map plot's documentation](http://sunpy.readthedocs.org/en/latest/code_ref/map.html#sunpy.map.mapbase.GenericMap.plot) shows the example not formatted properly.  This change should fix it.