### PR TITLE
Disable running figure tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,12 @@ env:
         # Modify these to represent the newest versions
         - LATEST_NUMPY=1.9.2
         - LATEST_PANDAS=0.16.2
+        - MATPLOTLIB_VERSION=">=1.5.1"
         # Fixed global vars
         - PYTHON_VERSION=2.7
         - TEST_MODE='offline'
-        - NUMPY_VERSION=$LATEST_NUMPY
-        - PANDAS_VERSION=$LATEST_PANDAS
+        - NUMPY_VERSION="=$LATEST_NUMPY"
+        - PANDAS_VERSION="=$LATEST_PANDAS"
 
     matrix:
         - PYTHON_VERSION=2.7
@@ -53,7 +54,7 @@ matrix:
          - os: linux
            env: PANDAS_VERSION=0.15.2
          - os: linux
-           env: TEST_MODE='figure'
+           env: TEST_MODE='figure' MATPLOTLIB_VERSION="=1.5.1"
          - os: linux
            env: TEST_MODE='astropy-dev'
          - os: linux
@@ -63,8 +64,7 @@ matrix:
          - os: linux
            env: TEST_MODE='doctest'
          - os: linux
-           env: PYTHON_VERSION=3.4
-           env: TEST_MODE='python3'
+           env: PYTHON_VERSION=3.4 TEST_MODE='python3'
 
 # If the online build fails, we don't want it to report the whole build broken.
     allow_failures:
@@ -80,17 +80,17 @@ install:
     - conda create --yes -n test python=$PYTHON_VERSION
     - conda config --add channels sunpy --add channels astropy --add channels astropy-ci-extras --add channels https://conda.binstar.org/sunpy/channel/citesting
     - source activate test
-    # Install default dependancies
+    # Install default dependencies
     - conda install --yes pip
-    - conda install -q --yes numpy=$NUMPY_VERSION pandas=$PANDAS_VERSION scipy matplotlib requests beautiful-soup sqlalchemy scikit-image pytest jinja2 cython wcsaxes
+    - conda install -q --yes numpy$NUMPY_VERSION pandas$PANDAS_VERSION scipy matplotlib$MATPLOTLIB_VERSION requests beautiful-soup sqlalchemy scikit-image pytest jinja2 cython wcsaxes
     - pip install pytest-cov coverage coveralls
     # Install sunpy conda packages
     - conda install -q --yes numpy=$NUMPY_VERSION suds-jurko glymur
     # Install the correct version of astropy
-    - if [[ $TEST_MODE != 'astropy-dev' ]]; then conda install -q --yes astropy>=0.4.0 numpy=$NUMPY_VERSION; fi
+    - if [[ $TEST_MODE != 'astropy-dev' ]]; then conda install -q --yes astropy>=0.4.0 numpy$NUMPY_VERSION; fi
     - if [[ $TEST_MODE == 'astropy-dev' ]]; then pip install git+git://github.com/astropy/astropy.git; fi
     # Install sphinx if needed
-    - if [[ $TEST_MODE == 'sphinx' || $TEST_MODE == 'doctest' ]]; then conda install -q --yes sphinx numpy=$NUMPY_VERSION; fi
+    - if [[ $TEST_MODE == 'sphinx' || $TEST_MODE == 'doctest' ]]; then conda install -q --yes sphinx numpy$NUMPY_VERSION; fi
     - if [[ $TEST_MODE == 'sphinx' || $TEST_MODE == 'doctest' ]]; then python -c "import sunpy.data; sunpy.data.download_sample_data()"; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,9 @@ env:
 matrix:
     include:
          - os: linux
-           env: NUMPY_VERSION=1.9.3
+           env: NUMPY_VERSION="=1.9.3"
          - os: linux
-           env: PANDAS_VERSION=0.16.2
+           env: PANDAS_VERSION="=0.16.2"
          - os: linux
            env: TEST_MODE='figure' MATPLOTLIB_VERSION="=1.5.1"
          - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,16 +80,15 @@ install:
     - source activate test
     # Install default dependancies
     - conda install --yes pip
