### PR TITLE
Modify test data machinery to use astropy package data

### DIFF
--- a/doc/source/code_ref/data.rst
+++ b/doc/source/code_ref/data.rst
@@ -1,0 +1,9 @@
+SunPy data
+==========
+
+The SunPy data module contains ways to access sample data and small test files
+for running the SunPy test suite.
+
+.. automodapi:: sunpy.data
+
+.. automodapi:: sunpy.data.test

--- a/doc/source/code_ref/index.rst
+++ b/doc/source/code_ref/index.rst
@@ -10,6 +10,7 @@ API Reference
    sunpy
    cm
    coordinates
+   data
    database
    image
    instr/index

--- a/sunpy/data/test/__init__.py
+++ b/sunpy/data/test/__init__.py
@@ -1,29 +1,44 @@
 """SunPy test data files"""
 from __future__ import absolute_import
-import sunpy
+
 import os
 import glob
 
-__author__ = "Keith Hughitt"
-__email__ = "keith.hughitt@nasa.gov"
+from astropy.utils.data import get_pkg_data_filename
+
+import sunpy
+
+__all__ = ['rootdir', 'file_list', 'get_test_filename']
 
 rootdir = os.path.join(os.path.dirname(sunpy.__file__), "data", "test")
 
-#
-# EVE
-#
-EVE_LEVEL0_CSV = os.path.join(rootdir, "LATEST_EVE_L0CS_DIODES_1m.txt")
-EVE_AVERAGES_CSV = os.path.join(rootdir, "EVE_He_II_304_averages.csv")
+def get_test_filename(filename, **kwargs):
+    """
+    Return the full path to a test file in the ``data/test`` directory.
 
-#
-# JPEG2000 sample
-#
-AIA_193_JP2 = os.path.join(rootdir,
-                           "2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")
+    Parameters
+    ----------
+    filename : `str`
+        The name of the file inside the ``data/test`` directory.
 
-#
-# aiaprep() test Map
-#
-aia_171_level1 = os.path.join(rootdir, "aia_171_level1.fits")
+    Return
+    ------
+    filepath : `str`
+        The full path to the file.
+
+    See Also
+    --------
+
+    astropy.utils.data.get_pkg_data_filename : Get package data filename
+
+    Notes
+    -----
+
+    This is a wrapper around `astropy.utils.data.get_pkg_data_filename` which
+    sets the ``package`` kwarg to be 'sunpy.data.test`.
+
+    """
+    return get_pkg_data_filename(filename, package="sunpy.data.test", **kwargs)
+
 
 file_list = glob.glob(os.path.join(rootdir, '*.[!p]*'))

--- a/sunpy/data/test/__init__.py
+++ b/sunpy/data/test/__init__.py
@@ -8,11 +8,11 @@ from astropy.utils.data import get_pkg_data_filename
 
 import sunpy
 
-__all__ = ['rootdir', 'file_list', 'get_test_filename']
+__all__ = ['rootdir', 'file_list', 'get_test_filepath']
 
 rootdir = os.path.join(os.path.dirname(sunpy.__file__), "data", "test")
 
