### PR TITLE
Add Fido search results to the database

### DIFF
--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -857,6 +857,14 @@ class Database(object):
                 query_result, self.default_waveunit),
             ignore_already_added)
 
+    def add_from_fido_search_result(self, search_result,
+            ignore_already_added=False):
+        self.add_many(
+            tables.entries_from_fido_search_result(
+                search_result, self.default_waveunit),
+            ignore_already_added)
+
+
     def add_from_dir(self, path, recursive=False, pattern='*',
                      ignore_already_added=False, time_string_parse_format=None):
         """Search the given directory for FITS files and use their FITS headers

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -858,26 +858,26 @@ class Database(object):
             ignore_already_added)
 
     def add_from_fido_search_result(self, search_result,
-            ignore_already_added=False):
-        """Generate database entries from a Fido search result and add all the
+                                    ignore_already_added=False):
+        """
+        Generate database entries from a Fido search result and add all the
         generated entries to this database.
 
         Parameters
         ----------
-        search_result : sunpy.net.dataretriever.downloader_factory.UnifiedResponse
+        search_result : `sunpy.net.dataretriever.downloader_factory.UnifiedResponse`
             A UnifiedResponse object that is used to store responses from the
             unified downloader. This is returned by the ``search`` method of a
             :class:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory`
             object.
 
-        ignore_already_added : bool
+        ignore_already_added : `bool`
             See :meth:`sunpy.database.Database.add`.
 
         """