-    - conda install -q --yes numpy=$NUMPY_VERSION pandas=$PANDAS_VERSION
-    - conda install -q --yes scipy matplotlib requests beautiful-soup sqlalchemy scikit-image pytest jinja2 cython wcsaxes
+    - conda install -q --yes numpy=$NUMPY_VERSION pandas=$PANDAS_VERSION scipy matplotlib requests beautiful-soup sqlalchemy scikit-image pytest jinja2 cython wcsaxes
     - pip install pytest-cov coverage coveralls
     # Install sunpy conda packages
-    - conda install -q --yes suds-jurko glymur
+    - conda install -q --yes numpy=$NUMPY_VERSION suds-jurko glymur
     # Install the correct version of astropy
-    - if [[ $TEST_MODE != 'astropy-dev' ]]; then conda install -q --yes astropy>=0.4.0; fi
+    - if [[ $TEST_MODE != 'astropy-dev' ]]; then conda install -q --yes astropy>=0.4.0 numpy=$NUMPY_VERSION; fi
     - if [[ $TEST_MODE == 'astropy-dev' ]]; then pip install git+git://github.com/astropy/astropy.git; fi
     # Install sphinx if needed
-    - if [[ $TEST_MODE == 'sphinx' || $TEST_MODE == 'doctest' ]]; then conda install -q --yes sphinx; fi
+    - if [[ $TEST_MODE == 'sphinx' || $TEST_MODE == 'doctest' ]]; then conda install -q --yes sphinx numpy=$NUMPY_VERSION; fi
     - if [[ $TEST_MODE == 'sphinx' || $TEST_MODE == 'doctest' ]]; then python -c "import sunpy.data; sunpy.data.download_sample_data()"; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ addons:
 env:
     global:
         # Modify these to represent the newest versions
-        - LATEST_NUMPY=1.9.2
-        - LATEST_PANDAS=0.16.2
+        - LATEST_NUMPY=1.10.2
+        - LATEST_PANDAS=0.17.1
         - MATPLOTLIB_VERSION=">=1.5.1"
         # Fixed global vars
         - PYTHON_VERSION=2.7
@@ -50,9 +50,9 @@ env:
 matrix:
     include:
          - os: linux
-           env: NUMPY_VERSION=1.8.1
+           env: NUMPY_VERSION=1.9.3
          - os: linux
-           env: PANDAS_VERSION=0.15.2
+           env: PANDAS_VERSION=0.16.2
          - os: linux
            env: TEST_MODE='figure' MATPLOTLIB_VERSION="=1.5.1"
          - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ matrix:
          - os: linux
            env: PANDAS_VERSION=0.15.2
          - os: linux
+           env: TEST_MODE='figure'
+         - os: linux
            env: TEST_MODE='astropy-dev'
          - os: linux
            env: TEST_MODE='sphinx'
@@ -92,10 +94,11 @@ install:
     - if [[ $TEST_MODE == 'sphinx' || $TEST_MODE == 'doctest' ]]; then python -c "import sunpy.data; sunpy.data.download_sample_data()"; fi
 
 script:
-    - if [[ $TEST_MODE == 'sphinx' ]]; then python setup.py build_sphinx -w; fi
     - if [[ $TEST_MODE == 'offline' || $TEST_MODE == 'astropy-dev' ]]; then python setup.py test; fi
+    - if [[ $TEST_MODE == 'figure' ]]; then python setup.py test --figure; fi
+    - if [[ $TEST_MODE == 'sphinx' ]]; then python setup.py build_sphinx -w; fi
     - if [[ $TEST_MODE == 'online' ]]; then python setup.py test --online --coverage --cov-report=html; fi
-    - if [[ $TEST_MODE == 'skip' ]]; then coveralls --rcfile='./sunpy/tests/coveragerc'; fi
+    #- if [[ $TEST_MODE == 'skip' ]]; then coveralls --rcfile='./sunpy/tests/coveragerc'; fi
     - if [[ $TEST_MODE == 'doctest' ]]; then python setup.py build_sphinx -b doctest; fi
     - if [[ $TEST_MODE == 'python3' ]]; then continuous-integration/python3.sh; fi
 

