### PR TITLE
Tests to increase test/code coverage for MetaDict

### DIFF
--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -1,0 +1,205 @@
+import pytest
+
+from sunpy.util.metadata import MetaDict
+
+
+class Base:
+
+    def setup_method(self):
+
+        self.seas = [['labrador', 'americas'],
+                     ['Norwegian', 'Europe'],
+                     ['BALTIC', 'europe'],
+                     ['LaPteV', 'arctic']]
+
+        # distinct keys to self.seas
+        self.more_seas = [['Aegean', 'greece'],
+                          ['CAtaLaN', 'mediterranean'],
+                          ['IONIAN', 'italy'],
+                          ['amundsen', 's.ocean']]
+
+        # some similar, 'like',  keys to self.seas
+        self.yet_more_seas = [['norwegian', 'NORWAY'],
+                              ['SCOTIA', 's.ocean'],
+                              ['laptev', 'russia'],
+                              ['Mawson', 'E.Antartica']]
+
+        self.md = MetaDict(self.seas)
+
+    @staticmethod
+    def check_contents(metadict_inst, expected):
+        assert len(metadict_inst) == len(expected)
+
+        for key, val in expected:
+            assert metadict_inst[key.upper()] == val
+
+    @staticmethod
+    def check_insertion_order(metadict_inst, expected):
+
+        def normalise_keys(lst_pairs):
+            return [key.lower() for key, _ in lst_pairs]
+
+        assert normalise_keys(metadict_inst.items()) == \
+            normalise_keys(expected)
+
+    @staticmethod
+    def check(metadict_inst, expected):
+        """ Check a MetaDict instance
+
+        actual against expected contents and ensure insertion order is
+        preserved.
+
+        :param metadict_inst: a MetaDict
+        :param expected: iterable of key/value pairs
+        """
+        Base.check_contents(metadict_inst, expected)
+        Base.check_insertion_order(metadict_inst, expected)
+
+    @staticmethod
+    def pairs_to_dict(lst_of_pairs):
+        """ convert a list/tuple of lists/tuples to a dictionary
+
+        E.g.  [['a', 1], ['b', 2]] -> {'a': 1, 'b': 2}
+        """
+        return {kv_pair[0]: kv_pair[1] for kv_pair in lst_of_pairs}
+
+
+class TestInitialisation(Base):
+    """ All forms of instantiating a MetaDict
+    """
+
+    def test_with_dict(self):
+        in_dict = TestInitialisation.pairs_to_dict(self.seas)
+
+        # Using traditional dictionary, order of insertion is *not* preserved
+        TestInitialisation.check_contents(MetaDict(in_dict), self.seas)
+
+    def test_with_list_of_lists(self):
+        TestInitialisation.check(MetaDict(self.more_seas), self.more_seas)
+
+    def test_init_with_tuple_of_tuples(self):
+        in_tuple = tuple(tuple(kv_pair) for kv_pair in self.seas)
+
+        TestInitialisation.check(MetaDict(in_tuple), self.seas)
+
+    def test_with_metadict(self):
+        TestInitialisation.check(MetaDict(MetaDict(self.yet_more_seas)),
+                                 self.yet_more_seas)
+
+    def test_with_illegal_arg(self):
+        with pytest.raises(TypeError):
+            MetaDict(set(('a', 'b', 'c', 'd')))
+
+
+class TestMethods(Base):
+
+    def test_membership(self):
+        assert 'LABRADOR' in self.md
+        assert 'labrador' in self.md
+        assert 'baLtiC' in self.md
+
+        assert 'pechora' not in self.md
+
+    def test_getitem(self):
+        assert self.md['norwegian'] == 'Europe'
+        assert self.md['NORWEGIAN'] != 'europe'
+        assert self.md['laptev'] == 'arctic'
+
+        assert self.md['Norwegian'] != 'europe'
+
+        with pytest.raises(KeyError):
+            self.md['key-not-exists']
+
+    def test_get(self):
+        assert self.md.get('baltic') == 'europe'
+        assert self.md.get('atlantic') is None
+
+        default_value = 'Unknown'
+        assert self.md.get('sargasso', default=default_value) == default_value
+
+    def test_setitem_existing(self):
+        len_before = len(self.md)
+        self.md['NORWEGIAN'] = 'Scandinavia'
+        assert len(self.md) == len_before
+
+        assert self.md['norwegian'] == 'Scandinavia'
+        assert self.md['NoRwEgIaN'] == 'Scandinavia'
+
+    def test_setitem_new(self):
+        len_before = len(self.md)
+        self.md['Irish'] = 'N.Europe'
+        assert len(self.md) == len_before + 1
+
+        assert self.md['Irish'] == 'N.Europe'
+        assert self.md['irish'] == 'N.Europe'
+        assert self.md['IRISH'] == 'N.Europe'
+
+        assert self.md['IrisH'] != 'n.europe'
+
+    def test_setdefault(self):
+        self.md.setdefault('poseidon', 'NOT-FOUND')
+        assert self.md.get('Poseidon') == 'NOT-FOUND'
+        assert self.md['pOSeidon'] == 'NOT-FOUND'
+
+        # Should only impact key 'poseidon'
+        assert self.md.get('Wandel') is None
+
+    def test_has_key(self):
+
+        # suppress pep8/flake8 'W601 .has_key() is deprecated, ...' warnings
+        # as MetaDict explicitly supports the 'has_key()' method
+        assert self.md.has_key('laptev') is True  # noqa
+        assert self.md.has_key('BALtIC') is True  # noqa
+
+        assert self.md.has_key('Beaufort') is False  # noqa
+
+    def test_pop(self):
+        len_before = len(self.md)
+
+        self.md.pop('kara') is None
+        assert len(self.md) == len_before
+
+        default_value = 'not-recognized'
+        assert self.md.pop('lincoln', default=default_value) == default_value
+        assert len(self.md) == len_before
+
+        assert self.md.pop('baltic') == 'europe'
+        assert len(self.md) == len_before - 1
+
+
+class TestUpdateMethod(Base):
+    """ MetaDict.update(...)
+    """
+
+    def setup(self):
+
+        # Expected when self.seas & self.yet_more_seas are added to a MetaDict
+        self.combined = [['labrador', 'americas'],
+                         ['Norwegian', 'NORWAY'],
+                         ['BALTIC', 'europe'],
+                         ['LaPteV', 'russia'],
+                         ['SCOTIA', 's.ocean'],
+                         ['Mawson', 'E.Antartica']]
+
+    def test_update_with_distinct_keys(self):
+        self.md.update(MetaDict(self.more_seas))
+
+        TestUpdateMethod.check(self.md, self.seas + self.more_seas)
+
+    def test_update_with_like_keys(self):
+        # values of existing keys should be updated but, original insertion
+        # order should be preserved
+        self.md.update(MetaDict(self.yet_more_seas))
+
+        TestUpdateMethod.check(self.md, self.combined)
+
+    def test_update_with_dict(self):
+        # Updating with a dictionary, order is *not* preserved
+        self.md.update(TestUpdateMethod.pairs_to_dict(self.yet_more_seas))
+
+        TestUpdateMethod.check_contents(self.md, self.combined)
+
+    def test_update_with_same_metadict(self):
+        self.md.update(self.md)
+
+        TestUpdateMethod.check(self.md, self.seas)

