### PR TITLE
SWAPClient with argument for deciding level.

### DIFF
--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -4,6 +4,7 @@ from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 from .dataretriever.attrs import goes
 
-from .vso.attrs import Time, Instrument, Wavelength, Level
+from .vso.attrs import Time, Instrument, Wavelength, Level, Source, Physobs, Detector
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc', 'goes']
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
+           'Source', 'Physobs', 'Detector']

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -4,7 +4,6 @@
 
 import copy
 import os
-import datetime
 from abc import ABCMeta
 from collections import OrderedDict, namedtuple
 from functools import partial
@@ -13,7 +12,6 @@ import numpy as np
 import astropy.table
 import astropy.units as u
 
-import sunpy
 from sunpy.extern import six
 from sunpy.time import TimeRange
 from sunpy.util import replacement_filename

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -58,7 +58,7 @@ class SWAPClient(GenericClient):
         returns list of urls corresponding to given TimeRange.
         """
         level = kwargs.get('level', 1)
-        if (level==1 or level==0):
+        if (level == 1 or level == 0):
             SWAP_STARTDATE = datetime.datetime(2009, 11, 24)
         else:
             SWAP_STARTDATE = datetime.datetime(2010, 1, 4)
@@ -66,7 +66,7 @@ class SWAPClient(GenericClient):
             raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(SWAP_STARTDATE))
         datatype = {0: 'eng', 1:'bsd', 'q':'qlk', 'Q':'qlk'}
         prefix = 'http://proba2.oma.be/swap/data/{datatype}/%Y/%m/%d/'
-        if (level==0 or level==1):
+        if (level == 0 or level == 1):
             suffix = '{instrument}_lv{level}_%Y%m%d_%H%M%S.fits'
         else:
             suffix = '%Y_%m_%d__%H_%M_%S__PROBA2_SWAP_SWAP_174.jp2'
@@ -107,7 +107,7 @@ class SWAPClient(GenericClient):
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'swap':
                 chk_var += 1
-            if x.__class__.__name__ == 'Level' and x.value in (0,1,'q','Q'):
+            if x.__class__.__name__ == 'Level' and x.value in (0, 1, 'q', 'Q'):
                 chk_var += 1
         if (chk_var == 2):
             return True

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -1,8 +1,8 @@
 """
 This module implements SWAPClient
 """
-#This module was developed with funding provided by
-#the Google Summer of Code 2016.
+# This module was developed with funding provided by
+# the Google Summer of Code 2016.
 
 __author__ = "Sudarshan Konge"
 __email__ = "sudk1896@gmail.com"
@@ -13,6 +13,7 @@ from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
 
 __all__ = ['SWAPClient']
+
 
 class SWAPClient(GenericClient):
     """
@@ -63,7 +64,7 @@ class SWAPClient(GenericClient):
             SWAP_STARTDATE = datetime.datetime(2010, 1, 4)
         if timerange.start < SWAP_STARTDATE:
             raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(SWAP_STARTDATE))
-        datatype = {0: 'eng', 1:'bsd', 'q':'qlk', 'Q':'qlk'}
+        datatype = {0: 'eng', 1: 'bsd', 'q': 'qlk', 'Q': 'qlk'}
         prefix = 'http://proba2.oma.be/swap/data/{datatype}/%Y/%m/%d/'
         if level == 0 or level == 1:
             suffix = '{instrument}_lv{level}_%Y%m%d_%H%M%S.fits'
