### PR TITLE
added missing numpy import in Lightcurve example

### DIFF
--- a/doc/source/guide/tour.rst
+++ b/doc/source/guide/tour.rst
@@ -49,6 +49,7 @@ remote file. Let's create some fake data and pass it into a lightcurve object.
 .. plot::
     :include-source:
 
+    import numpy as np
     import sunpy.data.sample
     from sunpy.lightcurve import LightCurve
     times = np.arange(1000) * 2.0


### PR DESCRIPTION
`numpy` import is missing from Lightcurve example in brief tour of Sunpy. Not a big problem but still.