--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -15,8 +15,7 @@ def check_insertion_order(metadict_inst, expected):
     def normalise_keys(lst_pairs):
         return [key.lower() for key, _ in lst_pairs]
 
-    assert normalise_keys(metadict_inst.items()) == \
-        normalise_keys(expected)
+    assert normalise_keys(metadict_inst.items()) == normalise_keys(expected)
 
 
 def check(metadict_inst, expected):
@@ -51,7 +50,7 @@ def std_test_data():
 @pytest.fixture
 def differet_keys_data():
     """
-    Contains distinct keys from 'std_test_data'
+    Contains keys distinct from 'std_test_data'
     """
     return [['Aegean', 'greece'],
             ['CAtaLaN', 'mediterranean'],
@@ -89,137 +88,137 @@ def std_metadict(std_test_data):
     return MetaDict(std_test_data)
 
 
-class TestInit:
-    """
-    All the ways on instantiating a MetaDict
-    """
-
-    def test_lst_of_lsts(self, std_test_data):
-        check(MetaDict(std_test_data), std_test_data)
-
-    def test_init_with_tuple_of_tuples(self, std_test_data):
-        in_tuple = tuple(tuple(kv_pair) for kv_pair in std_test_data)
-        check(MetaDict(in_tuple), std_test_data)
-
-    def test_with_dict(self, std_test_data):
-        # Using traditional dictionary, order of insertion is *not* preserved
-        check_contents(MetaDict(pairs_to_dict(std_test_data)), std_test_data)
-
-    def test_with_metadict(self, same_diff_keys_data):
-        check(MetaDict(MetaDict(same_diff_keys_data)), same_diff_keys_data)
-
-    def test_with_illegal_arg(self):
-        with pytest.raises(TypeError):
-            MetaDict(set(('a', 'b', 'c', 'd')))
+def test_init_with_lst_of_lsts(std_test_data):
+    check(MetaDict(std_test_data), std_test_data)
 
 
-class TestMethods:
-    """
-    Most of the API of MetaDict barring the initialization and 'update' methods
-    """
-
-    def test_membership(self, std_metadict):
-        assert 'LABRADOR' in std_metadict
-        assert 'labrador' in std_metadict
-        assert 'baLtiC' in std_metadict
-
-        assert 'pechora' not in std_metadict
-
-    def test_getitem(self, std_metadict):
-        assert std_metadict['norwegian'] == 'Europe'
-        assert std_metadict['NORWEGIAN'] != 'europe'
-        assert std_metadict['laptev'] == 'arctic'
-
-        assert std_metadict['Norwegian'] != 'europe'
-
-        with pytest.raises(KeyError):
-            std_metadict['key-not-exists']
-
-    def test_get(self, std_metadict):
-        assert std_metadict.get('baltic') == 'europe'
-        assert std_metadict.get('atlantic') is None
-
-        default_value = 'Unknown'
-        assert std_metadict.get('sargasso', default=default_value) \
-            == default_value
-
-    def test_setitem_existing(self, std_metadict):
-        len_before = len(std_metadict)
-        std_metadict['NORWEGIAN'] = 'Scandinavia'
-        assert len(std_metadict) == len_before
-
-        assert std_metadict['norwegian'] == 'Scandinavia'
-        assert std_metadict['NoRwEgIaN'] == 'Scandinavia'
-
-    def test_setitem_new(self, std_metadict):
-        len_before = len(std_metadict)
-        std_metadict['Irish'] = 'N.Europe'
-        assert len(std_metadict) == len_before + 1
-
-        assert std_metadict['Irish'] == 'N.Europe'
-        assert std_metadict['irish'] == 'N.Europe'
-        assert std_metadict['IRISH'] == 'N.Europe'
-
-        assert std_metadict['IrisH'] != 'n.europe'
-
-    def test_setdefault(self, std_metadict):
-        std_metadict.setdefault('poseidon', 'NOT-FOUND')
-        assert std_metadict.get('Poseidon') == 'NOT-FOUND'
-        assert std_metadict['pOSeidon'] == 'NOT-FOUND'
-
-        # Should only impact key 'poseidon'
-        assert std_metadict.get('Wandel') is None
-
-    def test_has_key(self, std_metadict):
-
-        # suppress pep8/flake8 'W601 .has_key() is deprecated, ...' warnings
-        # as MetaDict explicitly supports the 'has_key()' method
-        assert std_metadict.has_key('laptev') is True  # noqa
-        assert std_metadict.has_key('BALtIC') is True  # noqa
-
-        assert std_metadict.has_key('Beaufort') is False  # noqa
-
-    def test_pop(self, std_metadict):
-        len_before = len(std_metadict)
-
-        std_metadict.pop('kara') is None
-        assert len(std_metadict) == len_before
-
-        default_value = 'not-recognized'
-        assert std_metadict.pop('lincoln', default=default_value) \
-            == default_value
-        assert len(std_metadict) == len_before
-
-        assert std_metadict.pop('baltic') == 'europe'
-        assert len(std_metadict) == len_before - 1
+def test_init_with_tuple_of_tuples(std_test_data):
+    in_tuple = tuple(tuple(kv_pair) for kv_pair in std_test_data)
+    check(MetaDict(in_tuple), std_test_data)
 
 
-class TestUpdateMethod:
+def test_init_with_dict(std_test_data):
+    # Using traditional dictionary, order of insertion is *not* preserved
+    check_contents(MetaDict(pairs_to_dict(std_test_data)), std_test_data)
 
-    def test_update_with_distinct_keys(self, std_metadict, std_test_data,
-                                       differet_keys_data):
 
-        std_metadict.update(MetaDict(differet_keys_data))
+def test_init_with_metadict(same_diff_keys_data):
+    check(MetaDict(MetaDict(same_diff_keys_data)), same_diff_keys_data)
 
-        check(std_metadict, std_test_data + differet_keys_data)
 
-    def test_update_with_like_keys(self, std_metadict, same_diff_keys_data,
-                                   combined_data):
-        # values of existing keys should be updated but, original insertion
-        # order should be preserved
+def test_init_with_illegal_arg():
+    with pytest.raises(TypeError):
+        MetaDict(set(('a', 'b', 'c', 'd')))
 
-        std_metadict.update(MetaDict(same_diff_keys_data))
 
-        check(std_metadict, combined_data)
+def test_membership_op(std_metadict):
+    assert 'LABRADOR' in std_metadict
+    assert 'labrador' in std_metadict
+    assert 'baLtiC' in std_metadict
 
-    def test_update_with_dict(self, std_metadict, same_diff_keys_data,
-                              combined_data):
-        # Updating with a dictionary, order is *not* preserved
-        std_metadict.update(pairs_to_dict(same_diff_keys_data))
+    assert 'pechora' not in std_metadict
 
-        check_contents(std_metadict, combined_data)
 
-    def test_update_with_same_metadict(self, std_metadict, std_test_data):
-        std_metadict.update(std_metadict)
+def test_getitem_op(std_metadict):
+    assert std_metadict['norwegian'] == 'Europe'
+    assert std_metadict['NORWEGIAN'] != 'europe'
+    assert std_metadict['laptev'] == 'arctic'
 
-        check(std_metadict, std_test_data)
+    assert std_metadict['Norwegian'] != 'europe'
+
+    with pytest.raises(KeyError):
+        std_metadict['key-not-exists']
+
+
+def test_get_method(std_metadict):
+    assert std_metadict.get('baltic') == 'europe'
+    assert std_metadict.get('atlantic') is None
+
+    default_value = 'Unknown'
+    assert std_metadict.get('sargasso', default=default_value) == default_value
+
+
+def test_setitem_op_existing(std_metadict):
+    len_before = len(std_metadict)
+    std_metadict['NORWEGIAN'] = 'Scandinavia'
+    assert len(std_metadict) == len_before
+
+    assert std_metadict['norwegian'] == 'Scandinavia'
+    assert std_metadict['NoRwEgIaN'] == 'Scandinavia'
+
+
+def test_setitem_op_new(std_metadict):
+    len_before = len(std_metadict)
+    std_metadict['Irish'] = 'N.Europe'
+    assert len(std_metadict) == len_before + 1
+
+    assert std_metadict['Irish'] == 'N.Europe'
+    assert std_metadict['irish'] == 'N.Europe'
+    assert std_metadict['IRISH'] == 'N.Europe'
+
+    assert std_metadict['IrisH'] != 'n.europe'
+
+
+def test_setdefault_method(std_metadict):
+    std_metadict.setdefault('poseidon', 'NOT-FOUND')
+    assert std_metadict.get('Poseidon') == 'NOT-FOUND'
+    assert std_metadict['pOSeidon'] == 'NOT-FOUND'
+
+    # Should only impact key 'poseidon'
+    assert std_metadict.get('Wandel') is None
+
+
+def test_has_key_method(std_metadict):
+
+    # suppress pep8/flake8 'W601 .has_key() is deprecated, ...' warnings
+    # as MetaDict explicitly supports the 'has_key()' method
+    assert std_metadict.has_key('laptev') is True  # noqa
+    assert std_metadict.has_key('BALtIC') is True  # noqa
+
+    assert std_metadict.has_key('Beaufort') is False  # noqa
+
+
+def test_pop_method(std_metadict):
+    len_before = len(std_metadict)
+
+    std_metadict.pop('kara') is None
+    assert len(std_metadict) == len_before
+
+    default_value = 'not-recognized'
+    assert std_metadict.pop('lincoln', default=default_value) == default_value
+    assert len(std_metadict) == len_before
+
+    assert std_metadict.pop('baltic') == 'europe'
+    assert len(std_metadict) == len_before - 1
+
+
+def test_update_method_with_distinct_keys(std_metadict, std_test_data,
+                                          differet_keys_data):
+
+    std_metadict.update(MetaDict(differet_keys_data))
+
+    check(std_metadict, std_test_data + differet_keys_data)
+
+
+def test_update_method_with_like_keys(std_metadict, same_diff_keys_data,
+                                      combined_data):
+    # values of existing keys should be updated but, original insertion
+    # order should be preserved
+
+    std_metadict.update(MetaDict(same_diff_keys_data))
+
+    check(std_metadict, combined_data)
+
+
+def test_update_method_with_dict(std_metadict, same_diff_keys_data,
+                                 combined_data):
+    # Updating with a dictionary, order is *not* preserved
+    std_metadict.update(pairs_to_dict(same_diff_keys_data))
+
+    check_contents(std_metadict, combined_data)
+
+
+def test_update_method_with_same_metadict(std_metadict, std_test_data):
+    std_metadict.update(std_metadict)
+
+    check(std_metadict, std_test_data)

--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -4,6 +4,10 @@ from sunpy.util.metadata import MetaDict
 
 
 def check_contents(metadict_inst, expected):
+    """
+    Ensure that the key/values of `metadict_inst` match those of the key/value
+    pairs in `expected`. The case of the keys is ignored, as is the order.
+    """
     assert len(metadict_inst) == len(expected)
 
     for key, val in expected:
@@ -11,18 +15,21 @@ def check_contents(metadict_inst, expected):
 
 
 def check_insertion_order(metadict_inst, expected):
-
+    """
+    Ensure that the keys of `metadict_inst` are in the same order
+    as the keys in `expected`. The keys case is ignored.
+    """
     def normalise_keys(lst_pairs):
         return [key.lower() for key, _ in lst_pairs]
 
     assert normalise_keys(metadict_inst.items()) == normalise_keys(expected)
 
 
-def check(metadict_inst, expected):
+def check_contents_and_insertion_order(metadict_inst, expected):
     """
-    Check a MetaDict instance
-
-    Ensure content and insertion order are preserved
+    Ensure both the contents and order of the the key/values of
+    `metadict_inst` match the key/values in `expected`. Keys are
+    case insensitive.
 
     Parameters
     ----------
@@ -30,7 +37,7 @@ def check(metadict_inst, expected):
                   a Metadict instance under test
 
     expected: iterable object of key/value pairs
-             the value we expect from a test
+             the values we expect from a test
     """
     check_contents(metadict_inst, expected)
     check_insertion_order(metadict_inst, expected)
@@ -57,7 +64,7 @@ def pairs_to_dict(lst_of_pairs):
 
 
 @pytest.fixture
-def std_test_data():
+def sea_locations():
     return [['labrador', 'americas'],
             ['Norwegian', 'Europe'],
             ['BALTIC', 'europe'],
@@ -65,183 +72,293 @@ def std_test_data():
 
 
 @pytest.fixture
-def differet_keys_data():
-    """
-    Contains keys distinct from 'std_test_data'
-    """
-    return [['Aegean', 'greece'],
-            ['CAtaLaN', 'mediterranean'],
-            ['IONIAN', 'italy'],
-            ['amundsen', 's.ocean']]
+def atomic_weights():
+    return [['hydrogen', 1],
+            ['chromium', 24],
+            ['mercury', 80],
+            ['iridium', 77]]
 
 
 @pytest.fixture
-def same_diff_keys_data():
+def seas_metadict(sea_locations):
+    return MetaDict(sea_locations)
+
+
+# Test constructors `MetaDict.__init__(...)`
+
+
+def test_init_with_lst_of_lsts(seas_metadict, sea_locations):
     """
-    Contains a mixture of same and distinct keys from 'std_test_data'
+    Initialise `MetaDict` with a list of lists.
+
+    Each sub list is a key/value pair.
+
+    Example
+    -------
+    >>> m = MetaDict([['H', 'Hydrogen'], ['B', 'Boron']])
+    """
+    check_contents_and_insertion_order(MetaDict(sea_locations), sea_locations)
+
+
+def test_init_with_tuple_of_tuples(sea_locations):
+    """
+    Initialise `MetaDict` with a tuple of tuples.
+
+    Each 'sub-tuple' is a key/value pair.
+
+    Example
+    -------
+    >>> c = MetaDict((('Be', 21), ('Nb', 21)))
+    """
+    in_tuple = tuple(tuple(kv_pair) for kv_pair in sea_locations)
+    check_contents_and_insertion_order(MetaDict(in_tuple), sea_locations)
+
+
+def test_init_with_dict(sea_locations):
+    """
+    Initialise `MetaDict` with standard Python dictionary
+
+    Order of insertion is *not* preserved - only check the contents.
+    """
+    check_contents(MetaDict(pairs_to_dict(sea_locations)), sea_locations)
+
+
+def test_init_with_metadict(atomic_weights):
+    """
+    Initialise `MetaDict` with another `MetaDict`.
+    """
+    original = MetaDict(atomic_weights)
+    new = MetaDict(original)
+    check_contents_and_insertion_order(new, atomic_weights)
+
+    # It's not just a simple reassignemnet
+    assert id(original) != id(new)
+
+
+def test_init_with_illegal_arg():
+    """
+    Ensure attempt to initialise with a nonsensical data structure
+    is rejected.
+    """
+    with pytest.raises(TypeError):
+        MetaDict(set(('a', 'b', 'c', 'd')))
+
+
+# Test individual methods
+
+
+def test_membership(seas_metadict):
+    """
+    Test `MetaDict.__contains__(...)`
+    """
+    assert 'labrador' in seas_metadict
+    assert 'pechora' not in seas_metadict
+
+
+def test_getitem(seas_metadict):
+    """
+    Test `MetaDict.__getitem__(...)`
+    """
+    assert seas_metadict['Norwegian'] == 'Europe'
+    assert seas_metadict['BALTIC'] != 'arctic'
+
+    with pytest.raises(KeyError):
+        seas_metadict['key-not-exists']
+
+
+def test_setitem_existing_entry(seas_metadict):
+    """
+    Test `MetaDict.__setitem__(...)` on an existing entry
+    """
+    len_before = len(seas_metadict)
+    seas_metadict['NORWEGIAN'] = 'Scandinavia'
+    assert len(seas_metadict) == len_before
+
+    assert seas_metadict['NORWEGIAN'] == 'Scandinavia'
+
+
+def test_setitem_new_entry(seas_metadict):
+    """
+    Test `MetaDict.__setitem__(...)`. Add a new entry
+    """
+    len_before = len(seas_metadict)
+    seas_metadict['Irish'] = 'N.Europe'
+    assert len(seas_metadict) == len_before + 1
+
+    assert seas_metadict['Irish'] == 'N.Europe'
+
+
+def test_get(seas_metadict):
+    """
+    Test `MetaDict.get(...)`
+    """
+    assert seas_metadict.get('BALTIC') == 'europe'
+    assert seas_metadict.get('atlantic') is None
+
+    default_value = 'Unknown'
+    assert seas_metadict.get('sargasso', default=default_value) == default_value
+
+
+def test_setdefault(seas_metadict):
+    """
+    Test `MetaDict.setdefault(...)`
+    """
+    seas_metadict.setdefault('poseidon', 'NOT-FOUND')
+    assert seas_metadict.get('poseidon') == 'NOT-FOUND'
+    assert seas_metadict['poseidon'] == 'NOT-FOUND'
+
+    # Should only impact key 'poseidon'
+    assert seas_metadict.get('Wandel') is None
+
+
+def test_has_key(seas_metadict):
+    """
+    Test `MetaDict.has_key(...)`
+    """
+    # suppress pep8/flake8 'W601 .has_key() is deprecated, ...' warnings
+    # as MetaDict explicitly supports the 'has_key()' method
+    assert seas_metadict.has_key('LaPteV') is True  # noqa
+
+    assert seas_metadict.has_key('Beaufort') is False  # noqa
+
+
+def test_pop(seas_metadict):
+    """
+    Test `MetaDict.pop(...)`
+    """
+    # Nothing to 'pop', nothing should change
+    len_before = len(seas_metadict)
+    seas_metadict.pop('kara') is None
+    assert len(seas_metadict) == len_before
+
+    # Nothing to 'pop', nothing should change but, we should get the default value
+    default_value = 'not-recognized'
+    assert seas_metadict.pop('lincoln', default=default_value) == default_value
+    assert len(seas_metadict) == len_before
+
+    assert seas_metadict.pop('baltic') == 'europe'
+    assert len(seas_metadict) == len_before - 1
+
+
+#  Test `MetaDict.update(...)`.
+
+
+def test_update_with_distinct_keys(seas_metadict, sea_locations, atomic_weights):
+    """
+    Update the MetaDict 'world_seas', with another MetaDict, 'chem_elems'
+    which has a completley different set of keys.
+
+    This should result in adding 'chem_elems' onto 'world_seas'. Original
+    insertion order of 'world_seas' should be preserved.
+    """
+    world_seas = seas_metadict
+    chem_elems = MetaDict(atomic_weights)
+    world_seas.update(chem_elems)
+
+    check_contents_and_insertion_order(world_seas, sea_locations + atomic_weights)
+
+
+@pytest.fixture
+def seas_and_atomic_weights():
+    """
+    A mixture of key/value data from `seas` & `atomic_weights`
     """
     return [['norwegian', 'NORWAY'],
-            ['SCOTIA', 's.ocean'],
+            ['Chromium', 24],
             ['laptev', 'russia'],
-            ['Mawson', 'E.Antartica']]
+            ['Iridium', 77]]
 
 
 @pytest.fixture
-def combined_data():
+def combined_seas_atomic():
     """
-    The expected result of combining the 'std_test_data' &
-    'same_diff_keys_data' in a MetaDict
+    The expected result of a `MetaDict` initailsed with `sea_locations` and
+    then updated with `seas_and_atomic_weights`
     """
     return [['labrador', 'americas'],
             ['Norwegian', 'NORWAY'],
             ['BALTIC', 'europe'],
             ['LaPteV', 'russia'],
-            ['SCOTIA', 's.ocean'],
-            ['Mawson', 'E.Antartica']]
+            ['Chromium', 24],
+            ['Iridium', 77]]
 
 
-@pytest.fixture
-def std_metadict(std_test_data):
-    return MetaDict(std_test_data)
-
-
-def test_init_with_lst_of_lsts(std_test_data):
-    check(MetaDict(std_test_data), std_test_data)
-
-
-def test_init_with_tuple_of_tuples(std_test_data):
-    in_tuple = tuple(tuple(kv_pair) for kv_pair in std_test_data)
-    check(MetaDict(in_tuple), std_test_data)
-
-
-def test_init_with_dict(std_test_data):
-    # Using traditional dictionary, order of insertion is *not* preserved
-    check_contents(MetaDict(pairs_to_dict(std_test_data)), std_test_data)
-
-
-def test_init_with_metadict(same_diff_keys_data):
-    check(MetaDict(MetaDict(same_diff_keys_data)), same_diff_keys_data)
-
-
-def test_init_with_illegal_arg():
-    with pytest.raises(TypeError):
-        MetaDict(set(('a', 'b', 'c', 'd')))
-
-
-def test_membership_op(std_metadict):
-    assert 'LABRADOR' in std_metadict
-    assert 'labrador' in std_metadict
-    assert 'baLtiC' in std_metadict
-
-    assert 'pechora' not in std_metadict
-
-
-def test_getitem_op(std_metadict):
-    assert std_metadict['norwegian'] == 'Europe'
-    assert std_metadict['NORWEGIAN'] != 'europe'
-    assert std_metadict['laptev'] == 'arctic'
-
-    assert std_metadict['Norwegian'] != 'europe'
-
-    with pytest.raises(KeyError):
-        std_metadict['key-not-exists']
-
-
-def test_get_method(std_metadict):
-    assert std_metadict.get('baltic') == 'europe'
-    assert std_metadict.get('atlantic') is None
-
-    default_value = 'Unknown'
-    assert std_metadict.get('sargasso', default=default_value) == default_value
-
-
-def test_setitem_op_existing(std_metadict):
+def test_update_with_like_keys(seas_metadict, seas_and_atomic_weights, combined_seas_atomic):
     """
-    Update an existing entry
+    Update the `MetaDict` 'world_seas' with another `MetaDict`, 'atomic_seas'.
+
+    'atomic_seas' has some keys which are the same as 'world_seas', some
+    are different.
+
+    In 'world_seas', values of existing keys should be updated but, original
+    insertion order should be preserved
     """
