### PR TITLE
[unidown] fix for #1625 and small eve tidying up

### DIFF
--- a/sunpy/instr/rhessi.py
+++ b/sunpy/instr/rhessi.py
@@ -224,7 +224,6 @@ def get_obssumm_file(time_range):
     # TODO need to check which is the closest servers
     url_root = data_servers[0] + data_location
 
-
     url = url_root + get_obssum_filename(time_range)
 
     print('Downloading file: ' + url)
@@ -266,7 +265,8 @@ def parse_obssumm_file(filename):
               '50 - 100 keV', '100 - 300 keV', '300 - 800 keV', '800 - 7000 keV',
               '7000 - 20000 keV']
 
-    # the data stored in the fits file are "compressed" countrates stored as one byte
+    # The data stored in the FITS file are "compressed" countrates stored as
+    # one byte
     compressed_countrate = np.array(afits[6].data.field('countrate'))
 
     countrate = uncompress_countrate(compressed_countrate)
@@ -318,7 +318,7 @@ def hsi_linecolors():
     ----------
     hsi_linecolors.pro `<http://hesperia.gsfc.nasa.gov/ssw/hessi/idl/gen/hsi_linecolors.pro`_
     """
-    return ('black', 'magenta', 'lime', 'cyan', 'y', 'red', 'blue', 'orange', 'olive')
+    return 'black', 'magenta', 'lime', 'cyan', 'y', 'red', 'blue', 'orange', 'olive'
 
 
 def _backproject(calibrated_event_list, detector=8, pixel_size=(1., 1.),
@@ -351,8 +351,8 @@ def _backproject(calibrated_event_list, detector=8, pixel_size=(1., 1.),
     """
     afits = fits.open(calibrated_event_list)
 
-    #info_parameters = fits[2]
-    #detector_efficiency = info_parameters.data.field('cbe_det_eff$$REL')
+    # info_parameters = fits[2]
+    # detector_efficiency = info_parameters.data.field('cbe_det_eff$$REL')
 
     afits = fits.open(calibrated_event_list)
 