@@ -101,7 +102,6 @@ class SWAPClient(GenericClient):
 
         """
         chkattr = ['Time', 'Instrument', 'Level']
-        chklist = [x.__class__.__name__ in chkattr for x in query]
         chk_var = 0
         for x in query:
             if x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'swap':

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -1,3 +1,6 @@
+"""
+This module implements SWAPClient
+"""
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
 

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -1,0 +1,112 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+
+__author__ = "Sudarshan Konge"
+__email__ = "sudk1896@gmail.com"
+
+import datetime
+import urllib2
+
+
+from sunpy.net.dataretriever.client import GenericClient
+from sunpy.util.scraper import Scraper
+
+from sunpy.time import TimeRange
+
+__all__ = ['SWAPClient']
+
+class SWAPClient(GenericClient):
+    """
+    Returns a list of URLS to Proba2 SWAP files corresponding to value of input timerange.
+    URL source: `http://proba2.oma.be/swap/data/bsd/`.
+
+    The earliest date available is from 24-Nov-2009
+
+    Parameters
+    ----------
+    timerange: sunpy.time.TimeRange
+        time range for which data is to be downloaded.
+        Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
+    
+    Instrument: Fixed argument = 'swap'
+
+    Level: Level can take only 0 and 1 as arguments.
+
+    Returns
+    -------
+    urls: list
+    list of urls corresponding to requested time range.
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido
+    >>> from sunpy.net import attrs as a
+
+    >>> results = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('swap'), a.Level(1))
+    >>> print(results)
+    >>> [<Table length=2>
+         Start Time           End Time      Source Instrument
+           str19               str19         str6     str4   
+    ------------------- ------------------- ------ ----------
+    2015-12-28 00:00:00 2015-12-29 00:00:00 Proba2       swap
+    2015-12-29 00:00:00 2015-12-30 00:00:00 Proba2       swap]
+    
+    >>> response = Fido.fetch(results)
+    """
+    
+    def _get_url_for_timerange(self, timerange, **kwargs):
+        """ returns list of urls corresponding
+        to given TimeRange. """
+        Level = kwargs['level']
+        SWAP_STARTDATE = datetime.datetime(2009, 11, 24)
+        if timerange.start < SWAP_STARTDATE:
+            raise ValueError('Earliest date for which SWAP data is available is 2009-11-24')
+        prefix = ""
+        suffix = ""
+        if (Level == 1):
+            prefix = 'http://proba2.oma.be/swap/data/bsd/'
+            suffix = '%Y/%m/%d/{instrument}_lv1_%Y%m%d_%H%M%S.fits'
+        else:
+            prefix = 'http://proba2.oma.be/swap/data/eng/'
+            suffix = '%Y/%m/%d/{instrument}_lv0_%Y%m%d_%H%M%S.fits'
+        url_pattern = prefix + suffix
+        crawler = Scraper(url_pattern, instrument= 'swap')
+        if not timerange:
+            return []
+        result = crawler.filelist(timerange)
+        return result
+
+    def _makeimap(self):
+        """
+        Helper Function:used to hold information about source.
+        """
+        self.map_['source'] = 'Proba2'
+        self.map_['instrument'] = 'swap'
+        self.map_['phyobs'] = 'irradiance'
+        self.map_['provider'] = 'esa'
+
+    @classmethod
+    def _can_handle_query(cls, *query):
+        """
+        Answers whether client can service the query.
+        
+        Parameters
+        ----------
+        query : list of query objects
+        
+        Returns
+        -------
+        boolean: answer as to whether client can service the query
+        
+        """
+        chkattr = ['Time', 'Instrument', 'Level']
+        chklist = [x.__class__.__name__ in chkattr for x in query]
+        chk_var = 0
+        for x in query:
+            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'swap':
+                chk_var += 1
+            if x.__class__.__name__ == 'Level' and 0<=x.value<=1:
+                chk_var += 1
+        if (chk_var == 2):
+            return True
+        return False

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -105,7 +105,7 @@ class SWAPClient(GenericClient):
         chklist = [x.__class__.__name__ in chkattr for x in query]
         chk_var = 0
         for x in query:
-            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'swap':
+            if x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'swap':
                 chk_var += 1
             if x.__class__.__name__ == 'Level' and x.value in (0, 1, 'q', 'Q'):
                 chk_var += 1

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -5,13 +5,9 @@ __author__ = "Sudarshan Konge"
 __email__ = "sudk1896@gmail.com"
 
 import datetime
-import urllib2
-
 
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
-
-from sunpy.time import TimeRange
 
 __all__ = ['SWAPClient']
 
@@ -26,7 +22,7 @@ class SWAPClient(GenericClient):
     timerange: sunpy.time.TimeRange
         time range for which data is to be downloaded.
         Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
-    
+
     Instrument: Fixed argument = 'swap'
 
     Level: Level can take only 0,1 or 'q'/'Q' as arguments.
@@ -45,20 +41,20 @@ class SWAPClient(GenericClient):
     >>> print(results)
     >>> [<Table length=2>
          Start Time           End Time      Source Instrument
-           str19               str19         str6     str4   
+           str19               str19         str6     str4
     ------------------- ------------------- ------ ----------
     2015-12-28 00:00:00 2015-12-29 00:00:00 Proba2       swap
     2015-12-29 00:00:00 2015-12-30 00:00:00 Proba2       swap]
-    
+
     >>> response = Fido.fetch(results)
     """
