### PR TITLE
Fixed TimeRange bug regarding parse_time-compatible inputs

### DIFF
--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -27,10 +27,10 @@ class TimeRange(object):
     ----------
     a : str, number, `datetime.datetime`
         A time (usually the start time) specified as a parse_time-compatible
-        time string or number, or a datetime object.
-    b : str, `datetime.timedelta`, `astropy.units.Quantity` (time)
+        time string, number, or a datetime object.
+    b : str, number, `datetime.datetime`, `datetime.timedelta`, `astropy.units.Quantity` (time)
         Another time (usually the end time) specified as a
-        parse_time-compatible time string, or a datetime object.
+        parse_time-compatible time string, number, or a datetime object.
         May also be the size of the time range specified as a timedelta object,
         or a `astropy.units.Quantity`.
 
@@ -64,17 +64,6 @@ class TimeRange(object):
             x = parse_time(a)
             y = b
 
-        if isinstance(y, str):
-            y = parse_time(y)
-
-        if isinstance(y, datetime):
-            if x < y:
-                self._t1 = x
-                self._t2 = y
-            else:
-                self._t1 = y
-                self._t2 = x
-
         if isinstance(y, u.Quantity):
             y = timedelta(seconds=y.to('s').value)
 
@@ -85,6 +74,18 @@ class TimeRange(object):
                 self._t2 = x + y
             else:
                 self._t1 = x + y
+                self._t2 = x
+            return
+
+        # Otherwise, assume that the second argument is parse_time-compatible
+        y = parse_time(y)
+
+        if isinstance(y, datetime):
+            if x < y:
+                self._t1 = x
+                self._t2 = y
+            else:
+                self._t1 = y
                 self._t2 = x
 
     @property


### PR DESCRIPTION
There's a bug in `sunpy.time.TimeRange` where it will accept all `parse_time`-compatible inputs for the first argument, but not for the second argument (only strings are run through `parse_time`).  I presume this is a holdover from a pre-`Quantity` implementation where there'd be ambiguity whether a number as the second argument meant an `anytim`-epoch time or a duration.  I've rearranged the logic to fix this bug.

The trigger for this PR is that the LightCurve class (currently) uses the bounds of the `pandas.DataFrame` to generate a `TimeRange`.  Since the bounds are `pandas.Timestamp` objects, `TimeRange` actually breaks a little because it doesn't call `parse_time` on the "end" time to normalize it to a `datetime`.