### PR TITLE
[0.6] With new versions of NumPy (maybe due to a bug somewhere) the sintax

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -602,8 +602,8 @@ scale:\t\t {scale}
         x, y = self.wcs.wcs_pix2world(x, y, origin)
 
         # WCS always outputs degrees.
-        x *= u.deg
-        y *= u.deg
+        x = u.Quantity(x, u.deg)
+        y = u.Quantity(y, u.deg)
 
         x = Longitude(x, wrap_angle=180*u.deg)
         y = Latitude(y)


### PR DESCRIPTION
Backport of #1581.  Notice that the `wcs.is_celestial` in here is not used

```python
 x *= u.deg
```
fails. This commit changes them to a more explicity manner:
```python
 x = u.Quantity(x, u.deg)
```