### PR TITLE
Improve __repr__ for Unidown and VSO

### DIFF
--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -54,7 +54,7 @@ class UnifiedResponse(MutableSequence):
                     tmplst.append(block)
                     self._numfile += len(block)
                 else:
-                    raise Exception("{} is not a valid input to UnifiedResponse.".format(lst))
+                    raise Exception("{} is not a valid input to UnifiedResponse.".format(type(lst)))
 
         self._list = tmplst
 
@@ -64,10 +64,7 @@ class UnifiedResponse(MutableSequence):
     def __getitem__(self, aslice):
         ret = self._list[aslice]
         if ret:
-            if isinstance(ret, list):
-                return type(self)(ret)
-            else:
-                return type(self)(ret)
+            return type(self)(ret)
 
         return ret
 
@@ -103,7 +100,19 @@ class UnifiedResponse(MutableSequence):
     def _repr_html_(self):
         ret = ''
         for block in self.responses:
+            ret += "Results from the {}:\n".format(block.client.__class__.__name__)
             ret += block._repr_html_()
+            ret += '\n'
+
+        return ret
+
+    def __repr__(self):
+        ret = super(UnifiedResponse, self).__repr__()
+        ret += '\n'
+        for block in self.responses:
+            ret += "Results from the {}:\n".format(block.client.__class__.__name__)
+            ret += repr(block)
+            ret += '\n'
 
         return ret
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -164,6 +164,8 @@ def test_no_wait_fetch():
 
 """
 UnifiedResponse Tests
+
+Use LYRA here because it does not use the internet to return results.
 """
 
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -161,6 +161,7 @@ def test_no_wait_fetch():
         assert isinstance(res, DownloadResponse)
         assert isinstance(res.wait(), list)
 
+
 """
 UnifiedResponse Tests
 """
@@ -172,6 +173,7 @@ def test_unifiedresponse_slicing():
     assert isinstance(results[0:2], UnifiedResponse)
     assert isinstance(results[0], UnifiedResponse)
 
+
 def test_responses():
     results = Fido.search(
         a.Time("2012/1/1", "2012/1/5"), a.Instrument("lyra"))
@@ -180,3 +182,13 @@ def test_responses():
         assert isinstance(resp, QueryResponse)
 
     assert i + 1 == len(results)
+
+
+def test_repr():
+    results = Fido.search(
+        a.Time("2012/1/1", "2012/1/5"), a.Instrument("lyra"))
+
+    rep = repr(results)
+    rep = rep.split('\n')
+    # 6 header lines, the results table and a blank line at the end
+    assert len(rep) == 6 + len(list(results.responses)[0]) + 1

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -19,7 +19,7 @@ import threading
 
 from datetime import datetime, timedelta
 from functools import partial
-from collections import defaultdict
+from collections import defaultdict, UserList
 from suds import client, TypeNotFound
 
 import astropy
@@ -37,7 +37,8 @@ from sunpy.net.vso.attrs import walker, TIMEFORMAT
 from sunpy.util import replacement_filename
 from sunpy.time import parse_time
 
-from sunpy.extern.six import iteritems, text_type, u, PY2
+from sunpy.extern import six
+from sunpy.extern.six import iteritems, text_type
 from sunpy.extern.six.moves import input
 
 TIME_FORMAT = config.get("general", "time_format")
@@ -95,7 +96,7 @@ def iter_errors(response):
             yield prov_item
 
 
-class QueryResponse(list):
+class QueryResponse(UserList):
     def __init__(self, lst, queryresult=None, table=None):
         super(QueryResponse, self).__init__(lst)
         self.queryresult = queryresult
@@ -132,7 +133,7 @@ class QueryResponse(list):
         )
 
     def build_table(self):
-        keywords = ['Start Time', 'End Time', 'Source', 'Instrument', 'Type']
+        keywords = ['Start Time', 'End Time', 'Source', 'Instrument', 'Type', 'Wavelength']
         record_items = {}
         for key in keywords:
             record_items[key] = []
@@ -153,6 +154,26 @@ class QueryResponse(list):
             record_items['Instrument'].append(str(record.instrument))
             record_items['Type'].append(str(record.extent.type)
                                 if record.extent.type is not None else ['N/A'])
+            # If we have a start and end Wavelength, make a quantity
+            if hasattr(record, 'wave') and record.wave.wavemin and record.wave.wavemax:
+                record_items['Wavelength'].append(u.Quantity([float(record.wave.wavemin),
+                                                              float(record.wave.wavemax)],
+                                                             unit=record.wave.waveunit))
+            # If not save None
+            else:
+                record_items['Wavelength'].append(None)
+        # If we have no wavelengths for the whole list, drop the col
+        if all([a is None for a in record_items['Wavelength']]):
+            record_items.pop('Wavelength')
+            keywords.remove('Wavelength')
+        else:
+            # Make whole column a quantity
+            try:
+                with u.set_enabled_equivalencies(u.spectral()):
+                    record_items['Wavelength'] = u.Quantity(record_items['Wavelength'])
+            # If we have mixed units or some Nones just represent as strings
+            except (u.UnitConversionError, TypeError):
+                record_items['Wavelength'] = [str(a) for a in record_items['Wavelength']]
 
         return Table(record_items)[keywords]
 
@@ -316,7 +337,7 @@ class VSOClient(object):
         name = get_filename(sock, url)
         if not name:
             if not isinstance(response.fileid, text_type):
-                name = u(response.fileid, "ascii", "ignore")
+                name = six.u(response.fileid, "ascii", "ignore")
             else:
                 name = response.fileid
 
@@ -326,7 +347,7 @@ class VSOClient(object):
 
         name = slugify(name)
 
-        if PY2:
+        if six.PY2:
             name = name.encode(fs_encoding, "ignore")
 
         if not name:

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -19,7 +19,7 @@ import threading
 
 from datetime import datetime, timedelta
 from functools import partial
-from collections import defaultdict, UserList
+from collections import defaultdict
 from suds import client, TypeNotFound
 
 import astropy
@@ -96,7 +96,8 @@ def iter_errors(response):
             yield prov_item
 
 
-class QueryResponse(UserList):
+# TODO: Python 3 this should subclass from UserList
+class QueryResponse(list):
     def __init__(self, lst, queryresult=None, table=None):
         super(QueryResponse, self).__init__(lst)
         self.queryresult = queryresult


### PR DESCRIPTION
This adds a `__repr__` method to the `UnifiedResponse` object and improves the `vso.QueryResponse` object to show wavelength in a nice manner when there is wavelength data to show.