### PR TITLE
editorconfig - to get consistent coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# http://editorconfig.org
+
+root = true
+
+# utf, UNIX-style new line
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst,md}]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
`.editorconfig` is a simple file that sets the coding styles over many editors, including the online github editor!

Check [editorconfig website](http://editorconfig.org/) for more details on how to install the plugins.

If this seems ok to everyone I'll add soon to this PR a section in the documentation about this.