### PR TITLE
BBSOClient implemented. Supports query by level

### DIFF
--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,6 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level
+from .vso.attrs import Time, Instrument, Wavelength, Level, Source, Detector, Physobs
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc']
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
+           'Source', 'Detector', 'Physobs']

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,7 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level, Source, Detector, Physobs
+from .vso.attrs import Time, Instrument, Wavelength, Level, Source, Physobs, Detector, Filter
 
 __all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
-           'Source', 'Detector', 'Physobs']
+           'Source', 'Physobs', 'Detector', 'Filter']

--- a/sunpy/net/dataretriever/clients.py
+++ b/sunpy/net/dataretriever/clients.py
@@ -7,6 +7,8 @@ from .sources.goes import GOESClient
 from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 from .sources.noaa import NOAAIndicesClient, NOAAPredictClient
+from .sources.bbso import BBSOClient
+
 
 # Import and register other sources
 from sunpy.net.jsoc.jsoc import JSOCClient

--- a/sunpy/net/dataretriever/sources/bbso.py
+++ b/sunpy/net/dataretriever/sources/bbso.py
@@ -1,23 +1,24 @@
-#This module was developed with funding provided by
-#the Google Summer of Code 2016.
-
-__author__ = "Sudarshan Konge"
-__email__ = "sudk1896@gmail.com"
+# This module was developed with funding provided by
+# the Google Summer of Code 2016.
 
 import datetime
-import urllib2
+
 from bs4 import BeautifulSoup
 
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
-from sunpy.time import TimeRange
+
+from sunpy.extern.six.moves.urllib.request import urlopen
+__author__ = "Sudarshan Konge"
+__email__ = "sudk1896@gmail.com"
 
 __all__ = ['BBSOClient']
 
+
 class BBSOClient(GenericClient):
     """
-    Returns a list of URLS to BBSO files corresponding to value of input timerange.
-    URL source: `http://www.bbso.njit.edu/pub/archive/`.
+    Returns a list of URLS to BBSO files corresponding to value of input
+    timerange. URL source: `http://www.bbso.njit.edu/pub/archive/`.
 
 
     Parameters
@@ -25,7 +26,7 @@ class BBSOClient(GenericClient):
     timerange: sunpy.time.TimeRange
         time range for which data is to be downloaded.
         Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
-    
+
     Instrument: Fixed argument = 'bbso'
 
     Level: Level can take only 'fl' or 'fr' as arguments.
@@ -40,18 +41,19 @@ class BBSOClient(GenericClient):
     >>> from sunpy.net import Fido
     >>> from sunpy.net import attrs as a
 
-    >>> results = Fido.search(Time('2016/5/18 15:28:00','2016/5/18 16:30:00'), a.Instrument('bbso'), a.Level('fr'))
+    >>> results = Fido.search(a.Time('2016/5/18 15:28:00','2016/5/18 16:30:00'),
+                              a.Instrument('bbso'), a.Level('fr'))
     >>> print(results)
     [<Table length=2>
          Start Time           End Time              Source        Instrument
-           str19               str19                str21            str4   
+           str19               str19                str21            str4
     ------------------- ------------------- --------------------- ----------
     2016-05-18 00:00:00 2016-05-19 00:00:00 Global Halpha Network       bbso
     2016-05-19 00:00:00 2016-05-20 00:00:00 Global Halpha Network       bbso]
-    
+
     >>> response = Fido.fetch(results)
     """
