### PR TITLE
GOES Client with additional argument for Physobs

### DIFF
--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -3,6 +3,7 @@
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 
-from .vso.attrs import Time, Instrument, Wavelength, Level
+from .vso.attrs import Time, Instrument, Wavelength, Level, Physobs, Source, Detector, Filter
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc']
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc',
+           'Physobs', 'Source', 'Detector', 'Filter']

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -1,3 +1,6 @@
+"""
+This module implements GOES Client.
+"""
 #This module was developed with funding provided by
 #the Google Summer of Code 2016.
 
@@ -8,7 +11,7 @@ import datetime
 from bs4 import BeautifulSoup
 from six.moves.urllib.request import urlopen
 
-from sunpy.time import parse_time, TimeRange
+from sunpy.time import TimeRange
 from sunpy.util.scraper import Scraper
 
 from ..client import GenericClient
@@ -21,7 +24,8 @@ __all__ = ['GOESClient']
 
 class GOESClient(GenericClient):
     """
-    Returns a list of URLS to SOLIS VSM files corresponding to value of input timerange.
+    Returns a list of URLS to GOES files corresponding to value of input timerange
+    and Physical Observation value.
     URL source: `http://gong2.nso.edu/pubkeep/`.
     Parameters
     ----------
@@ -162,6 +166,7 @@ class GOESClient(GenericClient):
                 url_pattern = 'ftp://ftp.swpc.noaa.gov/pub/lists/xray/{date:%Y%m%d}_G{satord}_xr_{cad}m.txt'
                 g = lambda url, satord, date, cad: url.format(satord=satord, date=date, cad=cad)
                 result.extend([g(url_pattern, satord, now, cad) for cad in (1, 5) for satord in ('s', 'p')])
+
             return result
 
         def download_intensity(time_range):
@@ -176,7 +181,6 @@ class GOESClient(GenericClient):
             total_days = (time_range.end - time_range.start).days + 1
             all_dates = time_range.split(total_days)
             for day in all_dates:
-                print(prefix.format(date=day.end, sat=self._get_goes_sat_num(day.end)))
                 html = urlopen(prefix.format(date=day.end, sat=self._get_goes_sat_num(day.end)))
                 soup = BeautifulSoup(html, 'lxml')
                 for link in soup.findAll("a"):
@@ -231,9 +235,9 @@ class GOESClient(GenericClient):
         boolean
             answer as to whether client can service the query
         """
-        chkattr =  ['Time', 'Instrument', 'Physobs']
+        chkattr = ['Time', 'Instrument', 'Physobs']
         physobs = ['PARTICLE_FLUX', 'IRRADIANCE', 'INTENSITY']
-        chklist =  [x.__class__.__name__ in chkattr for x in query]
+        chklist = [x.__class__.__name__ in chkattr for x in query]
         chk_var = 0
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value == 'goes':

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -20,6 +20,40 @@ __all__ = ['GOESClient']
 
 
 class GOESClient(GenericClient):
