### PR TITLE
improve code coverage sunpy.net.vso.vso, add custom mock objects

### DIFF
--- a/sunpy/tests/mocks.py
+++ b/sunpy/tests/mocks.py
@@ -228,9 +228,6 @@ class MockOpenTextFile(MockObject):
         self.closed = True
         self.data = ''
 
-    def flush(self):
-        return
-
     def __repr__(self):
         return ("<{module}.{name} file '{file}' mode '{mode}' "
                 "at {address}>".format(module=self.__module__, name=self.__class__.__name__,

--- a/sunpy/tests/mocks.py
+++ b/sunpy/tests/mocks.py
@@ -106,6 +106,7 @@ class MockHTTPResponse(MockObject):
         The url of the connection
 
     headers : `dict` of `str` optional, default: empty dictionary
+        HTTP header fields of the response message.
 
     Limitations
     -----------

--- a/sunpy/tests/mocks.py
+++ b/sunpy/tests/mocks.py
@@ -1,0 +1,235 @@
+"""
+Support for creating our own mocked objects
+
+Author: Michael Charlton <m.charlton@mac.com>
+"""
+
+import io
+import os
+
+from collections import MutableMapping, defaultdict
+
+
+class MockObject(MutableMapping):
+    """
+    Object from which we can construct other 'mocked' objects. See
+    following examples.
+
+    Limitations
+    -----------
+
+    On initiation a `ValueError` will be raised if any of the `kwargs` have the same name as an
+    existing attribute/method of the `MockObject` or underlying data store.
+
+    Updating existing attributes, or adding new ones, should only be done using bracket
+    notation and *not* dot notation. Using dot notation will update the `MockObject` and not the
+    data store.
+
+    Examples
+    --------
+    >>> mo = MockObject(code=400)
+    >>> mo.code
+    400
+    >>> mo['code']
+    400
+    >>> mo.code = 210
+    >>> mo.code
+    210
+    >>> mo['code']
+    400
+
+    The recommended way of changing the value of an existing, or new, attribute is using bracket
+    notation:
+
+    >>> m = MockObject(start='now')
+    >>> m['start'] = 'Thursday'
+    >>> m['start']
+    'Thursday'
+    >>> m.start
+    'Thursday'
+    """
+    def __init__(self, *args, **kwargs):
+        self._datastore = dict()
+        self.prohibited_attrs = set(dir(self))
+        self.prohibited_attrs.update(dir(self._datastore))
+
+        for candidate in kwargs.keys():
+            if candidate in self.prohibited_attrs:
+                raise ValueError("kwarg '{kwarg}' is already an attribute "
+                                 "of {datastore} or {obj}".format(kwarg=candidate,
+                                                                  datastore=type(self._datastore),
+                                                                  obj=type(self)))
+        self.update(dict(*args, **kwargs))
+
+    def __getattr__(self, name):
+        if name in self._datastore:
+            return self._datastore[name]
+
+        raise AttributeError(name)
+
+    def __getitem__(self, name):
+        return self._datastore[name]
+
+    def __setitem__(self, name, value):
+        if name in self.prohibited_attrs:
+            raise ValueError("Name '{name}' is already an attribute "
+                             "of {datastore} or {obj}".format(name=name,
+                                                              datastore=type(self._datastore),
+                                                              obj=type(self)))
+        self._datastore[name] = value
+
+    def __delitem__(self, name):
+        raise NotImplementedError("'del' operation for {0} "
+                                  "not supported".format(self.__class__.__name__))
+
+    def __iter__(self):
+        return iter(self._datastore)
+
+    def __len__(self):
+        return len(self._datastore)
+
+    def __repr__(self):
+        return ("<{module}.{name} {contents} at {address}>".format(module=self.__module__,
+                                                                   name=self.__class__.__name__,
+                                                                   contents=self._datastore,
+                                                                   address=hex(id(self))))
+
+
+class MockHTTPResponse(MockObject):
+    """
+    The result of calling `urlopen(...)`. For this implementation we are only interested in
+    querying the 'headers' attribute, which is a http.client.HTTPMessage object.
+
+    Parameters
+    ----------
+
+    url : `str` optional, default: ''
+        The url of the connection
+
+    headers : `dict` of str optional, default: empty dictionary
+
+    Limitations
+    -----------
+
+    On a 'real' http.client.HTTPMessage, header name retrieval is case insensitive.
+    In this implementation the header names are case sensitive.
+
+    Examples
+    --------
+    >>> result = MockHTTPResponse(url='http://abc.com', headers={'Content-Type':'text/html'})
+    >>> result.headers.get('Content-Type')
+    text/html
+    """
+    def __init__(self, *args, **kwargs):
+        super(MockHTTPResponse, self).__init__(*args, **kwargs)
+
+        self.setdefault('url', '')
+
+        headers_store = defaultdict(lambda: None)
+
+        if 'headers' in self:
+            headers_store.update(self['headers'])
+
+        self['headers'] = headers_store
+
+
+class MockOpenFile(MockObject):
+    """
+    Partial implementation of a file like object.
+
+    Many methods not implemented, no attempt is made to keep track of where we are
+    in the file say in regards to any read operation.
+
+    Parameters
+    ----------
+    file : `str` optional, default:'UNKNOWN'
+        The name of the file. As per the builtin `open` function
+
+    mode : `str` optional, default:'r'
+        The way in which the file is to be used. As per the builtin `open` function
+
+    data : `str` optional keyword, default:''
+        The inital data which can be read from the file.
+
+    Limitations
+    -----------
+
+    Unlike in a real file, this implementation makes no attempt to keep
+    track of where we are, when reading or writing.
+
+    Examples
+    --------
+
+    >>> dummy_read_only = MockOpenFile()
+    >>> named_write = MockOpenFile(file='a.txt', mode='w')
+    >>> named_read = MockOpenFile('b.txt')
+    >>> named_rd_wr = MockOpenFile('c.txt', 'r+', data='Hello, world')
+    """
+    def __init__(self, *args, **kwargs):
+
+        # Positional and/or keword args can be used for the 'file' & 'mode'
+        # parameters. Could do a lot more checking to make sure all required
+        # arguments are present
+
+        num_pos_args = len(args)
+
+        if num_pos_args == 1:
+            kwargs['file'] = args[0]
+        elif num_pos_args == 2:
+            kwargs['file'] = args[0]
+            kwargs['mode'] = args[1]
+
+        if 'mode' not in kwargs:
+            kwargs['mode'] = 'r'
+
+        super(MockOpenFile, self).__init__(**kwargs)
+        self.setdefault('file', 'N/A')
+        self['name'] = self['file']
+        self.setdefault('closed', False)
+        self.setdefault('data', '')
+
+    def write(self, content):
+        if not self.writable():
+            raise io.UnsupportedOperation(':not writable')
+
+        self.data += content
+
+        return len(content)
+
+    def read(self):
+        if not self.readable():
+            raise io.UnsupportedOperation(': not readable')
+
+        return self.data
+
+    def readlines(self):
+        if self.closed:
+            raise ValueError('I/O operation on closed file')
+
+        new_line = os.linesep
+        return ['{0}{1}'.format(line, new_line) for line in self.data.split(new_line)]
+
+    def readable(self):
+        if self.closed:
+            raise ValueError('I/O operation on closed file')
+
+        return 'r' in self.mode
+
+    def writable(self):
+        if self.closed:
+            raise ValueError('I/O operation on closed file')
+
+        return ('w' in self.mode) or ('r+' in self.mode)
+
+    def close(self):
+        self.closed = True
+        self.data = ''
+
+    def flush(self):
+        return
+
+    def __repr__(self):
+        return ("<{module}.{name} file '{file}' mode '{mode}' "
+                "at {address}>".format(module=self.__module__, name=self.__class__.__name__,
+                                       file=self.file, mode=self.mode,
+                                       address=hex(id(self))))

--- a/sunpy/tests/mocks.py
+++ b/sunpy/tests/mocks.py
@@ -5,7 +5,6 @@ Author: Michael Charlton <m.charlton@mac.com>
 """
 
 import io
-import os
 
 from collections import MutableMapping, defaultdict
 
@@ -106,7 +105,7 @@ class MockHTTPResponse(MockObject):
     url : `str` optional, default: ''
         The url of the connection
 
-    headers : `dict` of str optional, default: empty dictionary
+    headers : `dict` of `str` optional, default: empty dictionary
 
     Limitations
     -----------
@@ -133,9 +132,10 @@ class MockHTTPResponse(MockObject):
         self['headers'] = headers_store
 
 
-class MockOpenFile(MockObject):
+class MockOpenTextFile(MockObject):
     """
-    Partial implementation of a file like object.
+    Partial implementation of a file like object for reading/wrtiing text files. Binary files
+    are *not* supported.
 
     Many methods not implemented, no attempt is made to keep track of where we are
     in the file say in regards to any read operation.
@@ -160,10 +160,10 @@ class MockOpenFile(MockObject):
     Examples
     --------
 
-    >>> dummy_read_only = MockOpenFile()
-    >>> named_write = MockOpenFile(file='a.txt', mode='w')
-    >>> named_read = MockOpenFile('b.txt')
-    >>> named_rd_wr = MockOpenFile('c.txt', 'r+', data='Hello, world')
+    >>> dummy_read_only = MockOpenTextFile()
+    >>> named_write = MockOpenTextFile(file='a.txt', mode='w')
+    >>> named_read = MockOpenTextFile('b.txt')
+    >>> named_rd_wr = MockOpenTextFile('c.txt', 'r+', data='Hello, world')
     """
     def __init__(self, *args, **kwargs):
 
@@ -182,7 +182,7 @@ class MockOpenFile(MockObject):
         if 'mode' not in kwargs:
             kwargs['mode'] = 'r'
 
-        super(MockOpenFile, self).__init__(**kwargs)
+        super(MockOpenTextFile, self).__init__(**kwargs)
         self.setdefault('file', 'N/A')
         self['name'] = self['file']
         self.setdefault('closed', False)
@@ -206,7 +206,9 @@ class MockOpenFile(MockObject):
         if self.closed:
             raise ValueError('I/O operation on closed file')
 
-        new_line = os.linesep
+        # Documentation recommends using '\n' as the line terminator when reading/writing text
+        # files. See `os.linesep` in https://docs.python.org/3/library/os.html
+        new_line = '\n'
         return ['{0}{1}'.format(line, new_line) for line in self.data.split(new_line)]
 
     def readable(self):

--- a/sunpy/tests/tests/test_mocks.py
+++ b/sunpy/tests/tests/test_mocks.py
@@ -183,10 +183,6 @@ def test_read_and_write_MockOpenTextFile():
 
     assert rd_wr.read() == data
 
-    rd_wr.flush()
-
-    assert rd_wr.read() == data
-
     rd_wr.close()
 
 

--- a/sunpy/tests/tests/test_mocks.py
+++ b/sunpy/tests/tests/test_mocks.py
@@ -46,7 +46,7 @@ def test_MockObject_attr(mocked_mockobject):
 
 def test_MockObject_get(mocked_mockobject):
     """
-    Getting attributes from MockObject using dot and bracket notation.
+    Getting attributes from `MockObject` using dot and bracket notation.
     """
     assert mocked_mockobject['records'] == 12
     assert mocked_mockobject.records == 12
@@ -60,8 +60,8 @@ def test_MockObject_get(mocked_mockobject):
 
 def test_MockObject_set_get(mocked_mockobject):
     """
-    Setting attributes in MockObject using bracket notation and *not*
-    using dot notation.
+    Setting attributes in `MockObject` using bracket notation *not*
+    dot notation.
     """
 
     # Only change the value of existing & new items using 'bracket' notation
@@ -82,14 +82,14 @@ def test_MockObject_set_get(mocked_mockobject):
 
 def test_MockObject_len():
     """
-    Testing MockObject.__len__
+    Testing `MockObject.__len__`
     """
     assert len(MockObject(responses=['a', 'b', 'c', 'd'], requests=(1, 2, 3))) == 2
 
 
 def test_MockObject_del(mocked_mockobject):
     """
-    Ensure MockObject.__delitem__ is *not* implemented.
+    Ensure `MockObject.__delitem__` is *not* implemented.
     """
     with pytest.raises(NotImplementedError):
         del mocked_mockobject['records']
@@ -97,14 +97,14 @@ def test_MockObject_del(mocked_mockobject):
 
 def test_MockObject_iter(mocked_mockobject):
     """
-    Test Test MockOpenTextFile.__iter__
+    Test `MockObject.__iter__`
     """
     assert list(iter(mocked_mockobject)) == ['records']
 
 
 def test_repr_MockObject():
     """
-    Test MockObject.__repr__
+    Test `MockObject.__repr__`
     """
     empty = MockObject()
 
@@ -115,7 +115,7 @@ def test_repr_MockObject():
 
 def test_read_only_mode_MockOpenTextFile():
     """
-    Reading from a read only file, wrtiting should be prohibited.
+    Reading from a read only file, writing should be prohibited.
     """
     new_line = '\n'
     content = r'a{0}bc{0}nd{0}{0}'.format(new_line)
@@ -192,7 +192,7 @@ def test_read_and_write_MockOpenTextFile():
 
 def test_repr_MockOpenTextFile():
     """
-    Test MockOpenTextFile.__repr__
+    Test `MockOpenTextFile.__repr__`
     """
     mo_p = re.compile((r"^(?P<_><)sunpy\.tests\.mocks\.MockOpenTextFile file \'a\' "
                        "mode \'r\' at 0x[0-9A-Fa-f]+L?(?(_)>|)$"))

--- a/sunpy/tests/tests/test_mocks.py
+++ b/sunpy/tests/tests/test_mocks.py
@@ -3,7 +3,7 @@ import re
 
 import pytest
 
-from ..mocks import MockObject, MockOpenFile, MockHTTPResponse
+from ..mocks import MockObject, MockOpenTextFile, MockHTTPResponse
 
 
 @pytest.fixture
@@ -97,36 +97,39 @@ def test_MockObject_del(mocked_mockobject):
 
 def test_MockObject_iter(mocked_mockobject):
     """
-    Test Test MockOpenFile.__iter__
+    Test Test MockOpenTextFile.__iter__
     """
     assert list(iter(mocked_mockobject)) == ['records']
 
 
-def test_repr_MockObject(mocked_mockobject):
+def test_repr_MockObject():
     """
-    Test MockOpenFile.__repr__
+    Test MockObject.__repr__
     """
-    mo_p = re.compile(r"^(?P<_><)sunpy\.tests\.mocks\.MockObject \{'records': 12\} "
-                      "at 0x[0-9A-Fa-f]+(?(_)>|)$")
+    empty = MockObject()
 
-    assert mo_p.match(repr(mocked_mockobject)) is not None
+    mo_p = re.compile(r"^(?P<_><)sunpy\.tests\.mocks\.MockObject \{\} "
+                      "at 0x[0-9A-Fa-f]+L?(?(_)>|)$")
+    assert mo_p.match(repr(empty)) is not None
 
 
-def test_read_only_mode_MockOpenFile():
+def test_read_only_mode_MockOpenTextFile():
     """
     Reading from a read only file, wrtiting should be prohibited.
     """
-    data = r'a\nbc\nd'
+    new_line = '\n'
+    content = r'a{0}bc{0}nd{0}{0}'.format(new_line)
 
-    read_only = MockOpenFile('rom.txt', data=data)
+    read_only = MockOpenTextFile('rom.txt', data=content)
     assert read_only.readable() is True
     assert read_only.writable() is False
 
     with pytest.raises(io.UnsupportedOperation):
         read_only.write('')
 
-    assert read_only.read() == data
-    assert read_only.readlines() == ['{}\n'.format(line) for line in data.split('\n')]
+    assert read_only.read() == content
+    assert read_only.readlines() == ['{0}{1}'.format(line, new_line)
+                                     for line in content.split(new_line)]
     read_only.close()
 
     with pytest.raises(ValueError):
@@ -142,11 +145,11 @@ def test_read_only_mode_MockOpenFile():
         read_only.readlines()
 
 
-def test_write_only_mode_MockOpenFile():
+def test_write_only_mode_MockOpenTextFile():
     """
     Writing to to write-only file, reading should be prohibited.
     """
-    write_only = MockOpenFile('write.txt', 'w')
+    write_only = MockOpenTextFile('write.txt', 'w')
 
     assert write_only.readable() is False
     assert write_only.writable() is True
@@ -160,11 +163,11 @@ def test_write_only_mode_MockOpenFile():
     assert num_chars == len(data)
 
 
-def test_read_and_write_MockOpenFile():
+def test_read_and_write_MockOpenTextFile():
     """
     Reading & wrtiting to a file with read/write access.
     """
-    rd_wr = MockOpenFile(mode='r+')
+    rd_wr = MockOpenTextFile(mode='r+')
 
     assert rd_wr.name == 'N/A'
     assert rd_wr.readable() is True
@@ -187,14 +190,14 @@ def test_read_and_write_MockOpenFile():
     rd_wr.close()
 
 
-def test_repr_MockOpenFile():
+def test_repr_MockOpenTextFile():
     """
-    Test MockOpenFile.__repr__
+    Test MockOpenTextFile.__repr__
     """
-    mo_p = re.compile((r"^(?P<_><)sunpy\.tests\.mocks\.MockOpenFile file \'a\' "
-                       "mode \'r\' at 0x[0-9A-Fa-f]+(?(_)>|)$"))
+    mo_p = re.compile((r"^(?P<_><)sunpy\.tests\.mocks\.MockOpenTextFile file \'a\' "
+                       "mode \'r\' at 0x[0-9A-Fa-f]+L?(?(_)>|)$"))
 
-    assert mo_p.match(repr(MockOpenFile('a', 'r'))) is not None
+    assert mo_p.match(repr(MockOpenTextFile('a', 'r'))) is not None
 
 
 def test_MockHTTPResponse():

--- a/sunpy/tests/tests/test_mocks.py
+++ b/sunpy/tests/tests/test_mocks.py
@@ -1,0 +1,215 @@
+import io
+import re
+
+import pytest
+
+from ..mocks import MockObject, MockOpenFile, MockHTTPResponse
+
+
+@pytest.fixture
+def mocked_mockobject():
+    return MockObject(records=12)
+
+
+def test_MockObject_illegal_kwargs(mocked_mockobject):
+    """
+    Any attempt to use a kwarg which has the same name as an attribute/method of the
+    underlying object or datastore will raise a ValueError.
+    """
+    with pytest.raises(ValueError):
+        MockObject(records=[], values=1)
+
+    with pytest.raises(ValueError):
+        MockObject(items=('a', 'b', 'c'))
+
+    with pytest.raises(ValueError):
+        MockObject(__hash__=0x23424)
+
+    # adding a new 'prohibited' attribute will be prevented
+    with pytest.raises(ValueError):
+        mocked_mockobject['keys'] = [3, 4]
+
+
+def test_MockObject_attr(mocked_mockobject):
+    """
+    builtin hasattr & getattr functions, these don't work on dictionaries
+    but they do on classes.
+    """
+    assert hasattr(mocked_mockobject, 'records') is True
+    assert hasattr(mocked_mockobject, 'cost') is False
+
+    assert getattr(mocked_mockobject, 'records') == 12
+
+    with pytest.raises(AttributeError):
+        getattr(mocked_mockobject, 'jobs')
+
+
+def test_MockObject_get(mocked_mockobject):
+    """
+    Getting attributes from MockObject using dot and bracket notation.
+    """
+    assert mocked_mockobject['records'] == 12
+    assert mocked_mockobject.records == 12
+
+    with pytest.raises(AttributeError):
+        mocked_mockobject.no_key
+
+    with pytest.raises(KeyError):
+        mocked_mockobject['not-here']
+
+
+def test_MockObject_set_get(mocked_mockobject):
+    """
+    Setting attributes in MockObject using bracket notation and *not*
+    using dot notation.
+    """
+
+    # Only change the value of existing & new items using 'bracket' notation
+    mocked_mockobject['records'] = 45
+    assert mocked_mockobject.records == 45
+    assert mocked_mockobject['records'] == 45
+
+    # Using 'dot' notation will set a new attribute on 'MockObject' not on the datastore
+    # DO NOT DO THIS!
+    mocked_mockobject.records = -344
+
+    # This is equivalent to seattr(mocked_mockobject, 'records', -344). Again, don't do this!
+    assert mocked_mockobject.records == -344
+
+    # The 'real' value remains unchanged.
+    assert mocked_mockobject['records'] == 45
+
+
+def test_MockObject_len():
+    """
+    Testing MockObject.__len__
+    """
+    assert len(MockObject(responses=['a', 'b', 'c', 'd'], requests=(1, 2, 3))) == 2
+
+
+def test_MockObject_del(mocked_mockobject):
+    """
+    Ensure MockObject.__delitem__ is *not* implemented.
+    """
+    with pytest.raises(NotImplementedError):
+        del mocked_mockobject['records']
+
+
+def test_MockObject_iter(mocked_mockobject):
+    """
+    Test Test MockOpenFile.__iter__
+    """
+    assert list(iter(mocked_mockobject)) == ['records']
+
+
+def test_repr_MockObject(mocked_mockobject):
+    """
+    Test MockOpenFile.__repr__
+    """
+    mo_p = re.compile(r"^(?P<_><)sunpy\.tests\.mocks\.MockObject \{'records': 12\} "
+                      "at 0x[0-9A-Fa-f]+(?(_)>|)$")
+
+    assert mo_p.match(repr(mocked_mockobject)) is not None
+
+
+def test_read_only_mode_MockOpenFile():
+    """
+    Reading from a read only file, wrtiting should be prohibited.
+    """
+    data = r'a\nbc\nd'
+
+    read_only = MockOpenFile('rom.txt', data=data)
+    assert read_only.readable() is True
+    assert read_only.writable() is False
+
+    with pytest.raises(io.UnsupportedOperation):
+        read_only.write('')
+
+    assert read_only.read() == data
+    assert read_only.readlines() == ['{}\n'.format(line) for line in data.split('\n')]
+    read_only.close()
+
+    with pytest.raises(ValueError):
+        read_only.readable()
+
+    with pytest.raises(ValueError):
+        read_only.writable()
+
+    with pytest.raises(ValueError):
+        read_only.read()
+
+    with pytest.raises(ValueError):
+        read_only.readlines()
+
+
+def test_write_only_mode_MockOpenFile():
+    """
+    Writing to to write-only file, reading should be prohibited.
+    """
+    write_only = MockOpenFile('write.txt', 'w')
+
+    assert write_only.readable() is False
+    assert write_only.writable() is True
+
+    with pytest.raises(io.UnsupportedOperation):
+        write_only.read()
+
+    data = '0123456789'
+
+    num_chars = write_only.write(data)
+    assert num_chars == len(data)
+
+
+def test_read_and_write_MockOpenFile():
+    """
+    Reading & wrtiting to a file with read/write access.
+    """
+    rd_wr = MockOpenFile(mode='r+')
+
+    assert rd_wr.name == 'N/A'
+    assert rd_wr.readable() is True
+    assert rd_wr.writable() is True
+
+    # Initailly empty
+    assert rd_wr.read() == ''
+
+    data = '0123456789'
+
+    num_chars = rd_wr.write(data)
+    assert num_chars == len(data)
+
+    assert rd_wr.read() == data
+
+    rd_wr.flush()
+
+    assert rd_wr.read() == data
+
+    rd_wr.close()
+
+
+def test_repr_MockOpenFile():
+    """
+    Test MockOpenFile.__repr__
+    """
+    mo_p = re.compile((r"^(?P<_><)sunpy\.tests\.mocks\.MockOpenFile file \'a\' "
+                       "mode \'r\' at 0x[0-9A-Fa-f]+(?(_)>|)$"))
+
+    assert mo_p.match(repr(MockOpenFile('a', 'r'))) is not None
+
+
+def test_MockHTTPResponse():
+    """
+    Simple tests querying the headers attribute.
+    """
+    headers = {'Content-Type': 'text/html',
+               'Content-Disposition': 'attachment; filename="filename.jpg"'}
+
+    response = MockHTTPResponse(url='http://abc.com', headers=headers)
+
+    assert response.url == 'http://abc.com'
+
+    assert response.headers.get('Content-Disposition') == 'attachment; filename="filename.jpg"'
+    assert response.headers.get('Content-Length') is None
+
+    # Key *not* case insensitive
+    assert response.headers.get('content-type') is None


### PR DESCRIPTION
- Added mocks.py to define our own 'mocked' objects
- Code coverage of vso.py increased: 25% -> 37%

I've added a new file 'sunpy/tests/mocks.py' and associated unit tests in 
'sunpy/tests/tests/test_mock.py'.

This allows us to define our own mocked objects. I've included some examples:

- `MockOpenTextFile(...)`, this is more for illustration purposes, but is 'usable'.
- `MockHTTPResponse(...)`. I've used this for testing `sunpy.util.net`, not 
   yet published.

Other examples, `MockQRRecord` & `MockQRResponse`, can be found in 
`sunpy/net/tests/test_vso.py`.

There are some limitations, and these are captured in the docstrings.

Originally made some changes to `sunpy/net/vso/vso.py` but, had to back these 
out as the following `pep8` error:

```
E731 do not assign a lambda expression, use a def
```

This seems impossible to suppress. 

```Python
# sunpy/net/vso/vso.py

447  sdk = lambda key: lambda value: {key: value}
```

I can see what the code is doing - for a kwarg if an alias key is available 
then use that but, keep the original value. If no alias is available then 
leave as is.

I wrote a replacement and some unit tests but left the original lambda 
in the unit tests to compare against my changes. Running pep8 results in 
same error of course.

Since backed out my changes.