-    
+
     def _get_url_for_timerange(self, timerange, **kwargs):
         """
         returns list of urls corresponding to given TimeRange.
@@ -59,29 +61,32 @@ class BBSOClient(GenericClient):
         level = kwargs.get('level', 'fr')
         START_DATE = datetime.datetime(2000, 11, 6)
         if timerange.start < START_DATE:
-            raise ValueError('Earliest date for which BBSO data is available is {:%Y-%m-%d}'.format(START_DATE))
+            raise ValueError(
+                'Earliest date for which BBSO data is available is {:%Y-%m-%d}'.
+                format(START_DATE))
         prefix = 'http://www.bbso.njit.edu'
         suffix = '/pub/archive/%Y/%m/%d/bbso_halph_{level}_%Y%m%d_%H%M%S.fts'
-        suffix_gz = suffix + '.gz' #Download compressed files as well, if available.
+        suffix_gz = suffix + '.gz'  #Download compressed files as well, if available.
         total_days = (timerange.end - timerange.start).days + 1
         all_dates = timerange.split(total_days)
         crawler = Scraper(suffix, level=level)
-        crawler_gz = Scraper(suffix_gz, level = level) 
+        crawler_gz = Scraper(suffix_gz, level=level)
         result = list()
         for day in all_dates:
-            url_to_open = 'http://www.bbso.njit.edu/pub/archive/{date:%Y/%m/%d/}'.format(date=day.end)
-            html_page = urllib2.urlopen(url_to_open)
+            url_to_open = 'http://www.bbso.njit.edu/pub/archive/{date:%Y/%m/%d/}'.format(
+                date=day.end)
+            html_page = urlopen(url_to_open)
             soup = BeautifulSoup(html_page)
             for link in soup.findAll('a'):
                 url = str(link.get('href'))
                 if crawler._URL_followsPattern(url):
                     datehref = crawler._extractDateURL(url)
-                    if datehref>=timerange.start and datehref<=timerange.end:
+                    if datehref >= timerange.start and datehref <= timerange.end:
                         result.append(prefix + url)
                 if crawler_gz._URL_followsPattern(url):
                     datehref = crawler_gz._extractDateURL(url)
-                    if datehref>=timerange.start and datehref<=timerange.end:
-                        result.append(prefix + url)           
+                    if datehref >= timerange.start and datehref <= timerange.end:
+                        result.append(prefix + url)
         return result
 
     def _makeimap(self):
@@ -91,22 +96,21 @@ class BBSOClient(GenericClient):
         self.map_['source'] = 'Global Halpha Network'
         self.map_['instrument'] = 'bbso'
         self.map_['phyobs'] = 'IRRADIANCE'
-##        self.map_['provider'] = 'esa'
         self.map_['wavelength'] = '174 AA'
 
     @classmethod
     def _can_handle_query(cls, *query):
         """
         Answers whether client can service the query.
-        
+
         Parameters
         ----------
         query : list of query objects
-        
+
         Returns
         -------
         boolean: answer as to whether client can service the query
-        
+
         """
         chkattr = ['Time', 'Instrument', 'Level']
         chklist = [x.__class__.__name__ in chkattr for x in query]
@@ -114,7 +118,8 @@ class BBSOClient(GenericClient):
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'bbso':
                 chk_var += 1
-            if x.__class__.__name__ == 'Level' and type(x.value) is str and x.value.lower() in ('fl', 'fr'):
+            if x.__class__.__name__ == 'Level' and type(
+                    x.value) is str and x.value.lower() in ('fl', 'fr'):
                 chk_var += 1
         if (chk_var == 2):
             return True

--- a/sunpy/net/dataretriever/sources/bbso.py
+++ b/sunpy/net/dataretriever/sources/bbso.py
@@ -7,6 +7,7 @@ __email__ = "sudk1896@gmail.com"
 import datetime
 import urllib2
 from bs4 import BeautifulSoup
+
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
 from sunpy.time import TimeRange
@@ -61,14 +62,14 @@ class BBSOClient(GenericClient):
             raise ValueError('Earliest date for which BBSO data is available is {:%Y-%m-%d}'.format(START_DATE))
         prefix = 'http://www.bbso.njit.edu'
         suffix = '/pub/archive/%Y/%m/%d/bbso_halph_{level}_%Y%m%d_%H%M%S.fts'
-        suffix_gz = suffix + '.gz' #Downlaod compressed files as well, if available.
+        suffix_gz = suffix + '.gz' #Download compressed files as well, if available.
         total_days = (timerange.end - timerange.start).days + 1
         all_dates = timerange.split(total_days)
-        crawler = Scraper(suffix, level = level)
+        crawler = Scraper(suffix, level=level)
         crawler_gz = Scraper(suffix_gz, level = level) 
         result = list()
         for day in all_dates:
-            url_to_open = 'http://www.bbso.njit.edu/pub/archive/{date:%Y/%m/%d/}'.format(date = day.end)
+            url_to_open = 'http://www.bbso.njit.edu/pub/archive/{date:%Y/%m/%d/}'.format(date=day.end)
             html_page = urllib2.urlopen(url_to_open)
             soup = BeautifulSoup(html_page)
             for link in soup.findAll('a'):

--- a/sunpy/net/dataretriever/sources/bbso.py
+++ b/sunpy/net/dataretriever/sources/bbso.py
@@ -89,7 +89,7 @@ class BBSOClient(GenericClient):
         """
         self.map_['source'] = 'Global Halpha Network'
         self.map_['instrument'] = 'bbso'
