### PR TITLE
Remove nesting of AttrAnd and AttrOr in Attr base

### DIFF
--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -39,6 +39,8 @@ class Attr(object):
             return AttrOr([elem & self for elem in other.attrs])
         if self.collides(other):
             return NotImplemented
+        if isinstance(other, AttrAnd):
+            return AttrAnd([self] + list(other.attrs))
         return AttrAnd([self, other])
 
     def __hash__(self):
@@ -48,6 +50,8 @@ class Attr(object):
         # Optimization.
         if self == other:
             return self
+        if isinstance(other, AttrOr):
+            return AttrOr([self] + list(other.attrs))
         return AttrOr([self, other])
 
     def collides(self, other):
@@ -254,6 +258,7 @@ def and_(*args):
     for elem in args:
         value &= elem
     return value
+
 
 def or_(*args):
     """ Trick operator precedence.

--- a/sunpy/net/tests/test_attr.py
+++ b/sunpy/net/tests/test_attr.py
@@ -4,9 +4,24 @@
 from __future__ import absolute_import
 
 from sunpy.net import attr
+from sunpy.net.vso import attrs
 
 def test_dummyattr():
     one = attr.DummyAttr()
     other = attr.ValueAttr({'a': 'b'})
     assert (one | other) is other
     assert (one & other) is other
+
+def test_and_nesting():
+    a = attr.and_(attrs.Level(0),
+                  attr.AttrAnd((attrs.Instrument('EVE'),
+                                attrs.Time("2012/1/1", "2012/01/02"))))
+    # Test that the nesting has been removed.
+    assert len(a.attrs) == 3
+
+def test_or_nesting():
+    a = attr.or_(attrs.Instrument('a'),
+                  attr.AttrOr((attrs.Instrument('b'),
+                               attrs.Instrument('c'))))
+    # Test that the nesting has been removed.
+    assert len(a.attrs) == 3


### PR DESCRIPTION
This changes the base Attr class so doing `and_(Attr, AttrAnd)` doe sresult in nested AttrAnd or AttrOr objects.

ping @derdon @segfaulthunter @dpshelio 