-    len_before = len(std_metadict)
-    std_metadict['NORWEGIAN'] = 'Scandinavia'
-    assert len(std_metadict) == len_before
+    world_seas = seas_metadict
+    atomic_seas = MetaDict(seas_and_atomic_weights)
+    world_seas.update(atomic_seas)
 
-    assert std_metadict['norwegian'] == 'Scandinavia'
-    assert std_metadict['NoRwEgIaN'] == 'Scandinavia'
+    check_contents_and_insertion_order(world_seas, combined_seas_atomic)
 
 
-def test_setitem_op_new(std_metadict):
+def test_update_with_dict(seas_metadict, seas_and_atomic_weights, combined_seas_atomic):
     """
-    Add a new entry
+    Update an existing `MetaDict` with a standard python dictionary some of whose
+    keys are the same, some are different.
+
+    In the updated `MetaDict`, values of existing keys should be updated but as
+    we are using a standard dictionary, insertion order of the new items is
+    non-deterministic so only check the contents of the updated structure.
     """
-    len_before = len(std_metadict)
-    std_metadict['Irish'] = 'N.Europe'
-    assert len(std_metadict) == len_before + 1
+    seas_metadict.update(pairs_to_dict(seas_and_atomic_weights))
 
-    assert std_metadict['Irish'] == 'N.Europe'
-    assert std_metadict['irish'] == 'N.Europe'
-    assert std_metadict['IRISH'] == 'N.Europe'
-
-    assert std_metadict['IrisH'] != 'n.europe'
+    check_contents(seas_metadict, combined_seas_atomic)
 
 
-def test_setdefault_method(std_metadict):
-    std_metadict.setdefault('poseidon', 'NOT-FOUND')
-    assert std_metadict.get('Poseidon') == 'NOT-FOUND'
-    assert std_metadict['pOSeidon'] == 'NOT-FOUND'
+def test_update_with_same_metadict(seas_metadict, sea_locations):
+    """
+    Upadate a 'MetaDict' with itself. Nothing should changes.
+    """
+    seas_metadict.update(seas_metadict)
 