-##        self.map_['phyobs'] = 'irradiance'
+        self.map_['phyobs'] = 'irradiance'
 ##        self.map_['provider'] = 'esa'
         self.map_['wavelength'] = '174 AA'
 
@@ -113,7 +113,7 @@ class BBSOClient(GenericClient):
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'bbso':
                 chk_var += 1
-            if x.__class__.__name__ == 'Level' and x.value.lower() in ('fl', 'fr'):
+            if x.__class__.__name__ == 'Level' and type(x.value) is str and x.value.lower() in ('fl', 'fr'):
                 chk_var += 1
         if (chk_var == 2):
             return True

--- a/sunpy/net/dataretriever/sources/bbso.py
+++ b/sunpy/net/dataretriever/sources/bbso.py
@@ -89,7 +89,7 @@ class BBSOClient(GenericClient):
         """
         self.map_['source'] = 'Global Halpha Network'
         self.map_['instrument'] = 'bbso'
-        self.map_['phyobs'] = 'irradiance'
+        self.map_['phyobs'] = 'IRRADIANCE'
 ##        self.map_['provider'] = 'esa'
         self.map_['wavelength'] = '174 AA'
 

--- a/sunpy/net/dataretriever/sources/bbso.py
+++ b/sunpy/net/dataretriever/sources/bbso.py
@@ -5,6 +5,7 @@ import datetime
 
 from bs4 import BeautifulSoup
 
+from sunpy.time.timerange import TimeRange
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
 
@@ -73,6 +74,17 @@ class BBSOClient(GenericClient):
         crawler_gz = Scraper(prefix + suffix_gz, level=level)
         result = crawler.filelist(timerange) + crawler_gz.filelist(timerange)
         return result
+
+    def _get_time_for_url(self, urls):
+        prefix = 'http://www.bbso.njit.edu'
+        suffix = '/pub/archive/%Y/%m/%d/bbso_halph_{level}_%Y%m%d_%H%M%S.fts'
+        level = 'fr'
+        crawler = Scraper(prefix + suffix, level=level)
+        times = list()
+        for url in urls:
+            t0 = crawler._extractDateURL(url)
+            times.append(TimeRange(t0, t0))
+        return times
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/sources/bbso.py
+++ b/sunpy/net/dataretriever/sources/bbso.py
@@ -1,0 +1,121 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+
+__author__ = "Sudarshan Konge"
+__email__ = "sudk1896@gmail.com"
+
+import datetime
+import urllib2
+from BeautifulSoup import BeautifulSoup
+
+from sunpy.net.dataretriever.client import GenericClient
+from sunpy.util.scraper import Scraper
+from sunpy.time import TimeRange
+
+__all__ = ['BBSOClient']
+
+class BBSOClient(GenericClient):
+    """
+    Returns a list of URLS to BBSO files corresponding to value of input timerange.
+    URL source: `http://www.bbso.njit.edu/pub/archive/`.
+
+
+    Parameters
+    ----------
+    timerange: sunpy.time.TimeRange
+        time range for which data is to be downloaded.
+        Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
+    
+    Instrument: Fixed argument = 'bbso'
+
+    Level: Level can take only 'fl' or 'fr' as arguments.
+
+    Returns
+    -------
+    urls: list
+    list of urls corresponding to requested time range.
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido
+    >>> from sunpy.net import attrs as a
+
+    >>> results = Fido.search(Time('2016/5/18 15:28:00','2016/5/18 16:30:00'), a.Instrument('bbso'), a.Level('fr'))
+    >>> print(results)
+    [<Table length=2>
+         Start Time           End Time              Source        Instrument
+           str19               str19                str21            str4   
+    ------------------- ------------------- --------------------- ----------
+    2016-05-18 00:00:00 2016-05-19 00:00:00 Global Halpha Network       bbso
+    2016-05-19 00:00:00 2016-05-20 00:00:00 Global Halpha Network       bbso]
+    
+    >>> response = Fido.fetch(results)
+    """
+    
+    def _get_url_for_timerange(self, timerange, **kwargs):
+        """
+        returns list of urls corresponding to given TimeRange.
+        """
+        level = kwargs.get('level', 'fr')
+        START_DATE = datetime.datetime(2000, 11, 6)
+        if timerange.start < START_DATE:
+            raise ValueError('Earliest date for which BBSO data is available is {:%Y-%m-%d}'.format(START_DATE))
+        prefix = 'http://www.bbso.njit.edu'
+        suffix = '/pub/archive/%Y/%m/%d/bbso_halph_{level}_%Y%m%d_%H%M%S.fts'
+        suffix_gz = suffix + '.gz' #Downlaod compressed files as well, if available.
+        total_days = (timerange.end - timerange.start).days + 1
+        all_dates = timerange.split(total_days)
+        crawler = Scraper(suffix, level = level)
+        crawler_gz = Scraper(suffix_gz, level = level) 
+        result = list()
+        for day in all_dates:
+            url_to_open = 'http://www.bbso.njit.edu/pub/archive/{date:%Y/%m/%d/}'.format(date = day.end)
+            html_page = urllib2.urlopen(url_to_open)
+            soup = BeautifulSoup(html_page)
+            for link in soup.findAll('a'):
+                url = str(link.get('href'))
+                if crawler._URL_followsPattern(url):
+                    datehref = crawler._extractDateURL(url)
+                    if datehref>=timerange.start and datehref<=timerange.end:
+                        result.append(prefix + url)
+                if crawler_gz._URL_followsPattern(url):
+                    datehref = crawler_gz._extractDateURL(url)
+                    if datehref>=timerange.start and datehref<=timerange.end:
+                        result.append(prefix + url)           
+        return result
+
+    def _makeimap(self):
+        """
+        Helper Function:used to hold information about source.
+        """
+        self.map_['source'] = 'Global Halpha Network'
+        self.map_['instrument'] = 'bbso'
+##        self.map_['phyobs'] = 'irradiance'
+##        self.map_['provider'] = 'esa'
+        self.map_['wavelength'] = '174 AA'
+
+    @classmethod
+    def _can_handle_query(cls, *query):
+        """
+        Answers whether client can service the query.
+        
+        Parameters
+        ----------
+        query : list of query objects
+        
+        Returns
+        -------
+        boolean: answer as to whether client can service the query
+        
+        """
+        chkattr = ['Time', 'Instrument', 'Level']
+        chklist = [x.__class__.__name__ in chkattr for x in query]
+        chk_var = 0
+        for x in query:
+            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'bbso':
+                chk_var += 1
+            if x.__class__.__name__ == 'Level' and x.value.lower() in ('fl', 'fr'):
+                chk_var += 1
+        if (chk_var == 2):
+            return True
+        return False

--- a/sunpy/net/dataretriever/sources/bbso.py
+++ b/sunpy/net/dataretriever/sources/bbso.py
@@ -69,24 +69,9 @@ class BBSOClient(GenericClient):
         suffix_gz = suffix + '.gz'  #Download compressed files as well, if available.
         total_days = (timerange.end - timerange.start).days + 1
         all_dates = timerange.split(total_days)
-        crawler = Scraper(suffix, level=level)
-        crawler_gz = Scraper(suffix_gz, level=level)
-        result = list()
-        for day in all_dates:
-            url_to_open = 'http://www.bbso.njit.edu/pub/archive/{date:%Y/%m/%d/}'.format(
-                date=day.end)
-            html_page = urlopen(url_to_open)
-            soup = BeautifulSoup(html_page)
-            for link in soup.findAll('a'):
-                url = str(link.get('href'))
-                if crawler._URL_followsPattern(url):
-                    datehref = crawler._extractDateURL(url)
-                    if datehref >= timerange.start and datehref <= timerange.end:
-                        result.append(prefix + url)
-                if crawler_gz._URL_followsPattern(url):
-                    datehref = crawler_gz._extractDateURL(url)
-                    if datehref >= timerange.start and datehref <= timerange.end:
-                        result.append(prefix + url)
+        crawler = Scraper(prefix + suffix, level=level)
+        crawler_gz = Scraper(prefix + suffix_gz, level=level)
+        result = crawler.filelist(timerange) + crawler_gz.filelist(timerange)
         return result
 
     def _makeimap(self):
@@ -94,9 +79,9 @@ class BBSOClient(GenericClient):
         Helper Function:used to hold information about source.
         """
         self.map_['source'] = 'Global Halpha Network'