--- a/continuous-integration/python3.sh
+++ b/continuous-integration/python3.sh
@@ -9,7 +9,7 @@ python -c "import sunpy.data; sunpy.data.download_sample_data()" || E=$?||$E
 python -c "import sunpy.data.sample" || E=$?||$E
 
 py.test sunpy/time || E=$?||$E
-py.test sunpy/map || E=$?||$E
+py.test sunpy/map -m "not figure"|| E=$?||$E
 py.test sunpy/io || E=$?||$E
 py.test sunpy/image || E=$?||$E
 py.test sunpy/sun || E=$?||$E

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-norecursedirs = build *.egg-info
+norecursedirs = build *.egg-info astropy_helpers
 python_files = test_?*.py
 addopts = -p no:doctest
 markers =

--- a/sunpy/tests/__init__.py
+++ b/sunpy/tests/__init__.py
@@ -11,7 +11,8 @@ except ImportError:
 
 
 def main(modulename='', coverage=False, cov_report=False,
-         online=False, offline=True, verbose=False, parallel=0, args=None):
+         online=False, offline=True, figure=False, verbose=False,
+         parallel=0, args=None):
     """
     Execute the test suite of the sunpy package. The parameters may be
     used to restrict the number of tests that will be executed or to
@@ -36,6 +37,9 @@ def main(modulename='', coverage=False, cov_report=False,
 
     offline: bool
         Run the tests that don't require an internet connection.
+
+    figure: bool
+        Include the figure tests in the test run.
 
     """
     print(modulename)
@@ -67,6 +71,8 @@ def main(modulename='', coverage=False, cov_report=False,
         all_args.append('-k-online')
     if not offline:
         all_args.append('-k online')
+    if not figure:
+        all_args.append('-m not figure')
     all_args.append(path)
 
     if args:

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -102,6 +102,7 @@ class SunPyTest(AstropyTest):
                'parallel={1.parallel!r}, '
                'online={online!r}, '
                'offline={offline!r}, '
+               'figure={figure!r}, '
                'coverage={1.coverage!r}, '
                'cov_report={1.cov_report!r})); '
                '{cmd_post}'

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -35,6 +35,9 @@ class SunPyTest(AstropyTest):
         # Run only online tests?
         ('online-only', None,
          'Only run test that do require a internet connection.'),
+        # Run tests that check figure generation
+        ('figure', None,
+         'Run tests that compare figures against stored hashes.')
         # Calculate test coverage
         ('coverage', 'c',
          'Create a coverage report. Requires the coverage package.'),
@@ -62,6 +65,7 @@ class SunPyTest(AstropyTest):
         self.args = None
         self.online = False
         self.online_only = False
+        self.figure = False
         self.coverage = False
         self.cov_report = 'term' if self.coverage else None
         self.docs_path = os.path.abspath('doc')
@@ -102,6 +106,11 @@ class SunPyTest(AstropyTest):
                'cov_report={1.cov_report!r})); '
                '{cmd_post}'
                'sys.exit(result)')
-        x = cmd.format('pass', self, online=online, offline=offline,
-                          cmd_pre=cmd_pre, cmd_post=cmd_post)
+        x = cmd.format('pass',
+                       self,
+                       online=online,
+                       offline=offline,
+                       figure=self.figure,
+                       cmd_pre=cmd_pre,
+                       cmd_post=cmd_post)
         return x

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -37,7 +37,7 @@ class SunPyTest(AstropyTest):
          'Only run test that do require a internet connection.'),
         # Run tests that check figure generation
         ('figure', None,
-         'Run tests that compare figures against stored hashes.')
+         'Run tests that compare figures against stored hashes.'),
         # Calculate test coverage
         ('coverage', 'c',
          'Create a coverage report. Requires the coverage package.'),

