### PR TITLE
Get and set for normalization properties in CompositeMap 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Latest
 ------
 
+* Get and set methods for composite maps now use Map plot_settings.
 * Simplified map names when plotting.
 * Add time format used by some SDO HMI FITS keywords
 * Fix bug in `wcs.convert_data_to_pixel` where crpix[1] was used for both axes.

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -41,18 +41,18 @@ class CompositeMap(object):
         Prints a list of the currently included maps.
     get_alpha(index=None)
         Returns the alpha-channel value for a layer in the composite image
+    get_levels(index=None)
+        Returns the list of contour levels for a map within the CompositeMap.
+    get_plot_settings(index=None)
+        Returns the plot settings for a map within the CompositeMap.
     get_zorder(index=None)
         Returns the layering preference (z-order) for a map within the composite.
-    get_levels(index=None)
-        Returns the list of contour levels for a map within the CompositeMap
-    set_norm(self, index, norm)
-        Sets the norm for a layer in the composite image.
-    set_levels(index, levels, percent=False)
-        Sets the contour levels for a layer in the CompositeMap.
-    set_colors(index, cm)
-        Sets the color map for a layer in the CompositeMap.
     set_alpha(index, alpha)
         Sets the alpha-channel value for a layer in the CompositeMap.
+    set_levels(index, levels, percent=False)
+        Sets the contour levels for a layer in the CompositeMap.
+    set_plot_settings(index, plot_setiings)
+        Set the plot settings for a map with the CompositeMap.
     set_zorder(index, zorder)
         Set the layering preference (z-order) for a map within the CompositeMap.
     plot(figure=None, overlays=None, draw_limb=False, gamma=1.0,
@@ -97,7 +97,7 @@ class CompositeMap(object):
 
         Parameters
         ----------
-        map : `~sunpy.map.GenericMap` or subclass
+        amap : `~sunpy.map.GenericMap` or subclass
             Map instance to be added
         zorder : `int`
             The index to use when determining where the map should lie along
@@ -143,11 +143,54 @@ class CompositeMap(object):
         return self._maps[index]
 
     def get_alpha(self, index=None):
-        """Returns the alpha-channel value for a layer in the composite image"""
+        """
+        Returns the alpha-channel value for a layer in the composite image.
+        """
         if index is None:
             return [_map.alpha for _map in self._maps]
         else:
             return self._maps[index].alpha
+
+    def get_levels(self, index=None):
+        """Returns the list of contour levels for a map within the
+        composite.
+
+        Parameters
+        ----------
+        index : {`int` | None}
+            The index of the map in the composite map.
+
+        Returns
+        -------
+        `list`
+            A list of the contour levels of map at index 'index' in the
+            composite map.  If index is None, then the contour levels of all
+            the maps are returned as a list of lists.
+        """
+        if index is None:
+            return [_map.levels for _map in self._maps]
+        else:
+            return self._maps[index].levels
+
+    def get_plot_settings(self, index=None):
+        """Returns the plot settings for a map within the composite map.
+
+        Parameters
+        ----------
+        index : {`int` | None}
+            The index of the map in the composite map.
+
+        Returns
+        -------
+        {`dict` | `list`}
+            The plot settings of the map(s) in the composite map.  If None
+            then the plot settings of all the maps are returned in a list.
+        """
+
+        if index is None:
+            return [_map.plot_settings for _map in self._maps]
+        else:
+            return self._maps[index].plot_settings
 
     def get_zorder(self, index=None):
         """Returns the layering preference (z-order) for a map within the
@@ -170,46 +213,26 @@ class CompositeMap(object):
         else:
             return self._maps[index].zorder
 
-    def get_plot_settings(self, index=None):
-        """Returns the plot settings for a map within the composite map.
+    def set_alpha(self, index, alpha):
+        """Sets the alpha-channel value for a layer in the composite image.
 
         Parameters
         ----------
-        index : {`int` | None}
+        index : `int`
             The index of the map in the composite map.
+
+        alpha : `float`
+            A float in the range 0 to 1.
 
         Returns
         -------
-        {`dict` | `list`}
-            The plot settings of the map(s) in the composite map.  If None
-            then the plot settings of all the maps are returned in a list.
+        `~sunpy.map.CompositeMap`
+            A composite map with alpha-channel value 'alpha' at layer 'index'.
         """
-
-        if index is None:
-            return [_map.plot_settings for _map in self._maps]
+        if 0 <= alpha <= 1:
+            self._maps[index].alpha = alpha
         else:
-            return self._maps[index].plot_settings
-
-    def get_levels(self, index=None):
-        """Returns the list of contour levels for a map within the
-        composite.
-
-        Parameters
-        ----------
-        index : {`int` | None}
-            The index of the map in the composite map.
-
-        Returns
-        -------
-        `list`
-            A list of the contour levels of map at index 'index' in the
-            composite map.  If index is None, then the contour levels of all
-            the maps are returned as a list of lists.
-        """
-        if index is None:
-            return [_map.levels for _map in self._maps]
-        else:
-            return self._maps[index].levels
+            raise OutOfRangeAlphaValue("Alpha value must be between 0 and 1.")
 
     def set_levels(self, index, levels, percent=False):
         """
@@ -238,24 +261,6 @@ class CompositeMap(object):
         else:
             self._maps[index].levels = [self._maps[index].max()*level/100.0 for level in levels]
 
-    def set_colors(self, index, cm):
-        """Sets the color map for a layer in the composite image.
-
-        Parameters
-        ----------
-        index : `int`
-            The index of the map in the composite map.
-
-        cm : a color map
-            The contour levels.
-
-        Returns
-        -------
-        `~sunpy.map.CompositeMap`
-            A composite map with colormap 'cm' at layer 'index'.
-        """
-        self._maps[index].plot_settings['cmap'] = cm
-
     def set_plot_settings(self, index, plot_settings):
         """Sets the plot settings for a layer in the composite image.
 
@@ -274,27 +279,6 @@ class CompositeMap(object):
             'index'.
         """
         self._maps[index].plot_settings = plot_settings
-
-    def set_alpha(self, index, alpha):
-        """Sets the alpha-channel value for a layer in the composite image.
-
-        Parameters
-        ----------
-        index : `int`
-            The index of the map in the composite map.
-
-        alpha : `float`
-            A float in the range 0 to 1.
-
-        Returns
-        -------
-        `~sunpy.map.CompositeMap`
-            A composite map with alpha-channel value 'alpha' at layer 'index'.
-        """
-        if 0 <= alpha <= 1:
-            self._maps[index].alpha = alpha
-        else:
-            raise OutOfRangeAlphaValue("Alpha value must be between 0 and 1.")
 
     def set_zorder(self, index, zorder):
         """Set the layering order (z-order) for a map within the

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -45,7 +45,7 @@ class CompositeMap(object):
         Returns the layering preference (z-order) for a map within the composite.
     get_colors(index=None)
         Returns the colors for a map within the CompositeMap.
-    get_norm(index=None)
+    get_normalization(index=None)
         Returns the normalization for a map within the CompositeMap.
     get_levels(index=None)
         Returns the list of contour levels for a map within the CompositeMap
@@ -194,7 +194,7 @@ class CompositeMap(object):
         else:
             return self._maps[index].plot_settings['cmap']
 
-    def get_mpl_color_normalizer(self, index=None):
+    def get_normalization(self, index=None):
         """Returns the color normalizer for a map within the
         composite.
 
@@ -211,9 +211,9 @@ class CompositeMap(object):
             a list.
         """
         if index is None:
-            return [_map.mpl_color_normalizer for _map in self._maps]
+            return [_map.plot_settings['norm'] for _map in self._maps]
         else:
-            return self._maps[index].mpl_color_normalizer
+            return self._maps[index].plot_settings['norm']
 
     def get_levels(self, index=None):
         """Returns the list of contour levels for a map within the
@@ -281,7 +281,7 @@ class CompositeMap(object):
         """
         self._maps[index].plot_settings['cmap'] = cm
 
-    def set_norm(self, index, norm):
+    def set_normalization(self, index, norm):
         """Sets the normalization for a layer in the composite image.
 
         Parameters

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -43,10 +43,6 @@ class CompositeMap(object):
         Returns the alpha-channel value for a layer in the composite image
     get_zorder(index=None)
         Returns the layering preference (z-order) for a map within the composite.
-    get_colors(index=None)
-        Returns the colors for a map within the CompositeMap.
-    get_normalization(index=None)
-        Returns the normalization for a map within the CompositeMap.
     get_levels(index=None)
         Returns the list of contour levels for a map within the CompositeMap
     set_norm(self, index, norm)
@@ -174,8 +170,8 @@ class CompositeMap(object):
         else:
             return self._maps[index].zorder
 
-    def get_colors(self, index=None):
-        """Returns the colors for a map within the composite map.
+    def get_plot_settings(self, index=None):
+        """Returns the plot settings for a map within the composite map.
 
         Parameters
         ----------
@@ -184,36 +180,15 @@ class CompositeMap(object):
 
         Returns
         -------
-        {`sunpy.cm` | `list`}
-            The colormaps of the map(s) in the composite map.  If None then the
-            colormaps of all the maps are returned in a list.
+        {`dict` | `list`}
+            The plot settings of the map(s) in the composite map.  If None
+            then the plot settings of all the maps are returned in a list.
         """
 
         if index is None:
-            return [_map.plot_settings['cmap'] for _map in self._maps]
+            return [_map.plot_settings for _map in self._maps]
         else:
-            return self._maps[index].plot_settings['cmap']
-
-    def get_normalization(self, index=None):
-        """Returns the color normalizer for a map within the
-        composite.
-
-        Parameters
-        ----------
-        index : {`int` | None}
-            The index of the map in the composite map.
-
-        Returns
-        -------
-        {color normalizer | `list`}
-            The color normalizer(s) of the map(s) in the composite map.
-            If None then the color normalizers of all the maps are returned in
-            a list.
-        """
-        if index is None:
-            return [_map.plot_settings['norm'] for _map in self._maps]
-        else:
-            return self._maps[index].plot_settings['norm']
+            return self._maps[index].plot_settings
 
     def get_levels(self, index=None):
         """Returns the list of contour levels for a map within the
@@ -281,25 +256,24 @@ class CompositeMap(object):
         """
         self._maps[index].plot_settings['cmap'] = cm
 
-    def set_normalization(self, index, norm):
-        """Sets the normalization for a layer in the composite image.
+    def set_plot_settings(self, index, plot_settings):
+        """Sets the plot settings for a layer in the composite image.
 
         Parameters
         ----------
         index : `int`
             The index of the map in the composite map.
 
-        norm : `matplotlib.colors.Normalize`
-            A normalizer that stretches the color table as requires.
-            Note that Astropy has a number of Normalization objects
-            that may be useful.
+        plot_settings : `dict`
+            A dictionary of the form
 
         Returns
         -------
         `~sunpy.map.CompositeMap`
-            A composite map with normalization 'norm' at layer 'index'.
+            A composite map with plot settings 'plot_settings' at layer
+            'index'.
         """
-        self._maps[index].plot_settings['norm'] = norm
+        self._maps[index].plot_settings = plot_settings
 
     def set_alpha(self, index, alpha):
         """Sets the alpha-channel value for a layer in the composite image.

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -316,12 +316,12 @@ class CompositeMap(object):
         `matplotlib.axes.Axes`
         """
         if index is None:
-            for i,amap in enumerate(self._maps):
-                if hasattr(amap,'rsun_obs'):
+            for i, amap in enumerate(self._maps):
+                if hasattr(amap, 'rsun_obs'):
                     index = i
                     break
 
-        index_check = hasattr(self._maps[index],'rsun_obs')
+        index_check = hasattr(self._maps[index], 'rsun_obs')
         if not index_check or index is None:
             raise ValueError("Specified index does not have all the required attributes to draw limb.")
 
@@ -347,14 +347,14 @@ class CompositeMap(object):
         `matplotlib.axes.Axes` object
         """
         needed_attrs = ['rsun_meters', 'dsun', 'heliographic_latitude',
-                            'heliographic_longitude']
+                        'heliographic_longitude']
         if index is None:
             for i, amap in enumerate(self._maps):