-        self.map_['instrument'] = 'bbso'
+        self.map_['instrument'] = 'BBSO'
         self.map_['phyobs'] = 'IRRADIANCE'
-        self.map_['wavelength'] = '174 AA'
+        self.map_['wavelength'] = '6562.8 AA'
 
     @classmethod
     def _can_handle_query(cls, *query):

--- a/sunpy/net/dataretriever/sources/bbso.py
+++ b/sunpy/net/dataretriever/sources/bbso.py
@@ -6,8 +6,7 @@ __email__ = "sudk1896@gmail.com"
 
 import datetime
 import urllib2
-from BeautifulSoup import BeautifulSoup
-
+from bs4 import BeautifulSoup
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
 from sunpy.time import TimeRange

--- a/sunpy/net/dataretriever/tests/test_bbso.py
+++ b/sunpy/net/dataretriever/tests/test_bbso.py
@@ -27,10 +27,10 @@ def test_get_url_for_time_range(timerange, url_start, url_end, level):
 
 trange = Time('2015/12/30', '2015/12/31')
 def test_can_handle_query():
-    assert BClient._can_handle_query(trange, Instrument('bbso'), Level('fl')) is True
-    assert BClient._can_handle_query(trange, Instrument('bbso'), Level('fr')) is True
-    assert BClient._can_handle_query(trange, Instrument('bbso'), Level('mag')) is False
-    assert BClient._can_handle_query(trange, Level('mag')) is False
+    assert BClient._can_handle_query(trange, Instrument('bbso'), Level('fl'))
+    assert BClient._can_handle_query(trange, Instrument('bbso'), Level('fr'))
+    assert not BClient._can_handle_query(trange, Instrument('bbso'), Level('mag'))
+    assert not BClient._can_handle_query(trange, Level('mag'))
 
 @pytest.mark.online
 #This test downloads 2 fits files