-    # Should only impact key 'poseidon'
-    assert std_metadict.get('Wandel') is None
+    check_contents_and_insertion_order(seas_metadict, sea_locations)
 
 
-def test_has_key_method(std_metadict):
+def test_key_case_insensitivity(seas_metadict):
+    """
+    The keys of a `Metadict` are case insensitive. Using the key 'BALTIC'
+    is identical to the key 'baltic'.
+    """
+
+    # membership
+    assert 'laptev' in seas_metadict
+    assert 'LAPTEV' in seas_metadict
+
+    # get
+    assert seas_metadict['norwegian'] == 'Europe'
+    assert seas_metadict['NORWEGIAN'] == 'Europe'
+
+    assert seas_metadict.get('labrador') == 'americas'
+    assert seas_metadict.get('labRAdor') == 'americas'
 
     # suppress pep8/flake8 'W601 .has_key() is deprecated, ...' warnings
     # as MetaDict explicitly supports the 'has_key()' method
-    assert std_metadict.has_key('laptev') is True  # noqa
-    assert std_metadict.has_key('BALtIC') is True  # noqa
+    assert seas_metadict.has_key('BALTIC')  # noqa
+    assert seas_metadict.has_key('balTIC')  # noqa
 
-    assert std_metadict.has_key('Beaufort') is False  # noqa
+    # This key already exists. It should *not* take on the default value
+    seas_metadict.setdefault('norwEgiaN', default='Sweden')
+    assert seas_metadict['norwEgiaN'] == 'Europe'
+    assert seas_metadict['Norwegian'] == 'Europe'
+    assert seas_metadict.get('norwEgiaN') == 'Europe'
 
