### PR TITLE
Sunpy issue 1140

### DIFF
--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -238,7 +238,9 @@ class Database(object):
         self._session_cls = sessionmaker(bind=self._engine)
         self.session = self._session_cls()
         self._command_manager = commands.CommandManager()
-        if default_waveunit is not None:
+        if default_waveunit is None:
+            self.default_waveunit = None
+        elif default_waveunit is not None:
             try:
                 self.default_waveunit = units.Unit(default_waveunit)
             except ValueError:

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -14,6 +14,8 @@ import os.path
 from sqlalchemy import create_engine, exists
 from sqlalchemy.orm import sessionmaker
 
+from astropy import units
+
 import sunpy
 from sunpy.database import commands, tables, serialize
 from sunpy.database.caching import LRUCache
@@ -236,7 +238,11 @@ class Database(object):
         self._session_cls = sessionmaker(bind=self._engine)
         self.session = self._session_cls()
         self._command_manager = commands.CommandManager()
-        self.default_waveunit = default_waveunit
+        if default_waveunit is not None:
+            try:
+                self.default_waveunit = units.Unit(default_waveunit)
+            except ValueError:
+                raise WaveunitNotConvertibleError(default_waveunit)
         self._enable_history = True
 
         class Cache(CacheClass):

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -156,16 +156,16 @@ class Database(object):
         The default value is :class:`sunpy.database.caching.LRUCache`.
     cache_size : int
         The maximum number of database entries, default is no limit.
-    default_waveunit : str or astropy.units.Unit, optional
+    default_waveunit : `str` or `~astropy.units.Unit`, optional
         The wavelength unit that will be used if an entry is added to the
         database but its wavelength unit cannot be found (either in the file or
         the VSO query result block, depending on the way the entry was added).
-        If an astropy.units.Unit is passed, it is assigned to default_waveunit.
-        If a str is passed, it will be converted to astropy.units.Unit through
-        the units.Unit() initializer, and then assigned to default_waveunit.
-        If an invalid string is passed, WaveunitNotConvertibleError is raised.
-        If `None` (the default), attempting to add an entry without knowing the
-        wavelength unit results in a
+        If an `~astropy.units.Unit` is passed, it is assigned to ``default_waveunit``.
+        If a `str` is passed, it will be converted to `~astropy.units.Unit` through
+        the `astropy.units.Unit()` initializer, and then assigned to default_waveunit.
+        If an invalid string is passed, `~sunpy.database.WaveunitNotConvertibleError`
+        is raised. If `None` (the default), attempting to add an entry without knowing
+        the wavelength unit results in a
         :exc:`sunpy.database.WaveunitNotFoundError`.
     """
     """

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -240,7 +240,7 @@ class Database(object):
         self._command_manager = commands.CommandManager()
         if default_waveunit is None:
             self.default_waveunit = None
-        elif default_waveunit is not None:
+        else:
             try:
                 self.default_waveunit = units.Unit(default_waveunit)
             except ValueError:

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -156,10 +156,14 @@ class Database(object):
         The default value is :class:`sunpy.database.caching.LRUCache`.
     cache_size : int
         The maximum number of database entries, default is no limit.
-    default_waveunit : str, optional
+    default_waveunit : str or astropy.units.Unit, optional
         The wavelength unit that will be used if an entry is added to the
         database but its wavelength unit cannot be found (either in the file or
         the VSO query result block, depending on the way the entry was added).
+        If an astropy.units.Unit is passed, it is assigned to default_waveunit.
+        If a str is passed, it will be converted to astropy.units.Unit through
+        the units.Unit() initializer, and then assigned to default_waveunit.
+        If an invalid string is passed, WaveunitNotConvertibleError is raised.
         If `None` (the default), attempting to add an entry without knowing the
         wavelength unit results in a
         :exc:`sunpy.database.WaveunitNotFoundError`.

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -238,9 +238,8 @@ class Database(object):
         self._session_cls = sessionmaker(bind=self._engine)
         self.session = self._session_cls()
         self._command_manager = commands.CommandManager()
-        if default_waveunit is None:
-            self.default_waveunit = None
-        else:
+        self.default_waveunit = default_waveunit
+        if self.default_waveunit is not None:
             try:
                 self.default_waveunit = units.Unit(default_waveunit)
             except ValueError:

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -851,7 +851,7 @@ def default_waveunit_database():
     return unit_database, str_database
 
 
-def test_default_waveunit():
-    unit_database, str_database = default_waveunit_database()
+def test_default_waveunit(default_waveunit_database):
+    unit_database, str_database = default_waveunit_database
     assert isinstance(unit_database.default_waveunit, units.UnitBase)
     assert isinstance(str_database.default_waveunit, units.UnitBase)

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -15,6 +15,8 @@ import sys
 import pytest
 import sqlalchemy
 
+from astropy import units
+
 import sunpy
 from sunpy.database import Database, EntryAlreadyAddedError,\
     EntryAlreadyStarredError, EntryAlreadyUnstarredError, NoSuchTagError,\
@@ -840,3 +842,16 @@ def test_disable_undo(database, download_query, tmpdir):
         db.clear()
     with pytest.raises(EmptyCommandStackError):
         database.undo()
+
+
+@pytest.fixture
+def default_waveunit_database():
+    unit_database = Database('sqlite:///:memory:', default_waveunit = units.meter)
+    str_database = Database('sqlite:///:memory:', default_waveunit = "m")
+    return unit_database, str_database
+
+
+def test_default_waveunit():
+    unit_database, str_database = default_waveunit_database()
+    assert isinstance(unit_database.default_waveunit, units.UnitBase)
+    assert isinstance(str_database.default_waveunit, units.UnitBase)


### PR DESCRIPTION
Fixed #1140. Now, argument for default_waveunit can be passed either as a string or as an astropy unit.