### PR TITLE
In Python 3, we don’t want to convert the filename to bytes

### DIFF
--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -34,7 +34,7 @@ from sunpy.net.vso.attrs import walker, TIMEFORMAT
 from sunpy.util import replacement_filename, Deprecated
 from sunpy.time import parse_time
 
-from sunpy.extern.six import iteritems, text_type, u
+from sunpy.extern.six import iteritems, text_type, u, PY2
 from sunpy.extern.six.moves import input
 
 TIME_FORMAT = config.get("general", "time_format")
@@ -398,7 +398,11 @@ class VSOClient(object):
         fs_encoding = sys.getfilesystemencoding()
         if fs_encoding is None:
             fs_encoding = "ascii"
-        name = slugify(name).encode(fs_encoding, "ignore")
+
+        name = slugify(name)
+
+        if PY2:
+            name = name.encode(fs_encoding, "ignore")
 
         if not name:
             name = "file"


### PR DESCRIPTION
On Python 3, this function returned paths like:

```
"/Users/tom/sunpy/data/b'aia_lev1_304a_2011_01_01t00_00_08_12z_image_lev1.1.fits'"
```

(@Cadair, note that this path was overall a string but contained already the bytes stuff!)