### PR TITLE
Kanzelhohe Client Implementation

### DIFF
--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,6 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level
+from .vso.attrs import Time, Instrument, Wavelength, Level, Source, Physobs, Detector, Filter
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc']
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
+           'Source', 'Physobs', 'Detector', 'Filter']

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -250,7 +250,6 @@ class GenericClient(object):
         GenericClient._makeargs(self, *args, **kwargs)
         kwergs = copy.copy(self.map_)
         kwergs.update(kwargs)
-        print(kwergs)
         urls = self._get_url_for_timerange(
             self.map_.get('TimeRange'), **kwergs)
         return QueryResponse.create(self.map_, urls)

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -188,7 +188,7 @@ class GenericClient(object):
                 else:
                     self.map_[elem.__class__.__name__.lower()] = (a_min, a_max)
             elif issubclass(elem.__class__, Wavelength):
-                self.map_['Wavelength'] = elem
+                self.map_[elem.__class__.__name__.lower()] = elem
             else:
                 if hasattr(elem, 'value'):
                     self.map_[elem.__class__.__name__.lower()] = elem.value

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -20,7 +20,7 @@ from sunpy.util import replacement_filename
 from sunpy import config
 
 from ..download import Downloader, Results
-from ..vso.attrs import Time, _Range
+from ..vso.attrs import Time, _Range, Wavelength
 
 TIME_FORMAT = config.get("general", "time_format")
 
@@ -171,6 +171,10 @@ class GenericClient(object):
         \*\*kwargs: `dict`
             None.
         """
+#       Currently Fido doesn't support Parsing Wavelength support.
+#       i.e. If you pass Wavelength object it will ot recognize it.
+#       To do recognize it, we store a key called wavelength and make it
+#       hold a .vso.attrs.Wavelength object.
         for elem in args:
             if isinstance(elem, Time):
                 self.map_['TimeRange'] = TimeRange(elem.start, elem.end)
@@ -183,6 +187,8 @@ class GenericClient(object):
                     self.map_[elem.__class__.__name__.lower()] = a_min
                 else:
                     self.map_[elem.__class__.__name__.lower()] = (a_min, a_max)
+            elif issubclass(elem.__class__, Wavelength):
+                self.map_['Wavelength'] = elem
             else:
                 if hasattr(elem, 'value'):
                     self.map_[elem.__class__.__name__.lower()] = elem.value
@@ -242,9 +248,9 @@ class GenericClient(object):
             `sunpy.net.attrs` objects representing the query.
         """
         GenericClient._makeargs(self, *args, **kwargs)
-
         kwergs = copy.copy(self.map_)
         kwergs.update(kwargs)
+        print(kwergs)
         urls = self._get_url_for_timerange(
             self.map_.get('TimeRange'), **kwergs)
         return QueryResponse.create(self.map_, urls)

--- a/sunpy/net/dataretriever/clients.py
+++ b/sunpy/net/dataretriever/clients.py
@@ -7,6 +7,7 @@ from .sources.goes import GOESClient
 from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 from .sources.noaa import NOAAIndicesClient, NOAAPredictClient
+from .sources.kanzelhohe import KanzelhoheClient
 
 # Import and register other sources
 from sunpy.net.jsoc.jsoc import JSOCClient

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -83,12 +83,11 @@ class KanzelhoheClient(GenericClient):
             START_DATE = date_table[wave]
             if timerange.start < START_DATE:
                 raise ValueError('Earliest date for which Kanzelhohe data is available is {:%Y-%m-%d}'.format(START_DATE))
-            prefix = "http://cesar.kso.ac.at/{datatype}/"
-            if (wave == 6563):
-                suffix = "%Y/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
-            else:
-                suffix = "%Y/%Y%m%d/processed/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
-            url_pattern = prefix + suffix
+            prefix = "http://cesar.kso.ac.at/{datatype}/%Y/"
+            suffix = ""
+            if (wave != 6563):
+                suffix = "%Y%m%d/processed/"
+            url_pattern = prefix + suffix + "kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
             crawler = Scraper(url_pattern, datatype=table[wave][0], datatype1=table[wave][1])
             if not timerange:
                 return []

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -72,25 +72,25 @@ class KanzelhoheClient(GenericClient):
                 db.append(wave_nums)
                 if np.isclose(da, db, 1e-10, 1e-10):
                     wave = wave_nums
-        except NameError:
-            print ("Enter valid wavelength range with proper units")
 
