### PR TITLE
More solar-x solar-y fixes.

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -211,10 +211,10 @@ scale:\t\t {scale}
         # "solar-y" ctypes.  This overrides the default assignment and
         # changes it to a ctype that is understood.  See Thompson, 2006, A.&A.,
         # 449, 791.
-        if w2.wcs.ctype[0].lower() == "solar-x":
+        if w2.wcs.ctype[0].lower() in ("solar-x", "solar_x"):
             w2.wcs.ctype[0] = 'HPLN-TAN'
 
-        if w2.wcs.ctype[1].lower() == "solar-y":
+        if w2.wcs.ctype[1].lower() in ("solar-y", "solar_y"):
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
         return w2


### PR DESCRIPTION
This catches the edge case of the old style WCS headers being passed to WCS where it is `solar_x` rather than `solar-x` like it is for MDI etc.

closes #1611 