### PR TITLE
Added link to sunpy.org in docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,8 +1,10 @@
 SunPy Documentation
 ===================
 
-Welcome to the SunPy documentation. SunPy is a community-developed, 
+Welcome to the SunPy documentation. SunPy is a community-developed,
 free and open-source solar data analysis environment for Python.
+You can find the official SunPy website at
+`sunpy.org <http://hesperia.gsfc.nasa.gov/rhessi3/index.html>`_.
 
 .. toctree::
   :maxdepth: 2
@@ -12,6 +14,3 @@ free and open-source solar data analysis environment for Python.
   dev
   bugs
   ssw
- 
-.. warning::
-    Having issues with links on this page? Make sure there is a trailing slash on the URL *e.g.* `http://docs.sunpy.org/en/latest/`

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,7 +4,7 @@ SunPy Documentation
 Welcome to the SunPy documentation. SunPy is a community-developed,
 free and open-source solar data analysis environment for Python.
 You can find the official SunPy website at
-`sunpy.org <http://hesperia.gsfc.nasa.gov/rhessi3/index.html>`_.
+`sunpy.org <http://www.sunpy.org>`_.
 
 .. toctree::
   :maxdepth: 2

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,7 +4,7 @@ SunPy Documentation
 Welcome to the SunPy documentation. SunPy is a community-developed,
 free and open-source solar data analysis environment for Python.
 You can find the official SunPy website at
-`sunpy.org <http://www.sunpy.org>`_.
+`sunpy.org <http://sunpy.org>`_.
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION
This PR adds a link to sunpy.org to the main page of the documentation. This deals with #1517.