### PR TITLE
XRTClient implemented. Supports query by filter argument.

### DIFF
--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,6 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level
+from .vso.attrs import Time, Instrument, Wavelength, Level, Source, Detector, Physobs
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc']
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
+           'Source', 'Detector', 'Physobs']

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -20,7 +20,7 @@ from sunpy.util import replacement_filename
 from sunpy import config
 
 from ..download import Downloader, Results
-from ..vso.attrs import Time, _Range
+from ..vso.attrs import Time, _Range, Wavelength
 
 TIME_FORMAT = config.get("general", "time_format")
 
@@ -183,6 +183,8 @@ class GenericClient(object):
                     self.map_[elem.__class__.__name__.lower()] = a_min
                 else:
                     self.map_[elem.__class__.__name__.lower()] = (a_min, a_max)
+            elif issubclass(elem.__class__, Wavelength):
+                self.map_[elem.__class__.__name__.lower()] = elem
             else:
                 if hasattr(elem, 'value'):
                     self.map_[elem.__class__.__name__.lower()] = elem.value

--- a/sunpy/net/dataretriever/clients.py
+++ b/sunpy/net/dataretriever/clients.py
@@ -7,6 +7,7 @@ from .sources.goes import GOESClient
 from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 from .sources.noaa import NOAAIndicesClient, NOAAPredictClient
+from .sources.xrt import XRTClient
 
 # Import and register other sources
 from sunpy.net.jsoc.jsoc import JSOCClient

--- a/sunpy/net/dataretriever/sources/xrt.py
+++ b/sunpy/net/dataretriever/sources/xrt.py
@@ -16,9 +16,44 @@ from sunpy.time import TimeRange
 __all__ = ['XRTClient']
 
 class XRTClient(GenericClient):
-
+    """
+    Returns a list of URLS to XRT files corresponding to value of input timerange.
+    URL source: `http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/`.
+    Parameters
+    ----------
+    timerange: sunpy.time.TimeRange
+        time range for which data is to be downloaded.
+        Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
+    
+    Instrument: Fixed argument = 'xrt'
+    Filter: Filter can take only 'almesh', 'alpoly', 'cpoly', 'tipoly', 'thinbe' as arguments.
+            Arguments are case-insensitive and can include non alphabetic characters as well.
+            Arguments like 'Al-mesh' or 'Al_mesh' or 'Al/mesh' would also work fine.
+            
+    Returns
+    -------
+    urls: list
+    list of urls corresponding to requested time range.
+    
+    Examples
+    --------
+    >>> from sunpy.net import Fido
+    >>> from sunpy.net import attrs as a
+    >>> results = Fido.search(Time('2016/5/18','2016/5/19'), a.Instrument('xrt'), a.Filter('al_mesh'))
+    >>> print(results)
+        [<Table length=2>
+         Start Time           End Time      Source Instrument
+           str19               str19         str6     str3   
+    ------------------- ------------------- ------ ----------
+    2016-05-18 00:00:00 2016-05-19 00:00:00 Hinode        XRT
+    2016-05-19 00:00:00 2016-05-20 00:00:00 Hinode        XRT]
+    
+    >>> response = Fido.fetch(results)
+    """
     def _get_url_for_timerange(self, timerange, **kwargs):
-
+        """
+        returns list of urls corresponding to given TimeRange.
+        """
         START_DATE = datetime.datetime(2014, 1, 10, 18, 14, 42)
         filter_type = kwargs['filter']
         regex = re.compile('[^a-zA-Z]')
@@ -36,6 +71,9 @@ class XRTClient(GenericClient):
         return result
 
     def _makeimap(self):
+        """
+        Helper Function:used to hold information about source.
+        """
         self.map_['source'] = 'Hinode'
         self.map_['instrument'] = 'XRT'
 