--- a/sunpy/net/dataretriever/tests/test_bbso.py
+++ b/sunpy/net/dataretriever/tests/test_bbso.py
@@ -5,7 +5,7 @@ import pytest
 from sunpy.time.timerange import TimeRange
 from sunpy.net.vso.attrs import Time, Instrument, Level
 from sunpy.net.dataretriever.client import QueryResponse
-from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a
 
@@ -39,8 +39,6 @@ def test_can_handle_query():
 
 
 @pytest.mark.online
-#This test downloads 2 fits files
-#each of size 8.4MB, total size 16.8MB
 def test_query():
     qr = BClient.query(
         Time('2016/5/18 15:28:00', '2016/5/18 16:30:00'),

--- a/sunpy/net/dataretriever/tests/test_bbso.py
+++ b/sunpy/net/dataretriever/tests/test_bbso.py
@@ -46,7 +46,7 @@ def test_query():
 #each of size 8.4MB, total size 16.8MB
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, level",
-[(Time('2016/5/18 15:28:00','2016/5/18 16:30:00'), Instrument('swepam'), Level('fr'))])
+[(Time('2016/5/18 15:28:00','2016/5/18 16:30:00'), Instrument('bbso'), Level('fr'))])
 def test_get(time, instrument, level):
     qr = BClient.query(time, instrument, level)
     res = BClient.get(qr)
@@ -61,6 +61,3 @@ def test_fido_query():
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile
-
-
-

--- a/sunpy/net/dataretriever/tests/test_bbso.py
+++ b/sunpy/net/dataretriever/tests/test_bbso.py
@@ -2,6 +2,7 @@
 # the Google Summer of Code 2016.
 import pytest
 
+from sunpy.time import parse_time
 from sunpy.time.timerange import TimeRange
 from sunpy.net.vso.attrs import Time, Instrument, Level
 from sunpy.net.dataretriever.client import QueryResponse
@@ -46,8 +47,8 @@ def test_query():
         Level='fr')
     assert isinstance(qr, QueryResponse)
     assert len(qr) == 2
