### PR TITLE
Read any valid HDUs if bad HDUs exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Latest
 * Now the `sunpy.database.tables.display_entries()` prints an astropy table.
 * Additional methods added inside the `sunpy.database` class to make it easier
   to display the database contents.
+* `sunpy.io.fits.read` will now return any parse-able HDUs even if some raise an error.
 
 0.7.0
 -----


### PR DESCRIPTION
This patch makes sunpy.io.fits.read return any valid HDUs rather than erroring if one or more HDUs are invalid (can not be read by astropy.io.fits). It raises a warning with the full last traceback as the warning message to give the user some debugging information.

This is born out of old GOES data having the science data in a valid primary HDU and other data in an invalid BinTable HDU afterwards, this allows us to get the interesting science data while ignoring the bad table.

ping @Alex-Ian-Hamilton @DanRyanIrish 