-    
+
     def _get_url_for_timerange(self, timerange, **kwargs):
         """
         returns list of urls corresponding to given TimeRange.
         """
         level = kwargs.get('level', 1)
-        if (level == 1 or level == 0):
+        if level == 1 or level == 0:
             SWAP_STARTDATE = datetime.datetime(2009, 11, 24)
         else:
             SWAP_STARTDATE = datetime.datetime(2010, 1, 4)
@@ -66,7 +62,7 @@ class SWAPClient(GenericClient):
             raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(SWAP_STARTDATE))
         datatype = {0: 'eng', 1:'bsd', 'q':'qlk', 'Q':'qlk'}
         prefix = 'http://proba2.oma.be/swap/data/{datatype}/%Y/%m/%d/'
-        if (level == 0 or level == 1):
+        if level == 0 or level == 1:
             suffix = '{instrument}_lv{level}_%Y%m%d_%H%M%S.fits'
         else:
             suffix = '%Y_%m_%d__%H_%M_%S__PROBA2_SWAP_SWAP_174.jp2'
@@ -91,15 +87,15 @@ class SWAPClient(GenericClient):
     def _can_handle_query(cls, *query):
         """
         Answers whether client can service the query.
-        
+
         Parameters
         ----------
         query : list of query objects
-        
+
         Returns
         -------
         boolean: answer as to whether client can service the query
-        
+
         """
         chkattr = ['Time', 'Instrument', 'Level']
         chklist = [x.__class__.__name__ in chkattr for x in query]

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -18,9 +18,8 @@ __all__ = ['SWAPClient']
 class SWAPClient(GenericClient):
     """
     Returns a list of URLS to Proba2 SWAP files corresponding to value of input timerange.
-    URL source: `http://proba2.oma.be/swap/data/bsd/`.
+    URL source: `http://proba2.oma.be/swap/data/`.
 
-    The earliest date available is from 24-Nov-2009
 
     Parameters
     ----------
@@ -30,7 +29,7 @@ class SWAPClient(GenericClient):
     
     Instrument: Fixed argument = 'swap'
 
-    Level: Level can take only 0 and 1 as arguments.
+    Level: Level can take only 0,1 or 'q'/'Q' as arguments.
 
     Returns
     -------
@@ -59,12 +58,18 @@ class SWAPClient(GenericClient):
         returns list of urls corresponding to given TimeRange.
         """
         level = kwargs.get('level', 1)
-        SWAP_STARTDATE = datetime.datetime(2009, 11, 24)
+        if (level==1 or level==0):
+            SWAP_STARTDATE = datetime.datetime(2009, 11, 24)
+        else:
+            SWAP_STARTDATE = datetime.datetime(2010, 1, 4)
         if timerange.start < SWAP_STARTDATE:
             raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(SWAP_STARTDATE))
-        datatype = {0: 'eng', 1:'bsd'}
-        prefix = 'http://proba2.oma.be/swap/data/{datatype}/'
-        suffix = '%Y/%m/%d/{instrument}_lv{level}_%Y%m%d_%H%M%S.fits'
+        datatype = {0: 'eng', 1:'bsd', 'q':'qlk', 'Q':'qlk'}
+        prefix = 'http://proba2.oma.be/swap/data/{datatype}/%Y/%m/%d/'
+        if (level==0 or level==1):
+            suffix = '{instrument}_lv{level}_%Y%m%d_%H%M%S.fits'
+        else:
+            suffix = '%Y_%m_%d__%H_%M_%S__PROBA2_SWAP_SWAP_174.jp2'
         url_pattern = prefix + suffix
         crawler = Scraper(url_pattern, instrument='swap', level=level, datatype=datatype[level])
         if not timerange:
@@ -102,7 +107,7 @@ class SWAPClient(GenericClient):
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'swap':
                 chk_var += 1
-            if x.__class__.__name__ == 'Level' and x.value in (0,1):
+            if x.__class__.__name__ == 'Level' and x.value in (0,1,'q','Q'):
                 chk_var += 1
         if (chk_var == 2):
             return True

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -61,12 +61,12 @@ class SWAPClient(GenericClient):
         level = kwargs.get('level', 1)
         SWAP_STARTDATE = datetime.datetime(2009, 11, 24)
         if timerange.start < SWAP_STARTDATE:
-            raise ValueError('Earliest date for which SWAP data is available is '+ str(SWAP_STARTDATE))
+            raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(SWAP_STARTDATE))
         datatype = {0: 'eng', 1:'bsd'}
         prefix = 'http://proba2.oma.be/swap/data/{datatype}/'
         suffix = '%Y/%m/%d/{instrument}_lv{level}_%Y%m%d_%H%M%S.fits'
         url_pattern = prefix + suffix
-        crawler = Scraper(url_pattern, instrument= 'swap', level = level, datatype = datatype[level])
+        crawler = Scraper(url_pattern, instrument='swap', level=level, datatype=datatype[level])
         if not timerange:
             return []
         result = crawler.filelist(timerange)

--- a/sunpy/net/dataretriever/sources/swap.py
+++ b/sunpy/net/dataretriever/sources/swap.py
@@ -109,6 +109,4 @@ class SWAPClient(GenericClient):
                 chk_var += 1
             if x.__class__.__name__ == 'Level' and x.value in (0, 1, 'q', 'Q'):
                 chk_var += 1
-        if (chk_var == 2):
-            return True
-        return False
+        return chk_var == 2

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -8,7 +8,7 @@ import pytest
 from sunpy.time.timerange import TimeRange
 from sunpy.net.vso.attrs import Time, Instrument, Level
 from sunpy.net.dataretriever.client import QueryResponse
-from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a
 

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -1,0 +1,58 @@
+import datetime
+import pytest
+
+from sunpy.time.timerange import TimeRange
+from sunpy.net.vso.attrs import Time,Instrument,Level
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+
+import sunpy.net.dataretriever.sources.swap as swap
+
+LCClient = swap.SWAPClient()
+
+@pytest.mark.online
+@pytest.mark.parametrize("timerange,url_start,url_end, level",
+                         [(TimeRange('2015/12/30 00:00:00','2015/12/30 23:59:59'),
+                           'http://proba2.oma.be/swap/data/bsd/2015/12/30/swap_lv1_20151230_000044.fits',
+                           'http://proba2.oma.be/swap/data/bsd/2015/12/30/swap_lv1_20151230_235935.fits', 1)])
+def test_get_url_for_time_range(timerange, url_start,url_end, level):
+    urls = LCClient._get_url_for_timerange(timerange, level = 1)
+    assert isinstance(urls, list)
+    assert urls[0] == url_start
+    assert urls[-1] == url_end
+
+def test_can_handle_query():
+    ans0 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('swap'), a.Level(1))
+    assert ans0 == True
+    ans1 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('swap'))
+    assert ans1 == False
+    ans2 = swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31'))
+    assert ans2 == False
+    ans3 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('eve'))
+    assert ans3 == False
+
+@pytest.mark.online
+def test_query():
+    qr1 = LCClient.query(Time('2015-12-30 00:00:00','2015-12-30 00:05:00'), Level = 1)
+    assert isinstance(qr1, QueryResponse)
+    assert len(qr1) == 4
+    assert qr1.time_range()[0] == '2015/12/30'
+    assert qr1.time_range()[1] == '2015/12/30'
+
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument, level",
+[(Time('2015/12/30 00:00:00','2015/12/30 00:05:00'), Instrument('swap'), Level(1))])
+def test_get(time, instrument, level):
+    qr1 = LCClient.query(time,instrument,level)
+    res = LCClient.get(qr1)
+    download_list = res.wait()
+    assert len(download_list) == len(qr1)
+
+@pytest.mark.online
+def test_fido_query():
+    qr = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('swap'), a.Level(1))
+    assert isinstance(qr, UnifiedResponse)
+    response = Fido.fetch(qr)
+    assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -27,14 +27,23 @@ def test_get_url_for_time_range(timerange, url_start, url_end, level):
     assert urls[0] == url_start
     assert urls[-1] == url_end
 
