### PR TITLE
Fixes SunPy's Helioviewer client

### DIFF
--- a/sunpy/net/helioviewer.py
+++ b/sunpy/net/helioviewer.py
@@ -43,8 +43,8 @@ class HelioviewerClient(object):
         """Finds the closest image available for the specified source and date.
 
         For more information on what types of requests are available and the
-        expected usage for the response, consult the Helioviewer
-        API documentation: http://helioviewer.org/api
+        expected usage for the response, consult the Helioviewer API
+        documentation: http://legacy.helioviewer.org/api/docs/v1/ .
 
         Parameters
         ----------

--- a/sunpy/net/helioviewer.py
+++ b/sunpy/net/helioviewer.py
@@ -24,15 +24,16 @@ class HelioviewerClient(object):
     """Helioviewer.org Client"""
     def __init__(self, url="http://legacy.helioviewer.org/api/"):
         """
-        :param url: location of the Helioviewer API.  The default location
-        points to version 1 of the API.  Version 1 of the Helioviewer API is
-        currently planned to be supported until the end of April 2017.
+        url : location of the Helioviewer API.  The default location points to
+            version 1 of the API.  Version 1 of the Helioviewer API is
+            currently planned to be supported until the end of April 2017.
         """
         self._api = url
 
     def get_data_sources(self, **kwargs):
-        """Returns a structured list of datasources available at
-        Helioviewer.org"""
+        """
+        Returns a structured list of datasources available at helioviewer.org.
+        """
         params = {"action": "getDataSources"}
         params.update(kwargs)
 

--- a/sunpy/net/helioviewer.py
+++ b/sunpy/net/helioviewer.py
@@ -22,11 +22,17 @@ __all__ = ['HelioviewerClient']
 
 class HelioviewerClient(object):
     """Helioviewer.org Client"""
-    def __init__(self, url="http://helioviewer.org/api/"):
+    def __init__(self, url="http://legacy.helioviewer.org/api/"):
+        """
+        :param url: location of the Helioviewer API.  The default location
+        points to version 1 of the API.  Version 1 of the Helioviewer API is
+        currently planned to be supported until the end of April 2017.
+        """
         self._api = url
 
     def get_data_sources(self, **kwargs):
-        """Returns a structured list of datasources available at Helioviewer.org"""
+        """Returns a structured list of datasources available at
+        Helioviewer.org"""
         params = {"action": "getDataSources"}
         params.update(kwargs)
 


### PR DESCRIPTION
The Helioviewer Project recently switched its default API from version 1 to version 2.  This broke SunPy's helioviewer client.  This PR fixes the helioviewer client by changing SunPy's default helioviewer API URL to point at version 1 of the API.  Fixes #1724.