### PR TITLE
Fixed error when running superpixel

### DIFF
--- a/sunpy/image/rescale.py
+++ b/sunpy/image/rescale.py
@@ -183,7 +183,7 @@ def reshape_image_to_4d_superpixel(img, dimensions):
     """
     # check that the dimensions divide into the image size exactly
 
-    if np.all((np.array(img.shape) % np.array(dimensions) != 0)):
+    if np.any(np.array(img.shape) % np.array(dimensions)):
         raise ValueError('New dimensions must divide original image size exactly.')
 
     # Reshape up to a higher dimensional array which is useful for higher

--- a/sunpy/image/tests/test_resample.py
+++ b/sunpy/image/tests/test_resample.py
@@ -43,7 +43,7 @@ def test_resample_spline():
     resample_method('spline')
 
 def test_reshape(aia171_test_map, shape):
-    imagebytwo = reshape_image_to_4d_superpixel(aia171_test_map.data, shape/2)
+    imagebytwo = reshape_image_to_4d_superpixel(aia171_test_map.data, (2, 2))
     assert imagebytwo.shape == (shape[0]/2, 2, shape[1]/2, 2)
     with pytest.raises(ValueError) as error_msg:    
         reshape_image_to_4d_superpixel(aia171_test_map.data, shape/3)

--- a/sunpy/image/tests/test_resample.py
+++ b/sunpy/image/tests/test_resample.py
@@ -46,5 +46,5 @@ def test_reshape(aia171_test_map, shape):
     imagebytwo = reshape_image_to_4d_superpixel(aia171_test_map.data, (2, 2))
     assert imagebytwo.shape == (shape[0]/2, 2, shape[1]/2, 2)
     with pytest.raises(ValueError) as error_msg:    
-        reshape_image_to_4d_superpixel(aia171_test_map.data, shape/3)
-    assert error_msg == 'New dimensions must divide original image size exactly.'
+        reshape_image_to_4d_superpixel(aia171_test_map.data, (3, 3))
+    assert 'New dimensions must divide original image size exactly.' in str(error_msg.value)

--- a/sunpy/image/tests/test_resample.py
+++ b/sunpy/image/tests/test_resample.py
@@ -43,12 +43,8 @@ def test_resample_spline():
     resample_method('spline')
 
 def test_reshape(aia171_test_map, shape):
-    for factor in np.arange(2, 10):
-        if np.all((shape % factor) == 0):
-            # it is a factor therefore should work
-            reshape_image_to_4d_superpixel(aia171_test_map.data, shape/factor)
-        else:
-            # it is not a factor so function should raise an error
-            with pytest.raises(ValueError):
-                reshape_image_to_4d_superpixel(aia171_test_map.data, shape/factor)
-
+    imagebytwo = reshape_image_to_4d_superpixel(aia171_test_map.data, shape/2)
+    assert imagebytwo.shape == (shape[0]/2, 2, shape[1]/2, 2)
+    with pytest.raises(ValueError) as error_msg:    
+        reshape_image_to_4d_superpixel(aia171_test_map.data, shape/3)
+    assert error_msg == 'New dimensions must divide original image size exactly.'


### PR DESCRIPTION
Fixed way `reshape_image_to_4d_superpixel` checks the dimension of the new image.

Previously, an array was compared with 0, which is always `False`.

Test updated accordingly.