### PR TITLE
Added tests to increase code coverage in sunpy.time package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Latest
 ------
 
-* User can now pass a custom time format as an argument inside 
+* User can now pass a custom time format as an argument inside
   `sunpy.database.add_from_dir()` in case the `date-obs` metadata cannot
   be read automatically from the files.
 * Get and set methods for composite maps now use Map plot_settings.
@@ -29,6 +29,8 @@ Latest
   imported with `from sunpy.net.helioviewer import HelioviewerClient`.
 * Removed compatibility with standalone ``wcsaxes`` and instead depend on the
   version in astropy 1.3. SunPy now therefore depends on astropy>=1.3.
+* Update to `TimeRange.__repr__`; now includes the qualified name and `id` of
+  the object.
 
 0.7.0
 -----

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import, division, print_function
 from datetime import datetime
 
 from sunpy import time
-from sunpy.time import parse_time
+from sunpy.time import parse_time, extract_time, is_time_in_given_format, get_day, find_time
 
+import astropy.time
 import numpy as np
 import pandas
 from sunpy.extern.six.moves import range
@@ -74,6 +75,21 @@ def test_parse_time_numpy_datetime():
 
     assert isinstance(dts, np.ndarray)
     assert all([isinstance(dt, datetime) for dt in dts])
+
+
+def test_parse_time_astropy():
+    astropy_time = parse_time(astropy.time.Time(['2016-01-02T23:00:01']))
+
+    assert astropy_time == datetime(year=2016, month=1, day=2, hour=23, minute=0, second=1)
+
+
+def test_parse_time_now():
+    """
+    Ensure 'parse_time' can be called with 'now' argument to get utc
+    """
+    # TODO: once mocking support is merged in, we can perform a like for like comparison,
+    #       the following at least ensures that 'now' is a legal argument.
+    assert isinstance(parse_time('now'), datetime) is True
 
 
 def test_ISO():
@@ -152,3 +168,75 @@ def test_time_string_parse_format():
         parse_time('01/06/2012')
     with pytest.raises(ValueError):
         parse_time('01/06/2012', time_string_parse_format='%d/%m/%m')
+
+    with pytest.raises(ValueError):
+        parse_time('2016', _time_string_parse_format='zz')
+
+
+def test__iter_empty():
+
+    class CountDown(object):
+
+        def __init__(self, start_from=0):
+            self.start = start_from
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self.start -= 1
+
+            if self.start < 0:
+                raise StopIteration
+
+            return self.start
+
+        next = __next__   # Support Py2.x
+
+    one_count = CountDown(1)
+    assert time.time._iter_empty(one_count) is False
+    assert time.time._iter_empty(one_count) is True
+
+
+def test_extract_time_illegal_args():
+
+    with pytest.raises(ValueError):
+        extract_time('2017')
+
+    with pytest.raises(ValueError):
+        extract_time('This is an ambiguous 2017-02-12-9 2017-02-12-9 timestring')
+
+
+def test_extract_time_best_effort():
+    """
+    Make a 'best-effort' guess as to what the time could be
+    """
+    assert extract_time('2017-02-12-9-02-12-9') == datetime(year=2017, month=2, day=12,
+                                                            hour=0, minute=0, second=0)
+
+
+def test_is_time():
+    assert time.is_time(datetime.utcnow()) is True
+    assert time.is_time('2017-02-14 08:08:12.999', "%Y-%m-%d %H:%M:%S.%f") is True
+
+    assert time.is_time(None) is False
+    assert time.is_time('2016-14-14 19:08', "%Y-%b-%d %H:%M:%S") is False
+
+
+def test_is_time_in_given_format():
+    assert is_time_in_given_format('2017-02-14 08:08:12.999', "%Y-%m-%d %H:%M:%S.%f") is True
+    assert is_time_in_given_format('2017-02-14 08:08:12.999', "%Y-%m-%dT%H:%M:%S.%f") is False
+
+
+def test_get_day():
+    end_of_day = datetime(year=2017, month=1, day=1, hour=23, minute=59, second=59,
+                          microsecond=999)
+
+    begining_of_day = get_day(end_of_day)
+    assert begining_of_day.year == 2017
+    assert begining_of_day.month == 1
+    assert begining_of_day.day == 1
+    assert begining_of_day.hour == 0
+    assert begining_of_day.minute == 0
+    assert begining_of_day.second == 0
+    assert begining_of_day.microsecond == 0

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -24,13 +24,105 @@ delta = end - start
     (tbegin_str, dt),
     (tbegin_str, datetime.timedelta(days=1))
 ])
-
 def test_timerange_inputs(inputs):
     timerange = sunpy.time.TimeRange(*inputs)
     assert isinstance(timerange, sunpy.time.TimeRange)
     assert timerange.start == start
     assert timerange.end == end
     assert timerange.dt == delta