-                if all([hasattr(amap,k) for k in needed_attrs]):
+                if all([hasattr(amap, k) for k in needed_attrs]):
                     index = i
                     break
 
-        index_check = all([hasattr(self._maps[index],k) for k in needed_attrs])
+        index_check = all([hasattr(self._maps[index], k) for k in needed_attrs])
         if not index_check or index is None:
             raise ValueError("Specified index does not have all the required attributes to draw grid.")
 
@@ -375,6 +375,9 @@ class CompositeMap(object):
         annotate : `bool`
             If true, the data is plotted at it's natural scale; with
             title and axis labels.
+
+        title : `str`
+            Title of the composite map.
 
         **matplot_args : `dict`
             Matplotlib Any additional imshow arguments that should be used
@@ -454,6 +457,12 @@ class CompositeMap(object):
         basic_plot : `bool`
             If true, the data is plotted by itself at it's natural scale; no
             title, labels, or axes are shown.
+
+        draw_limb : `bool`
+            If true, draws a circle representing the solar limb.
+
+        draw_grid :  `bool`
+            If true, draws a grid over the surface of the Sun.
 
         **matplot_args : dict
             Matplotlib Any additional imshow arguments that should be used

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -53,11 +53,11 @@ class CompositeMap(object):
         Sets the norm for a layer in the composite image.
     set_levels(index, levels, percent=False)
         Sets the contour levels for a layer in the CompositeMap.
