### PR TITLE
Mark two more tests as online

### DIFF
--- a/sunpy/instr/tests/test_goes.py
+++ b/sunpy/instr/tests/test_goes.py
@@ -329,6 +329,7 @@ def test_calc_rad_loss_obstime():
     assert_quantity_allclose(rad_loss_test["rad_loss_cumul"],
                        rad_loss_expected["rad_loss_cumul"], rtol=0.0001)
 
+@pytest.mark.online
 def test_calculate_xray_luminosity():
     # Check correct exceptions are raised to incorrect inputs
     not_goeslc = []

--- a/sunpy/instr/tests/test_lyra.py
+++ b/sunpy/instr/tests/test_lyra.py
@@ -76,6 +76,7 @@ def test_split_series_using_lytaf():
     assert split_no_lytaf[0]["subtimes"] == dummy_time
     assert split_no_lytaf[0]["subdata"].all() == dummy_data.all()
 
+@pytest.mark.online
 def test_remove_lytaf_events_from_lightcurve():
     """Test if artefacts are correctly removed from a LYRAlightCurve."""
     # Create sample LYRALightCurve


### PR DESCRIPTION
These two tests still require to download some data. A test without internet connection gives:
```
    def test_calculate_xray_luminosity():
        # Check correct exceptions are raised to incorrect inputs
        not_goeslc = []
        with pytest.raises(TypeError):
            goes_test = goes.calculate_xray_luminosity(not_goeslc)
        # Check function gives correct results.
        goeslc_input = lightcurve.GOESLightCurve.create("2014-01-01 00:00:00",
>                                               "2014-01-01 00:00:10")

sunpy/instr/tests/test_goes.py:339: 
[...]
uri = 'http://umbra.nascom.nasa.gov/goes/fits/2014/go1520140101.fits'
kwargs = {}, err = 'Unable to download data for specified date range'

    @staticmethod
    def _download(uri, kwargs,
                  err='Unable to download data at specified URL'):
        if not(os.path.isfile(filepath)) or (overwrite and
                                             os.path.isfile(filepath)):
            try:
                response = urllib2.urlopen(uri)
            except (urllib2.HTTPError, urllib2.URLError):
>               raise urllib2.URLError(err)
E               URLError: <urlopen error Unable to download data for specified date range>

sunpy/lightcurve/lightcurve.py:290: URLError
```
(similarly for `test_remove_lytaf_events_from_lightcurve`).