### PR TITLE
Fix parsing of double digit years in parse_time with _time_string_parse_format set

### DIFF
--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -148,6 +148,10 @@ def test_time_string_parse_format():
                       _time_string_parse_format='%d/%m/%Y') == datetime(2012, 6, 1, 0, 0)
     assert parse_time('06/01/2012',
                       _time_string_parse_format='%d/%m/%Y') == datetime(2012, 1, 6, 0, 0)
+    assert parse_time('06/01/85',
+                      _time_string_parse_format='%d/%m/%y') == datetime(1985, 1, 6, 0, 0)
+    assert parse_time('6/1/85',
+                      _time_string_parse_format='%d/%m/%y') == datetime(1985, 1, 6, 0, 0)
     with pytest.raises(ValueError):
         parse_time('01/06/2012')
     with pytest.raises(ValueError):

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -220,7 +220,10 @@ def parse_time(time_string, time_format='', **kwargs):
             try:
                 ts, time_delta = _regex_parse_time(time_string,
                                                    time_string_parse_format)
-                return datetime.strptime(ts, time_string_parse_format) + time_delta
+                if ts and time_delta:
+                    return datetime.strptime(ts, time_string_parse_format) + time_delta
+                else:
+                    return datetime.strptime(time_string, time_string_parse_format)
             except:
                 pass
         raise ValueError("{tstr!s} is not a valid time string!".format(tstr=time_string))


### PR DESCRIPTION
this is a small oversight from #1967