### PR TITLE
Add a North Offset factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
         - ASTROPY_VERSION='stable'
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='astropy astropy-ci-extras conda-forge'
-        - CONDA_DEPENDENCIES='glymur openjpeg Cython jinja2 scipy matplotlib requests beautifulsoup4 sqlalchemy scikit-image pytest wcsaxes pyyaml pandas nomkl pytest-cov coverage'
+        - CONDA_DEPENDENCIES='glymur openjpeg Cython jinja2 scipy matplotlib requests beautifulsoup4 sqlalchemy scikit-image pytest wcsaxes pyyaml pandas nomkl pytest-cov coverage hypothesis'
         - PIP_DEPENDENCIES='suds-jurko sphinx-gallery'
 
     matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Latest
 * `Map.peek(basic_plot=True)` no longer issues warnings
 * Remove the `sunpy.map.nddata_compat` module, this makes `Map.data` and
   `Map.meta` read only.
+* Add a `NorthOffsetFrame` class for generating HGS-like coordinate systems with a shifted north pole.
 
 0.7.0
 -----

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
       # See: http://stackoverflow.com/a/13751649/163740
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       CONDA_CHANNELS: "astropy astropy-ci-extras sunpy jevans"
-      CONDA_DEPENDENCIES: "numpy scipy astropy matplotlib pandas requests beautifulsoup4 sqlalchemy scikit-image pytest wcsaxes suds-jurko"
+      CONDA_DEPENDENCIES: "numpy scipy astropy matplotlib pandas requests beautifulsoup4 sqlalchemy scikit-image pytest wcsaxes suds-jurko hypothesis"
       PIP_DEPENDENCIES: "Glymur"
 
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       # /E:ON and /V:ON options are not enabled in the batch script intepreter
       # See: http://stackoverflow.com/a/13751649/163740
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-      CONDA_CHANNELS: "astropy astropy-ci-extras sunpy jevans"
+      CONDA_CHANNELS: "conda-forge astropy-ci-extras"
       CONDA_DEPENDENCIES: "numpy scipy astropy matplotlib pandas requests beautifulsoup4 sqlalchemy scikit-image pytest wcsaxes suds-jurko hypothesis"
       PIP_DEPENDENCIES: "Glymur"
 

--- a/doc/source/code_ref/coordinates.rst
+++ b/doc/source/code_ref/coordinates.rst
@@ -212,6 +212,9 @@ sunpy.coordinates Package
 .. automodapi:: sunpy.coordinates.representation
     :headings: ^#
 
+.. automodapi:: sunpy.coordinates.offset_frame
+    :headings: ^#
+
 .. automodapi:: sunpy.coordinates.wcs_utils
     :headings: ^#
 

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 
 from .frames import *
+from .offset_frame import *
 from .transformations import *
 
 from .wcs_utils import *

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -38,7 +38,7 @@ class NorthOffsetFrame():
         rep = origin_frame.represent_as(SphericalRepresentation)
         lon = rep.lon
         lat = rep.lat
-        if rep.lat > 0*u.deg:
+        if lat > 0*u.deg:
             lat = lat - 90*u.deg
             rotation = None
         else:

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -67,6 +67,11 @@ class NorthOffsetFrame(object):
     Using this frame is equivalent to using
     `~astropy.coordinates.SkyOffsetFrame` with ``lat = lat - 90*u.deg`` for a
     position of the north pole in the original northern hemisphere.
