### PR TITLE
init BasicRegistrationFactory with empty dict see #1988

### DIFF
--- a/sunpy/util/datatype_factory_base.py
+++ b/sunpy/util/datatype_factory_base.py
@@ -51,8 +51,8 @@ class BasicRegistrationFactory(object):
 
         self.default_widget_type = default_widget_type
 
-        self.validation_functions = \
-            ['_factory_validation_function'] + additional_validation_functions
+        self.validation_functions = (['_factory_validation_function'] +
+                                     additional_validation_functions)
 
     def __call__(self, *args, **kwargs):
         """ Method for running the factory.

--- a/sunpy/util/datatype_factory_base.py
+++ b/sunpy/util/datatype_factory_base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import inspect
 
+
 class BasicRegistrationFactory(object):
     """
     Generalized registerable factory type.
@@ -43,14 +44,15 @@ class BasicRegistrationFactory(object):
     def __init__(self, default_widget_type=None,
                  additional_validation_functions=[], registry=None):
 
-        if registry:
-            self.registry = registry
-        else:
+        if registry is None:
             self.registry = dict()
+        else:
+            self.registry = registry
 
         self.default_widget_type = default_widget_type
 
-        self.validation_functions = ['_factory_validation_function'] + additional_validation_functions
+        self.validation_functions = \
+            ['_factory_validation_function'] + additional_validation_functions
 
     def __call__(self, *args, **kwargs):
         """ Method for running the factory.
@@ -82,7 +84,9 @@ class BasicRegistrationFactory(object):
             else:
                 candidate_widget_types = [self.default_widget_type]
         elif n_matches > 1:
-            raise MultipleMatchError("Too many candidate types identified ({0}).  Specify enough keywords to guarantee unique type identification.".format(n_matches))
+            raise MultipleMatchError("Too many candidate types identified ({0})."
+                                     "Specify enough keywords to guarantee unique type "
+                                     "identification.".format(n_matches))
 
         # Only one is found
         WidgetType = candidate_widget_types[0]
@@ -133,10 +137,12 @@ class BasicRegistrationFactory(object):
                         found = True
                         break
                     else:
-                        raise ValidationFunctionError("{0}.{1} must be a classmethod.".format(WidgetType.__name__, vfunc_str))
+                        raise ValidationFunctionError("{0}.{1} must be a classmethod."
+                                                      .format(WidgetType.__name__, vfunc_str))
 
             if not found:
-                raise ValidationFunctionError("No proper validation function for class {0} found.".format(WidgetType.__name__))
+                raise ValidationFunctionError("No proper validation function for class {0} "
+                                              "found.".format(WidgetType.__name__))
 
     def unregister(self, WidgetType):
         """ Remove a widget from the factory's registry."""

--- a/sunpy/util/tests/test_datatype_factory_base.py
+++ b/sunpy/util/tests/test_datatype_factory_base.py
@@ -89,6 +89,15 @@ class TestBasicRegistrationFactory(object):
         with pytest.raises(ValidationFunctionError):
             DefaultFactory.register(MissingClassMethodWidget)
 
+        DefaultFactory.unregister(StandardWidget)
+        assert type(DefaultFactory(style='standard')) is not StandardWidget
+
+    def test_validation_fun_not_callable(self):
+        TestFactory = BasicRegistrationFactory()
+
+        with pytest.raises(AttributeError):
+            TestFactory.register(StandardWidget, validation_function='not_callable')
+
     def test_no_default_factory(self):
 
         NoDefaultFactory = BasicRegistrationFactory()
@@ -107,6 +116,20 @@ class TestBasicRegistrationFactory(object):
         assert type(NoDefaultFactory(style='standard')) is StandardWidget
         assert type(NoDefaultFactory(style='fancy', feature='present')) is FancyWidget
 
+    def test_with_external_registry(self):
+        external_registry = {}
+
+        FactoryWithExternalRegistry = \
+            BasicRegistrationFactory(registry=external_registry)
+
+        assert len(external_registry) == 0
+
+        FactoryWithExternalRegistry.register(StandardWidget)
+        assert type(FactoryWithExternalRegistry(style='standard')) is StandardWidget
+
+        # Ensure the 'external_registry' is being populated see #1988
+        assert len(external_registry) == 1
+
     def test_multiple_match_factory(self):
 
         MultipleMatchFactory = BasicRegistrationFactory()
@@ -118,7 +141,9 @@ class TestBasicRegistrationFactory(object):
             MultipleMatchFactory(style='standard')
 
     def test_extra_validation_factory(self):
-        ExtraValidationFactory = BasicRegistrationFactory(additional_validation_functions=['different_validation_function'])
+        ExtraValidationFactory = \
+            BasicRegistrationFactory(
+                additional_validation_functions=['different_validation_function'])
 
         ExtraValidationFactory.register(DifferentValidationWidget)
 


### PR DESCRIPTION
- Fixed bug 'Unable to initialize `BasicRegistrationFactory` with external empty
  dictionary #1988'

- Increased code coverage of sunpy/util/datatype_factory_base.py to 100%.

- Ensured that souce code files conform to pep8 guidelines. Mainly to do with
  keeping line length <= 100 chars long