+    # setting, existing entry
+    seas_metadict['LaPteV'] = 'japan'
+    assert seas_metadict['LaPteV'] == 'japan'
+    assert seas_metadict['LAPTEV'] == 'japan'
+    assert seas_metadict.get('LApTEV') == 'japan'
 
-def test_pop_method(std_metadict):
-    len_before = len(std_metadict)
-
-    std_metadict.pop('kara') is None
-    assert len(std_metadict) == len_before
-
-    default_value = 'not-recognized'
-    assert std_metadict.pop('lincoln', default=default_value) == default_value
-    assert len(std_metadict) == len_before
-
-    assert std_metadict.pop('baltic') == 'europe'
-    assert len(std_metadict) == len_before - 1
-
-
-def test_update_method_with_distinct_keys(std_metadict, std_test_data,
-                                          differet_keys_data):
-
-    std_metadict.update(MetaDict(differet_keys_data))
-
-    check(std_metadict, std_test_data + differet_keys_data)
-
-
-def test_update_method_with_like_keys(std_metadict, same_diff_keys_data,
-                                      combined_data):
-    # values of existing keys should be updated but, original insertion
-    # order should be preserved
-
-    std_metadict.update(MetaDict(same_diff_keys_data))
-
-    check(std_metadict, combined_data)
-
-
-def test_update_method_with_dict(std_metadict, same_diff_keys_data,
-                                 combined_data):
-    # Updating with a dictionary, order is *not* preserved
-    std_metadict.update(pairs_to_dict(same_diff_keys_data))
-
-    check_contents(std_metadict, combined_data)
-
-
-def test_update_method_with_same_metadict(std_metadict, std_test_data):
-    std_metadict.update(std_metadict)
-
-    check(std_metadict, std_test_data)
+    # setting, new entry
+    seas_metadict['bering'] = 'Russia'
+    assert seas_metadict['bering'] == 'Russia'
+    assert seas_metadict['BeRinG'] == 'Russia'
+    assert seas_metadict.get('BERING') == 'Russia'

