### PR TITLE
make peek(basic_plot=True) not issue warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Latest
 * `sunpy.io.fits.read` will now return any parse-able HDUs even if some raise an error.
 * `VSOClient` no longer prints a lot of XML junk if the query fails.
 * Remove unused `sunpy.visualization.plotting` module
+* `Map.peek(basic_plot=True)` no longer issues warnings
 
 0.7.0
 -----

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1546,8 +1546,7 @@ scale:\t\t {scale}
             axes = plt.Axes(figure, [0., 0., 1., 1.])
             axes.set_axis_off()
             figure.add_axes(axes)
-            matplot_args.update({'annotate': False})
-            matplot_args.update({"_basic_plot": True})
+            matplot_args.update({'annotate': False, "_basic_plot": True})
 
         # Normal plot
         else:
@@ -1604,7 +1603,7 @@ scale:\t\t {scale}
         """
 
         # extract hiddden kwarg
-        _basic_plot = imshow_kwargs.pop("_basic_plot", None)
+        _basic_plot = imshow_kwargs.pop("_basic_plot", False)
 
         # Get current axes
         if not axes:
@@ -1615,12 +1614,12 @@ scale:\t\t {scale}
             if (not wcsaxes_compat.is_wcsaxes(axes) and
                 not np.array_equal(self.rotation_matrix, np.matrix(np.identity(2)))):
                 warnings.warn("This map is not properly oriented. Plot axes may be incorrect",
-                            Warning)
+                              Warning)
 
             if not wcsaxes_compat.is_wcsaxes(axes) and wcsaxes_compat.HAVE_WCSAXES:
                 warnings.warn("WCSAxes is installed but not being used."
-                            " Plots may not have the expected behaviour.",
-                            Warning)
+                              " Plots may not have the expected behaviour.",
+                              Warning)
 
         # Normal plot
         imshow_args = deepcopy(self.plot_settings)
@@ -1663,7 +1662,7 @@ scale:\t\t {scale}
         if wcsaxes_compat.is_wcsaxes(axes):
             wcsaxes_compat.default_wcs_grid(axes)
 
-        #Set current image (makes colorbar work)
+        # Set current image (makes colorbar work)
         plt.sca(axes)
         plt.sci(ret)
         return ret

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1546,7 +1546,8 @@ scale:\t\t {scale}
             axes = plt.Axes(figure, [0., 0., 1., 1.])
             axes.set_axis_off()
             figure.add_axes(axes)
-            matplot_args.update({'annotate':False})
+            matplot_args.update({'annotate': False})
+            matplot_args.update({"_basic_plot": True})
 
         # Normal plot
         else:
@@ -1602,20 +1603,24 @@ scale:\t\t {scale}
 
         """
 
+        # extract hiddden kwarg
+        _basic_plot = imshow_kwargs.pop("_basic_plot", None)
+
         # Get current axes
         if not axes:
             axes = wcsaxes_compat.gca_wcs(self.wcs)
 
-        # Check that the image is properly oriented
-        if (not wcsaxes_compat.is_wcsaxes(axes) and
-            not np.array_equal(self.rotation_matrix, np.matrix(np.identity(2)))):
-            warnings.warn("This map is not properly oriented. Plot axes may be incorrect",
-                          Warning)
+        if not _basic_plot:
+            # Check that the image is properly oriented
+            if (not wcsaxes_compat.is_wcsaxes(axes) and
+                not np.array_equal(self.rotation_matrix, np.matrix(np.identity(2)))):
+                warnings.warn("This map is not properly oriented. Plot axes may be incorrect",
+                            Warning)
 
-        if not wcsaxes_compat.is_wcsaxes(axes) and wcsaxes_compat.HAVE_WCSAXES:
-            warnings.warn("WCSAxes is installed but not being used."
-                          " Plots may not have the expected behaviour.",
-                          Warning)
+            if not wcsaxes_compat.is_wcsaxes(axes) and wcsaxes_compat.HAVE_WCSAXES:
+                warnings.warn("WCSAxes is installed but not being used."
+                            " Plots may not have the expected behaviour.",
+                            Warning)
 
         # Normal plot
         imshow_args = deepcopy(self.plot_settings)


### PR DESCRIPTION
When doing basic plot the rotation of the image and using WCSAxes are not valid warnings.
