### PR TITLE
Animation titles

### DIFF
--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -173,7 +173,7 @@ class MapCube(object):
 
         # Normal plot
         def annotate_frame(i):
-            axes.set_title("{s.name} {s.date!s}".format(s=self[i]))
+            axes.set_title("{s.name}".format(s=self[i]))
 
             # x-axis label
             if self[0].coordinate_system.x == 'HG':

--- a/sunpy/map/mapcube.py
+++ b/sunpy/map/mapcube.py
@@ -146,7 +146,7 @@ class MapCube(object):
 
         >>> cube = Map(res, cube=True)   # doctest: +SKIP
 
-        >>> ani = cube.plot(controls=False)   # doctest: +SKIP
+        >>> ani = cube.plot()   # doctest: +SKIP
 
         >>> Writer = animation.writers['ffmpeg']   # doctest: +SKIP
         >>> writer = Writer(fps=10, metadata=dict(artist='SunPy'), bitrate=1800)   # doctest: +SKIP

--- a/sunpy/visualization/mapcubeanimator.py
+++ b/sunpy/visualization/mapcubeanimator.py
@@ -116,7 +116,7 @@ class MapCubeAnimator(imageanimator.BaseFuncAnimator):
         This may overwrite some stuff in `GenericMap.plot()`
         """
         # Normal plot
-        self.axes.set_title("{s.name} {s.date!s}".format(s=self.data[ind]))
+        self.axes.set_title("{s.name}".format(s=self.data[ind]))
 
         # x-axis label
         if self.data[ind].coordinate_system.x == 'HG':


### PR DESCRIPTION
Animations of mapcubes had repeated dates.  This was because the name property of a map contains the map date, and the mapcube animation also appended the map date.  Therefore, two dates in the mapcube animation title.  Also fixed docs, since the example led to an error.