--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -19,22 +19,39 @@ def check_insertion_order(metadict_inst, expected):
 
 
 def check(metadict_inst, expected):
-    """ Check a MetaDict instance
+    """
+    Check a MetaDict instance
 
-    actual against expected contents and ensure insertion order is
-    preserved.
+    Ensure content and insertion order are preserved
 
-    :param metadict_inst: a MetaDict
-    :param expected: iterable of key/value pairs
+    Parameters
+    ----------
+    metadict_inst: sunpy.util.metadata.MetaDict
+                  a Metadict instance under test
+
+    expected: iterable object of key/value pairs
+             the value we expect from a test
     """
     check_contents(metadict_inst, expected)
     check_insertion_order(metadict_inst, expected)
 
 
 def pairs_to_dict(lst_of_pairs):
-    """ convert a list/tuple of lists/tuples to a dictionary
+    """
+    Convert a list/tuple of lists/tuples to a dictionary
 
-    E.g.  [['a', 1], ['b', 2]] -> {'a': 1, 'b': 2}
+    Parameters
+    ----------
+    lst_of_pairs: iteterable object of iterable objects
+                  an iterable containing iterables, each of these
+                  contained iterables is a key/value pair.
+
+    Examples
+    --------
+    >>> pairs_to_dict([['a', 1], ['b', 2]])
+    {'a': 1, 'b': 2}
+    >>> pairs_to_dict([('x', 34), ('y', 56)])
+    {'x': 34, 'y': 56}
     """
     return {kv_pair[0]: kv_pair[1] for kv_pair in lst_of_pairs}
 
@@ -139,6 +156,9 @@ def test_get_method(std_metadict):
 
 
 def test_setitem_op_existing(std_metadict):
+    """
+    Update an existing entry
+    """
     len_before = len(std_metadict)
     std_metadict['NORWEGIAN'] = 'Scandinavia'
     assert len(std_metadict) == len_before
@@ -148,6 +168,9 @@ def test_setitem_op_existing(std_metadict):
 
 
 def test_setitem_op_new(std_metadict):
+    """
+    Add a new entry
+    """
     len_before = len(std_metadict)
     std_metadict['Irish'] = 'N.Europe'
     assert len(std_metadict) == len_before + 1


### PR DESCRIPTION
I'm looking to learn more about the sunpy codebase and thought a good idea 
would be to start with the unit tests. To this end I've added some tests
for `sunpy.util.metadata.MetaDict`.

There are a lot of tests but, I've aimed for test coverage as well as code
coverage.

I'll start with `sunpy.util` and submit more than one file at a time but thought 
that it would be useful to get some feedback on this initial commit before I go
any further. 

This is my first use of `pytest` so I may not be using the correct idioms.

Michael.