### PR TITLE
SOLIS VSM Client implemented. Test and docs included.

### DIFF
--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,6 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level
+from .vso.attrs import Time, Instrument, Wavelength, Level, Physobs
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc']
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
+           'Physobs']

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,7 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level, Physobs
+from .vso.attrs import Time, Instrument, Wavelength, Level, Source, Detector, Physobs
 
 __all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
-           'Physobs']
+           'Source', 'Detector', 'Physobs']

--- a/sunpy/net/dataretriever/clients.py
+++ b/sunpy/net/dataretriever/clients.py
@@ -7,6 +7,7 @@ from .sources.goes import GOESClient
 from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 from .sources.noaa import NOAAIndicesClient, NOAAPredictClient
+from .sources.vsm import VSMClient
 
 # Import and register other sources
 from sunpy.net.jsoc.jsoc import JSOCClient

--- a/sunpy/net/dataretriever/sources/vsm.py
+++ b/sunpy/net/dataretriever/sources/vsm.py
@@ -1,0 +1,76 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+
+__author__ = "Sudarshan Konge"
+__email__ = "sudk1896@gmail.com"
+
+import datetime
+import urllib2
+import re
+from bs4 import BeautifulSoup
+
+from sunpy.net.dataretriever.client import GenericClient
+from sunpy.util.scraper import Scraper
+from sunpy.time import TimeRange
+
+
+_all__ = ['VSMClient']
+
+class VSMClient(GenericClient):
+
+    def _get_url_for_timerange(self, timerange, **kwargs):
+        """
+        returns list of urls corresponding to given TimeRange.
+        """
+        wave = int(kwargs['Wavelength'].min.value)
+        table = {6302:'v72', 8542:'v82', 10830: 'v22'}
+        if (wave == 6302):
+            START_DATE = datetime.datetime(2003, 8, 21)
+        elif (wave == 8542):
+            START_DATE = datetime.datetime(2003, 8, 26)
+        elif (wave == 10830):
+            START_DATE = datetime.datetime(2004, 11, 4)
+
+        if timerange.start < START_DATE:
+            raise ValueError('Earliest date for which Kanzelhohe data is available is {:%Y-%m-%d}'.format(START_DATE))
+
+        prefix = 'http://gong2.nso.edu/pubkeep/{wave_type}/%Y%m'
+        suffix = 'k4{wave_type}%y%m%dt%H%M%S.fts.gz'
+        total_days = (timerange.end - timerange.start).days + 1
+        all_days = timerange.split(total_days)
+
+    def _makeimap(self):
+        """
+        Helper Function:used to hold information about source.
+        """
+        self.map_['source'] = 'SOLIS'
+        self.map_['instrument'] = 'vsm'
+
+    @classmethod
+    def _can_handle_query(cls, *query):
+        
+        """
+        Answers whether client can service the query.
+        
+        Parameters
+        ----------
+        query : list of query objects
+        
+        Returns
+        -------
+        boolean: answer as to whether client can service the query
+        
+        """
+        chkattr = ['Time', 'Instrument', 'Wavelength']
+        chklist = [x.__class__.__name__ in chkattr for x in query]
+        chk_var = 0
+        values = [6302, 8542, 10830]
+        for x in query:
+            if (x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'vsm'):
+                chk_var += 1
+            if (x.__class__.__name__ == 'Wavelength' and int(x.min.value) in values and int(x.max.value) in values and (x.unit.name).lower()=='angstrom'):
+                chk_var += 1
+        if (chk_var==2):
+            return True
+        return False
+        

--- a/sunpy/net/dataretriever/sources/vsm.py
+++ b/sunpy/net/dataretriever/sources/vsm.py
@@ -1,36 +1,39 @@
-#This module was developed with funding provided by
-#the Google Summer of Code 2016.
-
-__author__ = "Sudarshan Konge"
-__email__ = "sudk1896@gmail.com"
-
-import datetime
-import urllib2
+# This module was developed with funding provided by
+# the Google Summer of Code 2016.
 import re
-from bs4 import BeautifulSoup
+import datetime
+
 import numpy as np
+from bs4 import BeautifulSoup
 
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
 
