### PR TITLE
Data directory should not be created on import

### DIFF
--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -76,6 +76,10 @@ def download_sample_data(progress=True, overwrite=True, timeout=None):
     -------
     None
     """
+    # Creating the directory for sample files to be downloaded
+    if not os.path.isdir(config.get('downloads', 'sample_dir')):
+        os.makedirs(config.get('downloads', 'sample_dir'))
+
     number_of_files_fetched = 0
     print("Downloading sample files to {}".format(sampledata_dir))
     for file_name in six.itervalues(_files):

--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -42,8 +42,8 @@ _files = {
     "AIA_171_ROLL_IMAGE": ("aiacalibim5.fits.gz", ""),
     "AIA_94_CUTOUT": ("ssw_cutout_20121030_153001_AIA_94_.fts", ""),
     "EVE_LIGHTCURVE": ("20120620_EVE_L0CS_DIODES_1m.txt", ""),
-# Uncomment this if it needs to be used. Commented out to save bandwidth.
-#    "LYRA_LIGHTCURVE": ("lyra_20110810-000000_lev2_std.fits.gz", ""),
+    # Uncomment this if it needs to be used. Commented out to save bandwidth.
+    # "LYRA_LIGHTCURVE": ("lyra_20110810-000000_lev2_std.fits.gz", ""),
     "LYRA_LEVEL3_LIGHTCURVE": ("lyra_20150101-000000_lev3_std.fits.gz", ""),
     "GOES_LIGHTCURVE": ("go1520120601.fits.gz", ""),
     "GBM_LIGHTCURVE": ("glg_cspec_n5_110607_v00.pha", ""),
@@ -109,7 +109,9 @@ def download_sample_data(progress=True, overwrite=True, timeout=None):
                     number_of_files_fetched += 1
                     break
             except (socket.error, socket.timeout) as e:
-                warnings.warn("Download failed with error {}. \n Retrying with different mirror.".format(e))
+                warnings.warn("Download failed with error {}. \n"
+                              "Retrying with different mirror.".format(e))
 
     if number_of_files_fetched < len(list(_files.keys())):
-        raise URLError("Could not download all samples files. Problem with accessing sample data servers.")
+        raise URLError("Could not download all samples files."
+                       "Problem with accessing sample data servers.")

--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -14,6 +14,7 @@ from sunpy.extern import six
 from sunpy.extern.six.moves.urllib.error import URLError
 
 from sunpy.util.net import url_exists
+from sunpy.util.config import get_and_create_sample_dir
 from sunpy import config
 
 __author__ = "Steven Christe"
@@ -77,8 +78,7 @@ def download_sample_data(progress=True, overwrite=True, timeout=None):
     None
     """
     # Creating the directory for sample files to be downloaded
-    if not os.path.isdir(config.get('downloads', 'sample_dir')):
-        os.makedirs(config.get('downloads', 'sample_dir'))
+    sampledata_dir = get_and_create_sample_dir()
 
     number_of_files_fetched = 0
     print("Downloading sample files to {}".format(sampledata_dir))

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -805,7 +805,7 @@ def test_fetch_separate_filenames():
     )
 
     if not os.path.isdir(tmp_test_dir):