-        date_table = {6563: datetime.datetime(2000, 7, 20, 7, 45, 46), 5460: datetime.datetime(2011, 1, 7, 10, 7, 33),
-                      32768: datetime.datetime(2010, 7, 31, 8, 10, 59)}
-        START_DATE = date_table[wave]
-        if timerange.start < START_DATE:
-            raise ValueError('Earliest date for which Kanzelhohe data is available is {:%Y-%m-%d}'.format(START_DATE))
-        prefix = "http://cesar.kso.ac.at/{datatype}/"
-        if (wave == 6563):
-            suffix = "%Y/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
-        else:
-            suffix = "%Y/%Y%m%d/processed/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
-        url_pattern = prefix + suffix
-        crawler = Scraper(url_pattern, datatype = table[wave][0], datatype1 = table[wave][1])
-        if not timerange:
-            return []
-        result = crawler.filelist(timerange)
-        return result
+            date_table = {6563: datetime.datetime(2000, 7, 20, 7, 45, 46), 5460: datetime.datetime(2011, 1, 7, 10, 7, 33),
+                          32768: datetime.datetime(2010, 7, 31, 8, 10, 59)}
+            START_DATE = date_table[wave]
+            if timerange.start < START_DATE:
+                raise ValueError('Earliest date for which Kanzelhohe data is available is {:%Y-%m-%d}'.format(START_DATE))
+            prefix = "http://cesar.kso.ac.at/{datatype}/"
+            if (wave == 6563):
+                suffix = "%Y/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
+            else:
+                suffix = "%Y/%Y%m%d/processed/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
+            url_pattern = prefix + suffix
+            crawler = Scraper(url_pattern, datatype = table[wave][0], datatype1 = table[wave][1])
+            if not timerange:
+                return []
+            result = crawler.filelist(timerange)
+            return result
+        except:
+            print "Enter wavelength with proper values and units"
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -71,9 +71,9 @@ class KanzelhoheClient(GenericClient):
         Helper Function:used to hold information about source.
         """
         self.map_['source'] = 'Global Halpha Network'
-        self.map_['instrument'] = 'Kanzelhohe'
-##        self.map_['phyobs'] = 'irradiance'
-##        self.map_['provider'] = 'esa'
+        self.map_['instrument'] = 'Kanzelhohe HA2'
+        self.map_['phyobs'] = 'irradiance'
+        self.map_['provider'] = 'Kanzelhohe'
         self.map_['wavelength'] = '6563 AA'
 
     @classmethod

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -1,17 +1,16 @@
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
-
+"""
+This module implements Kanzelhohe Client.
+"""
 __author__ = "Sudarshan Konge"
 __email__ = "sudk1896@gmail.com"
 
 import datetime
-import urllib2
 import numpy as np
-
 
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
-from sunpy.time import TimeRange
 
 __all__ = ['KanzelhoheClient']
 
@@ -29,7 +28,7 @@ class KanzelhoheClient(GenericClient):
     timerange: sunpy.time.TimeRange
         time range for which data is to be downloaded.
         Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
-    
+
     Instrument: Fixed argument = 'kanzelhohe'
 
     Wavelength: Fixed argument = astropy.units.quantity.Quantity
@@ -50,10 +49,10 @@ class KanzelhoheClient(GenericClient):
     >>> print(results)
     [<Table length=1>
         Start Time           End Time              Source        Instrument
-        str19               str19                str21           str10   
+        str19               str19                str21           str10
     ------------------- ------------------- --------------------- ----------
     2015-12-28 00:00:00 2015-12-29 00:00:00 Global Halpha Network Kanzelhohe]
-    
+
     >>> response = Fido.fetch(results)
     """
     def _get_url_for_timerange(self, timerange, **kwargs):
@@ -85,7 +84,7 @@ class KanzelhoheClient(GenericClient):
                 raise ValueError('Earliest date for which Kanzelhohe data is available is {:%Y-%m-%d}'.format(START_DATE))
             prefix = "http://cesar.kso.ac.at/{datatype}/%Y/"
             suffix = ""
-            if (wave != 6563):
+            if wave != 6563:
                 suffix = "%Y%m%d/processed/"
             url_pattern = prefix + suffix + "kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
             crawler = Scraper(url_pattern, datatype=table[wave][0], datatype1=table[wave][1])
@@ -109,28 +108,24 @@ class KanzelhoheClient(GenericClient):
     def _can_handle_query(cls, *query):
         """
         Answers whether client can service the query.
-        
+
         Parameters
         ----------
         query : list of query objects
-        
+
         Returns
         -------
         boolean: answer as to whether client can service the query
-        
+
         """
         chkattr = ['Time', 'Instrument', 'Wavelength']
         chklist = [x.__class__.__name__ in chkattr for x in query]
         chk_var = 0
         values = [6563, 5460, 32768]
         for x in query:
-            if (x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'kanzelhohe'):
+            if x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'kanzelhohe':
                 chk_var += 1
-            if (x.__class__.__name__ == 'Wavelength'):
+            if x.__class__.__name__ == 'Wavelength':
                 chk_var += 1