--- a/sunpy/net/dataretriever/sources/xrt.py
+++ b/sunpy/net/dataretriever/sources/xrt.py
@@ -97,8 +97,6 @@ class XRTClient(GenericClient):
         boolean: answer as to whether client can service the query
 
         """
-        chkattr = ['Time', 'Instrument', 'Filter']
-        chklist = [x.__class__.__name__ in chkattr for x in query]
         chk_var = 0
         types = ['almesh', 'alpoly', 'cpoly', 'tipoly', 'thinbe']
         regex = re.compile('[^a-zA-Z]')

--- a/sunpy/net/dataretriever/sources/xrt.py
+++ b/sunpy/net/dataretriever/sources/xrt.py
@@ -1,3 +1,6 @@
+"""
+This module implements XRT Client.
+"""
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
 
@@ -5,12 +8,10 @@ __author__ = "Sudarshan Konge"
 __email__ = "sudk1896@gmail.com"
 
 import datetime
-import urllib2
 import re
 
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
-from sunpy.time import TimeRange
 
 __all__ = ['XRTClient']
 
@@ -23,17 +24,17 @@ class XRTClient(GenericClient):
     timerange: sunpy.time.TimeRange
         time range for which data is to be downloaded.
         Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
-    
+
     Instrument: Fixed argument = 'xrt'
     Filter: Filter can take only 'almesh', 'alpoly', 'cpoly', 'tipoly', 'thinbe' as arguments.
             Arguments are case-insensitive and can include non alphabetic characters as well.
             Arguments like 'Al-mesh' or 'Al_mesh' or 'Al/mesh' would also work fine.
-            
+
     Returns
     -------
     urls: list
     list of urls corresponding to requested time range.
-    
+
     Examples
     --------
     >>> from sunpy.net import Fido
@@ -42,11 +43,11 @@ class XRTClient(GenericClient):
     >>> print(results)
         [<Table length=2>
          Start Time           End Time      Source Instrument
-           str19               str19         str6     str3   
+           str19               str19         str6     str3
     ------------------- ------------------- ------ ----------
     2016-05-18 00:00:00 2016-05-19 00:00:00 Hinode        XRT
     2016-05-19 00:00:00 2016-05-20 00:00:00 Hinode        XRT]
-    
+
     >>> response = Fido.fetch(results)
     """
     def _get_url_for_timerange(self, timerange, **kwargs):
@@ -54,7 +55,7 @@ class XRTClient(GenericClient):
         returns list of urls corresponding to given TimeRange.
         """
         if not timerange:
-            return []      
+            return []
         START_DATE = datetime.datetime(2014, 1, 10, 18, 14, 42)
         filter_type = kwargs['filter']
         regex = re.compile('[^a-zA-Z]')
@@ -64,14 +65,14 @@ class XRTClient(GenericClient):
             raise ValueError('Earliest date for which XRT data is available is {:%Y-%m-%d}'.format(START_DATE))
         filter_dict = {'almesh':'Al_mesh', 'alpoly':'Al_poly', 'cpoly':'C_poly', 'tipoly':'Ti_poly', 'thinbe':'thin_Be'}
         url_pattern = ['http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_{filter}_%Y%m%d_%H%M%S.{s}.fits'.
-                       format(filter = filter_dict[filter_type], s=i) for i in range (0, 10)]
-        arr = [Scraper(pattern, filter = filter_dict[filter_type]).filelist(timerange) for pattern in url_pattern]
-        [result.extend(url) for url in arr if len(url)>0]
+                       format(filter=filter_dict[filter_type], s=i) for i in range(0, 10)]
+        arr = [Scraper(pattern, filter=filter_dict[filter_type]).filelist(timerange) for pattern in url_pattern]
+        [result.extend(url) for url in arr if len(url) > 0]
         #Integrate nascom.nasa.gov XRT data as well.
         url_pattern = ['http://sohowww.nascom.nasa.gov/sdb/hinode/xrt/l1q_synop/XRT_{filter}_%Y%m%d_%H%M%S.{s}.fits'.
-                       format(filter = filter_dict[filter_type], s=i) for i in range (0, 10)]
+                       format(filter=filter_dict[filter_type], s=i) for i in range(0, 10)]
         arr = [Scraper(pattern, filter = filter_dict[filter_type]).filelist(timerange) for pattern in url_pattern]
-        [result.extend(url) for url in arr if len(url)>0]
+        [result.extend(url) for url in arr if len(url) > 0]
 
         return result
 
@@ -86,15 +87,15 @@ class XRTClient(GenericClient):
     def _can_handle_query(cls, *query):
         """
         Answers whether client can service the query.
