### PR TITLE
[unidown] Possible logic error in GOESClient.

### DIFF
--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -58,18 +58,35 @@ class GOESClient(GenericClient):
             Data type to return for the particular GOES satellite. Supported
             types depend on the satellite number specified. (default = xrs_2s)
         """
-
+        start_date = parse_time(timerange.start)
+        end_date = parse_time(timerange.end)
+        
         # find out which satellite and datatype to query from the query times
         sat_num = self._get_goes_sat_num(timerange.start, timerange.end)
         base_url = 'http://umbra.nascom.nasa.gov/goes/fits/'
 
-        if timerange.start < parse_time('1999/01/15'):
-            url = base_url + "{date:%Y}/go{sat:02d}{date:%y%m%d}.fits".format(
-                date=timerange.start, sat=sat_num[0])
-        else:
-            url = base_url + "{date:%Y}/go{sat:02d}{date:%Y%m%d}.fits".format(
-                date=timerange.start, sat=sat_num[0])
-        return [url]
+        total_days = (end_date - start_date).days + 1
+
+        result = []
+        for day_number in range(total_days):
+            current_date = (start_date + datetime.timedelta(days=day_number)).date()
+            cur_date = datetime.datetime.combine(current_date, datetime.time())
+            if (cur_date < parse_time('1999/01/15')):
+                url = base_url + "{date:%Y}/go{sat:02d}{date:%y%m%d}.fits".format(
+                    date=cur_date, sat=self._get_goes_sat_num(cur_date,cur_date)[0])
+                result.append(url)
+            else:
+                url = base_url + "{date:%Y}/go{sat:02d}{date:%Y%m%d}.fits".format(
+                    date=cur_date, sat=self._get_goes_sat_num(cur_date,cur_date)[0])
+                result.append(url)
+            
+##        if timerange.start < parse_time('1999/01/15'):
+##            url = base_url + "{date:%Y}/go{sat:02d}{date:%y%m%d}.fits".format(
+##                date=timerange.start, sat=sat_num[0])
+##        else:
+##            url = base_url + "{date:%Y}/go{sat:02d}{date:%Y%m%d}.fits".format(
+##                date=timerange.start, sat=sat_num[0])
+        return result
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -4,6 +4,9 @@ from sunpy.time.timerange import TimeRange
 from sunpy.net.vso.attrs import Time, Instrument
 from sunpy.net.dataretriever.client import QueryResponse
 import sunpy.net.dataretriever.sources.goes as goes
+from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net import Fido
+from sunpy.net import attrs as a
 
 LCClient = goes.GOESClient()
 
@@ -52,8 +55,14 @@ def test_get(time, instrument):
 
 @pytest.mark.online
 def test_new_logic():
-    qr = LCClient.query(Time('2012/10/4','2012/10/6'),Instrument('goes'))
+    qr = LCClient.query(Time('2012/10/4','2012/10/6'), Instrument('goes'))
     res = LCClient.get(qr)
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
+@pytest.mark.online
+def test_fido_query():
+    qr = Fido.search(a.Time('2012/10/4','2012/10/6'), Instrument('goes'))
+    assert isinstance(qr, UnifiedResponse)
+    response = Fido.fetch(qr)
+    assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -11,10 +11,10 @@ LCClient = goes.GOESClient()
 @pytest.mark.parametrize("timerange,url_start,url_end",
 [(TimeRange('1995/06/03', '1995/06/04'),
 'http://umbra.nascom.nasa.gov/goes/fits/1995/go07950603.fits',
-'http://umbra.nascom.nasa.gov/goes/fits/1995/go07950603.fits'),
+'http://umbra.nascom.nasa.gov/goes/fits/1995/go07950604.fits'),
 (TimeRange('2008/06/02', '2008/06/03'),
 'http://umbra.nascom.nasa.gov/goes/fits/2008/go1020080602.fits',
-'http://umbra.nascom.nasa.gov/goes/fits/2008/go1020080602.fits')
+'http://umbra.nascom.nasa.gov/goes/fits/2008/go1020080603.fits')
 ])
 def test_get_url_for_time_range(timerange, url_start, url_end):
     urls = LCClient._get_url_for_timerange(timerange)
@@ -34,7 +34,7 @@ def test_can_handle_query():
 def test_query():
     qr1 = LCClient.query(Time('2012/8/9','2012/8/10'), Instrument('goes'))
     assert isinstance(qr1,QueryResponse)
-    assert len(qr1) == 1
+    assert len(qr1) == 2
     assert qr1.time_range()[0] == '2012/08/09'
     assert qr1.time_range()[1] == '2012/08/10'
 
@@ -49,4 +49,11 @@ def test_get(time, instrument):
     res = LCClient.get(qr1)
     download_list = res.wait()
     assert len(download_list) == len(qr1)
+
+@pytest.mark.online
+def test_new_logic():
+    qr = LCClient.query(Time('2012/10/4','2012/10/6'),Instrument('goes'))
+    res = LCClient.get(qr)
+    download_list = res.wait()
+    assert len(download_list) == len(qr)
 


### PR DESCRIPTION
Well , I found that for a particular timerange, GOESClient wasn't returning the intended fits file.
```python
from sunpy.time.timerange import TimeRange
from sunpy.net.vso.attrs import Time, Instrument
from sunpy.net.dataretriever.client import QueryResponse
import sunpy.net.dataretriever.sources.goes as goes

LCClient = goes.GOESClient()
qr = LCClient.query(Time('2012/10/4','2012/10/6'),Instrument('goes'))
res = LCClient.get(qr)
dl = res.wait()
print(len(qr)) #Length of query results
print(len(dl)) #no. of downloaded files.
```
Well, sometimes a particular **timerange** and **not a particular date**  might have multiple GOES satellite numbers, Think of a timerange which is spread over two different satellite numbers( see _get_goes_sat_num ) the earlier implementation didn't account for that. My implementation does that. I might be wrong here. This would need some testing as well. **Basically, the earlier logic was any given timerange by a user would belong to only one GOES sat number.** That might no be the case if we select a small timerange spread over the end of one satellite and beginning of the other. Correct me if I'm wrong.