-def test_can_handle_query():
-    trange = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
-    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level(1))
-    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('q'))
-    assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('s'))
-    assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'))
-    assert not swap.SWAPClient._can_handle_query(trange)
-    assert not swap.SWAPClient._can_handle_query(trange, Instrument('eve'))
+TRANGE = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
+@pytest.mark.parametrize("time, instrument, level, expected",
+                         [(TRANGE, Instrument('swap'), Level(1), True),
+                          (TRANGE, Instrument('swap'), Level('q'), True),
+                          (TRANGE, Instrument('swap'), Level('s'), False),
+                          (TRANGE, Instrument('swap'), None, False),
+                          (TRANGE, None, None, False),
+                          (TRANGE, Instrument('eve'), None, False)])
+def test_can_handle_query(time, instrument, level, expected):
+    assert LCClient._can_handle_query(time, instrument, level) is expected
+##    trange = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
+##    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level(1))
+##    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('q'))
+##    assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('s'))
+##    assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'))
+##    assert not swap.SWAPClient._can_handle_query(trange)
+##    assert not swap.SWAPClient._can_handle_query(trange, Instrument('eve'))
 
 @pytest.mark.online
 def test_query():

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -26,12 +26,12 @@ def test_get_url_for_time_range(timerange, url_start, url_end, level):
     assert urls[-1] == url_end
 
 def test_can_handle_query():
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level(1)) == True
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level('q')) == True
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level('s')) == False
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap')) == False
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31')) == False
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('eve')) == False
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level(1)) is True
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level('q')) is True
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level('s')) is False
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap')) is False
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31')) is False
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('eve')) is False
 
 @pytest.mark.online
 def test_query():
@@ -44,12 +44,16 @@ def test_query():
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, level",
 [(Time('2015/12/30 00:00:00','2015/12/30 00:05:00'), Instrument('swap'), Level('q'))])
+#This test will download 4 JP2 files
+#each of size 170KB.
 def test_get(time, instrument, level):
     qr1 = LCClient.query(time,instrument,level)
     res = LCClient.get(qr1)
     download_list = res.wait()
     assert len(download_list) == len(qr1)
 
+#This test will download 2 fits files
+#each of size 2MB
 @pytest.mark.online
 def test_fido_query():
     qr = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('swap'), a.Level(1))

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -37,13 +37,6 @@ TRANGE = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
                           (TRANGE, Instrument('eve'), None, False)])
 def test_can_handle_query(time, instrument, level, expected):
     assert LCClient._can_handle_query(time, instrument, level) is expected
-##    trange = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
-##    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level(1))
-##    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('q'))
-##    assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('s'))
-##    assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'))
-##    assert not swap.SWAPClient._can_handle_query(trange)
-##    assert not swap.SWAPClient._can_handle_query(trange, Instrument('eve'))
 
 @pytest.mark.online
 def test_query():

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -1,3 +1,5 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
 import datetime
 import pytest
 
@@ -20,26 +22,26 @@ LCClient = swap.SWAPClient()
 def test_get_url_for_time_range(timerange, url_start,url_end, level):
     urls = LCClient._get_url_for_timerange(timerange, level = 1)
     assert isinstance(urls, list)
-    assert urls[0] is url_start
-    assert urls[-1] is url_end
+    assert urls[0] == url_start
+    assert urls[-1] == url_end
 
 def test_can_handle_query():
     ans0 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('swap'), a.Level(1))
-    assert ans0 is True
+    assert ans0 == True
     ans1 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('swap'))
-    assert ans1 is False
+    assert ans1 == False
     ans2 = swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31'))
-    assert ans2 is False
+    assert ans2 == False
     ans3 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('eve'))
-    assert ans3 is False
+    assert ans3 == False
 
 @pytest.mark.online
 def test_query():
     qr1 = LCClient.query(Time('2015-12-30 00:00:00','2015-12-30 00:05:00'), Level = 1)
     assert isinstance(qr1, QueryResponse)