-        
+
         Parameters
         ----------
         query : list of query objects
-        
+
         Returns
         -------
         boolean: answer as to whether client can service the query
-        
+
         """
         chkattr = ['Time', 'Instrument', 'Filter']
         chklist = [x.__class__.__name__ in chkattr for x in query]
@@ -104,8 +105,6 @@ class XRTClient(GenericClient):
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'xrt':
                 chk_var += 1
-            if x.__class__.__name__ == 'Filter' and type(x.value) is str and regex.sub('',x.value).lower() in types:
+            if x.__class__.__name__ == 'Filter' and type(x.value) is str and regex.sub('', x.value).lower() in types:
                 chk_var += 1
-        if (chk_var == 2):
-            return True
-        return False
+        return chk_var == 2

--- a/sunpy/net/dataretriever/sources/xrt.py
+++ b/sunpy/net/dataretriever/sources/xrt.py
@@ -8,7 +8,6 @@ import datetime
 import urllib2
 import re
 
-
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
 from sunpy.time import TimeRange

--- a/sunpy/net/dataretriever/sources/xrt.py
+++ b/sunpy/net/dataretriever/sources/xrt.py
@@ -27,7 +27,8 @@ class XRTClient(GenericClient):
         if timerange.start < START_DATE:
             raise ValueError('Earliest date for which XRT data is available is {:%Y-%m-%d}'.format(START_DATE))
         filter_dict = {'almesh':'Al_mesh', 'alpoly':'Al_poly', 'cpoly':'C_poly', 'tipoly':'Ti_poly', 'thinbe':'thin_Be'}
-        url_pattern = ['http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_{filter}_%Y%m%d_%H%M%S.{s}.fits'.format(s=i) for i in range (0, 10)]
+        url_pattern = ['http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_{filter}_%Y%m%d_%H%M%S.{s}.fits'.
+                       format(filter = filter_dict[filter_type], s=i) for i in range (0, 10)]
         arr = [Scraper(pattern, filter = filter_dict[filter_type]).filelist(timerange) for pattern in url_pattern]
         [result.extend(url) for url in arr if len(url)>0]
         if not timerange:
@@ -38,7 +39,7 @@ class XRTClient(GenericClient):
         self.map_['source'] = 'Hinode'
         self.map_['instrument'] = 'XRT'
 
-     @classmethod
+    @classmethod
     def _can_handle_query(cls, *query):
         """
         Answers whether client can service the query.

--- a/sunpy/net/dataretriever/sources/xrt.py
+++ b/sunpy/net/dataretriever/sources/xrt.py
@@ -54,6 +54,8 @@ class XRTClient(GenericClient):
         """
         returns list of urls corresponding to given TimeRange.
         """
+        if not timerange:
+            return []      
         START_DATE = datetime.datetime(2014, 1, 10, 18, 14, 42)
         filter_type = kwargs['filter']
         regex = re.compile('[^a-zA-Z]')
@@ -71,8 +73,7 @@ class XRTClient(GenericClient):
                        format(filter = filter_dict[filter_type], s=i) for i in range (0, 10)]
         arr = [Scraper(pattern, filter = filter_dict[filter_type]).filelist(timerange) for pattern in url_pattern]
         [result.extend(url) for url in arr if len(url)>0]
-        if not timerange:
-            return []
+
         return result
 
     def _makeimap(self):

--- a/sunpy/net/dataretriever/sources/xrt.py
+++ b/sunpy/net/dataretriever/sources/xrt.py
@@ -66,6 +66,11 @@ class XRTClient(GenericClient):
                        format(filter = filter_dict[filter_type], s=i) for i in range (0, 10)]
         arr = [Scraper(pattern, filter = filter_dict[filter_type]).filelist(timerange) for pattern in url_pattern]
         [result.extend(url) for url in arr if len(url)>0]
+        #Integrate nascom.nasa.gov XRT data as well.
+        url_pattern = ['http://sohowww.nascom.nasa.gov/sdb/hinode/xrt/l1q_synop/XRT_{filter}_%Y%m%d_%H%M%S.{s}.fits'.
+                       format(filter = filter_dict[filter_type], s=i) for i in range (0, 10)]
+        arr = [Scraper(pattern, filter = filter_dict[filter_type]).filelist(timerange) for pattern in url_pattern]
+        [result.extend(url) for url in arr if len(url)>0]
         if not timerange:
             return []
         return result