-    assert qr.time_range()[0] == '2016/05/18'
-    assert qr.time_range()[1] == '2016/05/18'
+    assert qr.time_range().start == parse_time('2016/05/18 15:30:25')
+    assert qr.time_range().end == parse_time('2016/05/18 16:00:33')
 
 
 #This test downloads 2 fits files

--- a/sunpy/net/dataretriever/tests/test_bbso.py
+++ b/sunpy/net/dataretriever/tests/test_bbso.py
@@ -1,0 +1,66 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+import datetime
+import pytest
+
+from sunpy.time.timerange import TimeRange
+from sunpy.net.vso.attrs import Time,Instrument,Level
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+
+import sunpy.net.dataretriever.sources.bbso as bbso
+
+BClient = bbso.BBSOClient()
+
+@pytest.mark.online
+@pytest.mark.parametrize("timerange,url_start,url_end, level",
+                         [(TimeRange('2016/4/4 15:28:00','2016/4/4 16:40:00'),
+                           'http://www.bbso.njit.edu/pub/archive/2016/04/04/bbso_halph_fl_20160404_152959.fts',
+                          'http://www.bbso.njit.edu/pub/archive/2016/04/04/bbso_halph_fl_20160404_163016.fts', 'fl')])
+def test_get_url_for_time_range(timerange, url_start, url_end, level):
+    urls = BClient._get_url_for_timerange(timerange, level = level)
+    assert isinstance(urls, list)
+    assert urls[0] == url_start
+    assert urls[-1] == url_end
+
+trange = Time('2015/12/30', '2015/12/31')
+def test_can_handle_query():
+    assert BClient._can_handle_query(trange, Instrument('bbso'), Level('fl')) is True
+    assert BClient._can_handle_query(trange, Instrument('bbso'), Level('fr')) is True
+    assert BClient._can_handle_query(trange, Instrument('bbso'), Level('mag')) is False
+    assert BClient._can_handle_query(trange, Level('mag')) is False
+
+@pytest.mark.online
+#This test downloads 2 fits files
+#each of size 8.4MB, total size 16.8MB
+def test_query():
+    qr = BClient.query(Time('2016/5/18 15:28:00','2016/5/18 16:30:00'), Instrument = 'bbso', Level = 'fr')
+    assert isinstance(qr, QueryResponse)
+    assert len(qr) == 2
+    assert qr.time_range()[0] == '2016/05/18'
+    assert qr.time_range()[1] == '2016/05/18'
+
+#This test downloads 2 fits files
+#each of size 8.4MB, total size 16.8MB
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument, level",
+[(Time('2016/5/18 15:28:00','2016/5/18 16:30:00'), Instrument('swepam'), Level('fr'))])
+def test_get(time, instrument, level):
+    qr = BClient.query(time, instrument, level)
+    res = BClient.get(qr)
+    download_list = res.wait()
+    assert len(download_list) == len(qr)
+
+#This test downloads 2 fits files
+#each of size 8MB, total size 16MB
+@pytest.mark.online
+def test_fido_query():
+    qr = Fido.search(a.Time('2016/03/02 17:00:00', '2016/03/02 17:35:00'), a.Instrument('bbso'), a.Level('fl'))
+    assert isinstance(qr, UnifiedResponse)
+    response = Fido.fetch(qr)
+    assert len(response) == qr._numfile
+
+
+

--- a/sunpy/net/dataretriever/tests/test_bbso.py
+++ b/sunpy/net/dataretriever/tests/test_bbso.py
@@ -1,10 +1,9 @@
-#This module was developed with funding provided by
-#the Google Summer of Code 2016.
-import datetime
+# This module was developed with funding provided by
+# the Google Summer of Code 2016.
 import pytest
 
 from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time,Instrument,Level
+from sunpy.net.vso.attrs import Time, Instrument, Level
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
@@ -14,50 +13,65 @@ import sunpy.net.dataretriever.sources.bbso as bbso
 
 BClient = bbso.BBSOClient()
 
+
 @pytest.mark.online