+    """
+    Returns a list of URLS to SOLIS VSM files corresponding to value of input timerange.
+    URL source: `http://gong2.nso.edu/pubkeep/`.
+    Parameters
+    ----------
+    timerange: sunpy.time.TimeRange
+        time range for which data is to be downloaded.
+        Example value - TimeRange('2015-12-30 00:00:00','2015-12-31 00:01:00')
+
+    Instrument: Fixed argument - 'goes' ,case insensitive.
+
+    Physobs: Optional, includes 'INTENSITY', "IRRADIANCE'
+             'PARTICLE_FLUX'.
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido
+    >>> from sunpy.net import attrs as a
+    >>> res = Fido.search(a.Time('2016/6/4 00:00:00','2016/6/4 00:03:00'),
+                Instrument('goes'), a.Physobs('INTENSITY'))
+    >>> print (res)
+    [<Table length=7>
+         Start Time           End Time      Source Instrument
+           str19               str19         str4     str4
+    ------------------- ------------------- ------ ----------
+    2016-06-04 00:00:00 2016-06-05 00:00:00   nasa       goes
+    2016-06-05 00:00:00 2016-06-06 00:00:00   nasa       goes
+    2016-06-06 00:00:00 2016-06-07 00:00:00   nasa       goes
+    2016-06-07 00:00:00 2016-06-08 00:00:00   nasa       goes
+    2016-06-08 00:00:00 2016-06-09 00:00:00   nasa       goes
+    2016-06-09 00:00:00 2016-06-10 00:00:00   nasa       goes
+    2016-06-10 00:00:00 2016-06-11 00:00:00   nasa       goes]
+    """
+
     def _get_goes_sat_num(self, date):
         """
         Determines the satellite number for a given date.

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -11,7 +11,7 @@ import datetime
 from bs4 import BeautifulSoup
 from six.moves.urllib.request import urlopen
 
-from sunpy.time import TimeRange
+from sunpy.time import TimeRange, parse_time
 from sunpy.util.scraper import Scraper
 
 from ..client import GenericClient
@@ -200,8 +200,8 @@ class GOESClient(GenericClient):
             return result
 
 
-        physobs = kwargs['physobs']
-        start_dates = {'INTENSITY': datetime.datetime(2010, 6, 4), 'IRRADIANCE':datetime.datetime(1980, 1, 4),
+        physobs = kwargs['physobs'].upper()
+        start_dates = {'INTENSITY': datetime.datetime(2010, 6, 4), 'IRRADIANCE': datetime.datetime(1980, 1, 4),
                        'PARTICLE_FLUX': datetime.datetime(2015, 5, 30)}
         START_DATE = start_dates[physobs]
         if timerange.end < START_DATE:

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -44,13 +44,6 @@ def test_can_handle_query(time):
     ans3 = goes.GOESClient._can_handle_query(time, Instrument('eve'))
     assert ans3 is False
 
-def test_can_handle_query_b():
-    assert LCClient._can_handle_query(Time('2016/06/15', '2016/06/17'), Instrument('goes'), Physobs('PARTICLE_FLUX'))
-    assert LCClient._can_handle_query(Time('2016/06/15', '2016/06/17'), Instrument('goes'), Physobs('INTENSITY'))
-    assert LCClient._can_handle_query(Time('2016/06/15', '2016/06/17'), Instrument('goes'), Physobs('IRRADIANCE'))
-    assert not LCClient._can_handle_query(Time('2016/06/15', '2016/06/17'), Instrument('goes'))
-
-
 def test_no_satellite():
     with pytest.raises(ValueError):
         LCClient.search(Time("1950/01/01", "1950/02/02"), Instrument('goes'), Physobs('IRRADIANCE'))
@@ -131,6 +124,14 @@ def test_query_c(time, instrument, physobs, number_of_files):
     qr = GClient.query(time, instrument, physobs)
     assert len(qr) == number_of_files
 
+TRANGE = Time('2016/6/15', '2016/6/17')
+@pytest.mark.parametrize("time, instrument, physobs, expected",
+                         [(TRANGE, Instrument('goes'), Physobs('PARTICLE_FLUX'), True),
+                          (TRANGE, Instrument('goes'), Physobs('INTENSITY'), True),
+                          (TRANGE, Instrument('goes'), Physobs('IRRADIANCE'), True),
+                          (TRANGE, Instrument('goes'), None, False)])
+def test_can_handle_query_b(time, instrument, physobs, expected):
+    assert GClient._can_handle_query(time, instrument, physobs) is expected
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, physobs",

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -1,14 +1,18 @@
+
+"""
+This module tests GOES Client.
+"""
+#This module was developed by funding
+#provided by Google Summer of Code 2016.
 import pytest
 import datetime
 from itertools import product
 
 from sunpy.time.timerange import TimeRange, parse_time
 from sunpy.net.vso.attrs import Time, Instrument, Physobs
-from sunpy.net.dataretriever.client import QueryResponse
 import sunpy.net.dataretriever.sources.goes as goes
 from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido
-from sunpy.net import attrs as a
 
 from hypothesis import given, example
 from sunpy.net.tests.strategies import goes_time
@@ -81,6 +85,7 @@ def test_get(time, instrument, physobs):
 
 
 @pytest.mark.online
+
 def test_new_logic():
     qr = LCClient.search(Time('2012/10/4', '2012/10/6'), Instrument('goes'), Physobs('IRRADIANCE'))
     res = LCClient.fetch(qr)
@@ -115,6 +120,17 @@ def test_query_2(time, instrument, physobs):
     res = LCClient.get(qr)
     d_list = res.wait()
     assert len(qr) == len(d_list)
+
+@pytest.mark.parametrize("time, instrument, physobs, number_of_files",
+[(Time(datetime.datetime.now() - datetime.timedelta(days=2), datetime.datetime.now()), Instrument('goes'),
+  Physobs('PARTICLE_FLUX'), 8),
+ (Time(datetime.datetime.now() - datetime.timedelta(days=2), datetime.datetime.now()), Instrument('goes'),
+  Physobs('IRRADIANCE'), 16),
+ (Time('2016/7/1', '2016/7/3'), Instrument('goes'), Physobs('IRRADIANCE'), 10)])
+def test_query_c(time, instrument, physobs, number_of_files):
+    qr = GClient.query(time, instrument, physobs)
+    assert len(qr) == number_of_files
+
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument, physobs",

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -1,7 +1,9 @@
 import pytest
+import datetime
+from itertools import product
 
 from sunpy.time.timerange import TimeRange, parse_time
-from sunpy.net.vso.attrs import Time, Instrument
+from sunpy.net.vso.attrs import Time, Instrument, Physobs
 from sunpy.net.dataretriever.client import QueryResponse
 import sunpy.net.dataretriever.sources.goes as goes
 from sunpy.net.fido_factory import UnifiedResponse
@@ -12,7 +14,7 @@ from hypothesis import given, example
 from sunpy.net.tests.strategies import goes_time
 
 LCClient = goes.GOESClient()
-
+UTCnow = datetime.datetime.utcnow()
 
 @pytest.mark.parametrize(
     "timerange,url_start,url_end",
@@ -23,7 +25,7 @@ LCClient = goes.GOESClient()
       'http://umbra.nascom.nasa.gov/goes/fits/2008/go1020080602.fits',
       'http://umbra.nascom.nasa.gov/goes/fits/2008/go1020080604.fits')])
 def test_get_url_for_time_range(timerange, url_start, url_end):
-    urls = LCClient._get_url_for_timerange(timerange)
+    urls = LCClient._get_url_for_timerange(timerange, physobs='IRRADIANCE')
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
@@ -31,42 +33,48 @@ def test_get_url_for_time_range(timerange, url_start, url_end):
 
 @given(goes_time())
 def test_can_handle_query(time):
-    ans1 = goes.GOESClient._can_handle_query(time, Instrument('goes'))
+    ans1 = goes.GOESClient._can_handle_query(time, Instrument('goes'), Physobs('IRRADIANCE'))
     assert ans1 is True
     ans2 = goes.GOESClient._can_handle_query(time)
     assert ans2 is False
     ans3 = goes.GOESClient._can_handle_query(time, Instrument('eve'))
     assert ans3 is False
 
+def test_can_handle_query_b():
+    assert LCClient._can_handle_query(Time('2016/06/15', '2016/06/17'), Instrument('goes'), Physobs('PARTICLE_FLUX'))
+    assert LCClient._can_handle_query(Time('2016/06/15', '2016/06/17'), Instrument('goes'), Physobs('INTENSITY'))
+    assert LCClient._can_handle_query(Time('2016/06/15', '2016/06/17'), Instrument('goes'), Physobs('IRRADIANCE'))
+    assert not LCClient._can_handle_query(Time('2016/06/15', '2016/06/17'), Instrument('goes'))
+
 
 def test_no_satellite():
     with pytest.raises(ValueError):
-        LCClient.search(Time("1950/01/01", "1950/02/02"), Instrument('goes'))
+        LCClient.search(Time("1950/01/01", "1950/02/02"), Instrument('goes'), Physobs('IRRADIANCE'))
 
 @example(a.Time("2006-08-01", "2006-08-01"))
-@example(a.Time("1983-05-01", "1983-05-02"))
+@example(a.Time("1980-01-03", "1980-01-05"))
 # This example tests a time range with a satellite jump and no overlap
 @example(a.Time("2009-11-30", "2009-12-3"))
 @given(goes_time())
-def test_query(time):
+@pytest.mark.online
+def test_query_a(time):
     tr = TimeRange(time.start, time.end)
-    if parse_time("1983-05-01") in tr:
+    if parse_time("1980-01-03") in tr:
         with pytest.raises(ValueError):
-            LCClient.search(time, Instrument('goes'))
+            LCClient.search(time, Instrument('goes'), Physobs('IRRADIANCE'))
     else:
-        qr1 = LCClient.search(time, Instrument('goes'))
+        qr1 = LCClient.search(time, Instrument('goes'), Physobs('IRRADIANCE'))
         assert isinstance(qr1, QueryResponse)
         assert qr1.time_range().start == time.start
         assert qr1.time_range().end == time.end
 
-
 @pytest.mark.online
-@pytest.mark.parametrize("time, instrument", [
-    (Time('1983/06/17', '1983/06/18'), Instrument('goes')),
-    (Time('2012/10/4', '2012/10/6'), Instrument('goes')),
+@pytest.mark.parametrize("time, instrument, physobs", [
+    (('1983/06/17', '1983/06/18'), 'goes', 'IRRADIANCE'),
+    (('2012/10/04', '2012/10/6'), 'goes', 'IRRADIANCE'),
 ])
-def test_get(time, instrument):
-    qr1 = LCClient.search(time, instrument)
+def test_get(time, instrument, physobs):
+    qr1 = LCClient.search(Time(*time), Instrument(instrument), Physobs(physobs))
     res = LCClient.fetch(qr1)
     download_list = res.wait(progress=False)
     assert len(download_list) == len(qr1)
@@ -74,19 +82,48 @@ def test_get(time, instrument):
 
 @pytest.mark.online
 def test_new_logic():
-    qr = LCClient.search(Time('2012/10/4', '2012/10/6'), Instrument('goes'))
+    qr = LCClient.search(Time('2012/10/4', '2012/10/6'), Instrument('goes'), Physobs('IRRADIANCE'))
     res = LCClient.fetch(qr)
     download_list = res.wait(progress=False)
     assert len(download_list) == len(qr)
-
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument, physobs",
+                         product([('2016/06/15', '2016/06/22'),
+                                   (UTCnow - datetime.timedelta(days=7), UTCnow)],
+                                  'goes', 'PARTICLE_FLUX')
+                         )
+def test_query_b(time, instrument, physobs): # FIXME: Fails
+    qr = LCClient.query(a.Time(*time), Instrument(instrument), Physobs(physobs))
+    assert len(qr) == 8
 
 @pytest.mark.online
-@pytest.mark.parametrize(
-    "time, instrument",
-    [(a.Time("2012/10/4", "2012/10/6"), a.Instrument("goes")),
-     (a.Time('2013/10/5', '2013/10/7'), a.Instrument("goes"))])
-def test_fido(time, instrument):
-    qr = Fido.search(a.Time('2012/10/4', '2012/10/6'), Instrument('goes'))
+@pytest.mark.parametrize("time, instrument, physobs, exp",
+                         [(Time('2016/06/15', '2016/06/22'), 'goes', 'IRRADIANCE', 8),
+                          (Time(UTCnow, UTCnow), 'goes', 'IRRADIANCE', 4) # FIXME: it gives 5
+                         ])
+def test_query_1(time, instrument, physobs, exp):
+    qr = LCClient.query(time, Instrument(instrument), Physobs(physobs))
+    assert len(qr) == exp
+
+#Downloads 2 FITS files with total
+#size of ~2.MB
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument, physobs",
+                         [(('2016/06/04', '2016/06/04 00:01:00'), 'goes', 'INTENSITY')])
+def test_query_2(time, instrument, physobs):
+    qr = LCClient.query(Time(*time), Instrument(instrument), Physobs(physobs))
+    res = LCClient.get(qr)
+    d_list = res.wait()
+    assert len(qr) == len(d_list)
+
+@pytest.mark.online
+@pytest.mark.parametrize("time, instrument, physobs",
+                         [(("2012/10/04", "2012/10/06"), "goes", 'INTENSITY'),
+                          (('2013/10/05', '2013/10/07'), "goes", 'INTENSITY')
+                         ])
+def test_fido(time, instrument, physobs):
+    print(a.Time(*time))
+    qr = Fido.search(a.Time(*time), a.Instrument(instrument), Physobs(physobs))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -13,6 +13,7 @@ from sunpy.net.vso.attrs import Time, Instrument, Physobs
 import sunpy.net.dataretriever.sources.goes as goes
 from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido
+from sunpy.net import attrs as a
 
 from hypothesis import given, example
 from sunpy.net.tests.strategies import goes_time


### PR DESCRIPTION
With this users can now download real-time data for GOES Client. Users need to supply an additional argument `Physobs` which can take three values `PARTICLE_FLUX, INTENSITY, IRRADIANCE`. Real-time logic has also been implemented.
## Usage

```
qr = Fido.search(a.Time, a.Instrument('goes'), a.Physobs('PARTICLE_FLUX')
```

@dpshelio @wafels 
Review. 
With this I'm done for my Summer of Code mid-terms. I will now work on polishing existing code that I've written.