--- a/sunpy/net/dataretriever/sources/xrt.py
+++ b/sunpy/net/dataretriever/sources/xrt.py
@@ -1,0 +1,67 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+
+__author__ = "Sudarshan Konge"
+__email__ = "sudk1896@gmail.com"
+
+import datetime
+import urllib2
+import re
+
+
+from sunpy.net.dataretriever.client import GenericClient
+from sunpy.util.scraper import Scraper
+from sunpy.time import TimeRange
+
+__all__ = ['XRTClient']
+
+class XRTClient(GenericClient):
+
+    def _get_url_for_timerange(self, timerange, **kwargs):
+
+        START_DATE = datetime.datetime(2014, 1, 10, 18, 14, 42)
+        filter_type = kwargs['filter']
+        regex = re.compile('[^a-zA-Z]')
+        filter_type = regex.sub('', filter_type).lower()
+        result = list()
+        if timerange.start < START_DATE:
+            raise ValueError('Earliest date for which XRT data is available is {:%Y-%m-%d}'.format(START_DATE))
+        filter_dict = {'almesh':'Al_mesh', 'alpoly':'Al_poly', 'cpoly':'C_poly', 'tipoly':'Ti_poly', 'thinbe':'thin_Be'}
+        url_pattern = ['http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_{filter}_%Y%m%d_%H%M%S.{s}.fits'.format(s=i) for i in range (0, 10)]
+        arr = [Scraper(pattern, filter = filter_dict[filter_type]).filelist(timerange) for pattern in url_pattern]
+        [result.extend(url) for url in arr if len(url)>0]
+        if not timerange:
+            return []
+        return result
+
+    def _makeimap(self):
+        self.map_['source'] = 'Hinode'
+        self.map_['instrument'] = 'XRT'
+
+     @classmethod
+    def _can_handle_query(cls, *query):
+        """
+        Answers whether client can service the query.
+        
+        Parameters
+        ----------
+        query : list of query objects
+        
+        Returns
+        -------
+        boolean: answer as to whether client can service the query
+        
+        """
+        chkattr = ['Time', 'Instrument', 'Filter']
+        chklist = [x.__class__.__name__ in chkattr for x in query]
+        chk_var = 0
+        types = ['almesh', 'alpoly', 'cpoly', 'tipoly', 'thinbe']
+        regex = re.compile('[^a-zA-Z]')
+        for x in query:
+            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'xrt':
+                chk_var += 1
+            if x.__class__.__name__ == 'Filter' and type(x.value) is str and regex.sub('',x.value).lower() in types:
+                chk_var += 1
+        if (chk_var == 2):
+            return True
+        return False

--- a/sunpy/net/dataretriever/tests/test_xrt.py
+++ b/sunpy/net/dataretriever/tests/test_xrt.py
@@ -33,5 +33,15 @@ def test_can_handle_query():
     assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('thin_be')) is True
     assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('mag')) is not True
 
+@pytest.mark.online
+def test_query():
+    qr = XClient.query(Time('2016/5/18','2016/5/19'), Instrument = 'xrt', filter = 'al_mesh')
+    assert isinstance(qr, QueryResponse)
+    assert len(qr) == 2
+    assert qr.time_range()[0] == '2016/05/18'
+    assert qr.time_range()[1] == '2016/05/19'
+
+
+
 
     

--- a/sunpy/net/dataretriever/tests/test_xrt.py
+++ b/sunpy/net/dataretriever/tests/test_xrt.py
@@ -50,7 +50,9 @@ def test_get(time, instrument, filter_):
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
-
-
-
-    
+@pytest.mark.online
+def test_fido_query():
+    qr = Fido.search(a.Time('2016/5/18','2016/5/19'), a.Instrument('xrt'), a.Filter('al_mesh'))
+    assert isinstance(qr, UnifiedResponse)
+    response = Fido.fetch(qr)
+    assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_xrt.py
+++ b/sunpy/net/dataretriever/tests/test_xrt.py
@@ -1,10 +1,12 @@
+"""
+This module tests XRT Client.
+"""
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
-import datetime
 import pytest
 
 from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time,Instrument,Filter
