### PR TITLE
Fix #1991 Validity of override ... ignored when adding first fun

### DIFF
--- a/sunpy/util/multimethod.py
+++ b/sunpy/util/multimethod.py
@@ -78,8 +78,11 @@ class MultiMethod(object):
             will be issued, and with FAIL a TypeError is raised when
             attempting to override an existing definition.
         """
+        if override not in (SILENT, WARN, FAIL):
+            raise ValueError("Invalid value '{0}' for override.".format(override))
+
         overriden = False
-        if override:
+        if override != SILENT:
             for signature, _ in self.methods:
                 if all(issubclass(a, b) for a, b in zip(types, signature)):
                     overriden = True
@@ -87,14 +90,10 @@ class MultiMethod(object):
             raise TypeError
         elif overriden and override == WARN:
             # pylint: disable=W0631
-            warn(
-                'Definition ({0}) overrides prior definition ({1}).'.format(
-                _fmt_t(types), _fmt_t(signature)),
-                TypeWarning,
-                stacklevel=3
-            )
-        elif overriden:
-            raise ValueError('Invalid value for override.')
+            warn('Definition ({0}) overrides prior definition ({1}).'.format(_fmt_t(types),
+                                                                             _fmt_t(signature)),
+                 TypeWarning, stacklevel=3)
+
         self.methods.append((types, fun))
 
     def add_dec(self, *types, **kwargs):
@@ -103,6 +102,7 @@ class MultiMethod(object):
         override to control overriding behaviour. Compare add.
         """
         self.cache = {}
+
         def _dec(fun):
             self.add(fun, types, kwargs.get('override', SILENT))
             return fun

--- a/sunpy/util/tests/test_multimethod.py
+++ b/sunpy/util/tests/test_multimethod.py
@@ -4,8 +4,10 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+import sys
 
 from sunpy.util.multimethod import MultiMethod, FAIL, WARN, TypeWarning
+
 
 def test_super():
     class String(str):
@@ -13,11 +15,15 @@ def test_super():
 
     mm = MultiMethod(lambda *a: a)
 
+    with pytest.raises(TypeError):
+        mm.super()
+
     @mm.add_dec(str, str)
     def foo(foo, bar):
         return 'String'
 
-    @mm.add_dec(String, str)
+    # Suppress pep8 warning "F811 redefinition of unused 'foo' ..."
+    @mm.add_dec(String, str)  # noqa
     def foo(foo, bar):
         return 'Fancy', mm.super(super(String, foo), bar)
 
@@ -42,3 +48,43 @@ def test_override(recwarn):
     mm.add_dec(String, str, override=WARN)(lambda x, y: None)
     w = recwarn.pop(TypeWarning)
     assert 'Definition (String, str) overrides prior definition (str, str).' in str(w.message)
+
+    # Illegal value for 'override'
+    pytest.raises(
+        ValueError, mm.add_dec(String, String, override=sys.maxsize), lambda x, y: None
+    )
+
+
+def test_invalid_arg_for_override_to_add_method():
+
+    def dummy_validator():
+        pass
+
+    mm = MultiMethod(lambda *a: a)
+
+    # See #1991
+    with pytest.raises(ValueError):
+        mm.add(dummy_validator, tuple(), override=sys.maxsize)
+
+
+def test_call_cached():
+
+    def sum_together(first, second):
+        return first + second
+
+    # Setup
+    mm = MultiMethod(lambda *a: a)
+    mm.add(sum_together, (int, int, ))
+    assert mm(3, 4) == 7
+
+    # The following call 'should' use the previously cached call
+    # You'll only see the result of this in the code coverage test though
+    assert mm(1, 2) == 3
+
+
+def test_no_registered_methods():
+
+    mm = MultiMethod(lambda *a: a)
+
+    with pytest.raises(TypeError):
+        mm(2)


### PR DESCRIPTION
- Fixed bug #1991 Validity of 'override' kwarg of
  MultiMethod.add(...) method ignored when adding first
  function

- Added more unit tests - increased test coverage

- Minor changes to ensure changed files conform to `pep8`

There are still a couple of lines in `sunpy.util.multimethod.MultiMethod` which 
are not being hit and these are all in the `super` method. I'll update the tests
when I'm more familiar with the what the code is meant to do.  

Please review the `test_call_cached` test. This is only here to make sure the cache 
code is hit and so the code coverage is bumped up.

I did think of checking `self.cache` but I regard this as a implementation detail
and was reluctant to reference this in the tests. 

In order to avoid the duplication of the allowed arguments to override I'd thought 
of doing the following:

```python

def generate_vals(max_number):
    return tuple(range(max_number))

# ...

_valid_override_vals = generate_vals(3)

SILENT, WARN, FAIL = _valid_override_vals

# ...

    def add(self, fun, types, override=SILENT ):
        if override not in _valid_override_vals:
            # ERROR!
```

The advantage is that any attempt to add or remove another value will
result in an error at import time.

```
SILENT, WARN, FAIL, OTHER = _override_vals 
   ValueError: need more than 3 values to unpack
...

SILENT, WARN = _override_vals 
   ValueError: too many values to unpack   
```

The disadvantages are:

- It creates another layer of code to delve into.
- I can't see anywhere else in the code base this could be used, though I've not done an extensive search.
- The API of the `add` method looks stable and probably does not justify this change. 


