### PR TITLE
[0.6] fixes the helioviewer API root to take account of the change to HTTPS

### DIFF
--- a/sunpy/net/helioviewer.py
+++ b/sunpy/net/helioviewer.py
@@ -23,7 +23,7 @@ __all__ = ['HelioviewerClient']
 
 class HelioviewerClient(object):
     """Helioviewer.org Client"""
-    def __init__(self, url="http://legacy.helioviewer.org/api/"):
+    def __init__(self, url="https://legacy.helioviewer.org/api/"):
         """
         url : location of the Helioviewer API.  The default location points to
             version 1 of the API.  Version 1 of the Helioviewer API is


### PR DESCRIPTION
This PR fixes the helioviewer API root to take account of the change to HTTPS on the helioviewer.org server.