+from sunpy.net.vso.attrs import Time, Instrument, Filter
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
@@ -15,11 +17,11 @@ XClient = xrt.XRTClient()
 
 @pytest.mark.online
 @pytest.mark.parametrize("timerange,url_start,url_end, filter_",
-[(TimeRange('2016/5/18','2016/5/19'),
+[(TimeRange('2016/5/18', '2016/5/19'),
 'http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_Al_mesh_20160518_180137.1.fits',
-'http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_Al_mesh_20160518_062007.7.fits' ,'al_mesh')])
+'http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_Al_mesh_20160518_062007.7.fits', 'al_mesh')])
 def test_get_url_for_timerange(timerange, url_start, url_end, filter_):
-    urls = XClient._get_url_for_timerange(timerange, filter = filter_)
+    urls = XClient._get_url_for_timerange(timerange, filter=filter_)
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
@@ -35,7 +37,7 @@ def test_can_handle_query():
 
 @pytest.mark.online
 def test_query():
-    qr = XClient.query(Time('2016/5/18','2016/5/19'), Instrument = 'xrt', filter = 'al_mesh')
+    qr = XClient.query(Time('2016/5/18', '2016/5/19'), Instrument='xrt', filter='al_mesh')
     assert isinstance(qr, QueryResponse)
     assert len(qr) == 2
     assert qr.time_range()[0] == '2016/05/18'
@@ -43,7 +45,7 @@ def test_query():
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, filter_",
-[(Time('2016/5/18','2016/5/19'), Instrument('xrt'), Filter('al_mesh'))])
+[(Time('2016/5/18', '2016/5/19'), Instrument('xrt'), Filter('al_mesh'))])
 def test_get(time, instrument, filter_):
     qr = XClient.query(time, instrument, filter_)
     res = XClient.get(qr)
@@ -54,7 +56,7 @@ def test_get(time, instrument, filter_):
 #Total size = 8MB
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2016/5/18','2016/5/19'), a.Instrument('xrt'), a.Filter('al_mesh'))
+    qr = Fido.search(a.Time('2016/5/18', '2016/5/19'), a.Instrument('xrt'), a.Filter('al_mesh'))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_xrt.py
+++ b/sunpy/net/dataretriever/tests/test_xrt.py
@@ -26,12 +26,12 @@ def test_get_url_for_timerange(timerange, url_start, url_end, filter_):
 
 trange = Time('2015/12/30', '2015/12/31')
 def test_can_handle_query():
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('almesh')) is True
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('alpoly')) is True
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('cpoly')) is True
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('tipoly')) is True
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('thin_be')) is True
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('mag')) is not True
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('almesh'))
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('alpoly'))
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('cpoly'))
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('tipoly'))
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('thin_be'))
+    assert not XClient._can_handle_query(trange, Instrument('xrt'), Filter('mag'))
 
 @pytest.mark.online
 def test_query():
@@ -50,6 +50,8 @@ def test_get(time, instrument, filter_):
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
+#Downloads two fits files each of size 4MB
+#Total size = 8MB
 @pytest.mark.online
 def test_fido_query():
     qr = Fido.search(a.Time('2016/5/18','2016/5/19'), a.Instrument('xrt'), a.Filter('al_mesh'))

--- a/sunpy/net/dataretriever/tests/test_xrt.py
+++ b/sunpy/net/dataretriever/tests/test_xrt.py
@@ -41,6 +41,15 @@ def test_query():
     assert qr.time_range()[0] == '2016/05/18'
     assert qr.time_range()[1] == '2016/05/19'
 
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument, filter_",
+[(Time('2016/5/18','2016/5/19'), Instrument('xrt'), Filter('al_mesh'))])
+def test_get(time, instrument, filter_):
+    qr = XClient.query(time, instrument, filter_)
+    res = XClient.get(qr)
+    download_list = res.wait()
+    assert len(download_list) == len(qr)
+
 
 
 

