### PR TITLE
Fix rhessi.get_obssumm_file()

### DIFF
--- a/sunpy/instr/rhessi.py
+++ b/sunpy/instr/rhessi.py
@@ -516,3 +516,46 @@ def backprojection(calibrated_event_list, pixel_size=(1., 1.) * u.arcsec,
     result_map = sunpy.map.Map(image, dict_header)
 
     return result_map
+
+
+def _build_energy_bands(label, bands):
+    """
+    Parameters
+    ----------
+    label: `str`
+    bands: `list` of `str`
+    Returns
+    -------
+    bands_with_units: `list` of `str`
+        Each `str` item is an energy band and its unit
+    Example
+    -------
+    >>> build_energy_band_ranges('Energy bands (keV)', ['3 - 6', '6 - 12', '12 - 25'])
+    ['3 - 6 keV', '6 - 12 keV', '12 - 25 keV']
+    """
+
+    unit_pattern = re.compile(r'^.+\((?P<UNIT>\w+)\)$')
+
+    matched = unit_pattern.match(label)
+
+    if matched is None:
+        raise ValueError("Unable to find energy unit in '{0}' "
+                         "using REGEX '{1}'".format(label, unit_pattern.pattern))
+
+    unit = matched.group('UNIT').strip()
+
+    return ['{energy_band} {unit}'.format(energy_band=band, unit=unit) for band in bands]
+
+
+def _check_one_day(time_range):
+    """
+    Currently only support TimeRanges of a maximum of one day.
+    Issue a visible warning if `time_range` is greater than this
+    Parameters
+    ----------
+    time_range : `sunpy.time.TimeRange`
+    """
+    if time_range.days > 1 * u.day:
+        warnings.warn('Currently only support providing data from one whole day. Only data for {0} '
+                      'will be returned'.format(time_range.start.strftime("%Y-%m-%d")), UserWarning,
+                      stacklevel=2)

--- a/sunpy/instr/tests/test_rhessi.py
+++ b/sunpy/instr/tests/test_rhessi.py
@@ -1,16 +1,20 @@
+# -*- coding: utf-8 -*-
 """
-Because rhessi.py is code as well.
+Unit tests for `sunpy.instr.rhessi`
 """
 import os
+import socket
+import warnings
+from datetime import datetime
 
 import sunpy.map
 import sunpy.data.test
 import sunpy.instr.rhessi as rhessi
+from sunpy.extern.six.moves.urllib.error import URLError
 
 import numpy as np
 import pytest
-
-from datetime import datetime
+import mock
 
 testpath = sunpy.data.test.rootdir
 
@@ -82,3 +86,266 @@ def test_uncompress_countrate():
 
     # Random test value
     assert counts[1] == 4080
+
+
+@pytest.fixture
+def unsupported_start_time():
+    """
+    RHESSI summary files are not available for before 2002-02-01
+    """
+    return sunpy.time.TimeRange(("2002/01/31", "2002/02/03"))
+
+
+@pytest.fixture
+def one_day_timerange():
+    return sunpy.time.TimeRange(("2016/01/15", "2016/01/16"))
+
+
+@pytest.fixture
+def two_days_timerange():
+    return sunpy.time.TimeRange(("2016/01/15", "2016/01/17"))
+
+
+# Test `rhessi.get_base_url()`
+
+@mock.patch('sunpy.instr.rhessi.urlopen', return_value=None)
+def test_get_base_url(mock_urlopen):
+    """
+    Success case, can successfully 'ping' first data_server
+    """
+    assert rhessi.get_base_url() == rhessi.data_servers[0]
+
+
+@mock.patch('sunpy.instr.rhessi.urlopen', side_effect=URLError(''))
+def test_get_base_url_on_urlerror(mock_urlopen):
+    """
+    If all tested URLs raise `URLError`, then raise an `IOError`
+    """
+    with pytest.raises(IOError):
+        rhessi.get_base_url()
+
+
+@mock.patch('sunpy.instr.rhessi.urlopen', side_effect=socket.timeout)
+def test_get_base_url_on_timeout(mock_urlopen):
+    """
+    If all tested data servers timeout, then raise an `IOError`
+    """
+    with pytest.raises(IOError):
+        rhessi.get_base_url()
+
+
+# Test `rhessi.get_obssumm_dbase_file(...)`
+
+def test_get_obssumm_dbase_file_with_unsupported_start_time(unsupported_start_time):
+    """
+    RHESSI summary files are not available for before 2002-02-01, ensure
+    `ValueError` is raised.
+    """
+    with pytest.raises(ValueError):
+        rhessi.get_obssumm_dbase_file(unsupported_start_time)
+
+
+@mock.patch('sunpy.instr.rhessi.urlretrieve', return_value=None)
+@mock.patch('sunpy.instr.rhessi.get_base_url', return_value='http://www.example.com')
+def test_get_obssumm_dbase_file_timerange_warnings(mock_get_base_url,
+                                                   mock_urlretrieve,
+                                                   one_day_timerange,
+                                                   two_days_timerange):
+    """
+    With only one day in the time range, the `UserWarning` should *not* be issued.
+    With two days in the time range, the `UserWarning` should be issued.
+
+    Only interested in the presence/absence of the `UserWarning`, *not* the return
+    value of `get_obssumm_dbase_file`.
+    """
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        rhessi.get_obssumm_dbase_file(one_day_timerange)
+        assert len(caught_warnings) == 0
+
+    with pytest.warns(UserWarning):
+        rhessi.get_obssumm_dbase_file(two_days_timerange)
+
+
+@mock.patch('sunpy.instr.rhessi.urlretrieve', return_value=None)
+@mock.patch('sunpy.instr.rhessi.get_base_url', return_value='http://www.example.com')
+def test_get_obssumm_dbase_file_build_correct_url(mock_get_base_url, mock_urlretrieve,
+                                                  one_day_timerange):
+    """
+    This test ensures that we build the correct url which is then used
+    to get the database file.
+    """
+    rhessi.get_obssumm_dbase_file(one_day_timerange)
+    mock_urlretrieve.assert_called_with(
+        'http://www.example.com/dbase/hsi_obssumm_filedb_201601.txt')
+
+
+# Test `rhessi.parse_obssumm_dbase_file(...)`
+
+def hessi_data():
+    return """HESSI Filedb File:
+Created: 1972-04-14T12:41:26.000
+Number of Files:           2
+                    Filename  Orb_st Orb_end         Start_time           End_time Status_flag    Npackets Drift_start   Drift_end Data source
+hsi_obssumm_19721101_139.fit       7       8 01-Nov-72 00:00:00 02-Nov-72 00:00:00           3           2       0.000       0.000
+hsi_obssumm_19721102_144.fit       9      10 02-Nov-72 00:00:00 03-Nov-72 00:00:00           4           1       0.000       0.000
+""".splitlines()
+
+
+def test_parse_obssumm_dbase_file():
+    """
+    Ensure that all required data are extracted from the RHESSI
+    observing summary database file mocked in `hessi_data()`
+    """
+    mock_file = mock.mock_open()
+    mock_file.return_value.__iter__.return_value = hessi_data()
+
+    dbase_data = {}
+    with mock.patch('sunpy.instr.rhessi.open', mock_file):
+        dbase_data = rhessi.parse_obssumm_dbase_file(None)
+
+    assert len(dbase_data.keys()) == 7
+
+    # verify each of the 7 fields
+    assert dbase_data['filename'] == ['hsi_obssumm_19721101_139.fit',
+                                      'hsi_obssumm_19721102_144.fit']
+    assert dbase_data['orb_st'] == [7, 9]
+    assert dbase_data['orb_end'] == [8, 10]
+    assert dbase_data['start_time'] == [datetime(1972, 11, 1, 0, 0), datetime(1972, 11, 2, 0, 0)]
+    assert dbase_data['end_time'] == [datetime(1972, 11, 2, 0, 0), datetime(1972, 11, 3, 0, 0)]
+    assert dbase_data['status_flag'] == [3, 4]
+    assert dbase_data['npackets'] == [2, 1]
+
+
+# Test `rhessi.get_obssum_filename(...)`
+
+def parsed_dbase():
+    """
+    The result of calling `parse_obssumm_dbase_file(...)` on
+    https://hesperia.gsfc.nasa.gov/hessidata/dbase/hsi_obssumm_filedb_200311.txt but
+    only using the first two rows of data.
+    """
+    return {'filename': ['hsi_obssumm_20031101_139.fit', 'hsi_obssumm_20031102_144.fit'],
+            'orb_st': [0, 0],
+            'orb_end': [0, 0],
+            'start_time': [datetime(2003, 11, 1, 0, 0), datetime(2003, 11, 2, 0, 0)],
+            'end_time': [datetime(2003, 11, 2, 0, 0), datetime(2003, 11, 3, 0, 0)],
+            'status_flag': [0, 0],
+            'npackets': [0, 0]}
+
+
+@mock.patch('sunpy.instr.rhessi.get_base_url', return_value='http://www.example.com')
+@mock.patch('sunpy.instr.rhessi.parse_obssumm_dbase_file', return_value=parsed_dbase())
+@mock.patch('sunpy.instr.rhessi.get_obssumm_dbase_file', return_value=('', {}))
+def test_get_obssum_filename_one_day(mock_get_obssumm_dbase_file,
+                                     mock_parse_obssumm_dbase_file,
+                                     mock_get_base_url):
+    """
+    Given a time range of one day, make sure we get one days data back, i.e. one file.
+    """
+    filename = rhessi.get_obssum_filename(('2003-11-01', '2003-11-02'))
+
+    assert len(filename) == 1
+    assert filename[0] == 'http://www.example.com/metadata/catalog/hsi_obssumm_20031101_139.fits'
+
+
+@mock.patch('sunpy.instr.rhessi.get_base_url', return_value='http://www.example.com')
+@mock.patch('sunpy.instr.rhessi.parse_obssumm_dbase_file', return_value=parsed_dbase())
+@mock.patch('sunpy.instr.rhessi.get_obssumm_dbase_file', return_value=('', {}))
+def test_get_obssum_filename_two_days(mock_get_obssumm_dbase_file,
+                                      mock_parse_obssumm_dbase_file,
+                                      mock_get_base_url):
+    """
+    Given a time range of two days, make sure we get two files back, one
+    for each day.
+    """
+    filenames = rhessi.get_obssum_filename(('2003-11-01', '2003-11-03'))
+
+    assert len(filenames) == 2
+    assert filenames[0] == 'http://www.example.com/metadata/catalog/hsi_obssumm_20031101_139.fits'
+    assert filenames[1] == 'http://www.example.com/metadata/catalog/hsi_obssumm_20031102_144.fits'
+
+
+# Test `rhessi.get_obssumm_file(...)`
+
+@mock.patch('sunpy.instr.rhessi.urlretrieve', return_value=None)
+@mock.patch('sunpy.instr.rhessi.get_obssum_filename', return_value=['dummy.fits'])
+def test_get_obssumm_file_timerange_warnings(mock_get_obssum_filename,
+                                             mock_urlretrieve,
+                                             one_day_timerange,
+                                             two_days_timerange):
+    """
+    With only one day in the time range, the `UserWarning` should *not* be issued.
+    With two days in the time range, the `UserWarning` should be issued.
+
+    Only interested in the presence/absence of the `UserWarning`, *not* the return
+    value of `get_obssumm_file`.
+    """
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        rhessi.get_obssumm_file(one_day_timerange)
+        assert len(caught_warnings) == 0
+
+    with pytest.warns(UserWarning):
+        rhessi.get_obssumm_file(two_days_timerange)
+
+
+@mock.patch('sunpy.instr.rhessi.urlretrieve', return_value=None)
+@mock.patch('sunpy.instr.rhessi.get_obssum_filename', return_value=['http://first.org/file.txt',
+                                                                    'http://second.com/f.txt'])
+def test_get_obssumm_file_timerange_warnings(mock_get_obssum_filename,
+                                             mock_urlretrieve,
+                                             two_days_timerange):
+    """
+    Even though `get_obssum_filename` returns more than one file. Make sure that
+    `get_obssumm_file` only attempts to retrieve the first one.
+    """
+    rhessi.get_obssumm_file(two_days_timerange)
+
+    mock_urlretrieve.assert_called_with('http://first.org/file.txt')
+
+
+# Test `rhessi._build_energy_bands(...)`
+
+@pytest.fixture
+def raw_bands():
+    return ['3 - 6', '6 - 12', '12 - 25', '25 - 50', '50 - 100', '100 - 300', '300 - 800',
+            '800 - 7000', '7000 - 20000']
+
+
+def test__build_energy_bands_no_match(raw_bands):
+    """
+    If an energy unit cannot be found in the `label` then raise
+    a `ValueError`
+    """
+    with pytest.raises(ValueError):
+        rhessi._build_energy_bands(label='Energy bands GHz', bands=raw_bands)
+
+
+def test__build_energy_bands(raw_bands):
+    """
+    Success case.
+    """
+    built_ranges = rhessi._build_energy_bands(label='Energy bands (keV)', bands=raw_bands)
+
+    assert built_ranges == ['3 - 6 keV', '6 - 12 keV', '12 - 25 keV', '25 - 50 keV',
+                            '50 - 100 keV', '100 - 300 keV', '300 - 800 keV',
+                            '800 - 7000 keV', '7000 - 20000 keV']
+
+
+# Test `rhessi._check_one_day(...)`
+
+def test__check_one_day_with_warning(two_days_timerange):
+    """
+    Issue a warning if TimeRange > one day
+    """
+    with pytest.warns(UserWarning):
+        rhessi._check_one_day(two_days_timerange)
+
+
+def test__check_one_day(one_day_timerange):
+    """
+    Success case, time range is one day - no warnings should be raised
+    """
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        rhessi._check_one_day(one_day_timerange)
+        assert len(caught_warnings) == 0

--- a/sunpy/instr/tests/test_rhessi.py
+++ b/sunpy/instr/tests/test_rhessi.py
@@ -200,7 +200,7 @@ def test_parse_obssumm_dbase_file():
     mock_file.return_value.__iter__.return_value = hessi_data()
 
     dbase_data = {}
-    with mock.patch('sunpy.instr.rhessi.open', mock_file):
+    with mock.patch('sunpy.instr.rhessi.open', mock_file, create=True):
         dbase_data = rhessi.parse_obssumm_dbase_file(None)
 
     assert len(dbase_data.keys()) == 7

--- a/sunpy/net/helio/__init__.py
+++ b/sunpy/net/helio/__init__.py
@@ -7,3 +7,6 @@ A Module for accessing the HELIO web service
 """
 
 from __future__ import absolute_import
+
+from .parser import *
+from .hec import *

--- a/sunpy/net/helio/parser.py
+++ b/sunpy/net/helio/parser.py
@@ -1,10 +1,4 @@
 # -*- coding: utf-8 -*-
-# Author:   Michael Malocha <mjm159@humboldt.edu>
-# Last Edit:  September 22nd, 2013
-#
-# This module was developed with funding from the GSOC 2013 summer of code
-#
-
 """
 This module is meant to parse the HELIO registry and return WSDL endpoints to
 facilitate the interfacing between further modules and HELIO.
@@ -18,8 +12,7 @@ from contextlib import closing
 from sunpy.net.helio import registry_links as RL
 from sunpy.extern.six.moves import urllib
 
-__author__ = 'Michael Malocha'
-__version__ = 'September 22nd, 2013'
+__all__ = ['webservice_parser', 'endpoint_parser', 'wsdl_retriever']
 
 # Lifespan in seconds before a link times-out
 LINK_TIMEOUT = 3
@@ -61,7 +54,7 @@ def webservice_parser(service='HEC'):
         return None
     root = EL.fromstring(xml)
     links = []
-    
+
     for interface in root.iter('interface'):
         service_type = interface.attrib
         key = list(service_type.keys())

--- a/sunpy/net/tests/test_helio.py
+++ b/sunpy/net/tests/test_helio.py
@@ -1,13 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
-
-try:
-    # >= Py3.3
-    import unittest.mock as mock
-except ImportError:
-    # Py 2.7 - Py.3.2
-    import mock
+import mock
 
 from sunpy.net.helio import hec
 from sunpy.net.helio.parser import (endpoint_parser, link_test, taverna_parser, webservice_parser,

--- a/sunpy/tests/figure_tests_env_3.5.yml
+++ b/sunpy/tests/figure_tests_env_3.5.yml
@@ -32,6 +32,7 @@ dependencies:
 - libxml2=2.9.4=0
 - libxslt=1.1.29=0
 - lxml=3.7.2=py35_0
+- mock=1.6.2=py35_0
 - matplotlib=2.0.0=np111py35_0
 - mkl=2017.0.1=0
 - networkx=1.11=py35_0

--- a/sunpy/tests/figure_tests_env_3.5.yml
+++ b/sunpy/tests/figure_tests_env_3.5.yml
@@ -32,7 +32,7 @@ dependencies:
 - libxml2=2.9.4=0
 - libxslt=1.1.29=0
 - lxml=3.7.2=py35_0
-- mock=1.6.2=py35_0
+- mock=2.0.0=py35_0
 - matplotlib=2.0.0=np111py35_0
 - mkl=2017.0.1=0
 - networkx=1.11=py35_0


### PR DESCRIPTION
Minor problem causing get_obssumm_file not to fetch HESSI file

#### Changes

Made minor changes for the pep8 police. There are three lines in docstrings
which are longer than 100 hundred characters, but these contain very long 
URLs and I don't how to reformat these. 

##### `get_obssumm_file(...)`

Now works as expected. I've added a warning to inform the user if an attempt
is made to retrieve more than one whole day of data. This may be overkill as
this limitation is clearly stated in the docstring.

Also noticed that this check would have to be done in `get_obssumm_dbase_file(...)`,
and `get_obssum_filename(...)`. If that were the case these functions are called
be each other then you'd see the warning message more than once. I think
I've convinced my self to remove it.


##### Noticed the following

If your network connection is down, `get_base_url(...)` will return `None`

```python
def get_base_url():
    """
    Find the first mirror which is online
    """

    for server in data_servers:
        try:
            urlopen(server, timeout=1)
        except (URLError, socket.timeout):
            pass
        else:
            return server
```

Would it be safer to do the following:

```python
def get_base_url():
    """
    Find the first mirror which is online
    """

    for server in data_servers:
        try:
            urlopen(server, timeout=1)
            return server
        except (URLError, socket.timeout):
            pass

    raise IOError('Unable to find an online HESSI server from {0}'.format(data_servers))
```

Wording of exception message may need improving.

I've some ideas for unit tests. Is it worth submitting these? Or is 
the code in too fluid a state?