### PR TITLE
Add tests to map for new features and peek.

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -13,4 +13,4 @@ glymur
 suds-jurko
 beautifulsoup4
 requests
-wcsaxes>=0.6
+wcsaxes>=0.8

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ extras_require = {'database': ["sqlalchemy"],
                   'jpeg2000': ["glymur"],
                   'net': ["suds-jurko", "beautifulsoup4", "requests"]}
 extras_require['all'] = extras_require['database'] + extras_require['image'] + \
-                        extras_require['net'] + ["wcsaxes>=0.6"]
+                        extras_require['net'] + ["wcsaxes>=0.8"]
 
 setup(name=PACKAGENAME,
       version=VERSION,

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -20,6 +20,7 @@ import matplotlib.pyplot as plt
 import sunpy
 import sunpy.sun
 import sunpy.map
+import sunpy.coordinates
 import sunpy.data.test
 from sunpy.time import parse_time
 from sunpy.tests.helpers import figure_test, skip_wcsaxes
@@ -172,6 +173,15 @@ def test_heliographic_longitude(generic_map):
 
 def test_units(generic_map):
     generic_map.spatial_units == ('arcsec', 'arcsec')
+
+
+def test_coordinate_frame(aia171_test_map):
+    frame = aia171_test_map.coordinate_frame
+    assert isinstance(frame, sunpy.coordinates.Helioprojective)
+    assert frame.L0 == aia171_test_map.heliographic_longitude
+    assert frame.B0 == aia171_test_map.heliographic_latitude
+    assert frame.D0 == aia171_test_map.dsun
+    assert frame.dateobs == aia171_test_map.date
 
 
 #==============================================================================
@@ -480,9 +490,48 @@ def test_rotate_invalid_order(generic_map):
 
 
 @skip_wcsaxes
+def test_as_mpl_axes_aia171(aia171_test_map):
+    import wcsaxes  # import here because of skip
+    ax = plt.subplot(projection=aia171_test_map)
+    assert isinstance(ax, wcsaxes.WCSAxes)
+    # This test doesn't work, it seems that WCSAxes copies or changes the WCS
+    # object.
+    #  assert ax.wcs is aia171_test_map.wcs
+    assert all([ct1 == ct2 for ct1, ct2 in zip(ax.wcs.wcs.ctype,
+                                               aia171_test_map.wcs.wcs.ctype)])
+    # Map adds these attributes, so we use them to check.
+    assert hasattr(ax.wcs, 'heliographic_latitude')
+    assert hasattr(ax.wcs, 'heliographic_longitude')
+
+
+@skip_wcsaxes
 @figure_test
 def test_plot_aia171(aia171_test_map):
     aia171_test_map.plot()
+
+
+@skip_wcsaxes
+@figure_test
+def test_peek_aia171(aia171_test_map):
+    aia171_test_map.peek()
+
+
+@skip_wcsaxes
+@figure_test
+def test_peek_grid_aia171(aia171_test_map):
+    aia171_test_map.peek(draw_grid=True)
+
+
+@skip_wcsaxes
+@figure_test
+def test_peek_limb_aia171(aia171_test_map):
+    aia171_test_map.peek(draw_limb=True)
+
+
+@skip_wcsaxes
+@figure_test
+def test_peek_grid_limb_aia171(aia171_test_map):
+    aia171_test_map.peek(draw_grid=True, draw_limb=True)
 
 
 @figure_test

--- a/sunpy/tests/figure_hashes.json
+++ b/sunpy/tests/figure_hashes.json
@@ -1,5 +1,9 @@
 {
     "sunpy.map.tests.test_mapbase.test_draw_contours_aia": "d0b1c17af8be0cf71e2569b0723d4244b69cd570599cd6663e052cb53bde51ff",
+    "sunpy.map.tests.test_mapbase.test_peek_aia171": "2424ef15a6fcafa1118be1ceda58df6546b9bc6ab19cda5ab9e3e7707cbc2bc4",
+    "sunpy.map.tests.test_mapbase.test_peek_grid_aia171": "f981739b8b009c38edc629ffbbab871f68ad82bcfcb157d2811245b2fcee5799",
+    "sunpy.map.tests.test_mapbase.test_peek_grid_limb_aia171": "bae14540bbd09f72cb8034846f902c5b775c67f9cd1dca195aaa8dcc8990263f",
+    "sunpy.map.tests.test_mapbase.test_peek_limb_aia171": "ec483ad90b262e498c0f8f058d85b3b8328a525e315829d7e691527236cc122d",
     "sunpy.map.tests.test_mapbase.test_plot_aia171": "a317599f56bbabb7ed72d70293237bb857d49071b86d0d361db2da7db4d068e1",
     "sunpy.map.tests.test_mapbase.test_plot_aia171_nowcsaxes": "886c049b133c344f4b00a33c2968cc4bec2c9539e995db15f51a9da4cc21a57a",
     "sunpy.map.tests.test_mapbase.test_plot_aia171_superpixel": "5403e3e32f0385a13ce40f70e1f3865ac5a115640c2744c2ea803b1e0cd192f4",


### PR DESCRIPTION
This closes sunpy/sunpy#1759 by upgrading to wcsaxes 0.8 and adding tests.
It also adds tests for the new `coordinate_frame` and `_as_mpl_axes` methods to map.

Note, this should not be backported.