-        if (chk_var==2):
-            return True
-        return False
-            
-        
-    
+        return chk_var == 2
+

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -56,7 +56,7 @@ class KanzelhoheClient(GenericClient):
         """
         START_DATE = datetime.datetime(2000, 7, 20, 7, 45, 46)
         if timerange.start < START_DATE:
-            raise ValueError('Earliest date for which SWAP data is available is '+ str(START_DATE))
+            raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(START_DATE))
         prefix = "http://cesar.kso.ac.at/halpha2k/recent/"
         suffix = "%Y/kanz_halph_fr_%Y%m%d_%H%M%S.fts.gz"
         url_pattern = prefix + suffix

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -59,7 +59,7 @@ class KanzelhoheClient(GenericClient):
         """
         returns list of urls corresponding to given TimeRange.
         """
-        wave = int(kwargs['Wavelength'].min.value)
+        wave = int(kwargs['wavelength'].min.value)
         table = {6563:['halpha2k/recent', 'halph_fr'], 32768:['caiia', 'caiik_fi'], 5460:['phokada', 'bband_fi']}
         if (wave == 6563):
             START_DATE = datetime.datetime(2000, 7, 20, 7, 45, 46)

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -59,9 +59,14 @@ class KanzelhoheClient(GenericClient):
         table1 = {6563:'halph_fr', 32768:'caiik_fi', 5460:'bband_fi'}
         datatype = table[wave]
         datatype1 = table1[wave]
-##        START_DATE = datetime.datetime(2000, 7, 20, 7, 45, 46)
-##        if timerange.start < START_DATE:
-##            raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(START_DATE))
+        if (wave==6563):
+            START_DATE = datetime.datetime(2000, 7, 20, 7, 45, 46)
+        elif (wave==5460):
+            START_DATE = datetime.datetime(2011, 1, 7, 10, 7, 33)
+        elif (wave==32768):
+            START_DATE = datetime.datetime(2010, 7, 31, 8, 10, 59)
+        if timerange.start < START_DATE:
+            raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(START_DATE))
         prefix = "http://cesar.kso.ac.at/{datatype}/"
         if (wave==6563):
             suffix = "%Y/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
@@ -100,10 +105,11 @@ class KanzelhoheClient(GenericClient):
         chkattr = ['Time', 'Instrument', 'Wavelength']
         chklist = [x.__class__.__name__ in chkattr for x in query]
         chk_var = 0
+        values = [6563, 5460, 32768]
         for x in query:
             if (x.__class__.__name__ == 'Instrument' and x.value.lower() == 'kanzelhohe'):
                 chk_var += 1
-            if (x.__class__.__name__ == 'Wavelength' and int(x.min.value) in (6563, 5460, 32768) and (x.unit.name).lower()=='angstrom'):
+            if (x.__class__.__name__ == 'Wavelength' and int(x.min.value) in values and (x.unit.name).lower()=='angstrom') and int(x.max.value) in values:
                 chk_var += 1
         if (chk_var==2):
             return True

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -65,16 +65,16 @@ class KanzelhoheClient(GenericClient):
         table1 = {6563:'halph_fr', 32768:'caiik_fi', 5460:'bband_fi'}
         datatype = table[wave]
         datatype1 = table1[wave]
-        if (wave==6563):
+        if (wave == 6563):
             START_DATE = datetime.datetime(2000, 7, 20, 7, 45, 46)
-        elif (wave==5460):
+        elif (wave == 5460):
             START_DATE = datetime.datetime(2011, 1, 7, 10, 7, 33)
-        elif (wave==32768):
+        elif (wave == 32768):
             START_DATE = datetime.datetime(2010, 7, 31, 8, 10, 59)
         if timerange.start < START_DATE:
-            raise ValueError('Earliest date for which SWAP data is available is {:%Y-%m-%d}'.format(START_DATE))
+            raise ValueError('Earliest date for which Kanzelhohe data is available is {:%Y-%m-%d}'.format(START_DATE))
         prefix = "http://cesar.kso.ac.at/{datatype}/"
-        if (wave==6563):
+        if (wave == 6563):
             suffix = "%Y/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
         else:
             suffix = "%Y/%Y%m%d/processed/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -18,9 +18,11 @@ __all__ = ['KanzelhoheClient']
 class KanzelhoheClient(GenericClient):
     """
     Returns a list of URLS to Kanzelhohe H-alpha files corresponding to value of input timerange.
-    URL source: `http://cesar.kso.ac.at/halpha2k/recent/`.
+    URL source: `http://cesar.kso.ac.at/`.
 
-    The earliest date available is from 20-July-2000
+    The earliest data for H-alpha 2k - 20-Jul-2000
+                          Ca-II k - 31-Jul-2010
+                          Continuum - 7-Jan-2011
 
     Parameters
     ----------
@@ -29,6 +31,10 @@ class KanzelhoheClient(GenericClient):
         Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
     
     Instrument: Fixed argument = 'kanzelhohe'
+
+    Wavelength: Fixed argument = astropy.units.quantity.Quantity
+                The physical value of wavelength will belong to any of [5460, 6563, 32768]
+                and units will be Angstroms.
 
     Returns
     -------
