### PR TITLE
GONGClient implemented.

### DIFF
--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,7 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level, Physobs
+from .vso.attrs import Time, Instrument, Wavelength, Level, Source, Detector, Physobs
 
 __all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
-           'Physobs']
+           'Source','Detector', 'Physobs']

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,6 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level
+from .vso.attrs import Time, Instrument, Wavelength, Level, Physobs
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc']
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
+           'Physobs']

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -183,6 +183,8 @@ class GenericClient(object):
                     self.map_[elem.__class__.__name__.lower()] = a_min
                 else:
                     self.map_[elem.__class__.__name__.lower()] = (a_min, a_max)
+            elif issubclass(elem.__class__, Wavelength):
+                self.map_[elem.__class__.__name__.lower()] = elem
             else:
                 if hasattr(elem, 'value'):
                     self.map_[elem.__class__.__name__.lower()] = elem.value

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -20,7 +20,7 @@ from sunpy.util import replacement_filename
 from sunpy import config
 
 from ..download import Downloader, Results
-from ..vso.attrs import Time, _Range
+from ..vso.attrs import Time, Wavelength, _Range
 
 TIME_FORMAT = config.get("general", "time_format")
 

--- a/sunpy/net/dataretriever/clients.py
+++ b/sunpy/net/dataretriever/clients.py
@@ -7,6 +7,7 @@ from .sources.goes import GOESClient
 from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 from .sources.noaa import NOAAIndicesClient, NOAAPredictClient
+from .sources.gong import GONGClient, FARSIDEClient
 
 # Import and register other sources
 from sunpy.net.jsoc.jsoc import JSOCClient

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -95,17 +95,17 @@ class GONGClient(GenericClient):
                 else:
                     try:
                         wave_float = kwargs['wavelength'].min.value
-                        da = []
+                        da = list()
                         da.append(wave_float)
                         for wave_nums in pattern_table.keys():
-                            db = []
+                            db = list()
                             db.append(wave_nums)
                             if np.isclose(da, db, 1e-10, 1e-10):
                                 wave = wave_nums
                                 break
                         patterns.append(pattern_table[wave])
-                    except NameError:
-                        print ("Enter correct wavelength range and units")
+                    except:
+                        raise NameError("Enter correct wavelength range and units")
         #All valid patterns to be downloaded are in the patterns list.
         instruments_to = list() #The instruments from which user wants to download
         if not instrument_in:
@@ -159,7 +159,7 @@ class GONGClient(GenericClient):
             try:
                 check = urllib2.urlopen(urls)
                 final_result.append(urls)
-            except:
+            except (urllib2.HTTPError, urllib2.URLError) as e:
                 pass
         return final_result
 
@@ -169,8 +169,6 @@ class GONGClient(GenericClient):
         """   
         self.map_['source'] = 'GONG'
         
-        
-    
     @classmethod
     def _can_handle_query(cls, *query):
         """

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -25,7 +25,8 @@ class GONGClient(GenericClient):
         time range for which data is to be downloaded.
         Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
     
