### PR TITLE
Add needed test packages to installation  and documentation about it

### DIFF
--- a/doc/source/guide/installation/advanced.rst
+++ b/doc/source/guide/installation/advanced.rst
@@ -131,6 +131,8 @@ To install SunPy with database dependencies (sqlalchemy)::
 
     pip install sunpy[database]
 
+Other available options are: `[image]`, `[jpeg2000]` and `[tests]`
+
 .. warning::
     Users of the Anaconda python distribution should follow the instructions
     for :ref:`anaconda_install`.

--- a/setup.py
+++ b/setup.py
@@ -108,9 +108,10 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 extras_require = {'database': ["sqlalchemy"],
                   'image': ["scikit-image"],
                   'jpeg2000': ["glymur"],
-                  'net': ["suds-jurko", "beautifulsoup4", "requests"]}
+                  'net': ["suds-jurko", "beautifulsoup4", "requests"],
+                  'tests': ["pytest", "pytest-cov", "pytest-mock", "mock", "hypothesis"]}
 extras_require['all'] = extras_require['database'] + extras_require['image'] + \
-                        extras_require['net'] + ["wcsaxes>=0.8"]
+                        extras_require['net'] + extras_require['tests'] + ["wcsaxes>=0.8"]
 
 setup(name=PACKAGENAME,
       version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ extras_require = {'database': ["sqlalchemy"],
                   'net': ["suds-jurko", "beautifulsoup4", "requests"],
                   'tests': ["pytest", "pytest-cov", "pytest-mock", "mock", "hypothesis"]}
 extras_require['all'] = extras_require['database'] + extras_require['image'] + \
-                        extras_require['net'] + extras_require['tests'] + ["wcsaxes>=0.8"]
+                        extras_require['net'] + extras_require['tests']
 
 setup(name=PACKAGENAME,
       version=VERSION,


### PR DESCRIPTION
Do we need this? otherwise we should point to `pip install -r requirements/extra.txt` somewhere