@@ -40,7 +46,7 @@ class KanzelhoheClient(GenericClient):
     >>> from sunpy.net import Fido
     >>> from sunpy.net import attrs as a
 
-    >>> results = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('kanzelhohe'))
+    >>> results = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('kanzelhohe'), a.Wavelength(6563*u.AA))
     >>> print(results)
     >>> [<Table length=1>
         Start Time           End Time              Source        Instrument

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -65,10 +65,15 @@ class KanzelhoheClient(GenericClient):
         #Checking if value is close enough to a wavelength value.
         #Converting from one unit to other introduces precision errors.
         try:
-            da = []
+            #The isclose function in numpy can only check two arrays if they
+            #are close to each other within some precision. Standalone values such
+            #as int, doubles etc can't be checked that way. In order to do that, we put the
+            #two indiviual values in two seperate arrays da and db and then apply
+            #isclose on both those arrays.
+            da = list()
             da.append(wave_float)
             for wave_nums in table.keys():
-                db = []
+                db = list()
                 db.append(wave_nums)
                 if np.isclose(da, db, 1e-10, 1e-10):
                     wave = wave_nums
@@ -84,13 +89,13 @@ class KanzelhoheClient(GenericClient):
             else:
                 suffix = "%Y/%Y%m%d/processed/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
             url_pattern = prefix + suffix
-            crawler = Scraper(url_pattern, datatype = table[wave][0], datatype1 = table[wave][1])
+            crawler = Scraper(url_pattern, datatype=table[wave][0], datatype1=table[wave][1])
             if not timerange:
                 return []
             result = crawler.filelist(timerange)
             return result
         except:
-            print "Enter wavelength with proper values and units"
+            raise ValueError("Enter wavelength with proper values and units")
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -109,9 +109,9 @@ class KanzelhoheClient(GenericClient):
         chk_var = 0
         values = [6563, 5460, 32768]
         for x in query:
-            if (x.__class__.__name__ == 'Instrument' and x.value.lower() == 'kanzelhohe'):
+            if (x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'kanzelhohe'):
                 chk_var += 1
-            if (x.__class__.__name__ == 'Wavelength' and int(x.min.value) in values and (x.unit.name).lower()=='angstrom') and int(x.max.value) in values:
+            if (x.__class__.__name__ == 'Wavelength' and int(x.min.value) in values and int(x.max.value) in values and (x.unit.name).lower()=='angstrom'):
                 chk_var += 1
         if (chk_var==2):
             return True

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -10,7 +10,6 @@ import urllib2
 
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
-
 from sunpy.time import TimeRange
 
 __all__ = ['KanzelhoheClient']
@@ -45,10 +44,10 @@ class KanzelhoheClient(GenericClient):
     --------
     >>> from sunpy.net import Fido
     >>> from sunpy.net import attrs as a
-
-    >>> results = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('kanzelhohe'), a.Wavelength(6563*u.AA))
+    >>> timerange = a.Time('2015/12/28 00:00:00','2015/12/28 00:03:00')
+    >>> results = Fido.search(timerange, a.Instrument('kanzelhohe'), a.Wavelength(6563*u.AA))
     >>> print(results)