-    Instrument: Arguments are any one from ['bb', 'ct', 'le', 'ml', 'td', 'ud','z']
+    Instrument: Arguments are any one from ['bigbear', 'cerrotelolo',
+                'learmonth', 'maunaloa', 'teide', 'udaipur','tucson']
 
     Physobs: Two arguments or none 'intensity' and 'los_magnetic_field'
 

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -201,8 +201,8 @@ class GONGClient(GenericClient):
 
 class FARSIDEClient(GenericClient):
     """
-    Returns a list of URLS to XRT files corresponding to value of input timerange.
-    URL source: `http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/`.
+    Returns a list of URLS to FARSIDE files corresponding to value of input timerange.
+    URL source: `http://farside.nso.edu/oQR/fqo/`.
     Parameters
     ----------
     timerange: sunpy.time.TimeRange

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -252,7 +252,7 @@ class FARSIDEClient(GenericClient):
         for dt in all_days:
             times = [datetime.datetime(dt.start.year, dt.start.month, dt.start.day, 0, 0),
                      datetime.datetime(dt.start.year, dt.start.month, dt.start.day, 12, 0)]
-            [result.append(url_pattern.format(date = dt_)) for dt_ in times]
+            [result.append(url_pattern.format(date=dt_)) for dt_ in times]
         if not timerange:
             return []
         return result

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -90,6 +90,12 @@ class GONGClient(GenericClient):
                 patterns.append(url_pattern_1)
             else:
                 #Differentiate on basis of wavelength
+                
+                #The isclose function in numpy can only check two arrays if they
+                #are close to each other within some precision. Standalone values such
+                #as int, doubles etc can't be checked that way. In order to do that, we put the
+                #two indiviual values in two seperate arrays da and db and then apply
+                #isclose on both those arrays.
                 if not wavelength_in:
                     patterns.append(url_pattern_1), patterns.append(url_pattern_2)
                 else:

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -110,7 +110,39 @@ class GONGClient(GenericClient):
 
 
 class FARSIDEClient(GenericClient):
-
+    """
+    Returns a list of URLS to XRT files corresponding to value of input timerange.
+    URL source: `http://solar.physics.montana.edu/HINODE/XRT/QL/syn_comp_fits/`.
+    Parameters
+    ----------
+    timerange: sunpy.time.TimeRange
+        time range for which data is to be downloaded.
+        Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
+    
+    Instrument: Fixed argument = 'farside'
+            
+    Returns
+    -------
+    urls: list
+    list of urls corresponding to requested time range.
+    
+    Examples
+    --------
+    >>> from sunpy.net import Fido
+    >>> from sunpy.net import attrs as a
+    >>> results = Fido.search(Time('2015/4/2','2015/4/4'), a.Instrument('farside'))
+    >>> print(results)
+    [<Table length=4>
+         Start Time           End Time      Source Instrument
+           str19               str19         str4     str7   
+    ------------------- ------------------- ------ ----------
+    2015-04-02 00:00:00 2015-04-03 00:00:00   GONG    farside
+    2015-04-03 00:00:00 2015-04-04 00:00:00   GONG    farside
+    2015-04-04 00:00:00 2015-04-05 00:00:00   GONG    farside
+    2015-04-05 00:00:00 2015-04-06 00:00:00   GONG    farside]
+    
+    >>> response = Fido.fetch(results)
+    """
     def _get_url_for_timerange(self, timerange, **kwargs):
         """
         returns list of urls corresponding to given TimeRange.

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -1,0 +1,135 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+
+__author__ = "Sudarshan Konge"
+__email__ = "sudk1896@gmail.com"
+
+import datetime
+import re
+
+from sunpy.net.dataretriever.client import GenericClient
+from sunpy.util.scraper import Scraper
+from sunpy.time import TimeRange
+
+__all__ = ['GONGClient', 'FARSIDEClient']
+
+class GONGClient(GenericClient):
+
+    def _get_url_for_timerange(self, timerange, **kwargs):
+        
+        
+        table_physobs = {'intensity' : 'i', 'los_magnetic_field': 'b'} #legitimate physical observations.
+        table_instruments = ['bb', 'ct', 'le', 'ml', 'td', 'ud', 'z'] #all possible instruments
+        
+        physobs_in = True if ('physobs' in kwargs.keys() and kwargs['physobs'] in table_physobs) else False #Is PhysObs entered
+        instrument_in = True if 'instrument' in kwargs.keys() else False #Is instrument entered.
+        
+        url_pattern_1 =  'ftp://gong2.nso.edu/QR/{id}qa/%Y%m/{ObsID}bqa%y%m%d/{ObsID}bqa%y%m%dt%H%M.fits.gz'
+        url_pattern_2 = 'http://gong2.nso.edu/HA/{id}haf/%Y%m/%Y%m%d/%Y%m%d%H%M%S{ObsID}h.fits.fz' #'id' here is a dummy argument
+
+        generate = lambda url, id_, obs: url.format(id = id_, ObsID = obs) #Function generates urls based on instrument
+        
+        result = list() #final list of urls
+        patterns = list()
+        if not physobs_in:
+            patterns.append(url_pattern_1), patterns.append(url_pattern_2)
+        else:
+            if kwargs['physobs'] == 'los_magnetic_field':
+                patterns.append(url_pattern_1)
+            else:
+                #Differentiate on basis of wavelength
+                wavelength_in = True if 'wavelength' in kwargs.keys() else False
+                
+                
+                
+        # Create a lambda for generating urls for 1. and for 2.
+        
+        #table = {'bb':'B', 'ct':'ct', 'le', 'ml', 'td', 'ud', 'z'} #for H-alpha
+
+
+    def _makeimap(self):
+        self.map_['source'] = 'GONG'
+        
+        
+    
+    @classmethod
+    def _can_handle_query(cls, *query):
+        """
+        Answers whether client can service the query.
+        
+        Parameters
+        ----------
+        query : list of query objects
+        
+        Returns
+        -------
+        boolean: answer as to whether client can service the query
+        
+        """
+        chkattr = ['Time', 'Instrument', 'Physobs']
+        chklist = [x.__class__.__name__ in chkattr for x in query]
+        physobs = ['intensity', 'los_magnetic_field'] #from VSO
+        instruments = ['bb', 'ct', 'le', 'ml', 'td', 'ud', 'z'] #for Magnetogram and intensity
+        chk_instr, chk_physobs = 0, 0
+        chk_source, chk_wavelength = 0, 0
+        values = [6562, 6563, 6768]
+        for x in query:
+            if x.__class__.__name__ == 'Instrument' and x.value.lower() in instruments:
+                chk_instr += 1
+            if x.__class__.__name__ == 'Physobs' and x.value.lower() in physobs:
+                chk_physobs += 1
+            if x.__class__.__name__ == 'Source' and x.value.lower() == 'gong':
+                chk_source += 1
+            if (x.__class__.__name__ == 'Wavelength' and int(x.min.value) in values and int(x.max.value) in values and (x.unit.name).lower()=='angstrom'):
+                chk_wavelength += 1
+        if chk_instr == 1 or chk_physobs == 1:
+            return True
+        else:
+            return chk_source == 1
+
+
+class FARSIDEClient(GenericClient):
+
+    def _get_url_for_timerange(self, timerange, **kwargs):
+        """
+        returns list of urls corresponding to given TimeRange.
+        """
+        START_DATE = datetime.datetime(2006, 5, 13, 12, 0, 0)
+        if timerange.start < START:
+            raise ValueError('Earliest date for which XRT data is available is {:%Y-%m-%d}'.format(START_DATE))
+        url_pattern = 'http://farside.nso.edu/oQR/fqo/%Y%m/mrfqo%y%m%dt%H%M.fits'
+        crawler = Scraper(url_pattern)
+        if not timerange:
+            return []
+        result = Scraper.filelist(timerange)
+        return result
+
+    def _makeimap(self):
+        """
+        Helper Function:used to hold information about source.
+        """
+        self.map_['source'] = 'GONG'
+        self.map_['instrument'] = 'farside'
+
+    @classmethod
+    def _can_handle_query(cls, *query):
+        """
+        Answers whether client can service the query.
+        
+        Parameters
+        ----------
+        query : list of query objects
+        
+        Returns
+        -------
+        boolean: answer as to whether client can service the query
+        
+        """
+        chkattr = ['Time', 'Instrument']
+        chklist = [x.__class__.__name__ in chkattr for x in query]
+        for x in query:
+            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'farside':
+                return all(chklist)
+        return False
+        
+    

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -15,11 +15,59 @@ from sunpy.time import TimeRange
 __all__ = ['GONGClient', 'FARSIDEClient']
 
 class GONGClient(GenericClient):