--- a/sunpy/net/dataretriever/tests/test_xrt.py
+++ b/sunpy/net/dataretriever/tests/test_xrt.py
@@ -1,0 +1,26 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+import datetime
+import pytest
+
+from sunpy.time.timerange import TimeRange
+from sunpy.net.vso.attrs import Time,Instrument,Filter
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+import sunpy.net.dataretriever.sources.xrt as xrt
+
+XClient = xrt.XRTClient()
+
+@pytest.mark.online
+
+@pytest.mark.parametrize("timerange,url_start,url_end, filter_",
+[(TimeRange('2016/5/18','2016/5/19'),
+'http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_Al_mesh_20160518_180137.1.fits',
+'http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_Al_mesh_20160518_062007.7.fits' ,'al_mesh')])
+def test_get_url_for_timerange(timerange, url_start, url_end, filter_):
+    urls = XClient._get_url_for_timerange(timerange, filter = filter_)
+    assert isinstance(urls, list)
+    assert urls[0] == url_start
+    assert urls[-1] == url_end

--- a/sunpy/net/dataretriever/tests/test_xrt.py
+++ b/sunpy/net/dataretriever/tests/test_xrt.py
@@ -27,13 +27,15 @@ def test_get_url_for_timerange(timerange, url_start, url_end, filter_):
     assert urls[-1] == url_end
 
 trange = Time('2015/12/30', '2015/12/31')
-def test_can_handle_query():
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('almesh'))
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('alpoly'))
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('cpoly'))
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('tipoly'))
-    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('thin_be'))
-    assert not XClient._can_handle_query(trange, Instrument('xrt'), Filter('mag'))
+@pytest.mark.parametrize("timerange, instrument, filter_, expected",
+                         [(trange, Instrument('xrt'), Filter('almesh'), True),
+                          (trange, Instrument('xrt'), Filter('alpoly'), True),
+                          (trange, Instrument('xrt'), Filter('cpoly'), True),
+                          (trange, Instrument('xrt'), Filter('tipoly'), True),
+                          (trange, Instrument('xrt'), Filter('thin_be'), True),
+                          (trange, Instrument('xrt'), Filter('mag'), False)])
+def test_can_handle_query(timerange, instrument, filter_, expected):
+    assert XClient._can_handle_query(timerange, instrument, filter_) is expected  
 
 @pytest.mark.online
 def test_query():
@@ -56,7 +58,7 @@ def test_get(time, instrument, filter_):
 #Total size = 8MB
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2016/5/18', '2016/5/19'), a.Instrument('xrt'), a.Filter('al_mesh'))
+    qr = Fido.search(a.Time('2016/5/18', '2016/5/19'), a.Instrument('xrt'), Filter('al_mesh'))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_xrt.py
+++ b/sunpy/net/dataretriever/tests/test_xrt.py
@@ -14,7 +14,6 @@ import sunpy.net.dataretriever.sources.xrt as xrt
 XClient = xrt.XRTClient()
 
 @pytest.mark.online
-
 @pytest.mark.parametrize("timerange,url_start,url_end, filter_",
 [(TimeRange('2016/5/18','2016/5/19'),
 'http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/XRT_Al_mesh_20160518_180137.1.fits',
@@ -24,3 +23,15 @@ def test_get_url_for_timerange(timerange, url_start, url_end, filter_):
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
+
+trange = Time('2015/12/30', '2015/12/31')
+def test_can_handle_query():
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('almesh')) is True
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('alpoly')) is True
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('cpoly')) is True
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('tipoly')) is True
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('thin_be')) is True
+    assert XClient._can_handle_query(trange, Instrument('xrt'), Filter('mag')) is not True
+
+
+    


### PR DESCRIPTION
Users can query to obtain XRT data from [montana.edu](http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/). The query supports `filter` argument. The `filter` argument takes `al_mesh`, `al_poly`, `ti_poly`, `c_poly` and `thin_be` as arguments.
Read the docs to get a better understanding of the query parameters.
@dpshelio @wafels  Review.
Should I add support for [nascom website](http://sohowww.nascom.nasa.gov/sdb/hinode/xrt/l1q_synop/) as well.
P.S. David, I think you might like this implementation. Its the most 'pythonic' code I have ever written.
P.P.S. I added support for [nascom website](http://sohowww.nascom.nasa.gov/sdb/hinode/xrt/l1q_synop/) 
as well.