-def get_test_filename(filename, **kwargs):
+def get_test_filepath(filename, **kwargs):
     """
     Return the full path to a test file in the ``data/test`` directory.
 

--- a/sunpy/instr/tests/test_aia.py
+++ b/sunpy/instr/tests/test_aia.py
@@ -13,7 +13,7 @@ from sunpy.instr.aia import aiaprep
 
 @pytest.fixture
 def original():
-    return sunpy.map.Map(test.get_test_filename("aia_171_level1.fits"))
+    return sunpy.map.Map(test.get_test_filepath("aia_171_level1.fits"))
 
 @pytest.fixture
 def prep_map(original):

--- a/sunpy/instr/tests/test_aia.py
+++ b/sunpy/instr/tests/test_aia.py
@@ -2,18 +2,25 @@ from __future__ import absolute_import
 
 import tempfile
 
+import pytest
 import numpy as np
 
-import sunpy
+import sunpy.map
 import sunpy.data.test as test
 from sunpy.instr.aia import aiaprep
 
 # Define the original and prepped images first so they're available to all functions
-original = sunpy.map.Map(test.aia_171_level1)
-prep_map = aiaprep(original)
+
+@pytest.fixture
+def original():
+    return sunpy.map.Map(test.get_test_filename("aia_171_level1.fits"))
+
+@pytest.fixture
+def prep_map(original):
+    return aiaprep(original)
 
 
-def test_aiaprep():
+def test_aiaprep(original, prep_map):
     # Test that header info for the map has been correctly updated
     # Check all of these for Map attributes and .meta values?
     # Check array shape
@@ -31,7 +38,7 @@ def test_aiaprep():
     assert prep_map.meta['lvl_num'] == 1.5
 
 
-def test_filesave():
+def test_filesave(prep_map):
     # Test that adjusted header values are still correct after saving the map
     # and reloading it.
     afilename = tempfile.NamedTemporaryFile(suffix='fits').name

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -6,14 +6,14 @@ from __future__ import absolute_import
 #pylint: disable=C0103,R0904,W0201,W0212,W0232,E1103
 import numpy as np
 
-from sunpy.data.test import get_test_filename
+from sunpy.data.test import get_test_filepath
 from sunpy.io.header import FileHeader
 from sunpy.map import GenericMap
 from sunpy.map import Map
 
 from sunpy.tests.helpers import skip_glymur
 
-AIA_193_JP2 = get_test_filename("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")
+AIA_193_JP2 = get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")
 
 @skip_glymur
 

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -6,14 +6,17 @@ from __future__ import absolute_import
 #pylint: disable=C0103,R0904,W0201,W0212,W0232,E1103
 import numpy as np
 
-from sunpy.data.test import AIA_193_JP2
+from sunpy.data.test import get_test_filename
 from sunpy.io.header import FileHeader
 from sunpy.map import GenericMap
 from sunpy.map import Map
 
 from sunpy.tests.helpers import skip_glymur
 
+AIA_193_JP2 = get_test_filename("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")
+
 @skip_glymur
+
 def test_read_data():
     """Tests the reading of the JP2 data"""
     import glymur

--- a/sunpy/lightcurve/tests/test_eve.py
+++ b/sunpy/lightcurve/tests/test_eve.py
@@ -8,7 +8,9 @@ import pytest
 #pylint: disable=C0103,R0904,W0201,W0232,E1103
 import sunpy
 import sunpy.lightcurve
-from sunpy.data.test import (EVE_AVERAGES_CSV)
+from sunpy.data.test import get_test_filename
+
+EVE_AVERAGES_CSV = get_test_filename("EVE_He_II_304_averages.csv")
 
 @pytest.mark.online
 def test_eve():

--- a/sunpy/lightcurve/tests/test_eve.py
+++ b/sunpy/lightcurve/tests/test_eve.py
@@ -8,9 +8,9 @@ import pytest
 #pylint: disable=C0103,R0904,W0201,W0232,E1103
 import sunpy
 import sunpy.lightcurve
-from sunpy.data.test import get_test_filename
+from sunpy.data.test import get_test_filepath
 
-EVE_AVERAGES_CSV = get_test_filename("EVE_He_II_304_averages.csv")
+EVE_AVERAGES_CSV = get_test_filepath("EVE_He_II_304_averages.csv")
 
 @pytest.mark.online
 def test_eve():

--- a/sunpy/lightcurve/tests/test_lightcurve.py
+++ b/sunpy/lightcurve/tests/test_lightcurve.py
@@ -9,12 +9,15 @@ from __future__ import absolute_import
 
 #pylint: disable=C0103,R0904,W0201,W0232,E1101,E1103
 import numpy as np
+import pandas
 import pytest
 import datetime
+
 import sunpy
 import sunpy.lightcurve
-from sunpy.data.test import (EVE_AVERAGES_CSV)
-import pandas
+from sunpy.data.test import get_test_filename
+
+EVE_AVERAGES_CSV = get_test_filename("EVE_He_II_304_averages.csv")
 
 # Generate input test data
 base = datetime.datetime.today()

--- a/sunpy/lightcurve/tests/test_lightcurve.py
+++ b/sunpy/lightcurve/tests/test_lightcurve.py
@@ -15,9 +15,9 @@ import datetime
 
 import sunpy
 import sunpy.lightcurve
-from sunpy.data.test import get_test_filename
+from sunpy.data.test import get_test_filepath
 
-EVE_AVERAGES_CSV = get_test_filename("EVE_He_II_304_averages.csv")
+EVE_AVERAGES_CSV = get_test_filepath("EVE_He_II_304_averages.csv")
 
 # Generate input test data
 base = datetime.datetime.today()


### PR DESCRIPTION
This adds a helper function to `sunpy.test.data` to find names of package data, which makes us more consistent with Astropy and also avoids the need to do `os.path.join` in tests.

I blame @astrofrog for this :p