+
+    This class will only work for Heliographic-Stonyhurst and Heliographic
+    Carrington frames, and not helioprojective. If you want to rotate a
+    helioprojective frame, it would be more natural to use the
+    `~astropy.coordinates.SkyOffsetFrame`.
     """
 
     def __new__(cls, *args, **kwargs):

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -17,6 +17,46 @@ class NorthOffsetFrame():
     you to specify the position of the new north pole rather than the new
     origin to centre the new frame.
 
+    Examples
+    --------
+
+    A common use for this is to create a frame derived from Heliographic, which
+    has the north pole at some point of interest. In this new frame, lines of
+    longitude form great circles radially away from the point, and lines of
+    latitude measure angular distance from the point.
+
+    In this example the new frame is shifted so the new north pole is at (20,
+    20)˚ in the Heliographic Stonyhurst frame. The new grid is overplotted in
+    blue.
+
+    .. plot::
+        :include-source:
+
+        import matplotlib.pyplot as plt
+        import astropy.units as u
+
+        from astropy.coordinates import SkyCoord
+        from sunpy.coordinates import NorthOffsetFrame
+
+        import sunpy.map
+        from sunpy.data.sample import AIA_171_IMAGE
+
+        m = sunpy.map.Map(AIA_171_IMAGE)
+
+        north = SkyCoord(20*u.deg, 20*u.deg, frame="heliographic_stonyhurst")
+        new_frame = NorthOffsetFrame(north=north)
+
+        ax = plt.subplot(projection=m)
+        m.plot()
+
+        overlay = ax.get_coords_overlay('heliographic_stonyhurst')
+        overlay[0].set_ticks(spacing=30. * u.deg, color='white')
+        overlay.grid(ls='-', color='white')
+
+        overlay = ax.get_coords_overlay(new_frame)
+        overlay[0].set_ticks(spacing=30. * u.deg)
+        overlay.grid(ls='-', color='blue')
+
     Notes
     -----
     ``NorthOffsetFrame`` is a wrapper around the

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -1,0 +1,45 @@
+import astropy.units as u
+from astropy.coordinates import SkyOffsetFrame, SphericalRepresentation
+
+__all__ = ['NorthOffsetFrame']
+
+
+class NorthOffsetFrame():
+    """
+    A frame which is relative to some position and another frame. Based on
+    `astropy.coordinates.SkyOffsetFrame`
+
+    Coordinates in a NorthOffsetFrame are both centered on the position
+    specified bu the ``north`` keyword *and* they are oriented in the same
+    manner as the ``north`` frame.
+
+    Unlike `~astropy.coordinates.SkyOffsetFrame` a `NorthOffsetFrame` allows
+    you to specify the position of the new north pole rather than the new
+    origin to centre the new frame.
+
+    Notes
+    -----
+    ``NorthOffsetFrame`` is a wrapper around the
+    `~astropy.coordinates.SkyOffsetFrame` factory class. This class will
+    calculate the desired coordianates of the ``origin`` from the ``north``
+    keyword argument and then create a `~astropy.coordinates.SkyOffsetFrame`.
+
+    Using this frame is equivalent to using
+    `~astropy.coordinates.SkyOffsetFrame` with ``lat = lat - 90*u.deg``
+    """
+
+    def __new__(cls, *args, **kwargs):
+        origin_frame = kwargs.pop('north', None)
+        if origin_frame is None:
+            raise TypeError("Can't initialize an NorthOffsetFrame without origin= keyword.")
+        if hasattr(origin_frame, 'frame'):
+            origin_frame = origin_frame.frame
+
+        rep = origin_frame.represent_as(SphericalRepresentation)
+        new_rep = SphericalRepresentation(lon=rep.lon,
+                                          lat=rep.lat - 90*u.deg,
+                                          distance=rep.distance)
+
+        new_origin = origin_frame.realize_frame(new_rep)
+        kwargs['origin'] = new_origin
+        return SkyOffsetFrame(*args, **kwargs)

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -36,10 +36,20 @@ class NorthOffsetFrame():
             origin_frame = origin_frame.frame
 
         rep = origin_frame.represent_as(SphericalRepresentation)
-        new_rep = SphericalRepresentation(lon=rep.lon,
-                                          lat=rep.lat - 90*u.deg,
+        lon = rep.lon
+        lat = rep.lat
+        if rep.lat > 0*u.deg:
+            lat = lat - 90*u.deg
+            rotation = None
+        else:
+            lon = lon - 180*u.deg
+            lat = -90*u.deg - lat
+            rotation = 180*u.deg
+        new_rep = SphericalRepresentation(lon=lon,
+                                          lat=lat,
                                           distance=rep.distance)
 
         new_origin = origin_frame.realize_frame(new_rep)
         kwargs['origin'] = new_origin
+        kwargs['rotation'] = rotation
         return SkyOffsetFrame(*args, **kwargs)

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -26,7 +26,7 @@ class NorthOffsetFrame():
     latitude measure angular distance from the point.
 
     In this example the new frame is shifted so the new north pole is at (20,
-    20)˚ in the Heliographic Stonyhurst frame. The new grid is overplotted in
+    20) in the Heliographic Stonyhurst frame. The new grid is overplotted in
     blue.
 
     .. plot::

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -4,7 +4,7 @@ from astropy.coordinates import SkyOffsetFrame, SphericalRepresentation
 __all__ = ['NorthOffsetFrame']
 
 
-class NorthOffsetFrame():
+class NorthOffsetFrame(object):
     """
     A frame which is relative to some position and another frame. Based on
     `astropy.coordinates.SkyOffsetFrame`

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -1,5 +1,5 @@
 import astropy.units as u
-from astropy.coordinates import SkyOffsetFrame, SphericalRepresentation
+from astropy.coordinates import SkyOffsetFrame, SphericalRepresentation, UnitSphericalRepresentation
 
 __all__ = ['NorthOffsetFrame']
 
@@ -91,9 +91,14 @@ class NorthOffsetFrame(object):
             lat = -90*u.deg - lat
             rotation = 180*u.deg
 