+
+
+def test_timerange_invalid_range():
+    """
+    TimeRange can expect a range of two times. if this is not the case then
+    raise an exception
+    """
+    lower = '2016/01/04 09:30'
+    mid = '2016/06/04 09:30'
+    upper = '2017/03/04 09:30'
+
+    with pytest.raises(ValueError):
+        sunpy.time.TimeRange((lower,))
+
+    with pytest.raises(ValueError):
+        sunpy.time.TimeRange((lower, mid, upper))
+
+
+def test_equals():
+    """
+    Test the __eq__ operator
+    """
+    lower = '2016/01/04T09:30:00.000'
+    upper = '2016/06/04T09:30:00.000'
+    upper_plus_one_msec = '2016/06/04T09:30:00.001'
+
+    tr = sunpy.time.TimeRange((lower, upper))
+
+    # This should *always* hold true
+    assert tr == tr
+
+    # Same values, different format
+    tr_diff_format = sunpy.time.TimeRange('2016-01-04T09:30:00.000', '2016-06-04T09:30:00.000')
+
+    assert tr == tr_diff_format
+
+    lower_dt = datetime.datetime(year=2016, month=1, day=4, hour=9, minute=30, second=0)
+    upper_dt = datetime.datetime(year=2016, month=6, day=4, hour=9, minute=30, second=0)
+    tr_datetime = sunpy.time.TimeRange(lower_dt, upper_dt)
+
+    assert tr == tr_datetime
+
+    tr_plus_one_msec = sunpy.time.TimeRange((lower, upper_plus_one_msec))
+
+    assert (tr_plus_one_msec == tr) is False
+
+    # Attempt using objects which are *not* TimeRanges
+    assert (tr == lower_dt) is False
+    assert (lower_dt == tr) is False
+
+
+def test_not_equals():
+    """
+    Test __ne__ operator
+    """
+    a_st = '2016/01/04T09:30:00.000'
+    a_et = '2016/06/04T09:30:00.000'
+
+    b_st = '2017/01/04T09:30:00.000'
+    b_et = '2017/06/04T09:30:00.000'
+
+    # Same start time, different end times
+    assert sunpy.time.TimeRange(a_st, a_et) != sunpy.time.TimeRange(a_st, b_et)
+
+    # Different start times, same end times
+    assert sunpy.time.TimeRange(b_st, b_et) != sunpy.time.TimeRange(a_st, b_et)
+
+    # Different start & end times
+    assert sunpy.time.TimeRange(a_st, a_et) != sunpy.time.TimeRange(b_st, b_et)
+
+    # Different objects
+    assert sunpy.time.TimeRange(a_st, a_et) != dict()
+    assert list() != sunpy.time.TimeRange(a_st, a_et)
+
+
+def test_get_dates():
+    lower = '2016/01/04 09:30'
+    lower_plus_one_day = '2016/01/05 09:30'
+    upper = '2016/06/04 09:30'
+
+    single_day = sunpy.time.TimeRange((lower, lower))
+
+    assert single_day.get_dates() == [datetime.date(2016, 1, 4)]
+
+    two_days = sunpy.time.TimeRange((lower, lower_plus_one_day))
+
+    assert two_days.get_dates() == [datetime.date(2016, 1, 4), datetime.date(2016, 1, 5)]
+
+    one_year = sunpy.time.TimeRange('2017/01/01', '2017-12-31')
+    assert len(one_year.get_dates()) == 365
+
+    leap_year = sunpy.time.TimeRange('2016/01/01', '2016-12-31')
+    assert len(leap_year.get_dates()) == 366
 
 
 @pytest.mark.parametrize("ainput", [
@@ -45,6 +137,7 @@ def test_timerange_input(ainput):
     assert timerange.start == start
     assert timerange.end == end
     assert timerange.dt == delta
+
 
 @pytest.mark.parametrize("ainput", [
     (tbegin_str, tfin_str),
@@ -61,19 +154,22 @@ def test_start_lessthan_end(ainput):
     assert timerange.start == start
     assert timerange.end == end
 
+
 @pytest.fixture
 def timerange_a():
     return sunpy.time.TimeRange(tbegin_str, tfin_str)
+
 
 def test_center(timerange_a):
     assert timerange_a.center == datetime.datetime(year=2012, day=1, month=1,
                                                    hour=12)
 
+
 def test_split(timerange_a):
     expect = [sunpy.time.TimeRange('2012/1/1T00:00:00', '2012/1/1T12:00:00'),
               sunpy.time.TimeRange('2012/1/1T12:00:00', '2012/1/2T00:00:00')]
     split = timerange_a.split(n=2)
-    #Doing direct comparisons seem to not work
+    # Doing direct comparisons seem to not work
     assert all([wi.start == ex.start and wi.end == ex.end for wi, ex in zip(split, expect)])
 
 
@@ -81,9 +177,11 @@ def test_split_n_0_error(timerange_a):
     with pytest.raises(ValueError):
         timerange_a.split(n=0)
 
+
 def test_input_error(timerange_a):
     with pytest.raises(ValueError):
         sunpy.time.TimeRange((tbegin_str))
+
 
 def test_window(timerange_a):
     timerange = sunpy.time.TimeRange(tbegin_str, tfin_str)
@@ -92,36 +190,44 @@ def test_window(timerange_a):
               sunpy.time.TimeRange('2012/1/1T12:00:00', '2012/1/1T12:00:10'),
               sunpy.time.TimeRange('2012/1/2T00:00:00', '2012/1/2T00:00:10')]
     assert isinstance(window, list)
-    #Doing direct comparisons seem to not work
+    # Doing direct comparisons seem to not work
     assert all([wi.start == ex.start and wi.end == ex.end for wi, ex in zip(window, expect)])
 
+
 def test_window_timedelta(timerange_a):
-    timerange = sunpy.time.TimeRange(tbegin_str,tfin_str)
+    timerange = sunpy.time.TimeRange(tbegin_str, tfin_str)
     window = timerange.window(datetime.timedelta(hours=12), datetime.timedelta(seconds=10))
     expect = [sunpy.time.TimeRange('2012/1/1T00:00:00', '2012/1/1T00:00:10'),
               sunpy.time.TimeRange('2012/1/1T12:00:00', '2012/1/1T12:00:10'),
               sunpy.time.TimeRange('2012/1/2T00:00:00', '2012/1/2T00:00:10')]
     assert isinstance(window, list)
-    #Doing direct comparisons seem to not work
+    # Doing direct comparisons seem to not work
     assert all([wi.start == ex.start and wi.end == ex.end for wi, ex in zip(window, expect)])
+
 
 def test_days(timerange_a):
     assert timerange_a.days == u.Quantity(1, 'd')
 
+
 def test_start(timerange_a):
     assert timerange_a.start == start
+
 
 def test_end(timerange_a):
     assert timerange_a.end == end
 
+
 def test_seconds(timerange_a):
     assert timerange_a.seconds == dt
+
 
 def test_minutes(timerange_a):
     assert timerange_a.minutes == u.Quantity(24 * 60, 'min')
 
+
 def test_hours(timerange_a):
     assert timerange_a.hours == u.Quantity(24, 'hour')
+
 
 def test_next():
     timerange = sunpy.time.TimeRange(tbegin_str, tfin_str)
@@ -131,6 +237,7 @@ def test_next():
     assert timerange.end == end + delta
     assert timerange.dt == delta
 
+
 def test_previous():
     timerange = sunpy.time.TimeRange(tbegin_str, tfin_str)
     timerange.previous()
@@ -139,6 +246,7 @@ def test_previous():
     assert timerange.end == end - delta
     assert timerange.dt == delta
 
+
 def test_extend():
     timerange = sunpy.time.TimeRange(tbegin_str, tfin_str)
     timerange.extend(delta, delta)
@@ -146,6 +254,7 @@ def test_extend():
     assert timerange.start == start + delta
     assert timerange.end == end + delta
     assert timerange.dt == delta
+
 
 def test_contains(timerange_a):
     before = datetime.datetime(year=1990, month=1, day=1)

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -226,19 +226,22 @@ class TimeRange(object):
 
     def __repr__(self):
         """
-        Returns a human-readable representation of the TimeRange instance."""
+        Returns a human-readable representation of the TimeRange instance.
+        """
 
         t1 = self.start.strftime(TIME_FORMAT)
         t2 = self.end.strftime(TIME_FORMAT)
         center = self.center.strftime(TIME_FORMAT)
+        fully_qualified_name = '{0}.{1}'.format(self.__class__.__module__, self.__class__.__name__)
 
-        return ('    Start:'.ljust(11) + t1 +
+        return ('   <{0} object at {1}'.format(fully_qualified_name, hex(id(self))) +
+                '\n    Start:'.ljust(12) + t1 +
                 '\n    End:'.ljust(12) + t2 +
                 '\n    Center:'.ljust(12) + center +
                 '\n    Duration:'.ljust(12) + str(self.days.value) + ' days or' +
                 '\n    '.ljust(12) + str(self.hours.value) + ' hours or' +
                 '\n    '.ljust(12) + str(self.minutes.value) + ' minutes or' +
-                '\n    '.ljust(12) + str(self.seconds.value) + ' seconds' +
+                '\n    '.ljust(12) + str(self.seconds.value) + ' seconds' + '>'
                 '\n')
 
     def split(self, n=2):

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -234,14 +234,14 @@ class TimeRange(object):
         center = self.center.strftime(TIME_FORMAT)
         fully_qualified_name = '{0}.{1}'.format(self.__class__.__module__, self.__class__.__name__)
 
-        return ('   <{0} object at {1}'.format(fully_qualified_name, hex(id(self))) +
+        return ('   <{0} object at {1}>'.format(fully_qualified_name, hex(id(self))) +
                 '\n    Start:'.ljust(12) + t1 +
                 '\n    End:'.ljust(12) + t2 +
                 '\n    Center:'.ljust(12) + center +
                 '\n    Duration:'.ljust(12) + str(self.days.value) + ' days or' +
                 '\n    '.ljust(12) + str(self.hours.value) + ' hours or' +
                 '\n    '.ljust(12) + str(self.minutes.value) + ' minutes or' +
-                '\n    '.ljust(12) + str(self.seconds.value) + ' seconds' + '>'
+                '\n    '.ljust(12) + str(self.seconds.value) + ' seconds' +
                 '\n')
 
     def split(self, n=2):

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -185,8 +185,8 @@ class TimeRange(object):
         -------
         value : `astropy.units.Quantity`
         """
-        result = self.dt.microseconds * u.Unit('us') + self.dt.seconds * u.Unit('s') + self.dt.days * u.Unit('day')
-        return result
+        return (self.dt.microseconds * u.Unit('us') + self.dt.seconds * u.Unit('s') +
+                self.dt.days * u.Unit('day'))
 
     def __eq__(self, other):
         """
@@ -201,7 +201,28 @@ class TimeRange(object):
         -------
         result : `bool`
         """
-        return ((self.start == other.start) and (self.end == other.end))
+        if isinstance(other, TimeRange):
+            return (self.start == other.start) and (self.end == other.end)
+
+        return NotImplemented
+
+    def __ne__(self, other):
+        """
+        Check two TimeRange objects have different start or end datetimes.
+
+        Parameters
+        ----------
+        other : `~sunpy.time.timerange.TimeRange`
+            The second TimeRange object to compare to.
+
+        Returns
+        -------
+        result : `bool`
+        """
+        if isinstance(other, TimeRange):
+            return (self.start != other.start) or (self.end != other.end)
+
+        return NotImplemented
 
     def __repr__(self):
         """
@@ -347,7 +368,7 @@ class TimeRange(object):
         Return all partial days contained within the timerange
         """
         dates = []
-        dates =[ self.start.date() + timedelta(days=i) for i in range(int(self.days.value) + 1) ]
+        dates = [self.start.date() + timedelta(days=i) for i in range(int(self.days.value) + 1)]
         return dates
 
     def __contains__(self, time):
@@ -379,5 +400,3 @@ class TimeRange(object):
         """
         this_time = parse_time(time)
         return this_time >= self.start and this_time <= self.end
-    
-  


### PR DESCRIPTION
- code coverage increased: time.py, timerange.py
- `TimeRange.__eq__` method altered
- `TimeRange.__ne__` method added
- Minor formatting changes to satisfy pep8

#### Code coverage

- `sunpy.time.timerange`: 92% -> 96%
- `sunpy.time.time`: 58% -> 93%


#### Changes to `sunpy/time/timerange.py`

`__eq__`

Returns `NotImplemented` if an attempt is made to compare a 'TimeRange' against 
something which is *not* a `TimeRange`, in practice this evaluates to `False` see 
[here](http://stackoverflow.com/questions/878943/why-return-notimplemented-instead-of-raising-notimplementederror)

I reasoned the new behaviour is *neater* than the current but, I'd very much 
appreciate feedback. 

The current behaviour is:
```
>>> dict() == TimeRange(...)
...
File ".../sunpy/time/timerange.py", line 204, in __eq__
  return ((self.start == other.start) and (self.end == other.end))
AttributeError: 'dict' object has no attribute 'start'
``` 

`__ne__`

Implemented `__ne__` as usually a good idea to define if `__eq__` is already
present. Did not define in terms of `__eq__`. See [here](http://stackoverflow.com/questions/4352244/python-should-i-implement-ne-operator-based-on-eq)
for reasoning.

Minor changes to formatting to satisfy pep8.

##### Observations:

The `TimeRange.__repr__` method has the same behaviour as the `__str__` method usually has, that is
it returns a nicely formatted string suitable for human consumption. Ideally the return 
value of `__repr__` should be able to be evaluated by `eval`. [See here](http://brennerm.github.io/posts/python-str-vs-repr.html)

If needed, I can make the changes.   