-    set_colors(index=None, cm)
+    set_colors(index, cm)
         Sets the color map for a layer in the CompositeMap.
-    set_alpha(index=None, alpha)
+    set_alpha(index, alpha)
         Sets the alpha-channel value for a layer in the CompositeMap.
-    set_zorder(index=None, zorder)
+    set_zorder(index, zorder)
         Set the layering preference (z-order) for a map within the CompositeMap.
     plot(figure=None, overlays=None, draw_limb=False, gamma=1.0,
     draw_grid=False, colorbar=True, basic_plot=False,title="SunPy Plot",
@@ -236,24 +236,6 @@ class CompositeMap(object):
         else:
             return self._maps[index].levels
 
-    def set_mpl_color_normalizer(self, index, norm):
-        """Sets the color normalizer for a layer in the composite image.
-
-        Parameters
-        ----------
-        index : `int`
-            The index of the map in the composite map.
-
-        norm : a color normalizer
-            The function used to stretch the color table.
-
-        Returns
-        -------
-        `~sunpy.map.CompositeMap`
-            Sets the color normalizer of the map at index 'index' in the
-            composite map to the value given by 'norm'."""
-        self._maps[index].mpl_color_normalizer = norm
-
     def set_levels(self, index, levels, percent=False):
         """
         Sets the contour levels for a layer in the composite image.
@@ -298,6 +280,26 @@ class CompositeMap(object):
             A composite map with colormap 'cm' at layer 'index'.
         """
         self._maps[index].plot_settings['cmap'] = cm
+
+    def set_norm(self, index, norm):
+        """Sets the normalization for a layer in the composite image.
+
+        Parameters
+        ----------
+        index : `int`
+            The index of the map in the composite map.
+
+        norm : `matplotlib.colors.Normalize`
+            A normalizer that stretches the color table as requires.
+            Note that Astropy has a number of Normalization objects
+            that may be useful.
+
+        Returns
+        -------
+        `~sunpy.map.CompositeMap`
+            A composite map with normalization 'norm' at layer 'index'.
+        """
+        self._maps[index].plot_settings['norm'] = norm
 
     def set_alpha(self, index, alpha):
         """Sets the alpha-channel value for a layer in the composite image.


### PR DESCRIPTION
The get and set methods for the normalization of each layer in the CompositeMap object were not using the plot_settings property of the constituent maps.  This PR fixes that, and allows users to get and set the normalization of each layer in the CompositeMap object following the same API as the other get and set methods.  The relevant docstrings are also updated, and others are changed to be a bit more accurate on usage.