-        os.mkdir(tmp_test_dir)
+        os.makedirs(tmp_test_dir)
 
     path = tmp_test_dir + '{file}'
 

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -557,7 +557,7 @@ def _goes_get_chianti_temp(fluxratio, satellite=8, abundances="coronal",
 
     # Ensure input values of flux ratio are within limits of model table
     if np.min(fluxratio) < np.min(modelratio) or \
-      np.max(fluxratio) > np.max(modelratio):
+       np.max(fluxratio) > np.max(modelratio):
         raise ValueError(
             "For GOES {0}, all values in fluxratio input must be within " +
             "the range {1} - {2}.".format(satellite, np.min(modelratio),
@@ -701,7 +701,7 @@ def _goes_get_chianti_em(longflux, temp, satellite=8, abundances="coronal",
 
     # Initialize lists to hold model data of temperature - long channel
     # flux relationship read in from csv file.
-    modeltemp = [] # modelled temperature is in log_10 space in units of MK
+    modeltemp = []   # modelled temperature is in log_10 space in units of MK
     modelflux = []
     # Determine name of column in csv file containing model ratio values
     # for relevant GOES satellite
@@ -720,8 +720,8 @@ def _goes_get_chianti_em(longflux, temp, satellite=8, abundances="coronal",
 
     # Ensure input values of flux ratio are within limits of model table
     if np.min(log10_temp) < np.min(modeltemp) or \
-      np.max(log10_temp) > np.max(modeltemp) or \
-      np.isnan(np.min(log10_temp)):
+       np.max(log10_temp) > np.max(modeltemp) or \
+       np.isnan(np.min(log10_temp)):
         raise ValueError("All values in temp must be within the range "
                          "{0} - {1} MK.".format(np.min(10**modeltemp),
                                                 np.max(10**modeltemp)))
@@ -863,6 +863,7 @@ def calculate_radiative_loss_rate(goeslc, force_download=False,
 
     return lc_new
 
+
 @u.quantity_input(temp=u.MK, em=u.cm**(-3))
 def _calc_rad_loss(temp, em, obstime=None, force_download=False,
                    download_dir=None):
@@ -960,7 +961,7 @@ def _calc_rad_loss(temp, em, obstime=None, force_download=False,
 
     # Initialize lists to hold model data of temperature - rad loss rate
     # relationship read in from csv file
-    modeltemp = [] # modelled temperature is in log_10 space in units of MK
+    modeltemp = []    # modelled temperature is in log_10 space in units of MK
     model_loss_rate = []
 
     # Read data from csv file into lists, being sure to skip commented
@@ -976,7 +977,7 @@ def _calc_rad_loss(temp, em, obstime=None, force_download=False,
     model_loss_rate = np.asarray(model_loss_rate)
     # Ensure input values of flux ratio are within limits of model table
     if temp.value.min() < modeltemp.min() or \
-        temp.value.max() > modeltemp.max():
+    temp.value.max() > modeltemp.max():
         raise ValueError("All values in temp must be within the range " +
                          "{0} - {1} MK.".format(np.min(modeltemp/1e6),
                                                 np.max(modeltemp/1e6)))
@@ -1021,11 +1022,11 @@ def _calc_rad_loss(temp, em, obstime=None, force_download=False,
         rad_loss_cumul = cumtrapz(rad_loss, obstime_seconds)
         rad_loss_cumul = u.Quantity(rad_loss_cumul, unit=rad_loss.unit*u.s)
         # Enter results into output dictionary.
-        rad_loss_out = {"rad_loss_rate":rad_loss,
-                        "rad_loss_cumul" : rad_loss_cumul,
-                        "rad_loss_int":rad_loss_int}
+        rad_loss_out = {"rad_loss_rate": rad_loss,
+                        "rad_loss_cumul": rad_loss_cumul,
+                        "rad_loss_int": rad_loss_int}
     else:
-        rad_loss_out = {"rad_loss_rate":rad_loss}
+        rad_loss_out = {"rad_loss_rate": rad_loss}
 
     return rad_loss_out
 
@@ -1225,14 +1226,15 @@ def _goes_lx(longflux, shortflux, obstime=None, date=None):
         shortlum_cumul = cumtrapz(shortlum.value, obstime_seconds)
         shortlum_cumul = u.Quantity(shortlum_cumul,
                                     unit=shortlum.unit*u.s)
-        lx_out = {"longlum":longlum, "shortlum":shortlum,
-                  "longlum_cumul":longlum_cumul,
-                  "shortlum_cumul":shortlum_cumul,
-                  "longlum_int":longlum_int, "shortlum_int":shortlum_int}
+        lx_out = {"longlum": longlum, "shortlum": shortlum,
+                  "longlum_cumul": longlum_cumul,
+                  "shortlum_cumul": shortlum_cumul,
+                  "longlum_int": longlum_int, "shortlum_int": shortlum_int}
     else:
-        lx_out = {"longlum":longlum, "shortlum":shortlum}
+        lx_out = {"longlum": longlum, "shortlum": shortlum}
 
     return lx_out
+
 
 @u.quantity_input(flux=u.W/u.m/u.m)
 def _calc_xraylum(flux, date=None):
@@ -1307,13 +1309,13 @@ def flareclass_to_flux(flareclass):
     >>> flareclass_to_flux('X2.4')
     < Quantity 0.00024 W / m2>
     """
-    if type(flareclass) != type('str'):
+    if not isinstance(flareclass, type('str')):
         raise TypeError("Input must be a string")
-    #TODO should probably make sure the string is in the expected format.
+    # TODO should probably make sure the string is in the expected format.
 
     flareclass = flareclass.upper()
-    #invert the conversion dictionary
-    #conversion_dict = {v: k for k, v in GOES_CONVERSION_DICT.items()}
+    # invert the conversion dictionary
+    # conversion_dict = {v: k for k, v in GOES_CONVERSION_DICT.items()}
     return float(flareclass[1:]) * GOES_CONVERSION_DICT[flareclass[0]]
 
 
@@ -1362,7 +1364,7 @@ def flux_to_flareclass(goesflux):
         raise ValueError("Flux cannot be negative")
 
     decade = np.floor(np.log10(goesflux.to('W/m**2').value))
-    #invert the conversion dictionary
+    # invert the conversion dictionary
     conversion_dict = {v: k for k, v in GOES_CONVERSION_DICT.items()}
     if decade < -8:
         str_class = "A"
@@ -1371,6 +1373,6 @@ def flux_to_flareclass(goesflux):
         str_class = "X"
         decade = -4
     else:
-        str_class = conversion_dict.get(u.Quantity(10 ** decade, "W/m**2" ))
+        str_class = conversion_dict.get(u.Quantity(10 ** decade, "W/m**2"))
     goes_subclass = 10 ** -decade * goesflux.to('W/m**2').value
     return "{0}{1:.3g}".format(str_class, goes_subclass)

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -66,6 +66,7 @@ from sunpy.time import parse_time
 from sunpy import config
 from sunpy import lightcurve
 from sunpy.util.net import check_download_file
+from sunpy.util.config import create_download_dir
 from sunpy import sun
 
 GOES_CONVERSION_DICT = {'X': u.Quantity(1e-4, "W/m^2"),
@@ -88,6 +89,7 @@ except socket.gaierror:
 GOES_REMOTE_PATH = "http://{0}/ssw/gen/idl/synoptic/goes/".format(HOST)
 # Define location where data files should be downloaded to.
 DATA_PATH = config.get("downloads", "download_dir")
+create_download_dir()
 # Define variables for file names
 FILE_TEMP_COR = "goes_chianti_temp_cor.csv"
 FILE_TEMP_PHO = "goes_chianti_temp_pho.csv"

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -66,7 +66,7 @@ from sunpy.time import parse_time
 from sunpy import config
 from sunpy import lightcurve
 from sunpy.util.net import check_download_file
-from sunpy.util.config import create_download_dir
+from sunpy.util.config import get_and_create_download_dir
 from sunpy import sun
 
 GOES_CONVERSION_DICT = {'X': u.Quantity(1e-4, "W/m^2"),
@@ -87,9 +87,6 @@ try:
 except socket.gaierror:
     HOST = ''
 GOES_REMOTE_PATH = "http://{0}/ssw/gen/idl/synoptic/goes/".format(HOST)
-# Define location where data files should be downloaded to.
-DATA_PATH = config.get("downloads", "download_dir")
-create_download_dir()
 # Define variables for file names
 FILE_TEMP_COR = "goes_chianti_temp_cor.csv"
 FILE_TEMP_PHO = "goes_chianti_temp_pho.csv"
@@ -256,7 +253,7 @@ def calculate_temperature_em(goeslc, abundances="coronal",
     if not isinstance(goeslc, lightcurve.LightCurve):
         raise TypeError("goeslc must be a LightCurve object.")
     if not download_dir:
-        download_dir = DATA_PATH
+        download_dir = get_and_create_download_dir()
 
     # Find temperature and emission measure with _goes_chianti_tem
     temp, em = _goes_chianti_tem(
@@ -377,7 +374,7 @@ def _goes_chianti_tem(longflux, shortflux, satellite=8,
 
     """
     if not download_dir:
-        download_dir = DATA_PATH
+        download_dir = get_and_create_download_dir()
     # ENSURE INPUTS ARE OF CORRECT TYPE AND VALID VALUES
     longflux = longflux.to(u.W/u.m/u.m)
     shortflux = shortflux.to(u.W/u.m/u.m)
@@ -513,7 +510,7 @@ def _goes_get_chianti_temp(fluxratio, satellite=8, abundances="coronal",
 
     """
     if not download_dir:
-        download_dir = DATA_PATH
+        download_dir = get_and_create_download_dir()
     # If download kwarg is True, or required data files cannot be
     # found locally, download required data files.
     check_download_file(FILE_TEMP_COR, GOES_REMOTE_PATH, download_dir,
@@ -546,7 +543,7 @@ def _goes_get_chianti_temp(fluxratio, satellite=8, abundances="coronal",
     label = "ratioGOES{0}".format(satellite)
     # Read data representing appropriate temperature--flux ratio
     # relationship depending on satellite number and assumed abundances.
-    with open(os.path.join(DATA_PATH, data_file), "r") as csvfile:
+    with open(os.path.join(get_and_create_download_dir(), data_file), "r") as csvfile:
         startline = dropwhile(lambda l: l.startswith("#"), csvfile)
         csvreader = csv.DictReader(startline, delimiter=";")
         for row in csvreader:
@@ -669,7 +666,7 @@ def _goes_get_chianti_em(longflux, temp, satellite=8, abundances="coronal",
 
     """
     if not download_dir:
-        download_dir = DATA_PATH
+        download_dir = get_and_create_download_dir()
     # If download kwarg is True, or required data files cannot be
     # found locally, download required data files.
     check_download_file(FILE_EM_COR, GOES_REMOTE_PATH, download_dir,
@@ -709,7 +706,7 @@ def _goes_get_chianti_em(longflux, temp, satellite=8, abundances="coronal",
 
     # Read data representing appropriate temperature--long flux
     # relationship depending on satellite number and assumed abundances.
-    with open(os.path.join(DATA_PATH, data_file), "r") as csvfile:
+    with open(os.path.join(get_and_create_download_dir(), data_file), "r") as csvfile:
         startline = dropwhile(lambda l: l.startswith("#"), csvfile)
         csvreader = csv.DictReader(startline, delimiter=";")
         for row in csvreader:
@@ -833,7 +830,7 @@ def calculate_radiative_loss_rate(goeslc, force_download=False,
 
     """
     if not download_dir:
-        download_dir = DATA_PATH
+        download_dir = get_and_create_download_dir()
     # Check that input argument is of correct type
     if not isinstance(goeslc, lightcurve.LightCurve):
         raise TypeError("goeslc must be a LightCurve object.")
@@ -948,7 +945,7 @@ def _calc_rad_loss(temp, em, obstime=None, force_download=False,
     <Quantity [  3.01851392e+19,  3.01851392e+19] J / s>
     """
     if not download_dir:
-        download_dir = DATA_PATH
+        download_dir = get_and_create_download_dir()
     # Check inputs are correct
     temp = temp.to(u.K)
     em = em.to(1/u.cm**3)
@@ -966,7 +963,7 @@ def _calc_rad_loss(temp, em, obstime=None, force_download=False,
 
     # Read data from csv file into lists, being sure to skip commented
     # lines beginning with "#"
-    with open(os.path.join(DATA_PATH, FILE_RAD_COR),
+    with open(os.path.join(get_and_create_download_dir(), FILE_RAD_COR),
               "r") as csvfile:
         startline = csvfile.readlines()[7:]
         csvreader = csv.reader(startline, delimiter=" ")

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -14,14 +14,12 @@ import pandas
 from sunpy.time import parse_time
 from sunpy import config
 from sunpy.util.net import check_download_file
-from sunpy.util.config import create_download_dir
+from sunpy.util.config import get_and_create_download_dir
 from sunpy import lightcurve
 
 from sunpy.extern.six.moves import urllib
 
 LYTAF_REMOTE_PATH = "http://proba2.oma.be/lyra/data/lytaf/"
-LYTAF_PATH = config.get("downloads", "download_dir")
-create_download_dir()
 
 
 def remove_lytaf_events_from_lightcurve(lc, artifacts=None,
@@ -96,7 +94,7 @@ def remove_lytaf_events_from_lightcurve(lc, artifacts=None,
     """
     # Check that input argument is of correct type
     if not lytaf_path:
-        lytaf_path = LYTAF_PATH
+        lytaf_path = get_and_create_download_dir()
     if not isinstance(lc, lightcurve.LightCurve):
         raise TypeError("lc must be a LightCurve object.")
     # Remove artifacts from time series
@@ -224,7 +222,7 @@ def _remove_lytaf_events(time, channels=None, artifacts=None,
     """
     # Check inputs
     if not lytaf_path:
-        lytaf_path = LYTAF_PATH
+        lytaf_path = get_and_create_download_dir()
     if channels and type(channels) is not list:
         raise TypeError("channels must be None or a list of numpy arrays "
                         "of dtype 'float64'.")
@@ -410,7 +408,7 @@ def get_lytaf_events(start_time, end_time, lytaf_path=None,
     # Check inputs
     # Check lytaf path
     if not lytaf_path:
-        lytaf_path = LYTAF_PATH
+        lytaf_path = get_and_create_download_dir()
     # Check start_time and end_time is a date string or datetime object
     start_time = parse_time(start_time)
     end_time = parse_time(end_time)
@@ -530,7 +528,7 @@ def get_lytaf_event_types(lytaf_path=None, print_event_types=True):
     ----------
     lytaf_path : `str`
         Path location where LYTAF files are stored.
-        Default = LYTAF_PATH defined above.
+        Default = Path stored in confog file.
 
     print_event_types : `bool`
         If True, prints the artifacts in each lytaf database to screen.
@@ -543,7 +541,7 @@ def get_lytaf_event_types(lytaf_path=None, print_event_types=True):
     """
     # Set lytaf_path is not done by user
     if not lytaf_path:
-        lytaf_path = LYTAF_PATH
+        lytaf_path = get_and_create_download_dir()
     suffixes = ["lyra", "manual", "ppt", "science"]
     all_event_types = []
     # For each database file extract the event types and print them.

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -14,13 +14,14 @@ import pandas
 from sunpy.time import parse_time
 from sunpy import config
 from sunpy.util.net import check_download_file
+from sunpy.util.config import create_download_dir
 from sunpy import lightcurve
 
 from sunpy.extern.six.moves import urllib
 
 LYTAF_REMOTE_PATH = "http://proba2.oma.be/lyra/data/lytaf/"
 LYTAF_PATH = config.get("downloads", "download_dir")
-
+create_download_dir()
 
 def remove_lytaf_events_from_lightcurve(lc, artifacts=None,
                                         return_artifacts=False,

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -23,6 +23,7 @@ LYTAF_REMOTE_PATH = "http://proba2.oma.be/lyra/data/lytaf/"
 LYTAF_PATH = config.get("downloads", "download_dir")
 create_download_dir()
 
+
 def remove_lytaf_events_from_lightcurve(lc, artifacts=None,
                                         return_artifacts=False,
                                         lytaf_path=None,
@@ -115,6 +116,7 @@ def remove_lytaf_events_from_lightcurve(lc, artifacts=None,
         return lc_new, artifact_status
     else:
         return lc_new
+
 
 def _remove_lytaf_events(time, channels=None, artifacts=None,
                          return_artifacts=False, fitsfile=None,
@@ -520,6 +522,7 @@ def get_lytaf_events(start_time, end_time, lytaf_path=None,
 
     return lytaf
 
+
 def get_lytaf_event_types(lytaf_path=None, print_event_types=True):
     """Prints the different event types in the each of the LYTAF databases.
 
@@ -650,20 +653,21 @@ def split_series_using_lytaf(timearray, data, lytaf):
             # can't index h+1 here. Go to end of series
             subtimes = datetime_array[disc[h]:-1]
             subdata = data[disc[h]:-1]
-            subseries = {'subtimes':subtimes, 'subdata':subdata}
+            subseries = {'subtimes': subtimes, 'subdata': subdata}
             split_series.append(subseries)
         else:
             subtimes = datetime_array[disc[h]:disc[h+1]]
             subdata = data[disc[h]:disc[h+1]]
-            subseries = {'subtimes':subtimes, 'subdata':subdata}
+            subseries = {'subtimes': subtimes, 'subdata': subdata}
             split_series.append(subseries)
 
     return split_series
 
+
 def _lytaf_event2string(integers):
     if type(integers) == int:
         integers = [integers]
-    #else:
+    # else:
     #    n=len(integers)
     out = []
 
@@ -692,6 +696,7 @@ def _lytaf_event2string(integers):
             out.append('Venus in SWAP')
 
     return out
+
 
 def _prep_columns(time, channels=None, filecolumns=None):
     """

--- a/sunpy/lightcurve/lightcurve.py
+++ b/sunpy/lightcurve/lightcurve.py
@@ -66,7 +66,7 @@ class LightCurve(object):
         self.data = pandas.DataFrame(data)
         if meta == '' or meta is None:
             self.meta = OrderedDict()
-            self.meta.update({'name':None})
+            self.meta.update({'name': None})
         else:
             self.meta = OrderedDict(meta)
 
@@ -79,7 +79,7 @@ class LightCurve(object):
             Use .meta instead
         """
         warnings.warn("""lightcurve.header has been renamed to lightcurve.meta
-for compatibility with map, please use meta instead""", Warning)
+        for compatibility with map, please use meta instead""", Warning)
         return self.meta
 
     @classmethod
@@ -111,7 +111,7 @@ for compatibility with map, please use meta instead""", Warning)
             err="Unable to download data for specified date range"
         )
         result = cls.from_file(filepath)
-        result.data = result.data.truncate(start,end)
+        result.data = result.data.truncate(start, end)
         return result
 
     @classmethod
@@ -357,7 +357,7 @@ for compatibility with map, please use meta instead""", Warning)
         if isinstance(a, TimeRange):
             time_range = a
         else:
-            time_range = TimeRange(a,b)
+            time_range = TimeRange(a, b)
 
         truncated = self.data.truncate(time_range.start, time_range.end)
         return self.__class__.create(truncated, self.meta.copy())
@@ -405,8 +405,8 @@ for compatibility with map, please use meta instead""", Warning)
             raise TypeError("Lightcurve classes must match.")
 
         meta = OrderedDict()
-        meta.update({str(self.data.index[0]):self.meta.copy()})
-        meta.update({str(otherlightcurve.data.index[0]):otherlightcurve.meta.copy()})
+        meta.update({str(self.data.index[0]): self.meta.copy()})
+        meta.update({str(otherlightcurve.data.index[0]): otherlightcurve.meta.copy()})
 
         data = self.data.copy().append(otherlightcurve.data)
 

--- a/sunpy/lightcurve/lightcurve.py
+++ b/sunpy/lightcurve/lightcurve.py
@@ -17,6 +17,7 @@ import pandas
 from sunpy import config
 from sunpy.time import is_time, TimeRange, parse_time
 from sunpy.util.cond_dispatch import ConditionalDispatch, run_cls
+from sunpy.util.config import create_download_dir
 from sunpy.extern.six.moves import urllib
 from sunpy.extern import six
 
@@ -275,6 +276,7 @@ for compatibility with map, please use meta instead""", Warning)
             download_dir = os.path.expanduser(kwargs["directory"])
         else:
             download_dir = config.get("downloads", "download_dir")
+            create_download_dir()
 
         # overwrite the existing file if the keyword is present
         if "overwrite" in kwargs:

--- a/sunpy/lightcurve/lightcurve.py
+++ b/sunpy/lightcurve/lightcurve.py
@@ -17,7 +17,7 @@ import pandas
 from sunpy import config
 from sunpy.time import is_time, TimeRange, parse_time
 from sunpy.util.cond_dispatch import ConditionalDispatch, run_cls
-from sunpy.util.config import create_download_dir
+from sunpy.util.config import get_and_create_download_dir
 from sunpy.extern.six.moves import urllib
 from sunpy.extern import six
 
@@ -275,8 +275,7 @@ class LightCurve(object):
         if "directory" in kwargs:
             download_dir = os.path.expanduser(kwargs["directory"])
         else:
-            download_dir = config.get("downloads", "download_dir")
-            create_download_dir()
+            download_dir = get_and_create_download_dir()
 
         # overwrite the existing file if the keyword is present
         if "overwrite" in kwargs:

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -21,6 +21,7 @@ from sunpy.io.header import FileHeader
 from sunpy.util.net import download_file
 from sunpy.util import expand_list
 from sunpy.util.metadata import MetaDict
+from sunpy.util.config import create_download_dir
 
 from sunpy.util.datatype_factory_base import BasicRegistrationFactory
 from sunpy.util.datatype_factory_base import NoMatchError
@@ -207,6 +208,7 @@ class MapFactory(BasicRegistrationFactory):
             elif (isinstance(arg,six.string_types) and
                   _is_url(arg)):
                 default_dir = sunpy.config.get("downloads", "download_dir")
+                create_download_dir()
                 url = arg
                 path = download_file(url, default_dir)
                 pairs = self._read_file(path, **kwargs)

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -18,7 +18,7 @@ from sunpy.io.header import FileHeader
 from sunpy.util.net import download_file
 from sunpy.util import expand_list
 from sunpy.util.metadata import MetaDict
-from sunpy.util.config import create_download_dir
+from sunpy.util.config import get_and_create_download_dir
 
 from sunpy.util.datatype_factory_base import BasicRegistrationFactory
 from sunpy.util.datatype_factory_base import NoMatchError
@@ -211,10 +211,8 @@ class MapFactory(BasicRegistrationFactory):
             # A URL
             elif (isinstance(arg, six.string_types) and
                   _is_url(arg)):
-                default_dir = sunpy.config.get("downloads", "download_dir")
-                create_download_dir()
                 url = arg
-                path = download_file(url, default_dir)
+                path = download_file(url, get_and_create_download_dir())
                 pairs = self._read_file(path, **kwargs)
                 data_header_pairs += pairs
 

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-__authors__ = ["Russell Hewett, Stuart Mumford"]
-__email__ = "stuart@mumford.me.uk"
-
 import os
 import glob
 from collections import OrderedDict
@@ -31,6 +28,9 @@ from sunpy.extern import six
 
 from sunpy.extern.six.moves.urllib.request import urlopen
 
+__authors__ = ["Russell Hewett, Stuart Mumford"]
+__email__ = "stuart@mumford.me.uk"
+
 # Make a mock DatabaseEntry class if sqlalchemy is not installed
 
 try:
@@ -40,6 +40,7 @@ except ImportError:
         pass
 
 __all__ = ['Map', 'MapFactory']
+
 
 class MapFactory(BasicRegistrationFactory):
     """
@@ -62,7 +63,8 @@ class MapFactory(BasicRegistrationFactory):
 
     >>> mymap = sunpy.map.Map((data, header))   # doctest: +SKIP
 
-    headers are some base of `dict` or `collections.OrderedDict`, including `sunpy.io.header.FileHeader` or `sunpy.util.metadata.MetaDict` classes.
+    headers are some base of `dict` or `collections.OrderedDict`, including
+    `sunpy.io.header.FileHeader` or `sunpy.util.metadata.MetaDict` classes.
 
     * data, header pairs, not in tuples
 
@@ -90,11 +92,13 @@ class MapFactory(BasicRegistrationFactory):
 
     * Lists of any of the above
 
-    >>> mymap = sunpy.map.Map(['file1.fits', 'file2.fits', 'file3.fits', 'directory1/'])   # doctest: +SKIP
+    >>> mymap = sunpy.map.Map(['file1.fits', 'file2.fits', 'file3.fits', 'directory1/'])
+    # doctest: +SKIP
 
     * Any mixture of the above not in a list
 
-    >>> mymap = sunpy.map.Map((data, header), data2, header2, 'file1.fits', url_str, 'eit_*.fits')   # doctest: +SKIP
+    >>> mymap = sunpy.map.Map((data, header), data2, header2, 'file1.fits', url_str, 'eit_*.fits')
+    # doctest: +SKIP
     """
 
     def _read_file(self, fname, **kwargs):
@@ -102,14 +106,14 @@ class MapFactory(BasicRegistrationFactory):
             that file. """
 
         # File gets read here.  This needs to be generic enough to seamlessly
-        #call a fits file or a jpeg2k file, etc
+        # call a fits file or a jpeg2k file, etc
         pairs = read_file(fname, **kwargs)
 
         new_pairs = []
         for pair in pairs:
             filedata, filemeta = pair
             assert isinstance(filemeta, FileHeader)
-            #This tests that the data is more than 1D
+            # This tests that the data is more than 1D
             if len(np.shape(filedata)) > 1:
                 data = filedata
                 meta = MetaDict(filemeta)
@@ -177,17 +181,17 @@ class MapFactory(BasicRegistrationFactory):
 
                 pair = (args[i], OrderedDict(args[i+1]))
                 data_header_pairs.append(pair)
-                i += 1 # an extra increment to account for the data-header pairing
+                i += 1   # an extra increment to account for the data-header pairing
 
             # File name
-            elif (isinstance(arg,six.string_types) and
+            elif (isinstance(arg, six.string_types) and
                   os.path.isfile(os.path.expanduser(arg))):
                 path = os.path.expanduser(arg)
                 pairs = self._read_file(path, **kwargs)
                 data_header_pairs += pairs
 
             # Directory
-            elif (isinstance(arg,six.string_types) and
+            elif (isinstance(arg, six.string_types) and
                   os.path.isdir(os.path.expanduser(arg))):
                 path = os.path.expanduser(arg)
                 files = [os.path.join(path, elem) for elem in os.listdir(path)]
@@ -195,8 +199,8 @@ class MapFactory(BasicRegistrationFactory):
                     data_header_pairs += self._read_file(afile, **kwargs)
 
             # Glob
-            elif (isinstance(arg,six.string_types) and '*' in arg):
-                files = glob.glob( os.path.expanduser(arg) )
+            elif (isinstance(arg, six.string_types) and '*' in arg):
+                files = glob.glob(os.path.expanduser(arg))
                 for afile in files:
                     data_header_pairs += self._read_file(afile, **kwargs)
 
@@ -205,7 +209,7 @@ class MapFactory(BasicRegistrationFactory):
                 already_maps.append(arg)
 
             # A URL
-            elif (isinstance(arg,six.string_types) and
+            elif (isinstance(arg, six.string_types) and
                   _is_url(arg)):
                 default_dir = sunpy.config.get("downloads", "download_dir")
                 create_download_dir()
@@ -222,11 +226,10 @@ class MapFactory(BasicRegistrationFactory):
                 raise ValueError("File not found or invalid input")
 
             i += 1
-        #TODO:
+        # TODO:
         # In the end, if there are already maps it should be put in the same
         # order as the input, currently they are not.
         return data_header_pairs, already_maps
-
 
     def __call__(self, *args, **kwargs):
         """ Method for running the factory. Takes arbitrary arguments and
@@ -313,7 +316,9 @@ class MapFactory(BasicRegistrationFactory):
             else:
                 candidate_widget_types = [self.default_widget_type]
         elif n_matches > 1:
-            raise MultipleMatchError("Too many candidate types identified ({0}).  Specify enough keywords to guarantee unique type identification.".format(n_matches))
+            raise MultipleMatchError("Too many candidate types identified ({0})."
+                                     "Specify enough keywords to guarantee unique type"
+                                     "identification.".format(n_matches))
 
         # Only one is found
         WidgetType = candidate_widget_types[0]
@@ -328,20 +333,24 @@ def _is_url(arg):
         return False
     return True
 
+
 class InvalidMapInput(ValueError):
     """Exception to raise when input variable is not a Map instance and does
     not point to a valid Map input file."""
     pass
+
 
 class InvalidMapType(ValueError):
     """Exception to raise when an invalid type of map is requested with Map
     """
     pass
 
+
 class NoMapsFound(ValueError):
     """Exception to raise when input does not point to any valid maps or files
     """
     pass
+
 
 Map = MapFactory(default_widget_type=GenericMap,
                  additional_validation_functions=['is_datasource_for'])

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -285,7 +285,7 @@ class GenericClient(object):
 
             temp_dict = qres[i].map_.copy()
             temp_dict['file'] = filename
-            fname  = fname.format(**temp_dict)
+            fname = fname.format(**temp_dict)
             fname = os.path.expanduser(fname)
 
             if os.path.exists(fname):
@@ -299,10 +299,10 @@ class GenericClient(object):
 
         dobj = Downloader(max_conn=len(urls), max_total=len(urls))
 
-        # We cast to list here in list(zip... to force execution of 
+        # We cast to list here in list(zip... to force execution of
         # res.require([x]) at the start of the loop.
         for aurl, ncall, fname in list(zip(urls, map(lambda x: res.require([x]),
-                                              urls), paths)):
+                                           urls), paths)):
             dobj.download(aurl, fname, ncall, error_callback)
 
         return res

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -17,6 +17,7 @@ import sunpy
 from sunpy.extern import six
 from sunpy.time import TimeRange
 from sunpy.util import replacement_filename
+from sunpy.util.config import create_download_dir
 from sunpy import config
 
 from ..download import Downloader, Results
@@ -273,6 +274,7 @@ class GenericClient(object):
 
         # Create function to compute the filepath to download to if not set
         default_dir = sunpy.config.get("downloads", "download_dir")
+        create_download_dir()
 
         paths = []
         for i, filename in enumerate(filenames):

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -17,7 +17,7 @@ import sunpy
 from sunpy.extern import six
 from sunpy.time import TimeRange
 from sunpy.util import replacement_filename
-from sunpy.util.config import create_download_dir
+from sunpy.util.config import get_and_create_download_dir
 from sunpy import config
 
 from ..download import Downloader, Results
@@ -272,14 +272,10 @@ class GenericClient(object):
         for url in urls:
             filenames.append(url.split('/')[-1])
 
-        # Create function to compute the filepath to download to if not set
-        default_dir = sunpy.config.get("downloads", "download_dir")
-        create_download_dir()
-
         paths = []
         for i, filename in enumerate(filenames):
             if path is None:
-                fname = os.path.join(default_dir, '{file}')
+                fname = os.path.join(get_and_create_download_dir(), '{file}')
             elif isinstance(path, six.string_types) and '{file}' not in path:
                 fname = os.path.join(path, '{file}')
 

--- a/sunpy/net/download.py
+++ b/sunpy/net/download.py
@@ -21,7 +21,7 @@ from sunpy.extern.six import iteritems
 
 import sunpy
 from sunpy.util.progressbar import TTYProgressBar as ProgressBar
-
+from sunpy.util.config import create_download_dir
 
 def default_name(path, sock, url):
     name = sock.headers.get('Content-Disposition', url.rsplit('/', 1)[-1])
@@ -139,6 +139,7 @@ class Downloader(object):
 
         # Create function to compute the filepath to download to if not set
         default_dir = sunpy.config.get("downloads", "download_dir")
+        create_download_dir()
 
         if path is None:
             path = partial(default_name, default_dir)

--- a/sunpy/net/download.py
+++ b/sunpy/net/download.py
@@ -23,6 +23,7 @@ import sunpy
 from sunpy.util.progressbar import TTYProgressBar as ProgressBar
 from sunpy.util.config import create_download_dir
 
+
 def default_name(path, sock, url):
     name = sock.headers.get('Content-Disposition', url.rsplit('/', 1)[-1])
     return os.path.join(path, name)
@@ -178,7 +179,6 @@ class Downloader(object):
                             return
                     else:
                         break
-
 
 
 class Results(object):

--- a/sunpy/net/download.py
+++ b/sunpy/net/download.py
@@ -21,7 +21,7 @@ from sunpy.extern.six import iteritems
 
 import sunpy
 from sunpy.util.progressbar import TTYProgressBar as ProgressBar
-from sunpy.util.config import create_download_dir
+from sunpy.util.config import get_and_create_download_dir
 
 
 def default_name(path, sock, url):
@@ -139,11 +139,9 @@ class Downloader(object):
         server = self._get_server(url)
 
         # Create function to compute the filepath to download to if not set
-        default_dir = sunpy.config.get("downloads", "download_dir")
-        create_download_dir()
 
         if path is None:
-            path = partial(default_name, default_dir)
+            path = partial(default_name, get_and_create_download_dir())
         elif isinstance(path, six.string_types):
             path = partial(default_name, path)
         elif not callable(path):

--- a/sunpy/net/tests/test_download.py
+++ b/sunpy/net/tests/test_download.py
@@ -51,6 +51,17 @@ def wait_for(n, callback): #pylint: disable=W0613
 def path_fun(*args, **kwargs):
     raise ValueError
 
+
+def get_and_create_temp_directory(tmpdir):
+    sunpy.config = MockConfig()
+    sunpy.config.add_section(
+        "downloads", {"download_dir": tmpdir}
+    )
+    if not os.path.isdir(sunpy.config.get('downloads', 'download_dir')):
+        os.makedirs(sunpy.config.get('downloads', 'download_dir'))
+
+    return sunpy.config.get('downloads', 'download_dir')
+
 @pytest.mark.online
 def test_path_exception():
     x = threading.Event()
@@ -109,11 +120,7 @@ def test_download_default_dir():
 
     try:
         tmpdir = tempfile.mkdtemp()
-
-        sunpy.config = MockConfig()
-        sunpy.config.add_section(
-            "downloads", {"download_dir": tmpdir}
-        )
+        path = get_and_create_temp_directory(tmpdir)
 
         dw = Downloader(1, 1)
         _stop = lambda _: dw.stop()
@@ -122,6 +129,7 @@ def test_download_default_dir():
         errback = CalledProxy(_stop)
         dw.download(
             'http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js',
+            path=path,
             callback=_stop,
             errback=errback
         )

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -72,7 +72,8 @@ class TimeSeriesFactory(BasicRegistrationFactory):
 
     >>> my_timeseries = sunpy.timeseries.TimeSeries((data, header))   # doctest: +SKIP
 
-    headers and units are some base of `dict` or `~collections.OrderedDict` or `~sunpy.util.metadata.MetaDict`.
+    headers and units are some base of `dict` or `~collections.OrderedDict` or
+    `~sunpy.util.metadata.MetaDict`.
 
     * data, header pairs, or data, header units triples, not in tuples
 
@@ -87,7 +88,8 @@ class TimeSeriesFactory(BasicRegistrationFactory):
     * Multiple files can be combined into one TimeSeries, as long as they are
     the same source   # doctest: +SKIP
 
-    >>> my_timeseries = sunpy.timeseries.TimeSeries(['goesfile1.fits', 'goesfile2.fits'], concatenate=True)
+    >>> my_timeseries = sunpy.timeseries.TimeSeries(['goesfile1.fits', 'goesfile2.fits'],
+        concatenate=True)
 
     * All fits files in a directory by giving a directory
 
@@ -103,11 +105,13 @@ class TimeSeriesFactory(BasicRegistrationFactory):
 
     * Lists of any of the above
 
-    >>> my_timeseries = sunpy.timeseries.TimeSeries(['file1.fits', 'file2.fits', 'file3.fits', 'directory1/'])   # doctest: +SKIP
+    >>> my_timeseries = sunpy.timeseries.TimeSeries(['file1.fits', 'file2.fits',
+        'file3.fits', 'directory1/'])   # doctest: +SKIP
 
     * Any mixture of the above not in a list
 
-    >>> my_timeseries = sunpy.timeseries.TimeSeries((data, header), data2, header2, 'file1.fits', url, 'eit_*.fits')   # doctest: +SKIP
+    >>> my_timeseries = sunpy.timeseries.TimeSeries((data, header), data2, header2,
+        'file1.fits', url, 'eit_*.fits')   # doctest: +SKIP
     """
 
     def _read_file(self, fname, **kwargs):
@@ -210,7 +214,8 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             if len(table.primary_key) == 1:
                 table.primary_key[0]
             else:
-                raise ValueError("Invalid input Table, TimeSeries doesn't support conversion of tables with more then one index column.")
+                raise ValueError("Invalid input Table, TimeSeries doesn't support conversion"
+                                 " of tables with more then one index column.")
 
         # Extract, convert and remove the index column from the input table
         index = table[index_name]
@@ -275,7 +280,8 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             arg = args[i]
 
             # Data-header pair in a tuple
-            if (isinstance(arg, (np.ndarray, Table, pd.DataFrame))):# and self._validate_meta(args[i+1])):
+            if (isinstance(arg, (np.ndarray, Table, pd.DataFrame))):
+                # and self._validate_meta(args[i+1])):
                 # Assume a Pandas Dataframe is given
                 data = arg
                 units = OrderedDict()
@@ -287,7 +293,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                     data, meta, units = self._from_table(data)
                 elif isinstance(data, np.ndarray):
                     # We have a numpy ndarray. We assume the first column is a dt index
-                    data = pd.DataFrame(data=data[:,1:], index=Time(data[:,0]))
+                    data = pd.DataFrame(data=data[:, 1:], index=Time(data[:, 0]))
 
                 # If there are 1 or 2 more arguments:
                 for _ in range(2):
@@ -356,18 +362,18 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                 already_timeseries.append(arg)
 
             # A URL
-            elif (isinstance(arg,six.string_types) and
+            elif (isinstance(arg, six.string_types) and
                   _is_url(arg)):
                 default_dir = sunpy.config.get("downloads", "download_dir")
                 create_download_dir()
                 url = arg
                 path = download_file(url, default_dir)
                 pairs = self._read_file(path, **kwargs)
-                #data_header_pairs += pairs
+                # data_header_pairs += pairs
                 filepaths.append(pairs[1])
 
             else:
-                #raise ValueError("File not found or invalid input")
+                # raise ValueError("File not found or invalid input")
                 raise NoMatchError("File not found or invalid input")
             i += 1
 
@@ -508,7 +514,9 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             else:
                 candidate_widget_types = [self.default_widget_type]
         elif n_matches > 1:
-            raise MultipleMatchError("Too many candidate types identified ({0}).  Specify enough keywords to guarantee unique type identification.".format(n_matches))
+            raise MultipleMatchError("Too many candidate types identified ({0})."
+                                     "Specify enough keywords to guarantee unique type "
+                                     "identification.".format(n_matches))
 
         # Only one suitable source class is found
         return candidate_widget_types[0]
@@ -535,6 +543,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         # Now return a TimeSeries from the given file.
         return WidgetType(data, meta, units, **kwargs)
 
+
 def _is_url(arg):
     try:
         urlopen(arg)
@@ -542,21 +551,25 @@ def _is_url(arg):
         return False
     return True
 
+
 class InvalidTimeSeriesInput(ValueError):
     """Exception to raise when input variable is not a TimeSeries instance and
     does not point to a valid TimeSeries input file."""
     pass
+
 
 class InvalidTimeSeriesType(ValueError):
     """Exception to raise when an invalid type of time series is requested with
     TimeSeries."""
     pass
 
+
 class NoTimeSeriesFound(ValueError):
     """Exception to raise when input does not point to any valid time series or
     files."""
     pass
 
+
 TimeSeries = TimeSeriesFactory(default_widget_type=GenericTimeSeries,
-                 additional_validation_functions=['is_datasource_for'])
+                               additional_validation_functions=['is_datasource_for'])
 TimeSeries.registry = TIMESERIES_CLASSES

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -25,7 +25,7 @@ from sunpy.io.header import FileHeader
 
 from sunpy.util.net import download_file
 from sunpy.util import expand_list
-from sunpy.util.config import create_download_dir
+from sunpy.util.config import get_and_create_download_dir
 
 from sunpy.util.datatype_factory_base import BasicRegistrationFactory
 from sunpy.util.datatype_factory_base import NoMatchError
@@ -364,10 +364,8 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             # A URL
             elif (isinstance(arg, six.string_types) and
                   _is_url(arg)):
-                default_dir = sunpy.config.get("downloads", "download_dir")
-                create_download_dir()
                 url = arg
-                path = download_file(url, default_dir)
+                path = download_file(url, get_and_create_download_dir())
                 pairs = self._read_file(path, **kwargs)
                 # data_header_pairs += pairs
                 filepaths.append(pairs[1])

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -25,6 +25,7 @@ from sunpy.io.header import FileHeader
 
 from sunpy.util.net import download_file
 from sunpy.util import expand_list
+from sunpy.util.config import create_download_dir
 
 from sunpy.util.datatype_factory_base import BasicRegistrationFactory
 from sunpy.util.datatype_factory_base import NoMatchError
@@ -358,6 +359,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             elif (isinstance(arg,six.string_types) and
                   _is_url(arg)):
                 default_dir = sunpy.config.get("downloads", "download_dir")
+                create_download_dir()
                 url = arg
                 path = download_file(url, default_dir)
                 pairs = self._read_file(path, **kwargs)

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -40,14 +40,12 @@ def load_config():
         ('downloads', 'sample_dir')
     ]
     _fix_filepaths(config, filepaths)
-
+    
     # check for sunpy working directory and create it if it doesn't exist
-    if not os.path.isdir(config.get('downloads', 'download_dir')):
-        os.mkdir(config.get('downloads', 'download_dir'))
+    '''if not os.path.isdir(config.get('downloads', 'download_dir')):
+        os.makedirs(config.get('downloads', 'download_dir'))
 
-    if not os.path.isdir(config.get('downloads', 'sample_dir')):
-        os.mkdir(config.get('downloads', 'sample_dir'))
-
+    '''
     return config
 
 
@@ -157,10 +155,6 @@ def _fix_filepaths(config, filepaths):
         val = config.get(*f)
 
         filepath = _expand_filepath(val, working_dir)
-
-        # Create dir if it doesn't already exist
-        if not os.path.isdir(filepath):
-            os.makedirs(filepath)
 
         # Replace config value with full filepath
         params = f + (filepath,)

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -54,6 +54,18 @@ def get_and_create_download_dir():
 
     return config.get('downloads', 'download_dir')
 
+
+def get_and_create_sample_dir():
+    '''
+    Get the config of download directory and create one if not present.
+    '''
+    config = load_config()
+    if not os.path.isdir(config.get('downloads', 'sample_dir')):
+        os.makedirs(config.get('downloads', 'sample_dir'))
+
+    return config.get('downloads', 'sample_dir')
+
+
 def print_config():
     """Print current configuration options"""
     print("FILES USED:")

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -41,13 +41,15 @@ def load_config():
     ]
     _fix_filepaths(config, filepaths)
 
-    # check for sunpy working directory and create it if it doesn't exist
-    '''if not os.path.isdir(config.get('downloads', 'download_dir')):
-        os.makedirs(config.get('downloads', 'download_dir'))
-
-    '''
     return config
 
+def create_download_dir():
+    '''
+    Get the config of download directory and create one if not present.
+    '''
+    config = load_config()
+    if not os.path.isdir(config.get('downloads', 'download_dir')):
+        os.makedirs(config.get('downloads', 'download_dir'))
 
 def print_config():
     """Print current configuration options"""

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -40,7 +40,7 @@ def load_config():
         ('downloads', 'sample_dir')
     ]
     _fix_filepaths(config, filepaths)
-    
+
     # check for sunpy working directory and create it if it doesn't exist
     '''if not os.path.isdir(config.get('downloads', 'download_dir')):
         os.makedirs(config.get('downloads', 'download_dir'))

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -43,6 +43,7 @@ def load_config():
 
     return config
 
+
 def create_download_dir():
     '''
     Get the config of download directory and create one if not present.
@@ -50,6 +51,7 @@ def create_download_dir():
     config = load_config()
     if not os.path.isdir(config.get('downloads', 'download_dir')):
         os.makedirs(config.get('downloads', 'download_dir'))
+
 
 def print_config():
     """Print current configuration options"""

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -44,7 +44,7 @@ def load_config():
     return config
 
 
-def create_download_dir():
+def get_and_create_download_dir():
     '''
     Get the config of download directory and create one if not present.
     '''
@@ -52,6 +52,7 @@ def create_download_dir():
     if not os.path.isdir(config.get('downloads', 'download_dir')):
         os.makedirs(config.get('downloads', 'download_dir'))
 
+    return config.get('downloads', 'download_dir')
 
 def print_config():
     """Print current configuration options"""

--- a/sunpy/util/create.py
+++ b/sunpy/util/create.py
@@ -8,6 +8,7 @@ import glob
 
 from sunpy import config
 from sunpy.util.net import download_file
+from sunpy.util.config import create_download_dir
 
 from sunpy.util.cond_dispatch import ConditionalDispatch, run_cls
 from sunpy.extern import six
@@ -74,6 +75,7 @@ class Parent(object):
             URL to retrieve the data from
         """
         default_dir = config.get("downloads", "download_dir")
+        create_download_dir()
         path = download_file(url, default_dir)
         return cls.read(path)
 

--- a/sunpy/util/create.py
+++ b/sunpy/util/create.py
@@ -8,7 +8,7 @@ import glob
 
 from sunpy import config
 from sunpy.util.net import download_file
-from sunpy.util.config import create_download_dir
+from sunpy.util.config import get_and_create_download_dir
 
 from sunpy.util.cond_dispatch import ConditionalDispatch, run_cls
 from sunpy.extern import six
@@ -75,9 +75,7 @@ class Parent(object):
         url : str
             URL to retrieve the data from
         """
-        default_dir = config.get("downloads", "download_dir")
-        create_download_dir()
-        path = download_file(url, default_dir)
+        path = download_file(url, get_and_create_download_dir())
         return cls.read(path)
 
 

--- a/sunpy/util/create.py
+++ b/sunpy/util/create.py
@@ -16,6 +16,7 @@ from sunpy.extern.six.moves import map
 
 __all__ = ['Parent']
 
+
 class Parent(object):
     _create = ConditionalDispatch()
 
@@ -86,9 +87,9 @@ Parent._create.add(
     [type, six.string_types], check=False
 )
 Parent._create.add(
-# pylint: disable=W0108
-# The lambda is necessary because introspection is performed on the
-# argspec of the function.
+    # pylint: disable=W0108
+    # The lambda is necessary because introspection is performed on the
+    # argspec of the function.
     run_cls('from_dir'),
     lambda cls, directory: os.path.isdir(os.path.expanduser(directory)),
     [type, six.string_types], check=False
@@ -97,8 +98,8 @@ Parent._create.add(
 Parent._create.add(
     run_cls('from_single_glob'),
     lambda cls, singlepattern: ('*' in singlepattern and
-                           len(glob.glob(
-                               os.path.expanduser(singlepattern))) == 1),
+                                len(glob.glob(
+                                os.path.expanduser(singlepattern))) == 1),
     [type, six.string_types], check=False
 )
 # This case only gets executed under the condition that the previous one wasn't.


### PR DESCRIPTION
Fixes #2018 

Before:

Upon doing `import sunpy`, a directory was created on `/home/sunpy/data` , irrespective of whether we download data or not. 

After:

Upon doing `import sunpy`, the path is saved in the config file but the directory is not created. The directory is first created when we try downloading any data.