### PR TITLE
docs changes to make explicit SunPy's Python 2.7 and 3.x support

### DIFF
--- a/doc/source/guide/installation/index.rst
+++ b/doc/source/guide/installation/index.rst
@@ -2,10 +2,11 @@
 Installation
 ============
 
-SunPy is a Python package for solar physics, it relies on and enables the use
+SunPy is a Python package for solar physics.  It relies on and enables the use
 of the wider ecosystem of scientific Python packages for solar physics.
-Therefore getting a working SunPy installation is more about installing the
-whole scientific Python ecosystem than SunPy itself.
+Therefore a working SunPy installation is more about installing the scientific
+Python ecosystem than SunPy itself.  SunPy is Python 2.7.x, 3.4.x and 3.5.x
+compatible.
 
 If you are new to Python and scientific Python then continue to follow this
 guide to get setup with the whole environment. If you already have a working
@@ -18,17 +19,21 @@ Installing Scientific Python and SunPy
 --------------------------------------
 
 If you do not currently have a working scientific Python distribution this
-guide will set you up with the Anaconda Python distribution. Alternative options
-exist for different operating systems and can be found later in the
+guide will set you up with the Anaconda scientific Python distribution.
+Anaconda makes it easy to install and manage your scientific Python packages.
+Alternative scientific Python options exist and can be found later in the
 :ref:`advanced-install` section.
 
-Anaconda is a free distribution of Python and a large amount of common
-scientific packages, it is very powerful and easy to use. Installing Anaconda
-provides (almost) all the packages you need to use SunPy.
+Anaconda contains a free distribution of Python and a large number of common
+scientific packages.  Anaconda is very powerful and easy to use. Installing
+Anaconda provides (almost) all the packages you need to use SunPy.
 
 To install the Anaconda Python distribution follow the instructions
 `here <http://docs.continuum.io/anaconda/install.html>`_. You will need to
 select the correct download for your platform and follow the install procedure.
+Note that although Anaconda makes it simple to switch between Python versions,
+we recommend that new users install the latest Python 3.x version of Anaconda.
+This is because Python 2.7 is scheduled to be deprecated in 2020.
 
 Installing SunPy on top of Anaconda
 ###################################


### PR DESCRIPTION
Includes details given on http://www.uksolphys.org/general-news/sunpy-0-7-released/ about SunPy's Python support.  I believe it is important to let users know which versions of Python are supported - please correct me if we do not support 3.4.