### PR TITLE
change the rtd paths

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,8 +68,8 @@ except ImportError:
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if on_rtd:
-    os.environ['SUNPY_CONFIGDIR'] = '/home/docs/checkouts/readthedocs.org/user_builds/sunpy/'
-    os.environ['HOME'] = '/home/docs/checkouts/readthedocs.org/user_builds/sunpy/'
+    os.environ['SUNPY_CONFIGDIR'] = '/home/docs/'
+    os.environ['HOME'] = '/home/docs/'
 
 # -- Download Sample Data -----------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ builtins._ASTROPY_SETUP_ = True
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if on_rtd:
-    os.environ['HOME'] = '/home/docs/checkouts/readthedocs.org/user_builds/sunpy/'
-    os.environ['SUNPY_CONFIGDIR'] = '/home/docs/checkouts/readthedocs.org/user_builds/sunpy/'
+    os.environ['HOME'] = '/home/docs/'
+    os.environ['SUNPY_CONFIGDIR'] = '/home/docs/'
 
 from astropy_helpers.setup_helpers import (
     register_commands, adjust_compiler, get_debug_option, get_package_info)


### PR DESCRIPTION
This is a fix to the RTD path hack for sunpy config, as it was treading over affiliated packages builds.