-        self.add_many(
-            tables.entries_from_fido_search_result(
-                search_result, self.default_waveunit),
-            ignore_already_added)
+        self.add_many(tables.entries_from_fido_search_result(search_result,
+                                                             self.default_waveunit),
+                      ignore_already_added)
 
 
     def add_from_dir(self, path, recursive=False, pattern='*',

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -865,10 +865,10 @@ class Database(object):
 
         Parameters
         ----------
-        search_result : `sunpy.net.dataretriever.downloader_factory.UnifiedResponse`
+        search_result : `sunpy.net.fido_factory.UnifiedResponse`
             A UnifiedResponse object that is used to store responses from the
             unified downloader. This is returned by the ``search`` method of a
-            :class:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory`
+            :class:`sunpy.net.fido_factory.UnifiedDownloaderFactory`
             object.
 
         ignore_already_added : `bool`

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -879,7 +879,6 @@ class Database(object):
                                                              self.default_waveunit),
                       ignore_already_added)
 
-
     def add_from_dir(self, path, recursive=False, pattern='*',
                      ignore_already_added=False, time_string_parse_format=None):
         """Search the given directory for FITS files and use their FITS headers

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -859,6 +859,21 @@ class Database(object):
 
     def add_from_fido_search_result(self, search_result,
             ignore_already_added=False):
+        """Generate database entries from a Fido search result and add all the
+        generated entries to this database.
+
+        Parameters
+        ----------
+        search_result : sunpy.net.dataretriever.downloader_factory.UnifiedResponse
+            A UnifiedResponse object that is used to store responses from the
+            unified downloader. This is returned by the ``search`` method of a
+            :class:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory`
+            object.
+
+        ignore_already_added : bool
+            See :meth:`sunpy.database.Database.add`.
+
+        """
         self.add_many(
             tables.entries_from_fido_search_result(
                 search_result, self.default_waveunit),

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -336,10 +336,11 @@ class DatabaseEntry(Base):
                 raise WaveunitNotFoundError(qr_block)
             wavemax = unit.to(nm, float(wave.wavemax),
                               equivalencies.spectral())
-        source = str(qr_block.source) if qr_block.source is not None else None
-        provider = str(qr_block.provider) if qr_block.provider is not None else None
-        fileid = str(qr_block.fileid) if qr_block.fileid is not None else None
-        instrument = str(qr_block.instrument) if qr_block.instrument is not None else None
+        source = getattr(qr_block, 'source', None)
+        provider = getattr(qr_block, 'provider', None)
+        fileid = getattr(qr_block, 'fileid', None)
+        instrument = getattr(qr_block, 'instrument', None)
+        size = getattr(qr_block, 'size', -1)
         physobs = getattr(qr_block, 'physobs', None)
         if physobs is not None:
             physobs = str(physobs)

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -525,7 +525,8 @@ def entries_from_query_result(qr, default_waveunit=None):
 
 
 def entries_from_fido_search_result(sr, default_waveunit=None):
-    """Use a `sunpy.net.dataretriever.downloader_factory.UnifiedResponse`
+    """
+    Use a `sunpy.net.dataretriever.downloader_factory.UnifiedResponse`
     object returned from
     :meth:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory.search`
     to generate instances of :class:`DatabaseEntry`. Return an iterator

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -438,25 +438,23 @@ class DatabaseEntry(Base):
             wavemin=wavemin, wavemax=wavemax)
 
     def __eq__(self, other):
+
         if self.wavemin is None and other.wavemin is None:
             wavemins_equal = True
         elif not all([self.wavemin, other.wavemin]):
             # This means one is None and the other isnt
             wavemins_equal = False
         else:
-            wavemins_equal = (np.isnan(self.wavemin) and np.isnan(other.wavemin)) or\
-                             (self.wavemin is not None and other.wavemin is not None and
-                              round(self.wavemin, 10) == round(other.wavemin, 10))
-        # Order of comparisions is important, because isnan(None) throws error
+            wavemins_equal = np.allclose([self.wavemin], [other.wavemin], equal_nan=True)
+
         if self.wavemax is None and other.wavemax is None:
             wavemaxs_equal = True
         elif not all([self.wavemax, other.wavemax]):
             # This means one is None and the other isnt
             wavemaxs_equal = False
         else:
-            wavemaxs_equal = (np.isnan(self.wavemax) and np.isnan(other.wavemax)) or\
-                             (self.wavemax is not None and other.wavemax is not None and
-                              round(self.wavemax, 10) == round(other.wavemax, 10))
+            wavemaxs_equal = np.allclose([self.wavemax], [other.wavemax], equal_nan=True)
+
         return (
             (self.id == other.id or self.id is None or other.id is None) and
             self.source == other.source and

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -351,17 +351,18 @@ class DatabaseEntry(Base):
 
     @classmethod
     def _from_fido_search_result_block(cls, sr_block, default_waveunit=None):
-        """Make a new :class:`DatabaseEntry` instance from a Fido search
+        """
+        Make a new :class:`DatabaseEntry` instance from a Fido search
         result block.
 
         Parameters
         ----------
-        sr_block : sunpy.net.dataretriever.client.QueryResponseBlock
+        sr_block : `sunpy.net.dataretriever.client.QueryResponseBlock`
             A query result block is usually not created directly; instead,
             one gets instances of
             ``sunpy.net.dataretriever.client.QueryResponseBlock`` by iterating
             over each element of a Fido search result.
-        default_waveunit : str, optional
+        default_waveunit : `str`, optional
             The wavelength unit that is used if it cannot be found in the
             `sr_block`.
 
@@ -435,14 +436,15 @@ class DatabaseEntry(Base):
             self.tags == other.tags)
 
     def _compare_attributes(self, other, attribute_list):
-        """Compare a given list of attributes of two :class:`DatabaseEntry`
+        """
+        Compare a given list of attributes of two :class:`DatabaseEntry`
         instances and return True if all of them match.
 
         Parameters
         ----------
         other : :class:`DatabaseEntry` instance
 
-        attribute_list : list
+        attribute_list : `list`
             The list of attributes that will be compared in both instances,
             self and other.
 
@@ -477,16 +479,17 @@ class DatabaseEntry(Base):
 
 
 def entries_from_query_result(qr, default_waveunit=None):
-    """Use a query response returned from :meth:`sunpy.net.vso.VSOClient.query`
+    """
+    Use a query response returned from :meth:`sunpy.net.vso.VSOClient.query`
     or :meth:`sunpy.net.vso.VSOClient.query_legacy` to generate instances of
     :class:`DatabaseEntry`. Return an iterator over those instances.
 
     Parameters
     ----------
-    qr : sunpy.net.vso.vso.QueryResponse
+    qr : `sunpy.net.vso.vso.QueryResponse`
         The query response from which to build the database entries.
 
-    default_waveunit : str, optional
+    default_waveunit : `str`, optional
         See :meth:`sunpy.database.DatabaseEntry.from_query_result_block`.
 
     Examples
@@ -530,13 +533,13 @@ def entries_from_fido_search_result(sr, default_waveunit=None):
 
     Parameters
     ----------
-    search_result : sunpy.net.dataretriever.downloader_factory.UnifiedResponse
+    search_result : `sunpy.net.dataretriever.downloader_factory.UnifiedResponse`
             A UnifiedResponse object that is used to store responses from the
             unified downloader. This is returned by the ``search`` method of a
             :class:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory`
             object.
 
-    default_waveunit : str, optional
+    default_waveunit : `str`, optional
         The wavelength unit that is used if it cannot be found in the Query
         Response block.
 
@@ -564,7 +567,7 @@ def entries_from_fido_search_result(sr, default_waveunit=None):
     """
     for entry in sr:
         if isinstance(entry, sunpy.net.vso.vso.QueryResponse):
-            #This is because EVE doesn't return a Fido QueryResponse. It
+            #This is because Fido can search the VSO. It
             #returns a VSO QueryResponse.
             for block in entry:
                 yield DatabaseEntry._from_query_result_block(block,

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -390,14 +390,14 @@ class DatabaseEntry(Base):
         """
         # All attributes of DatabaseEntry that are not in QueryResponseBlock
         # are set as None for now.
-        source = str(sr_block.source) if sr_block.source is not None else None
-        provider = str(sr_block.provider) if sr_block.provider is not None else None
+        source = getattr(sr_block, 'source', None)
+        provider = getattr(sr_block, 'provider', None)
         # physobs is written as phyobs in
         # sunpy.net.dataretriever.client.QueryResponseBlock
         physobs = getattr(sr_block, 'phyobs', None)
         if physobs is not None:
             physobs = str(physobs)
-        instrument = str(sr_block.instrument) if sr_block.instrument is not None else None
+        instrument = getattr(sr_block, 'instrument', None)
         time_start = sr_block.time.start
         time_end = sr_block.time.end
         wavemin = None

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -569,18 +569,16 @@ def entries_from_fido_search_result(sr, default_waveunit=None):
     """
     for entry in sr:
         if isinstance(entry, sunpy.net.vso.vso.QueryResponse):
-            #This is because Fido can search the VSO. It
-            #returns a VSO QueryResponse.
+            # This is because Fido can search the VSO. It
+            # returns a VSO QueryResponse.
             for block in entry:
-                yield DatabaseEntry._from_query_result_block(block,
-                            default_waveunit)
+                yield DatabaseEntry._from_query_result_block(block, default_waveunit)
         elif isinstance(entry, sunpy.net.jsoc.jsoc.JSOCResponse):
-            #Adding JSOC results to the DB not supported for now
+            # Adding JSOC results to the DB not supported for now
             raise ValueError("Cannot add JSOC results to database")
         else:
             for block in entry:
-                yield DatabaseEntry._from_fido_search_result_block(block,
-                            default_waveunit)
+                yield DatabaseEntry._from_fido_search_result_block(block, default_waveunit)
 
 
 def entries_from_file(file, default_waveunit=None,

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -336,11 +336,10 @@ class DatabaseEntry(Base):
                 raise WaveunitNotFoundError(qr_block)
             wavemax = unit.to(nm, float(wave.wavemax),
                               equivalencies.spectral())
-        source = getattr(qr_block, 'source', None)
-        provider = getattr(qr_block, 'provider', None)
-        fileid = getattr(qr_block, 'fileid', None)
-        instrument = getattr(qr_block, 'instrument', None)
-        size = getattr(qr_block, 'size', -1)
+        source = str(qr_block.source) if qr_block.source is not None else None
+        provider = str(qr_block.provider) if qr_block.provider is not None else None
+        fileid = str(qr_block.fileid) if qr_block.fileid is not None else None
+        instrument = str(qr_block.instrument) if qr_block.instrument is not None else None
         physobs = getattr(qr_block, 'physobs', None)
         if physobs is not None:
             physobs = str(physobs)
@@ -352,12 +351,47 @@ class DatabaseEntry(Base):
 
     @classmethod
     def _from_fido_search_result_block(cls, sr_block, default_waveunit=None):
+        """Make a new :class:`DatabaseEntry` instance from a Fido search
+        result block.
+
+        Parameters
+        ----------
+        sr_block : sunpy.net.dataretriever.client.QueryResponseBlock
+            A query result block is usually not created directly; instead,
+            one gets instances of
+            ``sunpy.net.dataretriever.client.QueryResponseBlock`` by iterating
+            over each element of a Fido search result.
+        default_waveunit : str, optional
+            The wavelength unit that is used if it cannot be found in the
+            `sr_block`.
+
+        Examples
+        --------
+        >>> from sunpy.net import Fido, attrs
+        >>> from sunpy.database.tables import DatabaseEntry
+        >>> sr = Fido.search(attrs.Time("2012/1/1", "2012/1/2"),
+        ...    attrs.Instrument('lyra'))
+        >>> entry = DatabaseEntry._from_fido_search_result_block(sr[0][0])
+        >>> entry.source
+        'Proba2'
+        >>> entry.provider
+        'esa'
+        >>> entry.physobs
+        'irradiance'
+        >>> entry.fileid
+        'http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits'
+        >>> entry.observation_time_start, entry.observation_time_end
+        (datetime.datetime(2012, 1, 1, 0, 0), datetime.datetime(2012, 1, 2, 0, 0))
+        >>> entry.instrument
+        'lyra'
+
+        """
         # All attributes of DatabaseEntry that are not in QueryResponseBlock
         # are set as None for now.
         source = str(sr_block.source) if sr_block.source is not None else None
         provider = str(sr_block.provider) if sr_block.provider is not None else None
-
-        # physobs is written as phyobs in QueryResponseBlock
+        # physobs is written as phyobs in
+        # sunpy.net.dataretriever.client.QueryResponseBlock
         physobs = getattr(sr_block, 'phyobs', None)
         if physobs is not None:
             physobs = str(physobs)

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -488,6 +488,54 @@ def entries_from_query_result(qr, default_waveunit=None):
 
 
 def entries_from_fido_search_result(sr, default_waveunit=None):
+    """Use a `sunpy.net.dataretriever.downloader_factory.UnifiedResponse`
+    object returned from
+    :meth:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory.search`
+    to generate instances of :class:`DatabaseEntry`. Return an iterator
+    over those instances.
+
+    Parameters
+    ----------
+    search_result : sunpy.net.dataretriever.downloader_factory.UnifiedResponse
+            A UnifiedResponse object that is used to store responses from the
+            unified downloader. This is returned by the ``search`` method of a
+            :class:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory`
+            object.
+
+    default_waveunit : str, optional
+        The wavelength unit that is used if it cannot be found in the Query
+        Response block.
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido, attrs
+    >>> from sunpy.database.tables import entries_from_fido_search_result
+    >>> sr = Fido.search(attrs.Time("2012/1/1", "2012/1/2"),
+    ...     attrs.Instrument('lyra'))
+    >>> entries = entries_from_fido_search_result(sr)
+
+    >>> from sunpy.net import vso
+    >>> from sunpy.database.tables import entries_from_query_result
+    >>> client = vso.VSOClient()
+    >>> qr = client.query(
+    ...     vso.attrs.Time('2001/1/1', '2001/1/2'),
+    ...     vso.attrs.Instrument('eit'))
+    >>> entries = entries_from_query_result(qr)
+    >>> entry = entries.next()
+    >>> entry.source
+    'Proba2'
+    >>> entry.provider
+    'esa'
+    >>> entry.physobs
+    'irradiance'
+    >>> entry.fileid
+    'http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits'
+    >>> entry.observation_time_start, entry.observation_time_end
+    (datetime.datetime(2012, 1, 1, 0, 0), datetime.datetime(2012, 1, 2, 0, 0))
+    >>> entry.instrument
+    'lyra'
+
+    """
     for entry in sr:
         if isinstance(entry, sunpy.net.vso.vso.QueryResponse):
             #This is because EVE doesn't return a Fido QueryResponse. It

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -8,7 +8,6 @@ from time import strptime, mktime
 from datetime import datetime
 import fnmatch
 import os
-import math
 
 from astropy.units import Unit, nm, equivalencies, quantity
 import astropy.table
@@ -16,6 +15,7 @@ from sqlalchemy import Column, Integer, Float, String, DateTime, Boolean,\
     Table, ForeignKey
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
+import numpy as np
 
 from sunpy.time import parse_time, TimeRange
 from sunpy.io import fits, file_tools as sunpy_filetools
@@ -417,12 +417,12 @@ class DatabaseEntry(Base):
             if isinstance(val, quantity.Quantity):
                 unit = getattr(val, 'unit', None)
                 if unit is None:
-                    if  default_waveunit is not None:
+                    if default_waveunit is not None:
                         unit = Unit(default_waveunit)
                     else:
                         raise WaveunitNotFoundError(sr_block)
                 final_values[key] = unit.to(nm, float(val.value), equivalencies.spectral())
-            elif val is None or math.isnan(val):
+            elif val is None or np.isnan(val):
                 final_values[key] = val
 
         wavemin = final_values['wavemin']
@@ -444,8 +444,8 @@ class DatabaseEntry(Base):
             # This means one is None and the other isnt
             wavemins_equal = False
         else:
-            wavemins_equal = (math.isnan(self.wavemin) and math.isnan(other.wavemin)) or\
-                             (self.wavemin is not None and other.wavemin is not None and\
+            wavemins_equal = (np.isnan(self.wavemin) and np.isnan(other.wavemin)) or\
+                             (self.wavemin is not None and other.wavemin is not None and
                               round(self.wavemin, 10) == round(other.wavemin, 10))
         # Order of comparisions is important, because isnan(None) throws error
         if self.wavemax is None and other.wavemax is None:
@@ -454,8 +454,8 @@ class DatabaseEntry(Base):
             # This means one is None and the other isnt
             wavemaxs_equal = False
         else:
-            wavemaxs_equal = (math.isnan(self.wavemax) and math.isnan(other.wavemax)) or\
-                             (self.wavemax is not None and other.wavemax is not None and\
+            wavemaxs_equal = (np.isnan(self.wavemax) and np.isnan(other.wavemax)) or\
+                             (self.wavemax is not None and other.wavemax is not None and
                               round(self.wavemax, 10) == round(other.wavemax, 10))
         return (
             (self.id == other.id or self.id is None or other.id is None) and

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -547,14 +547,6 @@ def entries_from_fido_search_result(sr, default_waveunit=None):
     >>> sr = Fido.search(attrs.Time("2012/1/1", "2012/1/2"),
     ...     attrs.Instrument('lyra'))
     >>> entries = entries_from_fido_search_result(sr)
-
-    >>> from sunpy.net import vso
-    >>> from sunpy.database.tables import entries_from_query_result
-    >>> client = vso.VSOClient()
-    >>> qr = client.query(
-    ...     vso.attrs.Time('2001/1/1', '2001/1/2'),
-    ...     vso.attrs.Instrument('eit'))
-    >>> entries = entries_from_query_result(qr)
     >>> entry = entries.next()
     >>> entry.source
     'Proba2'

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -400,8 +400,13 @@ class DatabaseEntry(Base):
         instrument = getattr(sr_block, 'instrument', None)
         time_start = sr_block.time.start
         time_end = sr_block.time.end
-        wavemin = None
-        wavemax = None
+        wavelength_temp = getattr(sr_block, 'wavelength', None)
+        if isinstance(wavelength_temp, tuple):
+            wavemin = wavelength_temp[0]
+            wavemax = wavelength_temp[1]
+        else:
+            wavemin = wavelength_temp
+            wavemax = wavelength_temp
         # sr_block.url of a QueryResponseBlock attribute is stored in fileid
         fileid = str(sr_block.url) if sr_block.url is not None else None
         size = None
@@ -527,18 +532,18 @@ def entries_from_query_result(qr, default_waveunit=None):
 
 def entries_from_fido_search_result(sr, default_waveunit=None):
     """
-    Use a `sunpy.net.dataretriever.downloader_factory.UnifiedResponse`
+    Use a `sunpy.net.dataretriever.fido_factory.UnifiedResponse`
     object returned from
-    :meth:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory.search`
+    :meth:`sunpy.net.dataretriever.fido_factory.UnifiedDownloaderFactory.search`
     to generate instances of :class:`DatabaseEntry`. Return an iterator
     over those instances.
 
     Parameters
     ----------
-    search_result : `sunpy.net.dataretriever.downloader_factory.UnifiedResponse`
+    search_result : `sunpy.net.dataretriever.fido_factory.UnifiedResponse`
             A UnifiedResponse object that is used to store responses from the
             unified downloader. This is returned by the ``search`` method of a
-            :class:`sunpy.net.dataretriever.downloader_factory.UnifiedDownloaderFactory`
+            :class:`sunpy.net.dataretriever.fido_factory.UnifiedDownloaderFactory`
             object.
 
     default_waveunit : `str`, optional

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -393,16 +393,14 @@ class DatabaseEntry(Base):
         # are set as None for now.
         source = getattr(sr_block, 'source', None)
         provider = getattr(sr_block, 'provider', None)
-        # physobs is written as phyobs in
-        # sunpy.net.dataretriever.client.QueryResponseBlock
-        physobs = getattr(sr_block, 'phyobs', None)
+        physobs = getattr(sr_block, 'physobs', None)
         if physobs is not None:
             physobs = str(physobs)
         instrument = getattr(sr_block, 'instrument', None)
         time_start = sr_block.time.start
         time_end = sr_block.time.end
 
-        wavelengths = getattr(sr_block, 'wavelength', None)
+        wavelengths = getattr(sr_block, 'wave', None)
         wavelength_temp = {}
         if isinstance(wavelength_temp, tuple):
             # Tuple of values

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -403,7 +403,6 @@ class DatabaseEntry(Base):
         time_end = sr_block.time.end
 
         wavelengths = getattr(sr_block, 'wavelength', None)
-
         wavelength_temp = {}
         if isinstance(wavelength_temp, tuple):
             # Tuple of values
@@ -439,12 +438,15 @@ class DatabaseEntry(Base):
             wavemin=wavemin, wavemax=wavemax)
 
     def __eq__(self, other):
-        wavemins_equal = self.wavemin is None and other.wavemin is None or\
-            self.wavemin is not None and other.wavemin is not None and\
-            round(self.wavemin, 10) == round(other.wavemin, 10)
-        wavemaxs_equal = self.wavemax is None and other.wavemax is None or\
-            self.wavemax is not None and other.wavemax is not None and\
-            round(self.wavemax, 10) == round(other.wavemax, 10)
+        wavemins_equal = (self.wavemin is None and other.wavemin is None) or\
+                         (math.isnan(self.wavemin) and math.isnan(other.wavemin)) or\
+                         (self.wavemin is not None and other.wavemin is not None and\
+                          round(self.wavemin, 10) == round(other.wavemin, 10))
+        # Order of comparisions is important, because isnan(None) throws error
+        wavemaxs_equal = (self.wavemax is None and other.wavemax is None) or\
+                         (math.isnan(self.wavemax) and math.isnan(other.wavemax)) or\
+                         (self.wavemax is not None and other.wavemax is not None and\
+                          round(self.wavemax, 10) == round(other.wavemax, 10))
         return (
             (self.id == other.id or self.id is None or other.id is None) and
             self.source == other.source and

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -438,15 +438,23 @@ class DatabaseEntry(Base):
             wavemin=wavemin, wavemax=wavemax)
 
     def __eq__(self, other):
-        wavemins_equal = (self.wavemin is None and other.wavemin is None) or\
-                         (math.isnan(self.wavemin) and math.isnan(other.wavemin)) or\
-                         (self.wavemin is not None and other.wavemin is not None and\
-                          round(self.wavemin, 10) == round(other.wavemin, 10))
+        if not all([self.wavemin, other.wavemin]):
+            # This means one is None and the other isnt
+            wavemins_equal = False
+        else:
+            wavemins_equal = (self.wavemin is None and other.wavemin is None) or\
+                             (math.isnan(self.wavemin) and math.isnan(other.wavemin)) or\
+                             (self.wavemin is not None and other.wavemin is not None and\
+                              round(self.wavemin, 10) == round(other.wavemin, 10))
         # Order of comparisions is important, because isnan(None) throws error
-        wavemaxs_equal = (self.wavemax is None and other.wavemax is None) or\
-                         (math.isnan(self.wavemax) and math.isnan(other.wavemax)) or\
-                         (self.wavemax is not None and other.wavemax is not None and\
-                          round(self.wavemax, 10) == round(other.wavemax, 10))
+        if not all([self.wavemax, other.wavemax]):
+            # This means one is None and the other isnt
+            wavemaxs_equal = False
+        else:
+            wavemaxs_equal = (self.wavemax is None and other.wavemax is None) or\
+                             (math.isnan(self.wavemax) and math.isnan(other.wavemax)) or\
+                             (self.wavemax is not None and other.wavemax is not None and\
+                              round(self.wavemax, 10) == round(other.wavemax, 10))
         return (
             (self.id == other.id or self.id is None or other.id is None) and
             self.source == other.source and

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -438,21 +438,23 @@ class DatabaseEntry(Base):
             wavemin=wavemin, wavemax=wavemax)
 
     def __eq__(self, other):
-        if not all([self.wavemin, other.wavemin]):
+        if self.wavemin is None and other.wavemin is None:
+            wavemins_equal = True
+        elif not all([self.wavemin, other.wavemin]):
             # This means one is None and the other isnt
             wavemins_equal = False
         else:
-            wavemins_equal = (self.wavemin is None and other.wavemin is None) or\
-                             (math.isnan(self.wavemin) and math.isnan(other.wavemin)) or\
+            wavemins_equal = (math.isnan(self.wavemin) and math.isnan(other.wavemin)) or\
                              (self.wavemin is not None and other.wavemin is not None and\
                               round(self.wavemin, 10) == round(other.wavemin, 10))
         # Order of comparisions is important, because isnan(None) throws error
-        if not all([self.wavemax, other.wavemax]):
+        if self.wavemax is None and other.wavemax is None:
+            wavemaxs_equal = True
+        elif not all([self.wavemax, other.wavemax]):
             # This means one is None and the other isnt
             wavemaxs_equal = False
         else:
-            wavemaxs_equal = (self.wavemax is None and other.wavemax is None) or\
-                             (math.isnan(self.wavemax) and math.isnan(other.wavemax)) or\
+            wavemaxs_equal = (math.isnan(self.wavemax) and math.isnan(other.wavemax)) or\
                              (self.wavemax is not None and other.wavemax is not None and\
                               round(self.wavemax, 10) == round(other.wavemax, 10))
         return (

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -68,7 +68,8 @@ def fido_search_result():
         net_attrs.Time("2012/1/1", "2012/1/2"),
         net_attrs.Instrument('lyra')|net_attrs.Instrument('eve')|
         net_attrs.Instrument('goes')|net_attrs.Instrument('noaa-indices')|
-        net_attrs.Instrument('noaa-predict')|net_attrs.Instrument('norh')|
+        net_attrs.Instrument('noaa-predict')|
+        (net_attrs.Instrument('norh')&net_attrs.Wavelength(17*units.GHz))|
         net_attrs.Instrument('rhessi')|
         (net_attrs.Instrument('EVE')&net_attrs.Level(0))
         )

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -66,12 +66,12 @@ def fido_search_result():
     # No JSOC query
     return Fido.search(
         net_attrs.Time("2012/1/1", "2012/1/2"),
-        net_attrs.Instrument('lyra')|net_attrs.Instrument('eve')|
-        net_attrs.Instrument('goes')|net_attrs.Instrument('noaa-indices')|
-        net_attrs.Instrument('noaa-predict')|
-        (net_attrs.Instrument('norh')&net_attrs.Wavelength(17*units.GHz))|
-        net_attrs.Instrument('rhessi')|
-        (net_attrs.Instrument('EVE')&net_attrs.Level(0))
+        net_attrs.Instrument('lyra') | net_attrs.Instrument('eve') |
+        net_attrs.Instrument('goes') | net_attrs.Instrument('noaa-indices') |
+        net_attrs.Instrument('noaa-predict') |
+        (net_attrs.Instrument('norh') & net_attrs.Wavelength(17*units.GHz)) |
+        net_attrs.Instrument('rhessi') |
+        (net_attrs.Instrument('EVE') & net_attrs.Level(0))
         )
 
 
@@ -586,7 +586,7 @@ def test_add_entry_fido_search_result(database, fido_search_result):
 def test_add_entries_from_fido_search_result_JSOC_client(database):
     assert len(database) == 0
     search_result = Fido.search(
-        net_attrs.jsoc.Time('2014-01-01T00:00:00','2014-01-01T01:00:00'),
+        net_attrs.jsoc.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'),
         net_attrs.jsoc.Series('hmi.m_45s'),
         net_attrs.jsoc.Notify("sunpy@sunpy.org")
         )
@@ -595,8 +595,7 @@ def test_add_entries_from_fido_search_result_JSOC_client(database):
 
 
 @pytest.mark.online
-def test_add_entries_from_fido_search_result_duplicates(database,
-        fido_search_result):
+def test_add_entries_from_fido_search_result_duplicates(database, fido_search_result):
     assert len(database) == 0
     database.add_from_fido_search_result(fido_search_result)
     assert len(database) == 65
@@ -605,8 +604,7 @@ def test_add_entries_from_fido_search_result_duplicates(database,
 
 
 @pytest.mark.online
-def test_add_entries_from_fido_search_result_ignore_duplicates(database,
-        fido_search_result):
+def test_add_entries_from_fido_search_result_ignore_duplicates(database, fido_search_result):
     assert len(database) == 0
     database.add_from_fido_search_result(fido_search_result)
     assert len(database) == 65

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -29,6 +29,7 @@ from sunpy.data.test.waveunit import waveunitdir
 from sunpy.io import fits
 from sunpy.extern.six.moves import range
 from sunpy.extern.six.moves import configparser
+from sunpy.net import Fido, attrs as net_attrs
 
 import sunpy.data.test
 
@@ -57,6 +58,20 @@ def database_using_lfucache():
 @pytest.fixture
 def database():
     return Database('sqlite:///:memory:')
+
+
+@pytest.fixture
+def fido_search_result():
+    # A search query with responses from all instruments
+    # No JSOC query
+    return Fido.search(
+        net_attrs.Time("2012/1/1", "2012/1/2"),
+        net_attrs.Instrument('lyra')|net_attrs.Instrument('eve')|
+        net_attrs.Instrument('goes')|net_attrs.Instrument('noaa-indices')|
+        net_attrs.Instrument('noaa-predict')|net_attrs.Instrument('norh')|
+        net_attrs.Instrument('rhessi')|
+        (net_attrs.Instrument('EVE')&net_attrs.Level(0))
+        )
 
 
 @pytest.fixture
@@ -553,6 +568,49 @@ def test_add_entries_from_qr_ignore_duplicates(database, query_result):
     assert len(database) == 16
     database.add_from_vso_query_result(query_result, True)
     assert len(database) == 32
+
+
+@pytest.mark.online
+def test_add_entry_fido_search_result(database, fido_search_result):
+    assert len(database) == 0
+    database.add_from_fido_search_result(fido_search_result)
+    assert len(database) == 65
+    database.undo()
+    assert len(database) == 0
+    database.redo()
+    assert len(database) == 65
+
+
+@pytest.mark.online
+def test_add_entries_from_fido_search_result_JSOC_client(database):
+    assert len(database) == 0
+    search_result = Fido.search(
+        net_attrs.jsoc.Time('2014-01-01T00:00:00','2014-01-01T01:00:00'),
+        net_attrs.jsoc.Series('hmi.m_45s'),
+        net_attrs.jsoc.Notify("sunpy@sunpy.org")
+        )
+    with pytest.raises(ValueError):
+        database.add_from_fido_search_result(search_result)
+
+
+@pytest.mark.online
+def test_add_entries_from_fido_search_result_duplicates(database,
+        fido_search_result):
+    assert len(database) == 0
+    database.add_from_fido_search_result(fido_search_result)
+    assert len(database) == 65
+    with pytest.raises(EntryAlreadyAddedError):
+        database.add_from_fido_search_result(fido_search_result)
+
+
+@pytest.mark.online
+def test_add_entries_from_fido_search_result_ignore_duplicates(database,
+        fido_search_result):
+    assert len(database) == 0
+    database.add_from_fido_search_result(fido_search_result)
+    assert len(database) == 65
+    database.add_from_fido_search_result(fido_search_result, True)
+    assert len(database) == 2*65
 
 
 def test_add_fom_path(database):

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 import pytest
 import os
+import math
 
 from astropy import units as u
 from astropy import conf
@@ -122,6 +123,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
+        wavemin=math.nan, wavemax=math.nan,
         instrument='lyra')
     # 54 entries from EVE
     assert entries[2] == DatabaseEntry(
@@ -137,6 +139,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid='http://umbra.nascom.nasa.gov/goes/fits/2012/go1520120101.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
+        wavemin=math.nan, wavemax=math.nan,
         instrument='goes')
     # 1 entry from noaa-indices
     assert entries[58] == DatabaseEntry(
@@ -144,6 +147,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid='ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
+        wavemin=math.nan, wavemax=math.nan,
         instrument='noaa-indices')
     # 1 entry from noaa-predict
     assert entries[59] == DatabaseEntry(
@@ -151,6 +155,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid='http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
+        wavemin=math.nan, wavemax=math.nan,
         instrument='noaa-predict')
     # 2 entries from norh
     assert entries[60] == DatabaseEntry(
@@ -159,6 +164,7 @@ def test_entries_from_fido_search_result(fido_search_result):
                 "pub/nsro/norh/data/tcx/2012/01/tca120101"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
+        wavemin=17634850.470588233, wavemax=17634850.470588233,
         instrument='NORH')
     # 1 entry from rhessi
     assert entries[62] == DatabaseEntry(
@@ -167,6 +173,7 @@ def test_entries_from_fido_search_result(fido_search_result):
                 "hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
+        wavemin=math.nan, wavemax=math.nan,
         instrument='rhessi')
     # 2 entries from eve, level 0
     assert entries[63] == DatabaseEntry(
@@ -175,6 +182,7 @@ def test_entries_from_fido_search_result(fido_search_result):
                 "/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
+        wavemin=math.nan, wavemax=math.nan,
         instrument='eve')
 
 
@@ -201,6 +209,7 @@ def test_from_fido_search_result_block(fido_search_result):
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
+        wavemin=math.nan, wavemax=math.nan,
         instrument='lyra')
     assert entry == expected_entry
 

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -155,24 +155,24 @@ def test_entries_from_fido_search_result(fido_search_result):
     # 2 entries from norh
     assert entries[60] == DatabaseEntry(
         source='NAOJ', provider='NRO', physobs="",
-        fileid=('ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/',
-                'pub/nsro/norh/data/tcx/2012/01/tca120101'),
+        fileid=("ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/"
+                "pub/nsro/norh/data/tcx/2012/01/tca120101"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='NORH')
     # 1 entry from rhessi
     assert entries[62] == DatabaseEntry(
         source="rhessi", provider='nasa', physobs='irradiance',
-        fileid=('https://hesperia.gsfc.nasa.gov/',
-                'hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits'),
+        fileid=("https://hesperia.gsfc.nasa.gov/"
+                "hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='rhessi')
     # 2 entries from eve, level 0
     assert entries[63] == DatabaseEntry(
         source='SDO', provider='LASP', physobs='irradiance',
-        fileid=('http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook',
-                '/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt'),
+        fileid=("http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook"
+                "/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='eve')

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -190,7 +190,7 @@ def test_entries_from_fido_search_result_JSOC():
 @pytest.mark.online
 def test_from_fido_search_result_block(fido_search_result):
     entry = DatabaseEntry._from_fido_search_result_block(
-                fido_search_result[0][0])
+                fido_search_result[0, 0][0]._list[0][0])
     expected_entry = DatabaseEntry(
         source='Proba2', provider='esa', physobs='irradiance',
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -190,7 +190,7 @@ def test_entries_from_fido_search_result_JSOC():
 @pytest.mark.online
 def test_from_fido_search_result_block(fido_search_result):
     entry = DatabaseEntry._from_fido_search_result_block(
-                fido_search_result[0, 0][0]._list[0][0])
+                fido_search_result[0, 0][0].get_response(0)[0])
     expected_entry = DatabaseEntry(
         source='Proba2', provider='esa', physobs='irradiance',
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -28,7 +28,8 @@ EIT_195_IMAGE = os.path.join(testdir, 'EIT/efz20040301.000010_s.fits')
 GOES_DATA = os.path.join(testdir, 'go1520110607.fits')
 
 """
-The hsi_image_20101016_191218.fits file and go1520110607.fits file lie in the sunpy/data/tests dirctory.
+The hsi_image_20101016_191218.fits file and go1520110607.fits file lie in the
+sunpy/data/tests dirctory.
 The efz20040301.000010_s.fits file lies in the sunpy/data/tests/EIT directory.
 
 RHESSI_IMAGE = sunpy/data/test/hsi_image_20101016_191218.fits
@@ -37,19 +38,20 @@ GOES_DATA = sunpy/data/test/go1520110607.fits
 
 """
 
+
 @pytest.fixture
 def fido_search_result():
     # A search query with responses from all instruments
     # No JSOC query
     return Fido.search(
         net_attrs.Time("2012/1/1", "2012/1/2"),
-        net_attrs.Instrument('lyra')|net_attrs.Instrument('eve')|
-        net_attrs.Instrument('goes')|net_attrs.Instrument('noaa-indices')|
-        net_attrs.Instrument('noaa-predict')|
-        (net_attrs.Instrument('norh')&net_attrs.Wavelength(17*u.GHz))|
-        net_attrs.Instrument('rhessi')|
-        (net_attrs.Instrument('EVE')&net_attrs.Level(0))
-        )
+        net_attrs.Instrument('lyra') | net_attrs.Instrument('eve') |
+        net_attrs.Instrument('goes') | net_attrs.Instrument('noaa-indices') |
+        net_attrs.Instrument('noaa-predict') |
+        (net_attrs.Instrument('norh') & net_attrs.Wavelength(17 * u.GHz)) |
+        net_attrs.Instrument('rhessi') |
+        (net_attrs.Instrument('EVE') & net_attrs.Level(0))
+    )
 
 
 @pytest.fixture
@@ -118,38 +120,38 @@ def test_entries_from_fido_search_result(fido_search_result):
     assert entries[0] == DatabaseEntry(
         source='Proba2', provider='esa', physobs='irradiance',
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
-        observation_time_start= datetime(2012, 1, 1, 0, 0),
-        observation_time_end= datetime(2012, 1, 2, 0, 0),
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='lyra')
     # 54 entries from EVE
     assert entries[2] == DatabaseEntry(
         source='SDO', provider='LASP', physobs='irradiance',
         fileid='EVE_L1_esp_2012001_00',
-        observation_time_start= datetime(2012, 1, 1, 0, 0),
-        observation_time_end= datetime(2012, 1, 2, 0, 0),
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='EVE', size=-1.0,
         wavemin=0.1, wavemax=30.400000000000002)
     # 2 entries from goes
     assert entries[56] == DatabaseEntry(
-        source= 'nasa', provider= 'sdac', physobs= 'irradiance',
-        fileid= 'http://umbra.nascom.nasa.gov/goes/fits/2012/go1520120101.fits',
-        observation_time_start = datetime(2012, 1, 1, 0, 0),
-        observation_time_end = datetime(2012, 1, 2, 0, 0),
-        instrument= 'goes')
+        source='nasa', provider='sdac', physobs='irradiance',
+        fileid='http://umbra.nascom.nasa.gov/goes/fits/2012/go1520120101.fits',
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        instrument='goes')
     # 1 entry from noaa-indices
     assert entries[58] == DatabaseEntry(
-        source= 'sdic', provider= 'swpc', physobs= 'sunspot number',
-        fileid= 'ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt',
-        observation_time_start = datetime(2012, 1, 1, 0, 0),
-        observation_time_end = datetime(2012, 1, 2, 0, 0),
-        instrument= 'noaa-indices')
+        source='sdic', provider='swpc', physobs='sunspot number',
+        fileid='ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt',
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        instrument='noaa-indices')
     # 1 entry from noaa-predict
     assert entries[59] == DatabaseEntry(
-        source= 'ises', provider= 'swpc', physobs= 'sunspot number',
-        fileid= 'http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt',
-        observation_time_start = datetime(2012, 1, 1, 0, 0),
-        observation_time_end = datetime(2012, 1, 2, 0, 0),
-        instrument= 'noaa-predict')
+        source='ises', provider='swpc', physobs='sunspot number',
+        fileid='http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt',
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        instrument='noaa-predict')
     # 2 entries from norh
     assert entries[60] == DatabaseEntry(
         source='NAOJ', provider='NRO', physobs="",
@@ -159,27 +161,27 @@ def test_entries_from_fido_search_result(fido_search_result):
         instrument='NORH')
     # 1 entry from rhessi
     assert entries[62] == DatabaseEntry(
-        source="rhessi", provider= 'nasa', physobs= 'irradiance',
-        fileid= 'https://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits',
-        observation_time_start = datetime(2012, 1, 1, 0, 0),
-        observation_time_end = datetime(2012, 1, 2, 0, 0),
-        instrument= 'rhessi')
+        source="rhessi", provider='nasa', physobs='irradiance',
+        fileid='https://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits',
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        instrument='rhessi')
     # 2 entries from eve, level 0
     assert entries[63] == DatabaseEntry(
-        source= 'SDO', provider= 'LASP', physobs= 'irradiance',
-        fileid= 'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt',
-        observation_time_start = datetime(2012, 1, 1, 0, 0),
-        observation_time_end = datetime(2012, 1, 2, 0, 0),
-        instrument= 'eve')
+        source='SDO', provider='LASP', physobs='irradiance',
+        fileid='http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt',
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        instrument='eve')
 
 
 @pytest.mark.online
 def test_entries_from_fido_search_result_JSOC():
     search_result = Fido.search(
-        net_attrs.jsoc.Time('2014-01-01T00:00:00','2014-01-01T01:00:00'),
+        net_attrs.jsoc.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'),
         net_attrs.jsoc.Series('hmi.m_45s'),
         net_attrs.jsoc.Notify("sunpy@sunpy.org")
-        )
+    )
     with pytest.raises(ValueError):
         # Using list() here is important because the
         # entries_from_fido_search_result function uses yield.
@@ -190,12 +192,12 @@ def test_entries_from_fido_search_result_JSOC():
 @pytest.mark.online
 def test_from_fido_search_result_block(fido_search_result):
     entry = DatabaseEntry._from_fido_search_result_block(
-                fido_search_result[0, 0][0].get_response(0)[0])
+        fido_search_result[0, 0][0].get_response(0)[0])
     expected_entry = DatabaseEntry(
         source='Proba2', provider='esa', physobs='irradiance',
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
-        observation_time_start= datetime(2012, 1, 1, 0, 0),
-        observation_time_end= datetime(2012, 1, 2, 0, 0),
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='lyra')
     assert entry == expected_entry
 
@@ -214,7 +216,8 @@ def test_entry_from_qr_block(query_result):
 
 @pytest.mark.online
 def test_entry_from_qr_block_with_missing_physobs(qr_block_with_missing_physobs):
-    entry = DatabaseEntry._from_query_result_block(qr_block_with_missing_physobs)
+    entry = DatabaseEntry._from_query_result_block(
+        qr_block_with_missing_physobs)
     expected_entry = DatabaseEntry(
         source='STEREO_A', provider='SSC',
         fileid='swaves/2013/swaves_average_20130805_a_hfr.dat',
@@ -304,7 +307,7 @@ def test_entries_from_file_time_string_parse_format():
         entries = list(entries_from_file(GOES_DATA))
 
     entries = list(entries_from_file(GOES_DATA,
-                   time_string_parse_format='%d/%m/%Y'))
+                                     time_string_parse_format='%d/%m/%Y'))
 
     assert len(entries) == 4
     entry = entries[0]
@@ -316,7 +319,8 @@ def test_entries_from_file_time_string_parse_format():
 
 
 def test_entries_from_dir():
-    entries = list(entries_from_dir(waveunitdir, time_string_parse_format='%d/%m/%Y'))
+    entries = list(entries_from_dir(
+        waveunitdir, time_string_parse_format='%d/%m/%Y'))
     assert len(entries) == 4
     for entry, filename in entries:
         if filename.endswith('na120701.091058.fits'):

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -155,21 +155,24 @@ def test_entries_from_fido_search_result(fido_search_result):
     # 2 entries from norh
     assert entries[60] == DatabaseEntry(
         source='NAOJ', provider='NRO', physobs="",
-        fileid='ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/01/tca120101',
+        fileid=('ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/',
+                'pub/nsro/norh/data/tcx/2012/01/tca120101'),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='NORH')
     # 1 entry from rhessi
     assert entries[62] == DatabaseEntry(
         source="rhessi", provider='nasa', physobs='irradiance',
-        fileid='https://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits',
+        fileid=('https://hesperia.gsfc.nasa.gov/',
+                'hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits'),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='rhessi')
     # 2 entries from eve, level 0
     assert entries[63] == DatabaseEntry(
         source='SDO', provider='LASP', physobs='irradiance',
-        fileid='http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt',
+        fileid=('http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook',
+                '/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt'),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='eve')

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -132,7 +132,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         instrument='EVE', size=-1.0,
-        wavemin=0.1, wavemax=30.400000000000002)
+        wavemin=0.1, wavemax=30.4)
     # 2 entries from goes
     assert entries[56] == DatabaseEntry(
         source='nasa', provider='sdac', physobs='irradiance',

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -8,10 +8,10 @@ from datetime import datetime
 
 import pytest
 import os
-import math
 
 from astropy import units as u
 from astropy import conf
+import numpy as np
 
 from sunpy.database import Database
 from sunpy.database.tables import FitsHeaderEntry, FitsKeyComment, Tag,\
@@ -123,7 +123,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
-        wavemin=math.nan, wavemax=math.nan,
+        wavemin=np.nan, wavemax=np.nan,
         instrument='lyra')
     # 54 entries from EVE
     assert entries[2] == DatabaseEntry(
@@ -139,7 +139,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid='http://umbra.nascom.nasa.gov/goes/fits/2012/go1520120101.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
-        wavemin=math.nan, wavemax=math.nan,
+        wavemin=np.nan, wavemax=np.nan,
         instrument='goes')
     # 1 entry from noaa-indices
     assert entries[58] == DatabaseEntry(
@@ -147,7 +147,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid='ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
-        wavemin=math.nan, wavemax=math.nan,
+        wavemin=np.nan, wavemax=np.nan,
         instrument='noaa-indices')
     # 1 entry from noaa-predict
     assert entries[59] == DatabaseEntry(
@@ -155,7 +155,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid='http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
-        wavemin=math.nan, wavemax=math.nan,
+        wavemin=np.nan, wavemax=np.nan,
         instrument='noaa-predict')
     # 2 entries from norh
     assert entries[60] == DatabaseEntry(
@@ -173,7 +173,7 @@ def test_entries_from_fido_search_result(fido_search_result):
                 "hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
-        wavemin=math.nan, wavemax=math.nan,
+        wavemin=np.nan, wavemax=np.nan,
         instrument='rhessi')
     # 2 entries from eve, level 0
     assert entries[63] == DatabaseEntry(
@@ -182,7 +182,7 @@ def test_entries_from_fido_search_result(fido_search_result):
                 "/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
-        wavemin=math.nan, wavemax=math.nan,
+        wavemin=np.nan, wavemax=np.nan,
         instrument='eve')
 
 
@@ -209,7 +209,7 @@ def test_from_fido_search_result_block(fido_search_result):
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
-        wavemin=math.nan, wavemax=math.nan,
+        wavemin=np.nan, wavemax=np.nan,
         instrument='lyra')
     assert entry == expected_entry
 

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -45,7 +45,8 @@ def fido_search_result():
         net_attrs.Time("2012/1/1", "2012/1/2"),
         net_attrs.Instrument('lyra')|net_attrs.Instrument('eve')|
         net_attrs.Instrument('goes')|net_attrs.Instrument('noaa-indices')|
-        net_attrs.Instrument('noaa-predict')|net_attrs.Instrument('norh')|
+        net_attrs.Instrument('noaa-predict')|
+        (net_attrs.Instrument('norh')&net_attrs.Wavelength(17*u.GHz))|
         net_attrs.Instrument('rhessi')|
         (net_attrs.Instrument('EVE')&net_attrs.Level(0))
         )
@@ -152,14 +153,14 @@ def test_entries_from_fido_search_result(fido_search_result):
     # 2 entries from norh
     assert entries[60] == DatabaseEntry(
         source='NAOJ', provider='NRO', physobs="",
-        fileid='ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/01/tca120101',
+        fileid='ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/01/tca120101',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
-        instrument='RadioHelioGraph')
+        instrument='NORH')
     # 1 entry from rhessi
     assert entries[62] == DatabaseEntry(
-        source="", provider= 'nasa', physobs= 'irradiance',
-        fileid= 'http://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits',
+        source="rhessi", provider= 'nasa', physobs= 'irradiance',
+        fileid= 'https://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20120101_016.fits',
         observation_time_start = datetime(2012, 1, 1, 0, 0),
         observation_time_end = datetime(2012, 1, 2, 0, 0),
         instrument= 'rhessi')


### PR DESCRIPTION
Now Fido search results (except the ones from JSOC) can be added to the database. Each QueryResponseBlock forms a DatabaseEntry.

@Cadair 