-_all__ = ['VSMClient']
+from sunpy.extern.six.moves.urllib.request import urlopen
+
+__author__ = "Sudarshan Konge"
+__email__ = "sudk1896@gmail.com"
+
+__all__ = ['VSMClient']
+
 
 class VSMClient(GenericClient):
     """
-    Returns a list of URLS to SOLIS VSM files corresponding to value of input timerange.
-    URL source: `http://gong2.nso.edu/pubkeep/`.
+    Returns a list of URLS to SOLIS VSM files corresponding to value of input
+    timerange. URL source: `http://gong2.nso.edu/pubkeep/`.
+
     Parameters
     ----------
     timerange: sunpy.time.TimeRange
         time range for which data is to be downloaded.
         Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
-    
+
     Instrument: Fixed argument - 'vsm' ,case insensitive.
 
     Wavelength: Any of 6302, 8542 or 10830 Angstrom units or equivalent values in different units.
                 Expects a Wavelength object.
                 e.g. 6302*u.AA, 630.2*u.nm etc.
-                
+
     Physobs: Optional, includes 'LOS_MAGNETIC_FIELD', "VECTOR_MAGNETIC_FIELD'
              'EQUIVALENT_WIDTH'.
 
@@ -43,7 +46,7 @@ class VSMClient(GenericClient):
     >>> print (res)
     [<Table length=6>
          Start Time           End Time      Source Instrument
-           str19               str19         str5     str3   
+           str19               str19         str5     str3
     ------------------- ------------------- ------ ----------
     2015-01-03 00:00:00 2015-01-04 00:00:00  SOLIS        vsm
     2015-01-04 00:00:00 2015-01-05 00:00:00  SOLIS        vsm
@@ -52,23 +55,27 @@ class VSMClient(GenericClient):
     2015-01-07 00:00:00 2015-01-08 00:00:00  SOLIS        vsm
     2015-01-08 00:00:00 2015-01-09 00:00:00  SOLIS        vsm]
     """
+
     def _get_url_for_timerange(self, timerange, **kwargs):
         """
         returns list of urls corresponding to given TimeRange.
         """
-        table_physobs = ['EQUIVALENT_WIDTH', 'LOS_MAGNETIC_FIELD', 'VECTOR_MAGNETIC_FIELD']
-        table_wave = {6302:'v72', 8542: 'v82', 10830: 'v22'}
+        table_physobs = [
+            'EQUIVALENT_WIDTH', 'LOS_MAGNETIC_FIELD', 'VECTOR_MAGNETIC_FIELD'
+        ]
+        table_wave = {6302: 'v72', 8542: 'v82', 10830: 'v22'}
 
-        physobs_in = ('physobs' in kwargs.keys() and kwargs['physobs'] in table_physobs)
+        physobs_in = ('physobs' in kwargs.keys() and
+                      kwargs['physobs'] in table_physobs)
         url_pattern = 'http://gong2.nso.edu/pubkeep/{dtype}/%Y%m/k4{dtype}%y%m%d/k4{dtype}%y%m%dt%H%M%S{suffix}'
 
         wave_float = kwargs['wavelength'].min.value
 
-        #The isclose function in numpy can only check two arrays if they
-        #are close to each other within some precision. Standalone values such
-        #as int, doubles etc can't be checked that way. In order to do that, we put the
-        #two indiviual values in two seperate arrays da and db and then apply
-        #isclose on both those arrays.
+        # The isclose function in numpy can only check two arrays if they are
+        # close to each other within some precision. Standalone values such as
+        # int, doubles etc can't be checked that way. In order to do that, we
+        # put the two indiviual values in two seperate arrays da and db and
+        # then apply isclose on both those arrays.
         da = list()
         da.append(wave_float)
         for wave_nums in table_wave.keys():
@@ -77,10 +84,10 @@ class VSMClient(GenericClient):
             if np.isclose(da, db, 1e-10, 1e-10):
                 wave = wave_nums
                 break
-            
+
         if wave is None:
             raise ValueError("Enter correct wavelength values and units")
-        
+
         def download_from_nso(dtype, suffix, timerange):
             tmp_pattern = 'k4{dtype}%y%m%dt%H%M%S{suffix}'
             result = list()
@@ -89,41 +96,55 @@ class VSMClient(GenericClient):
             all_dates = timerange.split(total_days)
             for day in all_dates:
                 try:
-                    html = urllib2.urlopen(base_url.format(dtype=dtype, date=day.end))
+                    html = urlopen(base_url.format(dtype=dtype, date=day.end))
                     soup = BeautifulSoup(html)
                     for link in soup.findAll("a"):
-                        crawler = Scraper(tmp_pattern, dtype=dtype, suffix=suffix)
+                        crawler = Scraper(
+                            tmp_pattern, dtype=dtype, suffix=suffix)
                         simple_pattern = '%y%m%d_%H%M%S'
                         url = str(link.get('href'))
                         if (crawler._URL_followsPattern(url)):
-                            tmp = re.sub('k4'+dtype, '', url)
+                            tmp = re.sub('k4' + dtype, '', url)
                             tmp = re.sub('[a-zA-Z]', '', tmp)
                             crawler_ = Scraper(simple_pattern)
-                            if (timerange.start <= crawler_._extractDateURL(tmp) <= timerange.end):
-                                result.append(base_url.format(dtype=dtype, date=day.end)+url)
+                            if (timerange.start <=
+                                    crawler_._extractDateURL(tmp) <=
+                                    timerange.end):
+                                result.append(
+                                    base_url.format(
+                                        dtype=dtype, date=day.end) + url)
                 except:
                     pass
             return result
 
-        start_date = {6302: datetime.datetime(2003, 8, 21), 8542: datetime.datetime(2003, 8, 26),
-                      10830: datetime.datetime(2004, 11, 4)}
+        start_date = {
+            6302: datetime.datetime(2003, 8, 21),
+            8542: datetime.datetime(2003, 8, 26),
+            10830: datetime.datetime(2004, 11, 4)
+        }
         START_DATE = start_date[wave]
-        
+
         if timerange.start < START_DATE:
-            raise ValueError('Earliest date for which SOLIS VSM data is available is {:%Y-%m-%d}'.format(START_DATE))
-        
+            raise ValueError(
+                'Earliest date for which SOLIS VSM data is available is {:%Y-%m-%d}'.
+                format(START_DATE))
+
         result = list()
         if wave == 6302:
             if not physobs_in:
-                result.extend(download_from_nso('v72','.fts.gz',timerange))
-                result.extend(download_from_nso('v93','_FDISK.fts.gz', timerange))
+                result.extend(download_from_nso('v72', '.fts.gz', timerange))
+                result.extend(
+                    download_from_nso('v93', '_FDISK.fts.gz', timerange))
             else:
                 if kwargs['physobs'] == 'VECTOR_MAGNETIC_FIELD':
-                    result.extend(download_from_nso('v93','_FDISK.fts.gz', timerange))
+                    result.extend(
+                        download_from_nso('v93', '_FDISK.fts.gz', timerange))
                 else:
-                    result.extend(download_from_nso('v72', '.fts.gz', timerange))
+                    result.extend(
+                        download_from_nso('v72', '.fts.gz', timerange))
         else:
-            result.extend(download_from_nso(table_wave[wave]), '.fts.gz', timerange)
+            result.extend(
+                download_from_nso(table_wave[wave]), '.fts.gz', timerange)
         return result
 
     def _makeimap(self):
@@ -135,22 +156,22 @@ class VSMClient(GenericClient):
 
     @classmethod
     def _can_handle_query(cls, *query):
-        
         """
         Answers whether client can service the query.
-        
+
         Parameters
         ----------
         query : list of query objects
-        
+
         Returns
         -------
         boolean: answer as to whether client can service the query
-        
+
         """
         chk_var = 0
         for x in query:
-            if x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'vsm':
+            if x.__class__.__name__ == 'Instrument' and type(
+                    x.value) is str and x.value.lower() == 'vsm':
                 chk_var += 1
             if x.__class__.__name__ == 'Wavelength':
                 chk_var += 1

--- a/sunpy/net/dataretriever/sources/vsm.py
+++ b/sunpy/net/dataretriever/sources/vsm.py
@@ -12,8 +12,6 @@ import numpy as np
 
 from sunpy.net.dataretriever.client import GenericClient
 from sunpy.util.scraper import Scraper
-from sunpy.time import TimeRange
-
 
 _all__ = ['VSMClient']
 
