### PR TITLE
Error handling in break_time

### DIFF
--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -118,9 +118,6 @@ def _iter_empty(iter):
         return True
     return False
 
-
-
-
 def parse_time(time_string, time_format='', **kwargs):
     """Given a time string will parse and return a datetime object.
     Similar to the anytim function in IDL.

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -280,7 +280,11 @@ def day_of_year(time_string):
 def break_time(t='now', time_format=''):
     """Given a time returns a string. Useful for naming files."""
     # TODO: should be able to handle a time range
-    return parse_time(t, time_format).strftime("%Y%m%d_%H%M%S")
+    try:
+        time = parse_time(t, time_format).strftime("%Y%m%d_%H%M%S")
+        return time
+    except ValueError:
+        print(str(t) + " is not a valid time string!")
 
 
 def get_day(dt):

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -284,7 +284,7 @@ def break_time(t='now', time_format=''):
         time = parse_time(t, time_format).strftime("%Y%m%d_%H%M%S")
         return time
     except ValueError:
-        print(str(t) + " is not a valid time string!")
+        pass
 
 
 def get_day(dt):


### PR DESCRIPTION
Following code returns ValueError and is not handled properly:
`from sunpy.time import break_time`
`break_time('garbage')`

Following result is obtained on the terminal:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sunpy/time/time.py", line 283, in break_time
    return parse_time(t, time_format).strftime("%Y%m%d_%H%M%S")
  File "sunpy/time/time.py", line 199, in parse_time
    raise ValueError("{tstr!s} is not a valid time string!".format(tstr=time_string))
ValueError: garbage is not a valid time string!
```

This PR uses try-catch to handle the error input in break_time() function. `pass` is used as it is used in [line 186](https://github.com/swapsha96/sunpy/blob/breaktime/sunpy/time/time.py#L186) of same file.