### PR TITLE
Fix TRACE and Yohkoh map sources

### DIFF
--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -55,10 +55,21 @@ class TRACEMap(GenericMap):
         self.meta['obsrvtry'] = "TRACE"
         self._nickname = self.detector
         # Colour maps
-        self.plot_settings['cmap'] = cm.get_cmap('trace' + self.measurement)
+        self.plot_settings['cmap'] = cm.get_cmap('trace' + str(self.measurement))
         self.plot_settings['norm'] = colors.LogNorm()
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an TRACE image"""
         return header.get('instrume') == 'TRACE'
+
+    @property
+    def measurement(self):
+        """
+        Returns the measurement type.
+        """
+        s = self.meta['WAVE_LEN']
+        if s == 'WL':
+            s = 'white-light'
+            
+        return s

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -55,7 +55,7 @@ class TRACEMap(GenericMap):
         self.meta['obsrvtry'] = "TRACE"
         self._nickname = self.detector
         # Colour maps
-        self.plot_settings['cmap'] = cm.get_cmap('trace' + str(self.measurement))
+        self.plot_settings['cmap'] = cm.get_cmap('trace' + str(self.meta['WAVE_LEN']))
         self.plot_settings['norm'] = colors.LogNorm()
 
     @classmethod

--- a/sunpy/map/sources/yohkoh.py
+++ b/sunpy/map/sources/yohkoh.py
@@ -46,7 +46,7 @@ class SXTMap(GenericMap):
 
         self.meta['detector'] = "SXT"
         self.meta['telescop'] = "Yohkoh"
-        self.plot_settings['cmap'] = cm.get_cmap(name='yohkohsxt' + self.wavelength_string[0:2].lower())
+        self.plot_settings['cmap'] = cm.get_cmap(name='yohkohsxt' + self.measurement[0:2].lower())
         self.plot_settings['norm'] = ImageNormalize(stretch=PowerStretch(0.5))
 
         # 2012/12/19 - the SXT headers do not have a value of the distance from
@@ -67,7 +67,7 @@ class SXTMap(GenericMap):
         return self.meta.get('dsun_obs', self.meta['dsun_apparent'])
 
     @property
-    def wavelength_string(self):
+    def measurement(self):
         """
         Returns the type of data observed.
         """
@@ -75,7 +75,7 @@ class SXTMap(GenericMap):
         if s == 'Al.1':
             s = 'Al01'
         elif s.lower() == 'open':
-            s = 'white light'
+            s = 'white-light'
         return s
 
     @classmethod


### PR DESCRIPTION
Map Source (TRACE): Fix string conversion 
Map Source (TRACE): Add measurement type generation function to
standardize “white-light”  wavelength name
Map Source (Yohkoh): Rename method “wavelength_string” to “measurement” to keep consistency in all sources
Map Source (Yohkoh): standardize “white-light”  wavelength name