@@ -59,7 +57,7 @@ class VSMClient(GenericClient):
         returns list of urls corresponding to given TimeRange.
         """
         table_physobs = ['EQUIVALENT_WIDTH', 'LOS_MAGNETIC_FIELD', 'VECTOR_MAGNETIC_FIELD']
-        table_wave = { 6302:'v72', 8542: 'v82', 10830: 'v22'}
+        table_wave = {6302:'v72', 8542: 'v82', 10830: 'v22'}
 
         physobs_in = ('physobs' in kwargs.keys() and kwargs['physobs'] in table_physobs)
         url_pattern = 'http://gong2.nso.edu/pubkeep/{dtype}/%Y%m/k4{dtype}%y%m%d/k4{dtype}%y%m%dt%H%M%S{suffix}'
@@ -98,7 +96,7 @@ class VSMClient(GenericClient):
                         simple_pattern = '%y%m%d_%H%M%S'
                         url = str(link.get('href'))
                         if (crawler._URL_followsPattern(url)):
-                            tmp = re.sub('k4'+dtype,'',url)
+                            tmp = re.sub('k4'+dtype, '', url)
                             tmp = re.sub('[a-zA-Z]', '', tmp)
                             crawler_ = Scraper(simple_pattern)
                             if (timerange.start <= crawler_._extractDateURL(tmp) <= timerange.end):
@@ -115,7 +113,7 @@ class VSMClient(GenericClient):
             raise ValueError('Earliest date for which SOLIS VSM data is available is {:%Y-%m-%d}'.format(START_DATE))
         
         result = list()
-        if (wave == 6302):
+        if wave == 6302:
             if not physobs_in:
                 result.extend(download_from_nso('v72','.fts.gz',timerange))
                 result.extend(download_from_nso('v93','_FDISK.fts.gz', timerange))
@@ -123,7 +121,7 @@ class VSMClient(GenericClient):
                 if kwargs['physobs'] == 'VECTOR_MAGNETIC_FIELD':
                     result.extend(download_from_nso('v93','_FDISK.fts.gz', timerange))
                 else:
-                    result.extend(download_from_nso('v72','.fts.gz',timerange))
+                    result.extend(download_from_nso('v72', '.fts.gz', timerange))
         else:
             result.extend(download_from_nso(table_wave[wave]), '.fts.gz', timerange)
         return result
@@ -150,15 +148,10 @@ class VSMClient(GenericClient):
         boolean: answer as to whether client can service the query
         
         """
-        chkattr = ['Time', 'Instrument', 'Wavelength']
-        chklist = [x.__class__.__name__ in chkattr for x in query]
         chk_var = 0
-        values = [6302, 8542, 10830]
         for x in query:
-            if (x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'vsm'):
+            if x.__class__.__name__ == 'Instrument' and type(x.value) is str and x.value.lower() == 'vsm':
                 chk_var += 1
-            if (x.__class__.__name__ == 'Wavelength'):
+            if x.__class__.__name__ == 'Wavelength':
                 chk_var += 1
-        if (chk_var == 2):
-            return True
-        return False
+        return chk_var == 2

--- a/sunpy/net/dataretriever/sources/vsm.py
+++ b/sunpy/net/dataretriever/sources/vsm.py
@@ -92,7 +92,7 @@ class VSMClient(GenericClient):
                       10830: datetime.datetime(2004, 11, 4)}
         START_DATE = start_date[wave]
         if timerange.start < START_DATE:
-            raise ValueError('Earliest date for which Kanzelhohe data is available is {:%Y-%m-%d}'.format(START_DATE))
+            raise ValueError('Earliest date for which SOLIS VSM data is available is {:%Y-%m-%d}'.format(START_DATE))
 
         result = list()
         if (wave == 6302):

--- a/sunpy/net/dataretriever/sources/vsm.py
+++ b/sunpy/net/dataretriever/sources/vsm.py
@@ -60,7 +60,7 @@ class VSMClient(GenericClient):
         table_physobs = ['EQUIVALENT_WIDTH', 'LOS_MAGNETIC_FIELD', 'VECTOR_MAGNETIC_FIELD']
         table_wave = { 6302:'v72', 8542: 'v82', 10830: 'v22'}
 
