### PR TITLE
Fixed formatting of SunPy's license

### DIFF
--- a/licenses/SUNPY.rst
+++ b/licenses/SUNPY.rst
@@ -3,8 +3,8 @@ SunPy is released under a BSD-style open source licence:
 Copyright (c) 2013 The SunPy developers
 All rights reserved.
 
-* Redistribution and use in source and binary forms, with or without modification,
-  are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
 * Redistributions of source code must retain the above copyright notice,
   this list of conditions and the following disclaimer.


### PR DESCRIPTION
Very minor fix to the formatting of SunPy's license

(At a glance, I wondered whether we had switched from the 2-clause BSD license to the 3-clause license.)