### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -912,7 +912,7 @@ if sys.version_info[:2] < (2, 7):
             if level >= current_threshold:
                 if args:
                     msg = msg % args
-                sys.stderr.write('%s\n' % msg)
+                sys.stderr.write('{0!s}\n'.format(msg))
                 sys.stderr.flush()
 
     log = log()

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -41,7 +41,7 @@ def _check_call_py24(cmd, *args, **kwargs):
     class CalledProcessError(Exception):
         pass
     if not res == 0:
-        msg = "Command '%s' return non-zero exit status %d" % (cmd, res)
+        msg = "Command '{0!s}' return non-zero exit status {1:d}".format(cmd, res)
         raise CalledProcessError(msg)
 vars(subprocess).setdefault('check_call', _check_call_py24)
 
@@ -103,8 +103,7 @@ def _build_egg(egg, tarball, to_dir):
 
 
 def _do_download(version, download_base, to_dir, download_delay):
-    egg = os.path.join(to_dir, 'setuptools-%s-py%d.%d.egg'
-                       % (version, sys.version_info[0], sys.version_info[1]))
+    egg = os.path.join(to_dir, 'setuptools-{0!s}-py{1:d}.{2:d}.egg'.format(version, sys.version_info[0], sys.version_info[1]))
     if not os.path.exists(egg):
         tarball = download_setuptools(version, download_base,
                                       to_dir, download_delay)
@@ -172,7 +171,7 @@ def download_file_powershell(url, target):
     cmd = [
         'powershell',
         '-Command',
-        "(new-object System.Net.WebClient).DownloadFile(%(url)r, %(target)r)" % vars(),
+        "(new-object System.Net.WebClient).DownloadFile({url!r}, {target!r})".format(**vars()),
     ]
     _clean_check(cmd, target)
 
@@ -281,7 +280,7 @@ def download_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
     """
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
-    tgz_name = "setuptools-%s.tar.gz" % version
+    tgz_name = "setuptools-{0!s}.tar.gz".format(version)
     url = download_base + tgz_name
     saveto = os.path.join(to_dir, tgz_name)
     if not os.path.exists(saveto):  # Avoid repeated downloads
@@ -335,7 +334,7 @@ def _extractall(self, path=".", members=None):
             if self.errorlevel > 1:
                 raise
             else:
-                self._dbg(1, "tarfile: %s" % e)
+                self._dbg(1, "tarfile: {0!s}".format(e))
 
 
 def _build_install_args(options):

--- a/sunpy/extern/bundled/six.py
+++ b/sunpy/extern/bundled/six.py
@@ -465,7 +465,7 @@ def remove_move(name):
         try:
             del moves.__dict__[name]
         except KeyError:
-            raise AttributeError("no such move, %r" % (name,))
+            raise AttributeError("no such move, {0!r}".format(name))
 
 
 if PY3:

--- a/tools/hek_mkcls.py
+++ b/tools/hek_mkcls.py
@@ -246,7 +246,7 @@ def mk_gen(rest):
     ret = ''
     ret += '@apply\nclass Misc(object):\n'
     for elem in sorted(rest):
-        ret += '    %s = %s(%r)\n' %(elem, fields[elem], elem)
+        ret += '    {0!s} = {1!s}({2!r})\n'.format(elem, fields[elem], elem)
     return ret
 
 def mk_cls(key, used, pad=1, nokeys=True, init=True, name=None, base='EventType'):
@@ -260,14 +260,14 @@ def mk_cls(key, used, pad=1, nokeys=True, init=True, name=None, base='EventType'
     if not keys:
         if not nokeys:
             raise ValueError
-        return '%s = EventType(%r)' % (key, name.lower())
+        return '{0!s} = EventType({1!r})'.format(key, name.lower())
     ret = ''
-    ret += '@apply\nclass %s(%s):\n' % (name, base)
+    ret += '@apply\nclass {0!s}({1!s}):\n'.format(name, base)
     for k, v in keys:
-        ret += '    %s = %s(%r)\n' % (k[len(key) + pad:], v, k)
+        ret += '    {0!s} = {1!s}({2!r})\n'.format(k[len(key) + pad:], v, k)
     if init:
         ret += '''    def __init__(self):
-        EventType.__init__(self, %r)''' % name.lower()
+        EventType.__init__(self, {0!r})'''.format(name.lower())
     return ret
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sunpy:sunpy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sunpy:sunpy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)