### PR TITLE
added timeout parameter in download_sample_data()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Latest
 ------
+* Added `timeout` parameter in `sunpy.data.download_sample_data()`
 * Fixed `aiaprep` to return properly sized map.
 
 * Deprecation warnings fixed when using image coalignment.

--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -56,7 +56,7 @@ for key in _files:
     sample_files[key] = os.path.abspath(os.path.join(sampledata_dir, _files[key][0]))
 
 
-def download_sample_data(progress=True, overwrite=True):
+def download_sample_data(progress=True, overwrite=True, timeout=None):
     """
     Download the sample data.
 
@@ -66,6 +66,9 @@ def download_sample_data(progress=True, overwrite=True):
         Show a progress bar during download
     overwrite: bool
         If exist overwrites the downloaded sample data.
+    timeout: float
+        The timeout in seconds.
+        Default timeout is `astropy.utils.data.Conf.remote_timeout`.
 
     Returns
     -------
@@ -83,7 +86,7 @@ def download_sample_data(progress=True, overwrite=True):
         for base_url in _base_urls:
             full_file_name = file_name[0] + file_name[1]
             if url_exists(os.path.join(base_url, full_file_name)):
-                f = download_file(os.path.join(base_url, full_file_name))
+                f = download_file(os.path.join(base_url, full_file_name), timeout=timeout)
                 real_name, ext = os.path.splitext(full_file_name)
 
                 if file_name[1] == '.zip':


### PR DESCRIPTION
Default timeout for download_sample_data() is equal to `astropy.utils.data.Conf.remote_timeout` i.e 3sec. Believe me i'm on good connection and still it gives me timeout error everytime and i had to download sample data using `overwrite=False`.
Adding a `timeout` parameter will be helpful for users on slow connections.