### PR TITLE
[0.6] Correcting GOES 2 Operational time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
  * MapCube.plot and MapCube.peek now support a user defined plot_function argument for customising the animation.
  * Added new sample data file, an AIA cutout file.
  * Moved documentation build directory to doc/build
+ * Changed start of GOES 2 operational time range back to 1980-01-04 so data from 1980 can be read into GOESLightCurve object
 
 0.5.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 0.6.2
 -----
+ * Changed start of GOES 2 operational time range back to 1980-01-04 so data from 1980 can be read into GOESLightCurve object
 
 0.6.1
 -----
@@ -67,7 +68,6 @@
  * MapCube.plot and MapCube.peek now support a user defined plot_function argument for customising the animation.
  * Added new sample data file, an AIA cutout file.
  * Moved documentation build directory to doc/build
- * Changed start of GOES 2 operational time range back to 1980-01-04 so data from 1980 can be read into GOESLightCurve object
 
 0.5.0
 -----

--- a/sunpy/lightcurve/sources/goes.py
+++ b/sunpy/lightcurve/sources/goes.py
@@ -136,9 +136,9 @@ class GOESLightCurve(LightCurve):
         sat_list = []
         for sat_num in goes_operational:
             if ((start >= goes_operational[sat_num].start and
-                 start < goes_operational[sat_num].end and
+                 start <= goes_operational[sat_num].end and
                 (end >= goes_operational[sat_num].start and
-                 end < goes_operational[sat_num].end))):
+                 end <= goes_operational[sat_num].end))):
                 # if true then the satellite with sat_num is available
                 sat_list.append(sat_num)
 

--- a/sunpy/lightcurve/sources/goes.py
+++ b/sunpy/lightcurve/sources/goes.py
@@ -120,24 +120,24 @@ class GOESLightCurve(LightCurve):
         """Parses the query time to determine which GOES satellite to use."""
 
         goes_operational = {
-        2: TimeRange('1980-01-04', '1983-04-30'),
-        5: TimeRange('1983-05-02', '1984-07-31'),
-        6: TimeRange('1983-06-01', '1994-08-18'),
-        7: TimeRange('1994-01-01', '1996-08-13'),
-        8: TimeRange('1996-03-21', '2003-06-18'),
-        9: TimeRange('1997-01-01', '1998-09-08'),
-        10: TimeRange('1998-07-10', '2009-12-01'),
-        11: TimeRange('2006-06-20', '2008-02-15'),
-        12: TimeRange('2002-12-13', '2007-05-08'),
+        2: TimeRange('1980-01-04', '1983-05-01'),
+        5: TimeRange('1983-05-02', '1984-08-01'),
+        6: TimeRange('1983-06-01', '1994-08-19'),
+        7: TimeRange('1994-01-01', '1996-08-14'),
+        8: TimeRange('1996-03-21', '2003-06-19'),
+        9: TimeRange('1997-01-01', '1998-09-09'),
+        10: TimeRange('1998-07-10', '2009-12-02'),
+        11: TimeRange('2006-06-20', '2008-02-16'),
+        12: TimeRange('2002-12-13', '2007-05-09'),
         13: TimeRange('2006-08-01', '2006-08-01'),
-        14: TimeRange('2009-12-02', '2010-10-04'),
+        14: TimeRange('2009-12-02', '2010-11-05'),
         15: TimeRange('2010-09-01', datetime.datetime.utcnow())}
 
         sat_list = []
         for sat_num in goes_operational:
-            if ((start > goes_operational[sat_num].start and
+            if ((start >= goes_operational[sat_num].start and
                  start < goes_operational[sat_num].end and
-                (end > goes_operational[sat_num].start and
+                (end >= goes_operational[sat_num].start and
                  end < goes_operational[sat_num].end))):
                 # if true then the satellite with sat_num is available
                 sat_list.append(sat_num)

--- a/sunpy/lightcurve/sources/goes.py
+++ b/sunpy/lightcurve/sources/goes.py
@@ -120,7 +120,7 @@ class GOESLightCurve(LightCurve):
         """Parses the query time to determine which GOES satellite to use."""
 
         goes_operational = {
-        2: TimeRange('1981-01-01', '1983-04-30'),
+        2: TimeRange('1980-01-04', '1983-04-30'),
         5: TimeRange('1983-05-02', '1984-07-31'),
         6: TimeRange('1983-06-01', '1994-08-18'),
         7: TimeRange('1994-01-01', '1996-08-13'),

--- a/sunpy/lightcurve/tests/test_goes.py
+++ b/sunpy/lightcurve/tests/test_goes.py
@@ -19,6 +19,10 @@ class TestGOESLightCurve(object):
     def timerange_b(self):
         return TimeRange('1995/06/03', '1995/06/04')
 
+    @pytest.fixture
+    def timerange_c(self):
+        return TimeRange('1980/01/05', '1980/01/06')
+
     @pytest.mark.online
     def test_goes_range(self, timerange_a):
         """Test creation with two times"""
@@ -78,11 +82,12 @@ class TestGOESLightCurve(object):
         with pytest.raises((Exception)):
             self.compare(lc1, lc2)
 
-    def test_goes_sat_numbers(self, timerange_a, timerange_b):
+    def test_goes_sat_numbers(self, timerange_a, timerange_b, timerange_c):
         """Test the ability to return GOES satellite availability"""
         g = sunpy.lightcurve.GOESLightCurve
         assert g._get_goes_sat_num(timerange_a.start, timerange_a.end) == [10]
         assert g._get_goes_sat_num(timerange_b.start, timerange_b.end) == [7]
+        assert g._get_goes_sat_num(timerange_c.start, timerange_c.end) == [2]
 
     def test_get_url(self, timerange_a, timerange_b):
         """Test the getting of urls"""


### PR DESCRIPTION
This PR backports PR #1319 to the version 0.6 branch.