+    """
+    Returns a list of URLS to GONG files corresponding to value of input timerange.
+    URL source: `ftp://gong2.nso.edu/QR/` and `http://gong2.nso.edu/HA/haf/`.
+    Parameters
+    ----------
+    timerange: sunpy.time.TimeRange
+        time range for which data is to be downloaded.
+        Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
+    
+    Instrument: Arguments are any one from ['bb', 'ct', 'le', 'ml', 'td', 'ud','z']
 
+    Physobs: Two arguments or none 'intensity' and 'los_magnetic_field'
+
+    GONGClient expects at least one argument from Physobs or Instrument
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido
+    >>> from sunpy.net import attrs as a
+    >>> res = Fido.search(a.Time('2016/6/4', '2016/6/4 00:10:00'), a.Physobs('intensity'))
+    >>> print (res)
+    [<Table length=32>
+     Start Time           End Time      Source     Instrument    
+       str19               str19         str4        str18       
+    ------------------- ------------------- ------ ------------------
+    2016-06-04 00:00:00 2016-06-05 00:00:00   GONG Data not Available
+    2016-06-05 00:00:00 2016-06-06 00:00:00   GONG Data not Available
+    2016-06-06 00:00:00 2016-06-07 00:00:00   GONG Data not Available
+    2016-06-07 00:00:00 2016-06-08 00:00:00   GONG Data not Available
+    2016-06-08 00:00:00 2016-06-09 00:00:00   GONG Data not Available
+    2016-06-09 00:00:00 2016-06-10 00:00:00   GONG Data not Available
+    2016-06-10 00:00:00 2016-06-11 00:00:00   GONG Data not Available
+    2016-06-11 00:00:00 2016-06-12 00:00:00   GONG Data not Available
+    2016-06-12 00:00:00 2016-06-13 00:00:00   GONG Data not Available
+    2016-06-13 00:00:00 2016-06-14 00:00:00   GONG Data not Available
+                    ...                 ...    ...                ...
+    2016-06-26 00:00:00 2016-06-27 00:00:00   GONG Data not Available
+    2016-06-27 00:00:00 2016-06-28 00:00:00   GONG Data not Available
+    2016-06-28 00:00:00 2016-06-29 00:00:00   GONG Data not Available
+    2016-06-29 00:00:00 2016-06-30 00:00:00   GONG Data not Available
+    2016-06-30 00:00:00 2016-07-01 00:00:00   GONG Data not Available
+    2016-07-01 00:00:00 2016-07-02 00:00:00   GONG Data not Available
+    2016-07-02 00:00:00 2016-07-03 00:00:00   GONG Data not Available
+    2016-07-03 00:00:00 2016-07-04 00:00:00   GONG Data not Available
+    2016-07-04 00:00:00 2016-07-05 00:00:00   GONG Data not Available
+    2016-07-05 00:00:00 2016-07-06 00:00:00   GONG Data not Available]
+    """
     def _get_url_for_timerange(self, timerange, **kwargs):
-        
+        """
+        returns list of urls corresponding to given TimeRange.
+        """
         #TO-DO: Figure out where scraper would and wouldn't work
-        table_physobs = {'intensity' : 'i', 'los_magnetic_field': 'b'} #legitimate physical observations.
+        table_physobs = {'INTENSITY' : 'i', 'LOS_MAGNETIC_FIELD': 'b'} #legitimate physical observations.
         table_instruments = ['bb', 'ct', 'le', 'ml', 'td', 'ud','z'] #For magnetogram and intensity
         
         physobs_in = True if ('physobs' in kwargs.keys() and kwargs['physobs'] in table_physobs.keys()) else False #Is PhysObs entered
@@ -34,7 +82,7 @@ class GONGClient(GenericClient):
         if not physobs_in:
             patterns.append(url_pattern_1), patterns.append(url_pattern_2)
         else:
-            if kwargs['physobs'] == 'los_magnetic_field':
+            if kwargs['physobs'] == 'LOS_MAGNETIC_FIELD':
                 patterns.append(url_pattern_1)
             else:
                 #Differentiate on basis of wavelength
@@ -46,7 +94,6 @@ class GONGClient(GenericClient):
                         patterns.append(url_pattern_2)
                     elif wave == 6768:
                         patterns.append(url_pattern_1)
-
 
 
         #All valid patterns to be downloaded are in the patterns list.
@@ -112,6 +159,9 @@ class GONGClient(GenericClient):
         return final_result
 
     def _makeimap(self):
+        """
+        Helper Function: used to hold information about source.
+        """   
         self.map_['source'] = 'GONG'
         
         