-        physobs_in = True if ('physobs' in kwargs.keys() and kwargs['physobs'] in table_physobs) else False
+        physobs_in = ('physobs' in kwargs.keys() and kwargs['physobs'] in table_physobs)
         url_pattern = 'http://gong2.nso.edu/pubkeep/{dtype}/%Y%m/k4{dtype}%y%m%d/k4{dtype}%y%m%dt%H%M%S{suffix}'
 
         wave = int(kwargs['wavelength'].min.value)
@@ -87,14 +87,10 @@ class VSMClient(GenericClient):
                 except:
                     pass
             return result
-        
-        if (wave == 6302):
-            START_DATE = datetime.datetime(2003, 8, 21)
-        elif (wave == 8542):
-            START_DATE = datetime.datetime(2003, 8, 26)
-        elif (wave == 10830):
-            START_DATE = datetime.datetime(2004, 11, 4)
 
+        start_date = {6302: datetime.datetime(2003, 8, 21), 8542: datetime.datetime(2003, 8, 26),
+                      10830: datetime.datetime(2004, 11, 4)}
+        START_DATE = start_date[wave]
         if timerange.start < START_DATE:
             raise ValueError('Earliest date for which Kanzelhohe data is available is {:%Y-%m-%d}'.format(START_DATE))
 

--- a/sunpy/net/dataretriever/tests/test_vsm.py
+++ b/sunpy/net/dataretriever/tests/test_vsm.py
@@ -29,7 +29,7 @@ def test_can_handle_query():
     assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(6302*u.AA))
     assert not VClient._can_handle_query(trange, Instrument('vsm'))
     assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(8542*u.AA))
-    assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(10830*u.AA),
+    assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(1083.0*u.nm),
                                      Physobs('EQUIVALENT_WIDTH'))
 
 @pytest.mark.online
@@ -43,7 +43,7 @@ def test_query():
 #For wavelength 6302 Angstroms.
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2015/1/3', '2015/1/6'), a.Instrument('vsm'), a.Wavelength(6302*u.AA),
+    qr = Fido.search(a.Time('2015/1/3', '2015/1/6'), a.Instrument('vsm'), a.Wavelength(630.2*u.nm),
                      a.Physobs('VECTOR_MAGNETIC_FIELD'))
     assert isinstance(qr, UnifiedResponse)
     assert qr._numfile == 6

--- a/sunpy/net/dataretriever/tests/test_vsm.py
+++ b/sunpy/net/dataretriever/tests/test_vsm.py
@@ -19,8 +19,8 @@ trange = Time('2014/6/1', '2014/6/4')
 #they are very huge ranging from 75MB-100MB
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, wavelength, physobs",
-                         [(trange, Instrument('vsm'), Wavelength(6302*u.AA),
-                           Physobs("LOS_MAGNETIC_FIELD"))])
+[(trange, Instrument('vsm'), Wavelength(6302*u.AA),
+Physobs("LOS_MAGNETIC_FIELD"))])
 def test_query(time, instrument, physobs, wavelength):
     qr = VClient.query(time, instrument, physobs, wavelength)
     assert len(qr) == 3
@@ -30,7 +30,7 @@ def test_can_handle_query():
     assert not VClient._can_handle_query(trange, Instrument('vsm'))
     assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(8542*u.AA))
     assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(10830*u.AA),
-                                         Physobs('EQUIVALENT_WIDTH'))
+                                     Physobs('EQUIVALENT_WIDTH'))
 
 @pytest.mark.online
 def test_query():

