### PR TITLE
Removing packages that are installed by ci-helpers always

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='astropy astropy-ci-extras conda-forge'
-        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib requests beautifulsoup4 sqlalchemy scikit-image pytest pyyaml pandas nomkl pytest-cov coverage hypothesis'
+        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib requests beautifulsoup4 sqlalchemy scikit-image pyyaml pandas nomkl pytest-cov hypothesis'
         - PIP_DEPENDENCIES='suds-jurko sphinx-gallery glymur pytest-sugar'
         - EVENT_TYPE='pull_request push'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,13 @@ matrix:
          - python: 3.5
            env: SETUP_CMD='test --figure' CONDA_DEPENDENCIES=''
 
+    allow_failures:
+         # Temporarily allowing it to fail, but remove it from here asap once
+         # the build is passing again
+         - python: 3.5
+           env: SETUP_CMD='build_docs -w'
+                EVENT_TYPE='push pull_request cron'
+
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,15 @@ environment:
       # See: http://stackoverflow.com/a/13751649/163740
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       CONDA_CHANNELS: "conda-forge astropy-ci-extras"
-      CONDA_DEPENDENCIES: "scipy astropy matplotlib pandas requests beautifulsoup4 sqlalchemy scikit-image wcsaxes suds-jurko hypothesis"
+      CONDA_DEPENDENCIES: "scipy matplotlib pandas requests beautifulsoup4 sqlalchemy scikit-image wcsaxes suds-jurko hypothesis"
       PIP_DEPENDENCIES: "Glymur"
+      NUMPY_VERSION: "stable"
+      ASTROPY_VERSION: "stable"
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        NUMPY_VERSION: "stable"
       - PYTHON_VERSION: "3.5"
-        NUMPY_VERSION: "stable"
+
 matrix:
     fast_finish: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
       # See: http://stackoverflow.com/a/13751649/163740
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       CONDA_CHANNELS: "conda-forge astropy-ci-extras"
-      CONDA_DEPENDENCIES: "numpy scipy astropy matplotlib pandas requests beautifulsoup4 sqlalchemy scikit-image pytest wcsaxes suds-jurko hypothesis"
+      CONDA_DEPENDENCIES: "scipy astropy matplotlib pandas requests beautifulsoup4 sqlalchemy scikit-image wcsaxes suds-jurko hypothesis"
       PIP_DEPENDENCIES: "Glymur"
 
   matrix:


### PR DESCRIPTION
A few packages are always installed by ci-helpers, e.g. pytest. 
coverage is also installed whenever the word ``coverage`` is in SETUP_CMD.

If one uses ``NUMPY_VERSION`` or ``ASTROPY_VERSION``, those packages will be installed, too. No need to list them in CONDA_DEPENDENCIES. However I haven't removed it from the appveyor file as wasn't sure whether you want to test stable, or any versions that comes up automatically with conda.

~~@Cadair - backporting this to 0.7 should fix the failure there.~~ No need to backport any more as upstream changes have fixed the 0.7 failure.