-    assert len(qr1) is 4
-    assert qr1.time_range()[0] is '2015/12/30'
-    assert qr1.time_range()[1] is '2015/12/30'
+    assert len(qr1) == 4
+    assert qr1.time_range()[0] == '2015/12/30'
+    assert qr1.time_range()[1] == '2015/12/30'
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, level",
@@ -48,11 +50,11 @@ def test_get(time, instrument, level):
     qr1 = LCClient.query(time,instrument,level)
     res = LCClient.get(qr1)
     download_list = res.wait()
-    assert len(download_list) is len(qr1)
+    assert len(download_list) == len(qr1)
 
 @pytest.mark.online
 def test_fido_query():
     qr = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('swap'), a.Level(1))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
-    assert len(response) is qr._numfile
+    assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -1,10 +1,12 @@
+"""
+This module tests SWAPClient
+"""
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
-import datetime
 import pytest
 
 from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time,Instrument,Level
+from sunpy.net.vso.attrs import Time, Instrument, Level
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
@@ -26,7 +28,7 @@ def test_get_url_for_time_range(timerange, url_start, url_end, level):
     assert urls[-1] == url_end
 
 def test_can_handle_query():
-    trange = Time('2015/12/30 00:00:00','2015/12/31 00:05:00')
+    trange = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
     assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level(1))
     assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('q'))
     assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('s'))
@@ -36,7 +38,7 @@ def test_can_handle_query():
 
 @pytest.mark.online
 def test_query():
-    qr1 = LCClient.query(Time('2015-12-30 00:00:00','2015-12-30 00:05:00'), Level = 1)
+    qr1 = LCClient.query(Time('2015-12-30 00:00:00', '2015-12-30 00:05:00'), Level = 1)
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 4
     assert qr1.time_range()[0] == '2015/12/30'
@@ -44,11 +46,11 @@ def test_query():
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, level",
-[(Time('2015/12/30 00:00:00','2015/12/30 00:05:00'), Instrument('swap'), Level('q'))])
+[(Time('2015/12/30 00:00:00', '2015/12/30 00:05:00'), Instrument('swap'), Level('q'))])
 #This test will download 4 JP2 files
 #each of size 170KB.
 def test_get(time, instrument, level):
-    qr1 = LCClient.query(time,instrument,level)
+    qr1 = LCClient.query(time, instrument, level)
     res = LCClient.get(qr1)
     download_list = res.wait()
     assert len(download_list) == len(qr1)

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -20,13 +20,15 @@ LCClient = swap.SWAPClient()
                            'http://proba2.oma.be/swap/data/bsd/2015/12/30/swap_lv1_20151230_000044.fits',
                            'http://proba2.oma.be/swap/data/bsd/2015/12/30/swap_lv1_20151230_235935.fits', 1)])
 def test_get_url_for_time_range(timerange, url_start, url_end, level):
-    urls = LCClient._get_url_for_timerange(timerange, level = 1)
+    urls = LCClient._get_url_for_timerange(timerange, level = level)
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
 
 def test_can_handle_query():
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level(1)) == True 
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level(1)) == True
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level('q')) == True
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level('s')) == False
     assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap')) == False
     assert swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31')) == False
     assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('eve')) == False
@@ -41,7 +43,7 @@ def test_query():
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, level",
-[(Time('2015/12/30 00:00:00','2015/12/30 00:05:00'), Instrument('swap'), Level(1))])
+[(Time('2015/12/30 00:00:00','2015/12/30 00:05:00'), Instrument('swap'), Level('q'))])
 def test_get(time, instrument, level):
     qr1 = LCClient.query(time,instrument,level)
     res = LCClient.get(qr1)

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -25,13 +25,13 @@ def test_get_url_for_time_range(timerange, url_start, url_end, level):
     assert urls[0] == url_start
     assert urls[-1] == url_end
 
-trange = Time('2015/12/30 00:00:00','2015/12/31 00:05:00')
 def test_can_handle_query():
+    trange = Time('2015/12/30 00:00:00','2015/12/31 00:05:00')
     assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level(1))
     assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('q'))
-    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('s'))
+    assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('s'))
     assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'))