-        new_rep = origin_frame.representation(lon=lon,
-                                              lat=lat,
-                                              distance=rep.distance)
+        if isinstance(origin_frame.data, UnitSphericalRepresentation):
+            new_rep = origin_frame.representation(lon=lon,
+                                                  lat=lat)
+
+        else:
+            new_rep = origin_frame.representation(lon=lon,
+                                                  lat=lat,
+                                                  distance=rep.distance)
 
         new_origin = origin_frame.realize_frame(new_rep)
         kwargs['origin'] = new_origin

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -65,7 +65,8 @@ class NorthOffsetFrame():
     keyword argument and then create a `~astropy.coordinates.SkyOffsetFrame`.
 
     Using this frame is equivalent to using
-    `~astropy.coordinates.SkyOffsetFrame` with ``lat = lat - 90*u.deg``
+    `~astropy.coordinates.SkyOffsetFrame` with ``lat = lat - 90*u.deg`` for a
+    position of the north pole in the original northern hemisphere.
     """
 
     def __new__(cls, *args, **kwargs):
@@ -75,7 +76,11 @@ class NorthOffsetFrame():
         if hasattr(origin_frame, 'frame'):
             origin_frame = origin_frame.frame
 
-        rep = origin_frame.represent_as(SphericalRepresentation)
+        if not isinstance(origin_frame.data, SphericalRepresentation):
+            rep = origin_frame.represent_as(SphericalRepresentation)
+        else:
+            rep = origin_frame.data
+
         lon = rep.lon
         lat = rep.lat
         if lat > 0*u.deg:
@@ -85,11 +90,13 @@ class NorthOffsetFrame():
             lon = lon - 180*u.deg
             lat = -90*u.deg - lat
             rotation = 180*u.deg
-        new_rep = SphericalRepresentation(lon=lon,
-                                          lat=lat,
-                                          distance=rep.distance)
+
+        new_rep = origin_frame.representation(lon=lon,
+                                              lat=lat,
+                                              distance=rep.distance)
 
         new_origin = origin_frame.realize_frame(new_rep)
         kwargs['origin'] = new_origin
         kwargs['rotation'] = rotation
+
         return SkyOffsetFrame(*args, **kwargs)

--- a/sunpy/coordinates/tests/test_offset_frame.py
+++ b/sunpy/coordinates/tests/test_offset_frame.py
@@ -1,0 +1,33 @@
+import pytest
+import numpy as np
+
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.coordinates import SkyCoord, SkyOffsetFrame
+
+from sunpy.coordinates import NorthOffsetFrame
+
+
+def test_null():
+    """
+    test init of a frame where the origins are the same.
+    """
+    off = NorthOffsetFrame(north=SkyCoord(0*u.deg, 90*u.deg,
+                                          frame='heliographic_stonyhurst'))
+    assert isinstance(off, SkyOffsetFrame)
+    assert off.origin.lat == 0*u.deg
+    assert off.origin.lon == 0*u.deg
+
+
+def test_transform(lon=0*u.deg, lat=0*u.deg):
+    """
+    Test that the north pole in the new frame transforms back to the given
+    north argument.
+    """
+    north = SkyCoord(lon=lon, lat=lat, frame='heliographic_stonyhurst')
+    off = NorthOffsetFrame(north=north)
+    t_north = SkyCoord(lon=0*u.deg, lat=90*u.deg, frame=off)
+    t_north = t_north.transform_to('heliographic_stonyhurst')
+    assert_quantity_allclose(north.lon, t_north.lon, rtol=1e6)
+    assert_quantity_allclose(north.lat, t_north.lat, rtol=1e6)
+

--- a/sunpy/coordinates/tests/test_offset_frame.py
+++ b/sunpy/coordinates/tests/test_offset_frame.py
@@ -47,6 +47,13 @@ def test_transform(lon, lat):
     assert_quantity_allclose(north.lat, t_north.lat, atol=1e6*u.deg)
 
 
+def test_south_pole():
+    s = SkyCoord(-10*u.deg, 0*u.deg, frame='heliographic_stonyhurst')
+    off = NorthOffsetFrame(north=s)
+    assert_quantity_allclose(off.origin.lon, 170*u.deg)
+    assert_quantity_allclose(off.origin.lat, -90*u.deg)
+
+
 def test_error():
     with pytest.raises(TypeError):
         NorthOffsetFrame()


### PR DESCRIPTION
This allows the user to shift the north pole of a coordinate frame, which means lines of longitude are great circles from that point.

i.e.

```python
north = SkyCoord(20*u.deg, 20*u.deg, frame="heliographic_stonyhurst")
f = NorthOffsetFrame(north=north)

fig = plt.figure(figsize=(10,10))
ax = fig.add_subplot(111, projection=m)
m.plot()

overlay = ax.get_coords_overlay(f)
overlay[0].set_ticks(spacing=20. * u.deg, color='white')
overlay.grid(ls='-', color='red')
```
![great_circ](https://cloud.githubusercontent.com/assets/1391051/19917319/b525aeb6-a087-11e6-9755-c12a3db147c6.png)

ping @wafels @dpshelio 