@@ -443,7 +443,7 @@ def backprojection(calibrated_event_list, pixel_size=(1., 1.) * u.arcsec,
     for detector in detector_list:
         if detector > 0:
             image = image + _backproject(calibrated_event_list, detector=detector, pixel_size=pixel_size.value
-										 , image_dim=image_dim.value)
+                                         , image_dim=image_dim.value)
 
     dict_header = {
         "DATE-OBS": time_range.center().strftime("%Y-%m-%d %H:%M:%S"),

--- a/sunpy/instr/rhessi.py
+++ b/sunpy/instr/rhessi.py
@@ -155,8 +155,8 @@ def parse_obssumm_dbase_file(filename):
 def get_obssum_filename(time_range):
     """
     Download the RHESSI observing summary data from one of the RHESSI
-    servers, parses it, and returns the name of the obssumm file relevant for
-    the time range
+    servers, parses it, and returns the name of the obssumm files relevant for
+    the time range.
 
     Parameters
     ----------
@@ -165,13 +165,13 @@ def get_obssum_filename(time_range):
 
     Returns
     -------
-    out : string
-        Returns the filename of the observation summary file
+    out : list
+        Returns the filenames of the observation summary file
 
     Examples
     --------
     >>> import sunpy.instr.rhessi as rhessi
-    >>> rhessi.get_obssumm_filename(('2011/04/04', '2011/04/05'))   # doctest: +SKIP
+    >>> rhessi.get_obssum_filename(('2011/04/04', '2011/04/05'))   # doctest: +SKIP
 
     .. note::
         This API is currently limited to providing data from whole days only.
@@ -185,9 +185,10 @@ def get_obssum_filename(time_range):
     result = parse_obssumm_dbase_file(f[0])
     _time_range = TimeRange(time_range)
 
-    index_number = _time_range.start.day - 1
+    index_number_start = _time_range.start.day - 1
+    index_number_end = _time_range.end.day - 1
 
-    return data_servers[0] + data_location + result.get('filename')[index_number] + 's'
+    return [data_servers[0] + data_location + filename + 's' for filename in result.get('filename')[index_number_start:index_number_end]]
 
 
 def get_obssumm_file(time_range):
@@ -222,6 +223,7 @@ def get_obssumm_file(time_range):
 
     # TODO need to check which is the closest servers
     url_root = data_servers[0] + data_location
+
 
     url = url_root + get_obssum_filename(time_range)
 
@@ -272,10 +274,11 @@ def parse_obssumm_file(filename):
 
     time_array = [reference_time_ut + timedelta(0,time_interval_sec * a) for a in np.arange(dim)]
 
-    #TODO generate the labels for the dict automatically from labels
+    # TODO generate the labels for the dict automatically from labels
     data = {'time': time_array, 'data': countrate, 'labels': labels}
 
     return header, data
+
 
 def uncompress_countrate(compressed_countrate):
     """Convert the compressed count rate inside of observing summary file from
@@ -299,6 +302,7 @@ def uncompress_countrate(compressed_countrate):
             sum = lkup[16 * (i + 1) - 1] + 2 ** i
     return lkup[compressed_countrate]
 
+
 def hsi_linecolors():
     """Define discrete colors to use for RHESSI plots
 
@@ -315,6 +319,7 @@ def hsi_linecolors():
     hsi_linecolors.pro `<http://hesperia.gsfc.nasa.gov/ssw/hessi/idl/gen/hsi_linecolors.pro`_
     """
     return ('black', 'magenta', 'lime', 'cyan', 'y', 'red', 'blue', 'orange', 'olive')
+
 
 def _backproject(calibrated_event_list, detector=8, pixel_size=(1., 1.),
                  image_dim=(64, 64)):
@@ -374,6 +379,7 @@ def _backproject(calibrated_event_list, detector=8, pixel_size=(1., 1.),
     bproj_image = np.inner(probability_of_transmission, count).reshape(image_dim)
 
     return bproj_image
+
 
 def backprojection(calibrated_event_list, pixel_size=(1., 1.) * u.arcsec,
                    image_dim=(64, 64) * u.pix):

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -83,8 +83,8 @@ class QueryResponse(list):
         for i, qrblock in enumerate(self):
             columns['Start Time'].append((qrblock.time.start.date(
             ) + datetime.timedelta(days=i)).strftime(TIME_FORMAT))
-            columns['End Time'].append((qrblock.time.end.date(
-            ) + datetime.timedelta(days=i)).strftime(TIME_FORMAT))
+            columns['End Time'].append((qrblock.time.start.date(
+            ) + datetime.timedelta(days=i+1)).strftime(TIME_FORMAT))
             columns['Source'].append(qrblock.source)
             columns['Instrument'].append(qrblock.instrument)
 

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -92,14 +92,12 @@ class EVEClient(GenericClient):
         """
         chk_var = 0
         for x in query:
-            if (x.__class__.__name__ == 'Instrument' and
-                x.value.lower() == 'eve'):
-
+            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'eve':
                 chk_var += 1
 
             elif x.__class__.__name__ == 'Level' and x.value == 0:
                 chk_var += 1
 
-        if(chk_var == 2):
+        if chk_var == 2:
             return True
         return False

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -48,7 +48,6 @@ class LYRAClient(GenericClient):
         filename = "lyra_{0:%Y%m%d-}000000_lev{1:d}_std.fits".format(date, kwargs.get('level',2))
         base_url = "http://proba2.oma.be/lyra/data/bsd/"
         url_path = urlparse.urljoin(date.strftime('%Y/%m/%d/'), filename)
-        print(url_path)
         return urlparse.urljoin(base_url, url_path)
 
     def _makeimap(self):

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -45,8 +45,8 @@ class RHESSIClient(GenericClient):
         boolean
             answer as to whether client can service the query
         """
-        chkattr =  ['Time', 'Instrument']
-        chklist =  [x.__class__.__name__ in chkattr for x in query]
+        chkattr = ['Time', 'Instrument']
+        chklist = [x.__class__.__name__ in chkattr for x in query]
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value == 'rhessi':
                 return all(chklist)

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -1,12 +1,13 @@
-#Author: Rishabh Sharma <rishabh.sharma.gunner@gmail.com>
-#This module was developed under funding provided by
-#Google Summer of Code 2014
+# Author: Rishabh Sharma <rishabh.sharma.gunner@gmail.com>
+# This module was developed under funding provided by
+# Google Summer of Code 2014
 
 from sunpy.instr import rhessi
 
 from ..client import GenericClient
 
 __all__ = ['RHESSIClient']
+
 
 class RHESSIClient(GenericClient):
 
@@ -19,9 +20,7 @@ class RHESSIClient(GenericClient):
         Date range should be specified using a TimeRange, or start
         and end dates at datetime instances or date strings.
         """
-        url = rhessi.get_obssum_filename(timerange)
-        return [url]
-
+        return rhessi.get_obssum_filename(timerange)
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/tests/test_rhessi.py
+++ b/sunpy/net/dataretriever/tests/test_rhessi.py
@@ -7,13 +7,14 @@ import sunpy.net.dataretriever.sources.rhessi as rhessi
 
 LCClient = rhessi.RHESSIClient()
 
+
 @pytest.mark.parametrize("timerange,url_start",
 [
-(TimeRange('2012/7/1','2012/7/1'),
+(TimeRange('2012/7/1', '2012/7/2'),
 'http://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20120701_050.fits'),
-(TimeRange('2013/6/3','2013/6/4'),
+(TimeRange('2013/6/3', '2013/6/4'),
 'http://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20130603_042.fits'),
-(TimeRange('2012/7/1','2012/7/14'),
+(TimeRange('2012/7/1', '2012/7/14'),
 'http://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20120701_050.fits')
 ])
 def test_get_url_for_time_range(timerange, url_start):
@@ -21,27 +22,29 @@ def test_get_url_for_time_range(timerange, url_start):
     assert isinstance(urls, list)
     assert urls[0] == url_start
 
+
 def test_can_handle_query():
-    ans1 = rhessi.RHESSIClient._can_handle_query(Time('2012/8/9','2012/8/9'),Instrument('rhessi'))
-    assert ans1 == True
-    ans2 = rhessi.RHESSIClient._can_handle_query(Time('2013/2/7','2013/2/7'))
-    assert ans2 == False
+    ans1 = rhessi.RHESSIClient._can_handle_query(Time('2012/8/9', '2012/8/9'), Instrument('rhessi'))
+    assert ans1 is True
+    ans2 = rhessi.RHESSIClient._can_handle_query(Time('2013/2/7', '2013/2/7'))
+    assert ans2 is False
+
 
 def test_query():
-    qr1 = LCClient.query(Time('2011/4/9','2011/4/9'),Instrument('rhessi'))
-    assert isinstance(qr1,QueryResponse)
+    qr1 = LCClient.query(Time('2011/4/9', '2011/4/10'), Instrument('rhessi'))
+    assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 1
     assert qr1.time_range()[0] == '2011/04/09'
-    assert qr1.time_range()[1] == '2011/04/09'
+    assert qr1.time_range()[1] == '2011/04/10'
 
 
 @pytest.mark.online
 @pytest.mark.parametrize("time,instrument",
-[(Time('2012/11/27','2012/11/27'),Instrument('rhessi')),
- (Time('2012/10/4','2012/10/4'),Instrument('rhessi')),
+[(Time('2012/11/27', '2012/11/28'), Instrument('rhessi')),
+ (Time('2012/10/4', '2012/10/5'), Instrument('rhessi')),
 ])
-def test_get(time,instrument):
-    qr1 = LCClient.query(time,instrument)
+def test_get(time, instrument):
+    qr1 = LCClient.query(time, instrument)
     res = LCClient.get(qr1)
     download_list = res.wait()
     assert len(download_list) == len(qr1)


### PR DESCRIPTION
#1625 

RHESSI client now downloads all the data for a specified timerange.  How the time range is specified must be understood.

Given a time range that is specified by date only, the time range is understood as (start date at 0UT, end date at 0UT).  This means that if the start date and the end date are the same, then the time range is understood as (date at 0 UT, date at 0 UT).  Supplying such a time range has zero duration, and so no data is returned.  If you want data for the day 'date' then you must specify (date, date + 1 day).

#1624 
Fido response now shows the correct date range for each file found by Fido.