-@pytest.mark.parametrize("timerange,url_start,url_end, level",
-                         [(TimeRange('2016/4/4 15:28:00','2016/4/4 16:40:00'),
-                           'http://www.bbso.njit.edu/pub/archive/2016/04/04/bbso_halph_fl_20160404_152959.fts',
-                          'http://www.bbso.njit.edu/pub/archive/2016/04/04/bbso_halph_fl_20160404_163016.fts', 'fl')])
+@pytest.mark.parametrize("timerange,url_start,url_end, level", [(
+    TimeRange('2016/4/4 15:28:00', '2016/4/4 16:40:00'),
+    'http://www.bbso.njit.edu/pub/archive/2016/04/04/bbso_halph_fl_20160404_152959.fts',
+    'http://www.bbso.njit.edu/pub/archive/2016/04/04/bbso_halph_fl_20160404_163016.fts',
+    'fl')])
 def test_get_url_for_time_range(timerange, url_start, url_end, level):
-    urls = BClient._get_url_for_timerange(timerange, level = level)
+    urls = BClient._get_url_for_timerange(timerange, level=level)
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
 
+
 trange = Time('2015/12/30', '2015/12/31')
+
+
 def test_can_handle_query():
     assert BClient._can_handle_query(trange, Instrument('bbso'), Level('fl'))
     assert BClient._can_handle_query(trange, Instrument('bbso'), Level('fr'))
-    assert not BClient._can_handle_query(trange, Instrument('bbso'), Level('mag'))
+    assert not BClient._can_handle_query(trange,
+                                         Instrument('bbso'), Level('mag'))
     assert not BClient._can_handle_query(trange, Level('mag'))
+
 
 @pytest.mark.online
 #This test downloads 2 fits files
 #each of size 8.4MB, total size 16.8MB
 def test_query():
-    qr = BClient.query(Time('2016/5/18 15:28:00','2016/5/18 16:30:00'), Instrument = 'bbso', Level = 'fr')
+    qr = BClient.query(
+        Time('2016/5/18 15:28:00', '2016/5/18 16:30:00'),
+        Instrument='bbso',
+        Level='fr')
     assert isinstance(qr, QueryResponse)
     assert len(qr) == 2
     assert qr.time_range()[0] == '2016/05/18'
     assert qr.time_range()[1] == '2016/05/18'
 
+
 #This test downloads 2 fits files
 #each of size 8.4MB, total size 16.8MB
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, level",
-[(Time('2016/5/18 15:28:00','2016/5/18 16:30:00'), Instrument('bbso'), Level('fr'))])
+                         [(Time('2016/5/18 15:28:00', '2016/5/18 16:30:00'),
+                           Instrument('bbso'), Level('fr'))])
 def test_get(time, instrument, level):
     qr = BClient.query(time, instrument, level)
     res = BClient.get(qr)
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
+
 #This test downloads 2 fits files
 #each of size 8MB, total size 16MB
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2016/03/02 17:00:00', '2016/03/02 17:35:00'), a.Instrument('bbso'), a.Level('fl'))
+    qr = Fido.search(
+        a.Time('2016/03/02 17:00:00', '2016/03/02 17:35:00'),
+        a.Instrument('bbso'), a.Level('fl'))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/tests/strategies.py
+++ b/sunpy/net/tests/strategies.py
@@ -39,7 +39,7 @@ def online_instruments():
     Returns a strategy for any instrument that does not need the internet to do
     a query
     """
-    online_instr = ['rhessi']
+    online_instr = ['rhessi', 'bbso']
     online_instr = st.builds(a.Instrument, st.sampled_from(online_instr))
 
     return online_instr


### PR DESCRIPTION
Users can now download data from [BBSO](http://www.bbso.njit.edu/pub/archive). The query format looks like

``` python
qr = Fido.search(time, Instrument('bbso'), Level('fl'))
```

Level can be `fl` or `fr`. For now both sorts of files are donwloaded `.fts` and `.fts.gz`.
It is complete with passing tests and documentation.
@dpshelio @wafels Review.

@dpshelio: The scraper in util did not work on BBSO site. So I had to think of something else. The problem was that the Scraper was not able to scrape urls from the site (It was getting incomplete urls along with useless ones). So, I iterate over all days in the time range, open the html page for each day, then among all the extraneous urls , I get the url we want (using `Scarper._URL_followsPattern`) and build the complete url. I do this for both types files `.fts` and `.fts.gz`.