-    assert not swap.SWAPClient._can_handle_query(trange) is False
+    assert not swap.SWAPClient._can_handle_query(trange)
     assert not swap.SWAPClient._can_handle_query(trange, Instrument('eve'))
 
 @pytest.mark.online

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -25,13 +25,14 @@ def test_get_url_for_time_range(timerange, url_start, url_end, level):
     assert urls[0] == url_start
     assert urls[-1] == url_end
 
+trange = Time('2015/12/30 00:00:00','2015/12/31 00:05:00')
 def test_can_handle_query():
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level(1)) is True
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level('q')) is True
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level('s')) is False
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap')) is False
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31')) is False
-    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('eve')) is False
+    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level(1))
+    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('q'))
+    assert swap.SWAPClient._can_handle_query(trange, Instrument('swap'), a.Level('s'))
+    assert not swap.SWAPClient._can_handle_query(trange, Instrument('swap'))
+    assert not swap.SWAPClient._can_handle_query(trange) is False
+    assert not swap.SWAPClient._can_handle_query(trange, Instrument('eve'))
 
 @pytest.mark.online
 def test_query():

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -1,8 +1,8 @@
 """
 This module tests SWAPClient
 """
-#This module was developed with funding provided by
-#the Google Summer of Code 2016.
+# This module was developed with funding provided by
+# the Google Summer of Code 2016.
 import pytest
 
 from sunpy.time.timerange import TimeRange
@@ -15,19 +15,22 @@ from sunpy.net import attrs as a
 import sunpy.net.dataretriever.sources.swap as swap
 
 LCClient = swap.SWAPClient()
+TRANGE = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
+
 
 @pytest.mark.online
-@pytest.mark.parametrize("timerange,url_start,url_end, level",
-                         [(TimeRange('2015/12/30 00:00:00','2015/12/30 23:59:59'),
-                           'http://proba2.oma.be/swap/data/bsd/2015/12/30/swap_lv1_20151230_000044.fits',
-                           'http://proba2.oma.be/swap/data/bsd/2015/12/30/swap_lv1_20151230_235935.fits', 1)])
+@pytest.mark.parametrize("timerange, url_start, url_end, level",
+                         [(TimeRange('2015/12/30 00:00:00', '2015/12/30 23:59:59'),
+                           'bsd/2015/12/30/swap_lv1_20151230_000044.fits',
+                           'bsd/2015/12/30/swap_lv1_20151230_235935.fits', 1)])
 def test_get_url_for_time_range(timerange, url_start, url_end, level):
-    urls = LCClient._get_url_for_timerange(timerange, level = level)
+    urls = LCClient._get_url_for_timerange(timerange, level=level)
+    url_data = "http://proba2.oma.be/swap/data/"
     assert isinstance(urls, list)
-    assert urls[0] == url_start
-    assert urls[-1] == url_end
+    assert urls[0] == url_data + url_start
+    assert urls[-1] == url_data + url_end
 
-TRANGE = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
+
 @pytest.mark.parametrize("time, instrument, level, expected",
                          [(TRANGE, Instrument('swap'), Level(1), True),
                           (TRANGE, Instrument('swap'), Level('q'), True),
@@ -38,30 +41,35 @@ TRANGE = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
 def test_can_handle_query(time, instrument, level, expected):
     assert LCClient._can_handle_query(time, instrument, level) is expected
 
+
 @pytest.mark.online
 def test_query():
-    qr1 = LCClient.query(Time('2015-12-30 00:00:00', '2015-12-30 00:05:00'), Level = 1)
+    qr1 = LCClient.query(Time('2015-12-30 00:00:00', '2015-12-30 00:05:00'), Level=1)
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 4
     assert qr1.time_range()[0] == '2015/12/30'
     assert qr1.time_range()[1] == '2015/12/30'
 
+
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, level",
-[(Time('2015/12/30 00:00:00', '2015/12/30 00:05:00'), Instrument('swap'), Level('q'))])
-#This test will download 4 JP2 files
-#each of size 170KB.
+                         [(Time('2015/12/30 00:00:00', '2015/12/30 00:05:00'),
+                           Instrument('swap'), Level('q'))])
+# This test will download 4 JP2 files
+# each of size 170KB.
 def test_get(time, instrument, level):
     qr1 = LCClient.query(time, instrument, level)
     res = LCClient.get(qr1)
     download_list = res.wait()
     assert len(download_list) == len(qr1)
 