-    >>> [<Table length=1>
+    [<Table length=1>
         Start Time           End Time              Source        Instrument
         str19               str19                str21           str10   
     ------------------- ------------------- --------------------- ----------
@@ -61,10 +60,7 @@ class KanzelhoheClient(GenericClient):
         returns list of urls corresponding to given TimeRange.
         """
         wave = int(kwargs['Wavelength'].min.value)
-        table = {6563:'halpha2k/recent', 32768:'caiia', 5460:'phokada'}
-        table1 = {6563:'halph_fr', 32768:'caiik_fi', 5460:'bband_fi'}
-        datatype = table[wave]
-        datatype1 = table1[wave]
+        table = {6563:['halpha2k/recent', 'halph_fr'], 32768:['caiia', 'caiik_fi'], 5460:['phokada', 'bband_fi']}
         if (wave == 6563):
             START_DATE = datetime.datetime(2000, 7, 20, 7, 45, 46)
         elif (wave == 5460):
@@ -79,7 +75,7 @@ class KanzelhoheClient(GenericClient):
         else:
             suffix = "%Y/%Y%m%d/processed/kanz_{datatype1}_%Y%m%d_%H%M%S.fts.gz"
         url_pattern = prefix + suffix
-        crawler = Scraper(url_pattern, datatype = datatype, datatype1 = datatype1)
+        crawler = Scraper(url_pattern, datatype = table[wave][0], datatype1 = table[wave][1])
         if not timerange:
             return []
         result = crawler.filelist(timerange)
@@ -89,7 +85,7 @@ class KanzelhoheClient(GenericClient):
         """
         Helper Function:used to hold information about source.
         """
-        self.map_['source'] = 'Global Halpha Network'
+        self.map_['source'] = 'Global Halpha Network' #TODO: check with kanzelhohe
         self.map_['instrument'] = 'Kanzelhohe HA2'
         self.map_['phyobs'] = 'irradiance'
         self.map_['provider'] = 'Kanzelhohe'

--- a/sunpy/net/dataretriever/sources/kanzelhohe.py
+++ b/sunpy/net/dataretriever/sources/kanzelhohe.py
@@ -1,0 +1,101 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+
+__author__ = "Sudarshan Konge"
+__email__ = "sudk1896@gmail.com"
+
+import datetime
+import urllib2
+
+
+from sunpy.net.dataretriever.client import GenericClient
+from sunpy.util.scraper import Scraper
+
+from sunpy.time import TimeRange
+
+__all__ = ['KanzelhoheClient']
+
+class KanzelhoheClient(GenericClient):
+    """
+    Returns a list of URLS to Kanzelhohe H-alpha files corresponding to value of input timerange.
+    URL source: `http://cesar.kso.ac.at/halpha2k/recent/`.
+
+    The earliest date available is from 20-July-2000
+
+    Parameters
+    ----------
+    timerange: sunpy.time.TimeRange
+        time range for which data is to be downloaded.
+        Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
+    
+    Instrument: Fixed argument = 'kanzelhohe'
+
+    Returns
+    -------
+    urls: list
+    list of urls corresponding to requested time range.
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido
+    >>> from sunpy.net import attrs as a
+
+    >>> results = Fido.search(a.Time('2015/12/28 00:00:00', '2015/12/28 00:03:00'), a.Instrument('kanzelhohe'))
+    >>> print(results)
+    >>> [<Table length=1>
+        Start Time           End Time              Source        Instrument
+        str19               str19                str21           str10   
+    ------------------- ------------------- --------------------- ----------
+    2015-12-28 00:00:00 2015-12-29 00:00:00 Global Halpha Network Kanzelhohe]
+    
+    >>> response = Fido.fetch(results)
+    """
+    def _get_url_for_timerange(self, timerange, **kwargs):
+        """
+        returns list of urls corresponding to given TimeRange.
+        """
+        START_DATE = datetime.datetime(2000, 7, 20, 7, 45, 46)
+        if timerange.start < START_DATE:
+            raise ValueError('Earliest date for which SWAP data is available is '+ str(START_DATE))
+        prefix = "http://cesar.kso.ac.at/halpha2k/recent/"
+        suffix = "%Y/kanz_halph_fr_%Y%m%d_%H%M%S.fts.gz"
+        url_pattern = prefix + suffix
+        crawler = Scraper(url_pattern)
+        if not timerange:
+            return []
+        result = crawler.filelist(timerange)
+        return result
+
+    def _makeimap(self):
+        """
+        Helper Function:used to hold information about source.
+        """
+        self.map_['source'] = 'Global Halpha Network'
+        self.map_['instrument'] = 'Kanzelhohe'
+##        self.map_['phyobs'] = 'irradiance'
+##        self.map_['provider'] = 'esa'
+        self.map_['wavelength'] = '6563 AA'
+
+    @classmethod
+    def _can_handle_query(cls, *query):
+        """
+        Answers whether client can service the query.
+        
+        Parameters
+        ----------
+        query : list of query objects
+        
+        Returns
+        -------
+        boolean: answer as to whether client can service the query
+        
+        """
+        chkattr = ['Time', 'Instrument']
+        chklist = [x.__class__.__name__ in chkattr for x in query]
+        for x in query:
+            if (x.__class__.__name__ == 'Instrument' and x.value.lower() == 'kanzelhohe'):
+                return all(chklist)
+        return False
+            
+        
+    

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -1,0 +1,60 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+import datetime
+import pytest
+
+from sunpy.time.timerange import TimeRange
+from sunpy.net.vso.attrs import Time,Instrument,Level
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+
+import sunpy.net.dataretriever.sources.kanzelhohe as kanzelhohe
+
+LCClient = kanzelhohe.KanzelhoheClient()
+
+@pytest.mark.online
+@pytest.mark.parametrize("timerange, url_start, url_end",
+                         [(TimeRange('2015/01/10 00:00:00', '2015/01/10 12:00:00'),
+                           'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_102629.fts.gz',
+                           'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_113524.fts.gz')])
+def test_get_url_for_timerange(timerange, url_start, url_end):
+    urls = LCClient._get_url_for_timerange(timerange)
+    print(urls)
+    assert isinstance(urls, list)
+    assert urls[0] == url_start
+    assert urls[1] == url_end
+
+def test_can_handle_query():
+    ans1 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('kanzelhohe'))
+    assert ans1 == True
+    ans2 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'))
+    assert ans2 == False
+    ans3 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'))
+    assert ans3 == False
+
+@pytest.mark.online
+def test_query():
+    qr = LCClient.query(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'))
+    assert isinstance(qr, QueryResponse)
+    assert len(qr) == 2
+    assert qr.time_range()[0] == '2015/01/10'
+    assert qr.time_range()[1] == '2015/01/10'
+
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument",
+                         [(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'),
+                           Instrument('kanzelhohe'))])                          
+def test_get(time, instrument):
+    qr = LCClient.query(time, instrument)
+    res = LCClient.get(qr)
+    download_list = res.wait()
+    assert len(download_list) == len(qr)
+
+@pytest.mark.online
+def test_fido_query():
+    qr = Fido.search(a.Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'), a.Instrument('kanzelhohe') )
+    assert isinstance(qr, UnifiedResponse)
+    response = Fido.fetch(qr)
+    assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -20,7 +20,7 @@ KClient = kanzelhohe.KanzelhoheClient()
                            'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_102629.fts.gz',
                            'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_113524.fts.gz')])
 def test_get_url_for_timerange(timerange, wavelength, url_start, url_end):
-    urls = KClient._get_url_for_timerange(timerange, Wavelength = wavelength )
+    urls = KClient._get_url_for_timerange(timerange, wavelength = wavelength )
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[1] == url_end

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -1,11 +1,13 @@
+"""
+This module tests the Kanzelhohe Client
+"""
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
-import datetime
 import pytest
 
 from astropy import units as u
 from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time,Instrument,Level,Wavelength
+from sunpy.net.vso.attrs import Time, Instrument, Wavelength
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
@@ -20,13 +22,13 @@ KClient = kanzelhohe.KanzelhoheClient()
                            'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_102629.fts.gz',
                            'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_113524.fts.gz')])
 def test_get_url_for_timerange(timerange, wavelength, url_start, url_end):
-    urls = KClient._get_url_for_timerange(timerange, wavelength = wavelength )
+    urls = KClient._get_url_for_timerange(timerange, wavelength = wavelength)
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[1] == url_end
 
 def test_can_handle_query():
-    time = Time('2015/12/30 00:00:00','2015/12/31 00:05:00')
+    time = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
     assert kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(6563*u.AA))
     assert not kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('swap'))
     assert not kanzelhohe.KanzelhoheClient._can_handle_query(time)

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -46,7 +46,7 @@ def test_query():
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, wavelength",
-[(Time('2015/01/02 07:30:00', '2015/01/02 07:38:00'), Wavelength(32768*u.AA))])
+[(Time('2015/01/02 07:30:00', '2015/01/02 07:38:00'), Wavelength(3276.8*u.nm))])
 #This test downloads 3 files
 #Each file is 4.5MB, total size
 #is 13.4MB
@@ -61,7 +61,7 @@ def test_get(time, wavelength):
 #is 13.4MB
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2016/01/05 07:30:00', '2016/01/05 07:38:00'), a.Instrument('kanzelhohe'), a.Wavelength(5460*u.AA))
+    qr = Fido.search(a.Time('2016/01/05 07:30:00', '2016/01/05 07:38:00'), a.Instrument('kanzelhohe'), a.Wavelength(546.0*u.nm))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -26,13 +26,14 @@ def test_get_url_for_timerange(timerange, wavelength, url_start, url_end):
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[1] == url_end
-
-def test_can_handle_query():
-    time = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
-    assert kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(6563*u.AA))
-    assert not kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('swap'))
-    assert not kanzelhohe.KanzelhoheClient._can_handle_query(time)
-    assert kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(32768*u.AA))
+TRANGE = Time('2015/12/30 00:00:00', '2015/12/31 00:05:00')
+@pytest.mark.parametrize("time, instrument, wavelength, expected",
+                         [(TRANGE, Instrument('kanzelhohe'), Wavelength(6563*u.AA), True),
+                          (TRANGE, Instrument('swap'), None, False),
+                          (TRANGE, None, None, False),
+                          (TRANGE, Instrument('kanzelhohe'), Wavelength(32768*u.AA), True)])
+def test_can_handle_query(time, instrument, wavelength, expected):
+    assert KClient._can_handle_query(time, instrument, wavelength) is expected
 
 @pytest.mark.online
 def test_query():
@@ -54,9 +55,9 @@ def test_get(time, wavelength):
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
-#This test downloads 3 files
-#Each file is 4.5MB, total size
-#is 13.4MB
+This test downloads 3 files
+Each file is 4.5MB, total size
+is 13.4MB
 @pytest.mark.online
 def test_fido_query():
     qr = Fido.search(a.Time('2016/01/05 07:30:00', '2016/01/05 07:38:00'), a.Instrument('kanzelhohe'), a.Wavelength(546.0*u.nm))

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -47,12 +47,18 @@ def test_query():
 @pytest.mark.online
 @pytest.mark.parametrize("time, wavelength",
 [(Time('2015/01/02 07:30:00', '2015/01/02 07:38:00'), Wavelength(32768*u.AA))])
+#This test downloads 3 files
+#Each file is 4.5MB, total size
+#is 13.4MB
 def test_get(time, wavelength):
     qr = KClient.query(time, wavelength)
     res = KClient.get(qr)
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
+#This test downloads 3 files
+#Each file is 4.5MB, total size
+#is 13.4MB
 @pytest.mark.online
 def test_fido_query():
     qr = Fido.search(a.Time('2016/01/05 07:30:00', '2016/01/05 07:38:00'), a.Instrument('kanzelhohe'), a.Wavelength(5460*u.AA))

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -12,7 +12,7 @@ from sunpy.net import attrs as a
 
 import sunpy.net.dataretriever.sources.kanzelhohe as kanzelhohe
 
-LCClient = kanzelhohe.KanzelhoheClient()
+KClient = kanzelhohe.KanzelhoheClient()
 
 @pytest.mark.online
 @pytest.mark.parametrize("timerange, url_start, url_end",
@@ -20,8 +20,7 @@ LCClient = kanzelhohe.KanzelhoheClient()
                            'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_102629.fts.gz',
                            'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_113524.fts.gz')])
 def test_get_url_for_timerange(timerange, url_start, url_end):
-    urls = LCClient._get_url_for_timerange(timerange)
-    print(urls)
+    urls = KClient._get_url_for_timerange(timerange)
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[1] == url_end
@@ -36,7 +35,7 @@ def test_can_handle_query():
 
 @pytest.mark.online
 def test_query():
-    qr = LCClient.query(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'))
+    qr = KClient.query(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'))
     assert isinstance(qr, QueryResponse)
     assert len(qr) == 2
     assert qr.time_range()[0] == '2015/01/10'
@@ -44,11 +43,10 @@ def test_query():
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument",
-                         [(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'),
-                           Instrument('kanzelhohe'))])                          
+[(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'), Instrument('kanzelhohe'))])
 def test_get(time, instrument):
-    qr = LCClient.query(time, instrument)
-    res = LCClient.get(qr)
+    qr = KClient.query(time, instrument)
+    res = KClient.get(qr)
     download_list = res.wait()
     assert len(download_list) == len(qr)
 

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -27,14 +27,10 @@ def test_get_url_for_timerange(timerange, wavelength, url_start, url_end):
 
 def test_can_handle_query():
     time = Time('2015/12/30 00:00:00','2015/12/31 00:05:00')
-    ans1 = kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(6563*u.AA))
-    assert ans1 is True
-    ans2 = kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('swap'))
-    assert ans2 is False
-    ans3 = kanzelhohe.KanzelhoheClient._can_handle_query(time)
-    assert ans3 is False
-    ans4 = kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(32768*u.AA))
-    assert ans4 is True
+    assert kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(6563*u.AA))
+    assert not kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('swap'))
+    assert not kanzelhohe.KanzelhoheClient._can_handle_query(time)
+    assert kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(32768*u.AA))
 
 @pytest.mark.online
 def test_query():

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -55,10 +55,10 @@ def test_get(time, wavelength):
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
-This test downloads 3 files
-Each file is 4.5MB, total size
-is 13.4MB
-@pytest.mark.online
+##This test downloads 3 files
+##Each file is 4.5MB, total size
+##is 13.4MB
+##@pytest.mark.online
 def test_fido_query():
     qr = Fido.search(a.Time('2016/01/05 07:30:00', '2016/01/05 07:38:00'), a.Instrument('kanzelhohe'), a.Wavelength(546.0*u.nm))
     assert isinstance(qr, UnifiedResponse)

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -4,55 +4,58 @@ import datetime
 import pytest
 
 from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time,Instrument,Level
+from sunpy.net.vso.attrs import Time,Instrument,Level,Wavelength
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a
+from astropy import units as u
 
 import sunpy.net.dataretriever.sources.kanzelhohe as kanzelhohe
 
 KClient = kanzelhohe.KanzelhoheClient()
 
 @pytest.mark.online
-@pytest.mark.parametrize("timerange, url_start, url_end",
-                         [(TimeRange('2015/01/10 00:00:00', '2015/01/10 12:00:00'),
+@pytest.mark.parametrize("timerange, wavelength, url_start, url_end",
+                         [(TimeRange('2015/01/10 00:00:00', '2015/01/10 12:00:00'), Wavelength(6563*u.AA),
                            'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_102629.fts.gz',
                            'http://cesar.kso.ac.at/halpha2k/recent/2015/kanz_halph_fr_20150110_113524.fts.gz')])
-def test_get_url_for_timerange(timerange, url_start, url_end):
-    urls = KClient._get_url_for_timerange(timerange)
+def test_get_url_for_timerange(timerange, wavelength, url_start, url_end):
+    urls = KClient._get_url_for_timerange(timerange, Wavelength = wavelength )
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[1] == url_end
 
 def test_can_handle_query():
-    ans1 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('kanzelhohe'))
+    ans1 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('kanzelhohe'), Wavelength(6563*u.AA))
     assert ans1 == True
     ans2 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'))
     assert ans2 == False
     ans3 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'))
     assert ans3 == False
+    ans4 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('kanzelhohe'), Wavelength(32768*u.AA))
+    assert ans4 == True
 
 @pytest.mark.online
 def test_query():
-    qr = KClient.query(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'))
+    qr = KClient.query(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'), Wavelength(6563*u.AA))
     assert isinstance(qr, QueryResponse)
     assert len(qr) == 2
     assert qr.time_range()[0] == '2015/01/10'
     assert qr.time_range()[1] == '2015/01/10'
 
 @pytest.mark.online
-@pytest.mark.parametrize("time, instrument",
-[(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'), Instrument('kanzelhohe'))])
-def test_get(time, instrument):
-    qr = KClient.query(time, instrument)
+@pytest.mark.parametrize("time, wavelength",
+[(Time('2015/01/02 07:30:00', '2015/01/02 07:38:00'), Wavelength(32768*u.AA))])
+def test_get(time, wavelength):
+    qr = KClient.query(time, wavelength)
     res = KClient.get(qr)
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'), a.Instrument('kanzelhohe') )
+    qr = Fido.search(a.Time('2016/01/05 07:30:00', '2016/01/05 07:38:00'), a.Instrument('kanzelhohe'), a.Wavelength(5460*u.AA))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -3,14 +3,13 @@
 import datetime
 import pytest
 
+from astropy import units as u
 from sunpy.time.timerange import TimeRange
 from sunpy.net.vso.attrs import Time,Instrument,Level,Wavelength
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a
-from astropy import units as u
-
 import sunpy.net.dataretriever.sources.kanzelhohe as kanzelhohe
 
 KClient = kanzelhohe.KanzelhoheClient()
@@ -27,20 +26,21 @@ def test_get_url_for_timerange(timerange, wavelength, url_start, url_end):
     assert urls[1] == url_end
 
 def test_can_handle_query():
-    ans1 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('kanzelhohe'), Wavelength(6563*u.AA))
+    time = Time('2015/12/30 00:00:00','2015/12/31 00:05:00')
+    ans1 = kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(6563*u.AA))
     assert ans1 is True
-    ans2 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'))
+    ans2 = kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('swap'))
     assert ans2 is False
-    ans3 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'))
+    ans3 = kanzelhohe.KanzelhoheClient._can_handle_query(time)
     assert ans3 is False
-    ans4 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('kanzelhohe'), Wavelength(32768*u.AA))
+    ans4 = kanzelhohe.KanzelhoheClient._can_handle_query(time, Instrument('kanzelhohe'), Wavelength(32768*u.AA))
     assert ans4 is True
 
 @pytest.mark.online
 def test_query():
     qr = KClient.query(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'), Wavelength(6563*u.AA))
     assert isinstance(qr, QueryResponse)
-    assert len(qr) is 2
+    assert len(qr) == 2
     assert qr.time_range()[0] == '2015/01/10'
     assert qr.time_range()[1] == '2015/01/10'
 

--- a/sunpy/net/dataretriever/tests/test_kanzelhohe.py
+++ b/sunpy/net/dataretriever/tests/test_kanzelhohe.py
@@ -28,19 +28,19 @@ def test_get_url_for_timerange(timerange, wavelength, url_start, url_end):
 
 def test_can_handle_query():
     ans1 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('kanzelhohe'), Wavelength(6563*u.AA))
-    assert ans1 == True
+    assert ans1 is True
     ans2 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('swap'))
-    assert ans2 == False
+    assert ans2 is False
     ans3 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'))
-    assert ans3 == False
+    assert ans3 is False
     ans4 = kanzelhohe.KanzelhoheClient._can_handle_query(Time('2015/12/30 00:00:00','2015/12/31 00:05:00'), Instrument('kanzelhohe'), Wavelength(32768*u.AA))
-    assert ans4 == True
+    assert ans4 is True
 
 @pytest.mark.online
 def test_query():
     qr = KClient.query(Time('2015/01/10 00:00:00', '2015/01/10 12:00:00'), Wavelength(6563*u.AA))
     assert isinstance(qr, QueryResponse)
-    assert len(qr) == 2
+    assert len(qr) is 2
     assert qr.time_range()[0] == '2015/01/10'
     assert qr.time_range()[1] == '2015/01/10'
 


### PR DESCRIPTION
Users can now query Kanzelhohe H-alpha Client with this implementation (tests included). It pulls fits files from - [cesar.kso.ac.at](http://cesar.kso.ac.at/halpha2k/recent/). 
A few details that I'm unaware of have been commented out in `makeimap_`. If someone could provide those details, I could complete the implementation. Specifically, 
- Who is the provider for these fits files ?
- What physical observation does Kanzelhohe measure ?

Bbso Client would follow soon.
Query looks like this -

``` python
Fido.query( timerange, Instrument('kanzelhohe') )
```

@Cadair @dpshelio @wafels Please review.
