### PR TITLE
Map should error nicely if not passed a 2D array

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -158,9 +158,30 @@ class GenericMap(NDData):
         this class will not process the WCS.
         Also the rotation_matrix does not work if the CDELT1 and CDELT2
         keywords are exactly equal.
+        Also, if a file with more than two dimensions is loaded into the class,
+        only the first two dimensions (NAXIS1, NAXIS2) will be loaded, and the
+        rest will be discarded.
     """
 
     def __init__(self, data, header, plot_settings=None, **kwargs):
+
+
+        # If the data has more than two dimensions, the first dimensions
+        # (NAXIS1, NAXIS2) are used and the rest are discarded.
+        N_DIM = len(data.shape)
+        if N_DIM > 2:
+            # We create a slice that removes all but the 'last' two
+            # dimensions. (Note dimensions in ndarray are in reverse order)
+
+            new_2d_slice = [0]*(N_DIM-2)
+            new_2d_slice.extend([slice(None),slice(None)])
+            data = data[new_2d_slice]
+            # Warn the user that the data has been truncated
+            warnings.warn_explicit("This file contains more than 2 dimensions. "
+                    "Only the first two dimensions will be used."
+                    " The truncated data will not be saved in a new file.",
+                    Warning, __file__,
+                    inspect.currentframe().f_back.f_lineno)
 
         super(GenericMap, self).__init__(data, meta=header, **kwargs)
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -158,30 +158,28 @@ class GenericMap(NDData):
         this class will not process the WCS.
         Also the rotation_matrix does not work if the CDELT1 and CDELT2
         keywords are exactly equal.
-        Also, if a file with more than two dimensions is loaded into the class,
-        only the first two dimensions (NAXIS1, NAXIS2) will be loaded, and the
+        Also, if a file with more than two dimensions is feed into the class,
+        only the first two dimensions (NAXIS1, NAXIS2) will be loaded and the
         rest will be discarded.
     """
 
     def __init__(self, data, header, plot_settings=None, **kwargs):
 
-
         # If the data has more than two dimensions, the first dimensions
         # (NAXIS1, NAXIS2) are used and the rest are discarded.
-        N_DIM = len(data.shape)
-        if N_DIM > 2:
+        ndim = data.ndim
+        if ndim > 2:
             # We create a slice that removes all but the 'last' two
             # dimensions. (Note dimensions in ndarray are in reverse order)
 
-            new_2d_slice = [0]*(N_DIM-2)
-            new_2d_slice.extend([slice(None),slice(None)])
+            new_2d_slice = [0]*(ndim-2)
+            new_2d_slice.extend([slice(None), slice(None)])
             data = data[new_2d_slice]
             # Warn the user that the data has been truncated
             warnings.warn_explicit("This file contains more than 2 dimensions. "
-                    "Only the first two dimensions will be used."
-                    " The truncated data will not be saved in a new file.",
-                    Warning, __file__,
-                    inspect.currentframe().f_back.f_lineno)
+                                   "Only the first two dimensions will be used."
+                                   " The truncated data will not be saved in a new file.",
+                                   Warning, __file__, inspect.currentframe().f_back.f_lineno)
 
         super(GenericMap, self).__init__(data, meta=header, **kwargs)
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -653,4 +653,4 @@ def test_more_than_two_dimensions():
     bad_map = sunpy.map.Map(bad_data, hdr)
     # Test fails if map.ndim > 2 and if the dimensions of the array are wrong.
     assert bad_map.ndim is 2
-    assert_quantity_allclose(bad_map.dimensions, (5 * u.pix, 3 * u.pix))
+    assert_quantity_allclose(bad_map.dimensions, (5, 3) * u.pix)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -648,6 +648,11 @@ def test_more_than_two_dimensions():
     bad_data = np.random.rand(2,2,2)
     hdr = fits.Header()
     hdr['TELESCOP'] = 'XXX'
-    bad_map = sunpy.map.Map(bad_data, hdr)
+    # Test fails if there is no user warning
+    warnings.simplefilter('always')
+    pytest.warns(Warning,'sunpy.map.Map(bad_data, hdr)')
     # Test fails if the bad_map.__repr__() causes an exception
+    bad_map = sunpy.map.Map(bad_data, hdr)
     repr(bad_map)
+    # Test fails if map.ndim > 2
+    assert bad_map.ndim is 2

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -639,3 +639,15 @@ def test_hc_warn():
 
     with pytest.warns(UserWarning):
         sunpy.map.Map((data, header))
+
+def test_more_than_two_dimensions():
+    """Check to see if an appropriate error is provided when a FIT data with more than two dimensions is loaded
+    Fixes #1919
+    To replicate the bug we need to load a >2-dim dataset with a OBSERVATORY header
+    """
+    bad_data = np.random.rand(2,2,2)
+    hdr = fits.Header()
+    hdr['TELESCOP'] = 'XXX'
+    bad_map = sunpy.map.Map(bad_data, hdr)
+    # Test fails if the bad_map.__repr__() causes an exception
+    repr(bad_map)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -30,7 +30,6 @@ from sunpy.extern import six
 
 testpath = sunpy.data.test.rootdir
 
-
 @pytest.fixture
 def aia171_test_map():
     return sunpy.map.Map(os.path.join(testpath, 'aia_171_level1.fits'))
@@ -640,19 +639,18 @@ def test_hc_warn():
     with pytest.warns(UserWarning):
         sunpy.map.Map((data, header))
 
+# Dimension testing
+
+
 def test_more_than_two_dimensions():
-    """Check to see if an appropriate error is provided when a FIT data with more than two dimensions is loaded
-    Fixes #1919
-    To replicate the bug we need to load a >2-dim dataset with a OBSERVATORY header
-    """
-    bad_data = np.random.rand(2,2,2)
+    """Checks to see if an appropriate error is raised when a FITs with more than two dimensions is loaded.
+    We need to load a >2-dim dataset with a TELESCOP header"""
+
+    # Data crudely represnts 4 stokes, 4 wavelengths with Y,X of 3 and 5.
+    bad_data = np.random.rand(4, 4, 3, 5)
     hdr = fits.Header()
     hdr['TELESCOP'] = 'XXX'
-    # Test fails if there is no user warning
-    warnings.simplefilter('always')
-    pytest.warns(Warning,'sunpy.map.Map(bad_data, hdr)')
-    # Test fails if the bad_map.__repr__() causes an exception
     bad_map = sunpy.map.Map(bad_data, hdr)
-    repr(bad_map)
-    # Test fails if map.ndim > 2
+    # Test fails if map.ndim > 2 and if the dimensions of the array are wrong.
     assert bad_map.ndim is 2
+    assert_quantity_allclose(bad_map.dimensions, (5 * u.pix, 3 * u.pix))


### PR DESCRIPTION
Fixes #1919 
This pull request fixes the referenced error by removing all but the first two dimensions of the array and providing a warning to the user.