--- a/sunpy/tests/tests/test_main.py
+++ b/sunpy/tests/tests/test_main.py
@@ -68,7 +68,7 @@ def test_main_only_online(monkeypatch):
 
 def test_main_figures(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
-    args = sunpy.tests.main(figures=True)
+    args = sunpy.tests.main(figure=True)
     assert args in (['-k-online', 'sunpy'],
                     ['-k-online', root_dir])
 

--- a/sunpy/tests/tests/test_main.py
+++ b/sunpy/tests/tests/test_main.py
@@ -23,14 +23,15 @@ def test_main_stdlib_module():
 def test_main_noargs(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main()
-    assert args in (['-k-online', 'sunpy'], ['-k-online', root_dir])
+    assert args in (['-k-online', '-m not figure', 'sunpy'],
+                    ['-k-online', '-m not figure', root_dir])
 
 
 def test_main_submodule(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map')
-    assert args in (['-k-online'] + [os.path.join('sunpy', 'map', 'tests')],
-                    ['-k-online'] + [os.path.join(root_dir, 'map', 'tests')])
+    assert args in (['-k-online', '-m not figure'] + [os.path.join('sunpy', 'map', 'tests')],
+                    ['-k-online', '-m not figure'] + [os.path.join(root_dir, 'map', 'tests')])
 
 
 def test_main_with_cover(monkeypatch):
@@ -38,29 +39,36 @@ def test_main_with_cover(monkeypatch):
     args = sunpy.tests.main('map', coverage=True)
     covpath = os.path.abspath(
         os.path.join(sunpy.tests.testdir, os.path.join(os.pardir, 'map')))
-    assert args in (['--cov', covpath, '-k-online', os.path.join('sunpy', 'map', 'tests')],
-                    ['--cov', covpath, '-k-online', os.path.join(root_dir, 'map', 'tests')])
+    assert args in (['--cov', covpath, '-k-online', '-m not figure', os.path.join('sunpy', 'map', 'tests')],
+                    ['--cov', covpath, '-k-online', '-m not figure', os.path.join(root_dir, 'map', 'tests')])
 
 
 def test_main_with_show_uncovered_lines(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map', cov_report='term-missing')
-    assert args in (['--cov-report', 'term-missing', '-k-online',
+    assert args in (['--cov-report', 'term-missing', '-k-online', '-m not figure',
                      os.path.join('sunpy', 'map', 'tests')],
-                    ['--cov-report', 'term-missing', '-k-online',
+                    ['--cov-report', 'term-missing', '-k-online', '-m not figure',
                      os.path.join(root_dir, 'map', 'tests')])
 
 
 def test_main_exclude_online(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map', online=False)
-    assert args in (['-k-online', os.path.join('sunpy', 'map', 'tests')],
-                    ['-k-online', os.path.join(root_dir, 'map', 'tests')])
+    assert args in (['-k-online', '-m not figure', os.path.join('sunpy', 'map', 'tests')],
+                    ['-k-online', '-m not figure', os.path.join(root_dir, 'map', 'tests')])
 
 
 def test_main_only_online(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map', offline=False, online=True)
-    assert args in (['-k online', os.path.join('sunpy', 'map', 'tests')],
-                    ['-k online', os.path.join(root_dir, 'map', 'tests')])
+    assert args in (['-k online', '-m not figure', os.path.join('sunpy', 'map', 'tests')],
+                    ['-k online', '-m not figure', os.path.join(root_dir, 'map', 'tests')])
+
+
+def test_main_figures(monkeypatch):
+    monkeypatch.setattr(pytest, 'main', lambda x: x)
+    args = sunpy.tests.main(figures=True)
+    assert args in (['-k-online', 'sunpy'],
+                    ['-k-online', root_dir])
 


### PR DESCRIPTION
This changes the defaults for `sunpy.self_test` and `python setup.py test` to not run the tests with the `pytest.mark.figure` mark.

It also adds a keyword argument to `self_test` and a `--figure` flag to `setup.py test` to re-enable these tests.