### PR TITLE
[0.6] fixes grid drawing functionality when using peek method of map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 0.6.5
 -----
-
+ * The draw_grid keyword of the peek method of Map now accepts booleans or astropy quantities.
 
 0.6.4
 -----

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1288,10 +1288,10 @@ scale:\t\t {scale}
         if isinstance(draw_grid, bool):
             if draw_grid:
                 self.draw_grid(axes=axes)
-        elif isinstance(draw_grid, (int, long, float)):
+        elif isinstance(draw_grid, u.Quantity):
             self.draw_grid(axes=axes, grid_spacing=draw_grid)
         else:
-            raise TypeError("draw_grid should be bool, int, long or float")
+            raise TypeError("draw_grid should be a bool or an astropy Quantity.")
 
         figure.show()
 


### PR DESCRIPTION
A backport of #1760 to the 0.6 branch.