@@ -132,7 +182,7 @@ class GONGClient(GenericClient):
         """
         chkattr = ['Time', 'Instrument', 'Physobs', 'Wavelength']
         chklist = [x.__class__.__name__ in chkattr for x in query]
-        physobs = ['intensity', 'los_magnetic_field'] #from VSO
+        physobs = ['INTENSITY', 'LOS_MAGNETIC_FIELD'] #from VSO
         instruments = ['bb', 'ct', 'le', 'ml', 'td', 'ud', 'z'] #for Magnetogram and intensity
         chk_instr, chk_physobs = 0, 0
         chk_wavelength = 0
@@ -140,7 +190,7 @@ class GONGClient(GenericClient):
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value.lower() in instruments:
                 chk_instr += 1
-            if x.__class__.__name__ == 'Physobs' and x.value.lower() in physobs:
+            if x.__class__.__name__ == 'Physobs' and x.value in physobs:
                 chk_physobs += 1
             if (x.__class__.__name__ == 'Wavelength' and int(x.min.value) in values and int(x.max.value) in values and (x.unit.name).lower()=='angstrom'):
                 chk_wavelength += 1
@@ -230,4 +280,3 @@ class FARSIDEClient(GenericClient):
                 return all(chklist)
         return False
         
-    

--- a/sunpy/net/dataretriever/tests/test_farside.py
+++ b/sunpy/net/dataretriever/tests/test_farside.py
@@ -26,12 +26,11 @@ def test_get_url_for_timerange(timerange, url_start, url_end):
     assert urls[0] == url_start
     assert urls[-1] == url_end
 
-trange = Time('2015/12/28', '2015/12/30')
 def test_can_handle_query():
-    assert FClient._can_handle_query(trange, Instrument('farside')) is True
-    assert FClient._can_handle_query(trange, Instrument('Farside')) is True
-    assert FClient._can_handle_query(trange) is not True
-    assert FClient._can_handle_query(trange, Instrument('bbso')) is not True
+    assert FClient._can_handle_query(Time('2015/12/28', '2015/12/30'), Instrument('farside'))
+    assert FClient._can_handle_query(Time('2015/12/28', '2015/12/30'), Instrument('Farside'))
+    assert not FClient._can_handle_query(Time('2015/12/28', '2015/12/30'))
+    assert not FClient._can_handle_query(Time('2015/12/28', '2015/12/30'), Instrument('bbso'))
 
 @pytest.mark.online
 def test_query():
@@ -41,6 +40,8 @@ def test_query():
     assert qr.time_range()[0] == '2016/01/01'
     assert qr.time_range()[1] == '2016/01/05'
 
+#Downloads 7 fits files each of size
+#160KB. Total size ~ 1.2MB
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument",
                          [(Time('2016/1/1 00:00:00', '2016/1/4 10:00:00'),
@@ -51,6 +52,8 @@ def test_get(time, instrument):
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
+#Downloads 5 fits files each of size 160KB.
+#Total size ~ 800KB.
 @pytest.mark.online
 def test_fido_query():
     qr = Fido.search(a.Time('2016/5/18', '2016/5/20'), a.Instrument('farside'))

--- a/sunpy/net/dataretriever/tests/test_farside.py
+++ b/sunpy/net/dataretriever/tests/test_farside.py
@@ -5,7 +5,7 @@ import pytest
 
 from astropy import units as u
 from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time,Instrument,Physobs, Wavelength
+from sunpy.net.vso.attrs import Time,Instrument
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
@@ -40,3 +40,20 @@ def test_query():
     assert len(qr) == 8
     assert qr.time_range()[0] == '2016/01/01'
     assert qr.time_range()[1] == '2016/01/05'
+
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument",
+                         [(Time('2016/1/1 00:00:00', '2016/1/4 10:00:00'),
+                           Instrument('farside'))])
+def test_get(time, instrument):
+    qr = FClient.query(time, instrument)
+    res = FClient.get(qr)
+    download_list = res.wait()
+    assert len(download_list) == len(qr)
+
+@pytest.mark.online
+def test_fido_query():
+    qr = Fido.search(a.Time('2016/5/18', '2016/5/20'), a.Instrument('farside'))
+    assert isinstance(qr, UnifiedResponse)
+    response = Fido.fetch(qr)
+    assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_farside.py
+++ b/sunpy/net/dataretriever/tests/test_farside.py
@@ -32,3 +32,11 @@ def test_can_handle_query():
     assert FClient._can_handle_query(trange, Instrument('Farside')) is True
     assert FClient._can_handle_query(trange) is not True
     assert FClient._can_handle_query(trange, Instrument('bbso')) is not True
+
+@pytest.mark.online
+def test_query():
+    qr = FClient.query(Time('2016/1/1', '2016/1/5'), instrument = 'farside')
+    assert isinstance(qr, QueryResponse)
+    assert len(qr) == 8
+    assert qr.time_range()[0] == '2016/01/01'
+    assert qr.time_range()[1] == '2016/01/05'

--- a/sunpy/net/dataretriever/tests/test_farside.py
+++ b/sunpy/net/dataretriever/tests/test_farside.py
@@ -1,0 +1,34 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+import datetime
+import pytest
+
+from astropy import units as u
+from sunpy.time.timerange import TimeRange
+from sunpy.net.vso.attrs import Time,Instrument,Physobs, Wavelength
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+
+import sunpy.net.dataretriever.sources.gong as gong
+
+FClient = gong.FARSIDEClient()
+
+@pytest.mark.online
+@pytest.mark.parametrize("timerange, url_start, url_end",
+                         [(TimeRange('2014/2/1', '2014/2/5'),
+                           'http://farside.nso.edu/oQR/fqo/201402/mrfqo140201/mrfqo140201t0000.fits',
+                           'http://farside.nso.edu/oQR/fqo/201402/mrfqo140204/mrfqo140204t1200.fits')])
+def test_get_url_for_timerange(timerange, url_start, url_end):
+    urls = FClient._get_url_for_timerange(timerange)
+    assert isinstance(urls, list)
+    assert urls[0] == url_start
+    assert urls[-1] == url_end
+
+trange = Time('2015/12/28', '2015/12/30')
+def test_can_handle_query():
+    assert FClient._can_handle_query(trange, Instrument('farside')) is True
+    assert FClient._can_handle_query(trange, Instrument('Farside')) is True
+    assert FClient._can_handle_query(trange) is not True
+    assert FClient._can_handle_query(trange, Instrument('bbso')) is not True

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -17,11 +17,11 @@ GONGClient = gong.GONGClient()
 
 ##downloads 4 fits files each of size 3MB.
 ##Total size = 12MB.
-trange = Time('2014/6/4 00:00:00', '2014/6/4 00:07:00')
+TRANGE = Time('2014/6/4 00:00:00', '2014/6/4 00:07:00')
 @pytest.mark.online
 @pytest.mark.parametrize("time, physobs, instrument, wavelength",
-                         [(trange, Physobs('INTENSITY'), Instrument('M'), Wavelength(6563*u.AA)),
-                          (trange, Physobs('INTENSITY'), Instrument(''), Wavelength(6563*u.AA))])
+                         [(TRANGE, Physobs('INTENSITY'), Instrument('maunaloa'), Wavelength(6563*u.AA)),
+                          (TRANGE, Physobs('INTENSITY'), Instrument(''), Wavelength(6563*u.AA))])
 def test_query(time, physobs, instrument, wavelength):
     qr = GONGClient.query(time, physobs, instrument, wavelength)
     res = GONGClient.get(qr)
@@ -29,16 +29,15 @@ def test_query(time, physobs, instrument, wavelength):
     assert len(download_list) == len(qr)
 
 def test_can_handle_query():
-    assert GONGClient._can_handle_query(trange, Instrument('bb'), Physobs('INTENSITY'))
-    assert GONGClient._can_handle_query(trange, Physobs('LOS_MAGNETIC_FIELD'))
-    assert GONGClient._can_handle_query(trange, Instrument('z'))
-    assert GONGClient._can_handle_query(trange, Instrument('ct'), Physobs('INTENSITY'), Wavelength(6563*u.AA))
-    assert not GONGClient._can_handle_query(trange)
-    
-trange = Time('2016/6/4 00:00:00', '2016/6/4 00:30:00')
+    assert GONGClient._can_handle_query(TRANGE, Instrument('bigbear'), Physobs('INTENSITY'))
+    assert GONGClient._can_handle_query(TRANGE, Physobs('LOS_MAGNETIC_FIELD'))
+    assert GONGClient._can_handle_query(TRANGE, Instrument('tucson'))
+    assert GONGClient._can_handle_query(TRANGE, Instrument('cerrotololo'), Physobs('INTENSITY'), Wavelength(6563*u.AA))
+    assert not GONGClient._can_handle_query(TRANGE)
+
 @pytest.mark.online
 def test_query():
-    qr = GONGClient.query(trange, physobs = 'LOS_MAGNETIC_FIELD', instrument='bb')
+    qr = GONGClient.query(Time('2016/6/4 00:00:00', '2016/6/4 00:30:00'), physobs = 'LOS_MAGNETIC_FIELD', instrument='bigbear')
     assert len(qr) == 3
     assert qr.time_range()[0] == '2016/06/04'
     assert qr.time_range()[1] == '2016/06/04'
@@ -48,7 +47,7 @@ def test_query():
 @pytest.mark.online
 @pytest.mark.parametrize("time, physobs, instrument, wavelength",
                          [(Time('2016/6/13 03:00', '2016/6/13 04:00'), Physobs('INTENSITY'),
-                           Instrument('ud'), Wavelength(6768*u.AA))])
+                           Instrument('udaipur'), Wavelength(6768*u.AA))])
 def test_get(time, physobs, instrument, wavelength):
     qr = GONGClient.query(time, physobs, instrument, wavelength)
     res = GONGClient.get(qr)

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -28,12 +28,19 @@ def test_query(time, physobs, instrument, wavelength):
     download_list = res.wait()
     assert len(download_list) == len(qr)
 
-def test_can_handle_query():
-    assert GONGClient._can_handle_query(TRANGE, Instrument('bigbear'), Physobs('INTENSITY'))
-    assert GONGClient._can_handle_query(TRANGE, Physobs('LOS_MAGNETIC_FIELD'))
-    assert GONGClient._can_handle_query(TRANGE, Instrument('tucson'))
-    assert GONGClient._can_handle_query(TRANGE, Instrument('cerrotololo'), Physobs('INTENSITY'), Wavelength(6563*u.AA))
-    assert not GONGClient._can_handle_query(TRANGE)
+@pytest.mark.parametrize("time, instrument, physobs, wavelength, expected",
+                         [(TRANGE, Instrument('bigbear'), Physobs('INTENSITY'), None, True),
+                          (TRANGE, None, Physobs('LOS_MAGNETIC_FIELD'), None, True),
+                          (TRANGE, Instrument('tucson'), None, None, True),
+                          (TRANGE, Instrument('cerrotololo'), Physobs('INTENSITY'), Wavelength(6563*u.AA), True),
+                          (TRANGE, None, None, None, False)])
+def test_can_handle_query(time, instrument, physobs, wavelength, expected):
+    assert GONGClient._can_handle_query(time, instrument, physobs, wavelength) is expected
+##    assert GONGClient._can_handle_query(TRANGE, Instrument('bigbear'), Physobs('INTENSITY'))
+##    assert GONGClient._can_handle_query(TRANGE, Physobs('LOS_MAGNETIC_FIELD'))
+##    assert GONGClient._can_handle_query(TRANGE, Instrument('tucson'))
+##    assert GONGClient._can_handle_query(TRANGE, Instrument('cerrotololo'), Physobs('INTENSITY'), Wavelength(6563*u.AA))
+##    assert not GONGClient._can_handle_query(TRANGE)
 
 @pytest.mark.online
 def test_query():

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -18,18 +18,21 @@ GONGClient = gong.GONGClient()
 #downloads 4 fits files each of size 3MB.
 #Total size = 12MB.
 trange = Time('2014/6/4 00:00:00', '2014/6/4 00:07:00')
-##@pytest.mark.online
-##@pytest.mark.parametrize("time, physobs, instrument, wavelength",
-##                         [(trange, Physobs('intensity'), Instrument('M'), Wavelength(6563*u.AA)),
-##                          (trange, Physobs('intensity'), Instrument(''), Wavelength(6563*u.AA))])
-##def test_query(time, physobs, instrument, wavelength):
-##    qr = GONGClient.query(time, physobs, instrument, wavelength)
-##    res = GONGClient.get(qr)
-##    download_list = res.wait()
-##    assert len(download_list) == len(qr)
+@pytest.mark.online
+@pytest.mark.parametrize("time, physobs, instrument, wavelength",
+                         [(trange, Physobs('intensity'), Instrument('M'), Wavelength(6563*u.AA)),
+                          (trange, Physobs('intensity'), Instrument(''), Wavelength(6563*u.AA))])
+def test_query(time, physobs, instrument, wavelength):
+    qr = GONGClient.query(time, physobs, instrument, wavelength)
+    res = GONGClient.get(qr)
+    download_list = res.wait()
+    assert len(download_list) == len(qr)
 
 def test_can_handle_query():
     assert GONGClient._can_handle_query(trange, Instrument('bb'), Physobs('intensity')) is True
     assert GONGClient._can_handle_query(trange, Physobs('los_magnetic_field')) is True
     assert GONGClient._can_handle_query(trange, Instrument('z')) is True
+    assert GONGClient._can_handle_query(trange, Instrument('ct'), Physobs('intensity'), Wavelength(6563*u.AA))
+
+
                            

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -32,7 +32,10 @@ def test_can_handle_query():
     assert GONGClient._can_handle_query(trange, Instrument('bb'), Physobs('intensity')) is True
     assert GONGClient._can_handle_query(trange, Physobs('los_magnetic_field')) is True
     assert GONGClient._can_handle_query(trange, Instrument('z')) is True
-    assert GONGClient._can_handle_query(trange, Instrument('ct'), Physobs('intensity'), Wavelength(6563*u.AA))
+    assert GONGClient._can_handle_query(trange, Instrument('ct'), Physobs('intensity'), Wavelength(6563*u.AA)) is True
+    assert GONGClient._can_handle_query(trange) is not True
+
+
 
 
                            

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -1,0 +1,31 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+import datetime
+import pytest
+
+from astropy import units as u
+from sunpy.time.timerange import TimeRange
+from sunpy.net.vso.attrs import Time,Instrument,Physobs, Wavelength
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+
+import sunpy.net.dataretriever.sources.gong as gong
+
+GONGClient = gong.GONGClient()
+FClient = gong.FARSIDEClient()
+
+
+#downloads 4 fits files each of size 3MB.
+#Total size = 12MB.
+@pytest.mark.online
+@pytest.mark.parametrize("time, physobs, instrument, wavelength",
+                         [(Time('2014/6/4 00:00:00', '2014/6/4 00:07:00'),
+                           Physobs('intensity'), Instrument('M'), Wavelength(6563*u.AA))])
+def test_query(time, physobs, instrument, wavelength):
+    qr = GONGClient.query(time, physobs, instrument, wavelength)
+    res = GONGClient.get(qr)
+    download_list = res.wait()
+    assert len(download_list) == len(qr)
+                           

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -14,18 +14,22 @@ from sunpy.net import attrs as a
 import sunpy.net.dataretriever.sources.gong as gong
 
 GONGClient = gong.GONGClient()
-FClient = gong.FARSIDEClient()
-
 
 #downloads 4 fits files each of size 3MB.
 #Total size = 12MB.
-@pytest.mark.online
-@pytest.mark.parametrize("time, physobs, instrument, wavelength",
-                         [(Time('2014/6/4 00:00:00', '2014/6/4 00:07:00'),
-                           Physobs('intensity'), Instrument('M'), Wavelength(6563*u.AA))])
-def test_query(time, physobs, instrument, wavelength):
-    qr = GONGClient.query(time, physobs, instrument, wavelength)
-    res = GONGClient.get(qr)
-    download_list = res.wait()
-    assert len(download_list) == len(qr)
+trange = Time('2014/6/4 00:00:00', '2014/6/4 00:07:00')
+##@pytest.mark.online
+##@pytest.mark.parametrize("time, physobs, instrument, wavelength",
+##                         [(trange, Physobs('intensity'), Instrument('M'), Wavelength(6563*u.AA)),
+##                          (trange, Physobs('intensity'), Instrument(''), Wavelength(6563*u.AA))])
+##def test_query(time, physobs, instrument, wavelength):
+##    qr = GONGClient.query(time, physobs, instrument, wavelength)
+##    res = GONGClient.get(qr)
+##    download_list = res.wait()
+##    assert len(download_list) == len(qr)
+
+def test_can_handle_query():
+    assert GONGClient._can_handle_query(trange, Instrument('bb'), Physobs('intensity')) is True
+    assert GONGClient._can_handle_query(trange, Physobs('los_magnetic_field')) is True
+    assert GONGClient._can_handle_query(trange, Instrument('z')) is True
                            

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -15,13 +15,13 @@ import sunpy.net.dataretriever.sources.gong as gong
 
 GONGClient = gong.GONGClient()
 
-downloads 4 fits files each of size 3MB.
-Total size = 12MB.
+##downloads 4 fits files each of size 3MB.
+##Total size = 12MB.
 trange = Time('2014/6/4 00:00:00', '2014/6/4 00:07:00')
 @pytest.mark.online
 @pytest.mark.parametrize("time, physobs, instrument, wavelength",
-                         [(trange, Physobs('intensity'), Instrument('M'), Wavelength(6563*u.AA)),
-                          (trange, Physobs('intensity'), Instrument(''), Wavelength(6563*u.AA))])
+                         [(trange, Physobs('INTENSITY'), Instrument('M'), Wavelength(6563*u.AA)),
+                          (trange, Physobs('INTENSITY'), Instrument(''), Wavelength(6563*u.AA))])
 def test_query(time, physobs, instrument, wavelength):
     qr = GONGClient.query(time, physobs, instrument, wavelength)
     res = GONGClient.get(qr)
@@ -29,16 +29,16 @@ def test_query(time, physobs, instrument, wavelength):
     assert len(download_list) == len(qr)
 
 def test_can_handle_query():
-    assert GONGClient._can_handle_query(trange, Instrument('bb'), Physobs('intensity')) is True
-    assert GONGClient._can_handle_query(trange, Physobs('los_magnetic_field')) is True
-    assert GONGClient._can_handle_query(trange, Instrument('z')) is True
-    assert GONGClient._can_handle_query(trange, Instrument('ct'), Physobs('intensity'), Wavelength(6563*u.AA)) is True
-    assert GONGClient._can_handle_query(trange) is not True
+    assert GONGClient._can_handle_query(trange, Instrument('bb'), Physobs('INTENSITY'))
+    assert GONGClient._can_handle_query(trange, Physobs('LOS_MAGNETIC_FIELD'))
+    assert GONGClient._can_handle_query(trange, Instrument('z'))
+    assert GONGClient._can_handle_query(trange, Instrument('ct'), Physobs('INTENSITY'), Wavelength(6563*u.AA))
+    assert not GONGClient._can_handle_query(trange)
     
 trange = Time('2016/6/4 00:00:00', '2016/6/4 00:30:00')
 @pytest.mark.online
 def test_query():
-    qr = GONGClient.query(trange, physobs = 'los_magnetic_field', instrument='bb')
+    qr = GONGClient.query(trange, physobs = 'LOS_MAGNETIC_FIELD', instrument='bb')
     assert len(qr) == 3
     assert qr.time_range()[0] == '2016/06/04'
     assert qr.time_range()[1] == '2016/06/04'
@@ -47,7 +47,7 @@ def test_query():
 #size 1.2MB. Total size = 4.8MB.
 @pytest.mark.online
 @pytest.mark.parametrize("time, physobs, instrument, wavelength",
-                         [(Time('2016/6/13 03:00', '2016/6/13 04:00'), Physobs('intensity'),
+                         [(Time('2016/6/13 03:00', '2016/6/13 04:00'), Physobs('INTENSITY'),
                            Instrument('ud'), Wavelength(6768*u.AA))])
 def test_get(time, physobs, instrument, wavelength):
     qr = GONGClient.query(time, physobs, instrument, wavelength)
@@ -59,7 +59,7 @@ def test_get(time, physobs, instrument, wavelength):
 #Total size is 2.5MB.
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2016/6/4', '2016/6/4 00:10:00'), a.Physobs('intensity'), a.Wavelength(6768*u.AA))
+    qr = Fido.search(a.Time('2016/6/4', '2016/6/4 00:10:00'), a.Physobs('INTENSITY'), a.Wavelength(6768*u.AA))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -15,12 +15,12 @@ import sunpy.net.dataretriever.sources.gong as gong
 
 GONGClient = gong.GONGClient()
 
-##downloads 4 fits files each of size 3MB.
-##Total size = 12MB.
+downloads 4 fits files each of size 3MB.
+Total size = 12MB.
 TRANGE = Time('2014/6/4 00:00:00', '2014/6/4 00:07:00')
 @pytest.mark.online
 @pytest.mark.parametrize("time, physobs, instrument, wavelength",
-                         [(TRANGE, Physobs('INTENSITY'), Instrument('maunaloa'), Wavelength(6563*u.AA)),
+                         [(TRANGE, Physobs('INTENSITY'), Instrument('maunaloa'), Wavelength(656.3*u.nm)),
                           (TRANGE, Physobs('INTENSITY'), Instrument(''), Wavelength(6563*u.AA))])
 def test_query(time, physobs, instrument, wavelength):
     qr = GONGClient.query(time, physobs, instrument, wavelength)
@@ -47,7 +47,7 @@ def test_query():
 @pytest.mark.online
 @pytest.mark.parametrize("time, physobs, instrument, wavelength",
                          [(Time('2016/6/13 03:00', '2016/6/13 04:00'), Physobs('INTENSITY'),
-                           Instrument('udaipur'), Wavelength(6768*u.AA))])
+                           Instrument('udaipur'), Wavelength(676.8*u.nm))])
 def test_get(time, physobs, instrument, wavelength):
     qr = GONGClient.query(time, physobs, instrument, wavelength)
     res = GONGClient.get(qr)

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -15,8 +15,8 @@ import sunpy.net.dataretriever.sources.gong as gong
 
 GONGClient = gong.GONGClient()
 
-downloads 4 fits files each of size 3MB.
-Total size = 12MB.
+##downloads 4 fits files each of size 3MB.
+##Total size = 12MB.
 TRANGE = Time('2014/6/4 00:00:00', '2014/6/4 00:07:00')
 @pytest.mark.online
 @pytest.mark.parametrize("time, physobs, instrument, wavelength",

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -15,8 +15,8 @@ import sunpy.net.dataretriever.sources.gong as gong
 
 GONGClient = gong.GONGClient()
 
-#downloads 4 fits files each of size 3MB.
-#Total size = 12MB.
+downloads 4 fits files each of size 3MB.
+Total size = 12MB.
 trange = Time('2014/6/4 00:00:00', '2014/6/4 00:07:00')
 @pytest.mark.online
 @pytest.mark.parametrize("time, physobs, instrument, wavelength",
@@ -34,8 +34,32 @@ def test_can_handle_query():
     assert GONGClient._can_handle_query(trange, Instrument('z')) is True
     assert GONGClient._can_handle_query(trange, Instrument('ct'), Physobs('intensity'), Wavelength(6563*u.AA)) is True
     assert GONGClient._can_handle_query(trange) is not True
+    
+trange = Time('2016/6/4 00:00:00', '2016/6/4 00:30:00')
+@pytest.mark.online
+def test_query():
+    qr = GONGClient.query(trange, physobs = 'los_magnetic_field', instrument='bb')
+    assert len(qr) == 3
+    assert qr.time_range()[0] == '2016/06/04'
+    assert qr.time_range()[1] == '2016/06/04'
 
+#Downoads 4 fits files each of
+#size 1.2MB. Total size = 4.8MB.
+@pytest.mark.online
+@pytest.mark.parametrize("time, physobs, instrument, wavelength",
+                         [(Time('2016/6/13 03:00', '2016/6/13 04:00'), Physobs('intensity'),
+                           Instrument('ud'), Wavelength(6768*u.AA))])
+def test_get(time, physobs, instrument, wavelength):
+    qr = GONGClient.query(time, physobs, instrument, wavelength)
+    res = GONGClient.get(qr)
+    download_list = res.wait()
+    assert len(qr) == len(download_list)
 
-
-
-                           
+#Downloads 2 fits.gz files of size 1.2MB each.
+#Total size is 2.5MB.
+@pytest.mark.online
+def test_fido_query():
+    qr = Fido.search(a.Time('2016/6/4', '2016/6/4 00:10:00'), a.Physobs('intensity'), a.Wavelength(6768*u.AA))
+    assert isinstance(qr, UnifiedResponse)
+    response = Fido.fetch(qr)
+    assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -36,11 +36,6 @@ def test_query(time, physobs, instrument, wavelength):
                           (TRANGE, None, None, None, False)])
 def test_can_handle_query(time, instrument, physobs, wavelength, expected):
     assert GONGClient._can_handle_query(time, instrument, physobs, wavelength) is expected
-##    assert GONGClient._can_handle_query(TRANGE, Instrument('bigbear'), Physobs('INTENSITY'))
-##    assert GONGClient._can_handle_query(TRANGE, Physobs('LOS_MAGNETIC_FIELD'))
-##    assert GONGClient._can_handle_query(TRANGE, Instrument('tucson'))
-##    assert GONGClient._can_handle_query(TRANGE, Instrument('cerrotololo'), Physobs('INTENSITY'), Wavelength(6563*u.AA))
-##    assert not GONGClient._can_handle_query(TRANGE)
 
 @pytest.mark.online
 def test_query():

--- a/sunpy/net/dataretriever/tests/test_gong.py
+++ b/sunpy/net/dataretriever/tests/test_gong.py
@@ -1,12 +1,12 @@
+"""
+This module tests GONG Client
+"""
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
-import datetime
 import pytest
 
 from astropy import units as u
-from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time,Instrument,Physobs, Wavelength
-from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.vso.attrs import Time, Instrument, Physobs, Wavelength
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a
@@ -37,7 +37,7 @@ def test_can_handle_query():
 
 @pytest.mark.online
 def test_query():
-    qr = GONGClient.query(Time('2016/6/4 00:00:00', '2016/6/4 00:30:00'), physobs = 'LOS_MAGNETIC_FIELD', instrument='bigbear')
+    qr = GONGClient.query(Time('2016/6/4 00:00:00', '2016/6/4 00:30:00'), physobs='LOS_MAGNETIC_FIELD', instrument='bigbear')
     assert len(qr) == 3
     assert qr.time_range()[0] == '2016/06/04'
     assert qr.time_range()[1] == '2016/06/04'


### PR DESCRIPTION
This implements GONG Client. This client is a bit different than the other ones. GONG measures two physical observations namely `LOS_MAGNETIC_FIELD` and `INTENSITY` (In capitals regarding VSO convention [here](http://sdac.virtualsolar.org/cgi/show_details?keyword=PHYSOBS). For `INTENSITY`, again there are two types of files to be downloaded based on Wavelength, One is for H-alpha and the other one I don't know (Needs to be updated). 

GONG Client requires at least one of `Physobs` or `Instrument` to function. Instrument takes 7 values defined as `udaipur, bigbear, cerrotelolo, learmonth, maunaloa, teide` and `tucson` only for H-alpha files (Tucson engineering).

If user supplies only `Physobs` it would download all files in the give timerange for all the `Instruments` corresponding to that `Physobs`.

If user supplies only `Instrument`, it would download all files in the given timerange for both the `Physobs` but specific only to the provided `Instrument`.

If user specifies `INTENSITY` as `Physobs` then, user needs to enter the wavelength as `6768`` or`6562-6563``` Angstrom units or equivalent value in different units to download the specific files. If wavelength is not entered, then GONG Client would download all corresponding files for both the wavelength ranges.
## Usage.

```
qr = Fido.search( a.Time('2016/4/4', '2016/4/7'), a.Instrument('bigbear') )
```

Downloads all files corresp. to the timerange for instrument Big Bear and for both `Physobs`.

```
qr = Fido.search(a.Time('2016/4/4', '2016/4/7'), a.Instrument('udaipur'), a.Physobs('INTENSITY')
                             a.Wavelength(6563*u.AA) )
```

```
qr = Fido.search(a.Time('2016/4/4', '2016/4/7'), a.Instrument('udaipur'), a.Physobs('INTENSITY')
                             a.Wavelength(656.3*u.nm) )
Download files corresp. to H-alpha from Instrument Udaipur.


```

qr = Fido.search( a.Time('2016/4/4', '2016/4/7'), a.Physobs('LOS_MAGNETIC_FIELD'))

``````
Download all files corresp. to ```Physobs - LOS_MAGNETIC_FIELD``` and for all ```Instruments```.

P.S. [passing tests here](https://travis-ci.org/sunpy/sunpy/jobs/137290291#L1134)
``````