--- a/sunpy/net/dataretriever/tests/test_vsm.py
+++ b/sunpy/net/dataretriever/tests/test_vsm.py
@@ -1,0 +1,49 @@
+#This module was developed with funding provided by
+#the Google Summer of Code 2016.
+import datetime
+import pytest
+
+from astropy import units as u
+from sunpy.time.timerange import TimeRange
+from sunpy.net.vso.attrs import Time,Instrument,Physobs, Wavelength
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+import sunpy.net.dataretriever.sources.vsm as vsm
+
+VClient = vsm.VSMClient()
+
+trange = Time('2014/6/1', '2014/6/4')
+#Not downloading fits files since
+#they are very huge ranging from 75MB-100MB
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument, wavelength, physobs",
+                         [(trange, Instrument('vsm'), Wavelength(6302*u.AA),
+                           Physobs("LOS_MAGNETIC_FIELD"))])
+def test_query(time, instrument, physobs, wavelength):
+    qr = VClient.query(time, instrument, physobs, wavelength)
+    assert len(qr) == 3
+
+def test_can_handle_query():
+    assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(6302*u.AA))
+    assert not VClient._can_handle_query(trange, Instrument('vsm'))
+    assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(8542*u.AA))
+    assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(10830*u.AA),
+                                         Physobs('EQUIVALENT_WIDTH'))
+
+@pytest.mark.online
+def test_query():
+    qr = VClient.query(trange, Instrument('vsm'), Wavelength(6302*u.AA))
+    assert len(qr) == 9
+    assert qr.time_range()[0] == '2014/06/01'
+    assert qr.time_range()[1] == '2014/06/04'
+
+#FDISK files for VECTOR_MAGNETIC_FIELD
+#For wavelength 6302 Angstroms.
+@pytest.mark.online
+def test_fido_query():
+    qr = Fido.search(a.Time('2015/1/3', '2015/1/6'), a.Instrument('vsm'), a.Wavelength(6302*u.AA),
+                     a.Physobs('VECTOR_MAGNETIC_FIELD'))
+    assert isinstance(qr, UnifiedResponse)
+    assert qr._numfile == 6

--- a/sunpy/net/dataretriever/tests/test_vsm.py
+++ b/sunpy/net/dataretriever/tests/test_vsm.py
@@ -1,5 +1,5 @@
-#This module was developed with funding provided by
-#the Google Summer of Code 2016.
+# This module was developed with funding provided by
+# the Google Summer of Code 2016.
 import pytest
 
 from astropy import units as u
@@ -12,37 +12,47 @@ import sunpy.net.dataretriever.sources.vsm as vsm
 VClient = vsm.VSMClient()
 
 trange = Time('2014/6/1', '2014/6/4')
-#Not downloading fits files since
-#they are very huge ranging from 75MB-100MB
+
+
+# Not downloading fits files since
+# they are very huge ranging from 75MB-100MB
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, wavelength, physobs",
-[(trange, Instrument('vsm'), Wavelength(6302*u.AA),
-Physobs("LOS_MAGNETIC_FIELD"))])
+                         [(trange, Instrument('vsm'), Wavelength(6302 * u.AA),
+                           Physobs("LOS_MAGNETIC_FIELD"))])
 def test_query(time, instrument, physobs, wavelength):
     qr = VClient.query(time, instrument, physobs, wavelength)
     assert len(qr) == 3
 
-@pytest.mark.parametrize("timerange, instrument, wavelength, physobs, expected",
-                         [(trange, Instrument('vsm'), Wavelength(6302*u.AA), None, True),
-                          (trange, Instrument('vsm'), None, None, False),
-                          (trange, Instrument('vsm'), Wavelength(8542*u.AA), None, True),
-                          (trange, Instrument('vsm'), Wavelength(1083.0*u.nm), Physobs('EQUIVALENT_WIDTH'),
-                           True)])
-def test_can_handle_query(timerange, instrument, wavelength, physobs, expected):
-    assert VClient._can_handle_query(timerange, instrument, wavelength, physobs) is expected
+
+@pytest.mark.parametrize(
+    "timerange, instrument, wavelength, physobs, expected",
+    [(trange, Instrument('vsm'), Wavelength(6302 * u.AA), None, True),
+     (trange, Instrument('vsm'), None, None, False),
+     (trange, Instrument('vsm'), Wavelength(8542 * u.AA), None, True), (
+         trange, Instrument('vsm'), Wavelength(1083.0 * u.nm),
+         Physobs('EQUIVALENT_WIDTH'), True)])
+def test_can_handle_query(timerange, instrument, wavelength, physobs,
+                          expected):
+    assert VClient._can_handle_query(timerange, instrument, wavelength,
+                                     physobs) is expected
+
 
 @pytest.mark.online
-def test_query():
-    qr = VClient.query(trange, Instrument('vsm'), Wavelength(6302*u.AA))
+def test_query_2():
+    qr = VClient.query(trange, Instrument('vsm'), Wavelength(6302 * u.AA))
     assert len(qr) == 9
     assert qr.time_range()[0] == '2014/06/01'
     assert qr.time_range()[1] == '2014/06/04'
 