-#This test will download 2 fits files
-#each of size 2MB
+
+# This test will download 2 fits files
+# each of size 2MB
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('swap'), a.Level(1))
+    qr = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'),
+                     a.Instrument('swap'), a.Level(1))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -20,26 +20,26 @@ LCClient = swap.SWAPClient()
 def test_get_url_for_time_range(timerange, url_start,url_end, level):
     urls = LCClient._get_url_for_timerange(timerange, level = 1)
     assert isinstance(urls, list)
-    assert urls[0] == url_start
-    assert urls[-1] == url_end
+    assert urls[0] is url_start
+    assert urls[-1] is url_end
 
 def test_can_handle_query():
     ans0 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('swap'), a.Level(1))
-    assert ans0 == True
+    assert ans0 is True
     ans1 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('swap'))
-    assert ans1 == False
+    assert ans1 is False
     ans2 = swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31'))
-    assert ans2 == False
+    assert ans2 is False
     ans3 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('eve'))
-    assert ans3 == False
+    assert ans3 is False
 
 @pytest.mark.online
 def test_query():
     qr1 = LCClient.query(Time('2015-12-30 00:00:00','2015-12-30 00:05:00'), Level = 1)
     assert isinstance(qr1, QueryResponse)
-    assert len(qr1) == 4
-    assert qr1.time_range()[0] == '2015/12/30'
-    assert qr1.time_range()[1] == '2015/12/30'
+    assert len(qr1) is 4
+    assert qr1.time_range()[0] is '2015/12/30'
+    assert qr1.time_range()[1] is '2015/12/30'
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, level",
@@ -48,11 +48,11 @@ def test_get(time, instrument, level):
     qr1 = LCClient.query(time,instrument,level)
     res = LCClient.get(qr1)
     download_list = res.wait()
-    assert len(download_list) == len(qr1)
+    assert len(download_list) is len(qr1)
 
 @pytest.mark.online
 def test_fido_query():
     qr = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('swap'), a.Level(1))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
-    assert len(response) == qr._numfile
+    assert len(response) is qr._numfile

--- a/sunpy/net/dataretriever/tests/test_swap.py
+++ b/sunpy/net/dataretriever/tests/test_swap.py
@@ -19,21 +19,17 @@ LCClient = swap.SWAPClient()
                          [(TimeRange('2015/12/30 00:00:00','2015/12/30 23:59:59'),
                            'http://proba2.oma.be/swap/data/bsd/2015/12/30/swap_lv1_20151230_000044.fits',
                            'http://proba2.oma.be/swap/data/bsd/2015/12/30/swap_lv1_20151230_235935.fits', 1)])
-def test_get_url_for_time_range(timerange, url_start,url_end, level):
+def test_get_url_for_time_range(timerange, url_start, url_end, level):
     urls = LCClient._get_url_for_timerange(timerange, level = 1)
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
 
 def test_can_handle_query():
-    ans0 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('swap'), a.Level(1))
-    assert ans0 == True
-    ans1 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('swap'))
-    assert ans1 == False
-    ans2 = swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31'))
-    assert ans2 == False
-    ans3 = swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'),Instrument('eve'))
-    assert ans3 == False
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'), a.Level(1)) == True 
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap')) == False
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30','2015/12/31')) == False
+    assert swap.SWAPClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('eve')) == False
 
 @pytest.mark.online
 def test_query():


### PR DESCRIPTION
SWAPClient implementation.
With this users can now query from [PROBA2](http://proba2.oma.be) for SWAP data from both levels 0 and 1 by passing an argument. The query interface now looks like. P.S. It now supports argument for downloading qlk data as well, Level can be supplied with `'q'/'Q'` as well.

```
Fido.query( a.Time, a.Instrument('swap'), a.Level(1) )
```

@dpshelio @Cadair @wafels 
Please review this and inputs are welcome.
P.S. Tests for test_swap.py have passed, check the Travis build. Tests are failing due to other issues.