-#FDISK files for VECTOR_MAGNETIC_FIELD
-#For wavelength 6302 Angstroms.
+
+# FDISK files for VECTOR_MAGNETIC_FIELD
+# For wavelength 6302 Angstroms.
 @pytest.mark.online
 def test_fido_query():
-    qr = Fido.search(a.Time('2015/1/3', '2015/1/6'), a.Instrument('vsm'), a.Wavelength(630.2*u.nm),
-                     a.Physobs('VECTOR_MAGNETIC_FIELD'))
+    qr = Fido.search(
+        a.Time('2015/1/3', '2015/1/6'),
+        a.Instrument('vsm'),
+        a.Wavelength(630.2 * u.nm), a.Physobs('VECTOR_MAGNETIC_FIELD'))
     assert isinstance(qr, UnifiedResponse)
     assert qr._numfile == 6

--- a/sunpy/net/dataretriever/tests/test_vsm.py
+++ b/sunpy/net/dataretriever/tests/test_vsm.py
@@ -1,12 +1,9 @@
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
-import datetime
 import pytest
 
 from astropy import units as u
-from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time,Instrument,Physobs, Wavelength
-from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.vso.attrs import Time, Instrument, Physobs, Wavelength
 from sunpy.net.dataretriever.downloader_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a
@@ -25,12 +22,14 @@ def test_query(time, instrument, physobs, wavelength):
     qr = VClient.query(time, instrument, physobs, wavelength)
     assert len(qr) == 3
 
-def test_can_handle_query():
-    assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(6302*u.AA))
-    assert not VClient._can_handle_query(trange, Instrument('vsm'))
-    assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(8542*u.AA))
-    assert VClient._can_handle_query(trange, Instrument('vsm'), Wavelength(1083.0*u.nm),
-                                     Physobs('EQUIVALENT_WIDTH'))
+@pytest.mark.parametrize("timerange, instrument, wavelength, physobs, expected",
+                         [(trange, Instrument('vsm'), Wavelength(6302*u.AA), None, True),
+                          (trange, Instrument('vsm'), None, None, False),
+                          (trange, Instrument('vsm'), Wavelength(8542*u.AA), None, True),
+                          (trange, Instrument('vsm'), Wavelength(1083.0*u.nm), Physobs('EQUIVALENT_WIDTH'),
+                           True)])
+def test_can_handle_query(timerange, instrument, wavelength, physobs, expected):
+    assert VClient._can_handle_query(timerange, instrument, wavelength, physobs) is expected
 
 @pytest.mark.online
 def test_query():

--- a/sunpy/net/tests/strategies.py
+++ b/sunpy/net/tests/strategies.py
@@ -39,7 +39,7 @@ def online_instruments():
     Returns a strategy for any instrument that does not need the internet to do
     a query
     """
-    online_instr = ['rhessi']
+    online_instr = ['rhessi', 'vsm']
     online_instr = st.builds(a.Instrument, st.sampled_from(online_instr))
 
     return online_instr


### PR DESCRIPTION
This implements SOLIS VSM Client. It supports query by `Wavelength` and includes an optional argument for `Physobs`. The implementation is different from how we would normally implement via `Scarper` in `sunpy.util`. But it still uses the scraper implementation.

The user needs to provide a wavelength object (defined in `vso.attrs`) with arguments as `6302, 8542 or 10830` in Angstrom units or the equivalent values in different units.

`Physobs` takes three values `LOS_MAGNETIC_FIELD, VECTOR_MAGNETIC_FIELD and INTENSITY`. 
## Usage

To download fits files for 6302 Angstroms for both physical observation.

```
qr = Fido.search(a.Time, a.Instrument('vsm'), a.Wavelength(630.2*u.nm) )
```

To download data for 8542 or 10830 Angstroms, simply

```
qr = Fido.search(a.Time, a.Instrument('vsm'), a.Wavelength(8542*u.AA) )

or

qr = qr = Fido.search(a.Time, a.Instrument('vsm'), a.Wavelength(10830*u.AA) )
```

To download data for `Physobs` , `VECTOR_MAGNETIC_FIELD`.

```
qr = Fido.search(a.Time, a.Instrument('vsm'), a.Wavelength(6302*u.AA), 
                            a.Physobs('VECTOR_MAGNETIC_FIELD') )
```

`Physobs` are all Case-sensitive due to VSO naming conventions.
