### PR TITLE
Scraper fixes

### DIFF
--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -248,7 +248,7 @@ class GenericClient(object):
         kwergs.update(kwargs)
         urls = self._get_url_for_timerange(
             self.map_.get('TimeRange'), **kwergs)
-        if getattr(self, "_get_time_for_url", None):
+        if urls and getattr(self, "_get_time_for_url", None):
             return QueryResponse.create(self.map_, urls, self._get_time_for_url(urls))
         return QueryResponse.create(self.map_, urls)
 

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -3,7 +3,10 @@
 # Google Summer of Code 2014
 
 from __future__ import absolute_import, division, print_function
+import datetime
 
+from sunpy.time import TimeRange
+from sunpy.util.scraper import Scraper
 from sunpy.extern.six.moves.urllib.parse import urljoin
 
 from ..client import GenericClient
@@ -39,7 +42,7 @@ class EVEClient(GenericClient):
 
         Parameters
         ----------
-        timerange: sunpy.time.TimeRange
+        timerange: `sunpy.time.TimeRange`
             time range for which data is to be downloaded.
 
         Returns
@@ -47,27 +50,26 @@ class EVEClient(GenericClient):
         urls : list
             list of URLs corresponding to the requested time range
         """
-        days = timerange.get_dates()
-        urls = []
-        for day in days:
-            urls.append(self._get_url_for_date(day, **kwargs))
-        return urls
+        baseurl = ('http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
+                   'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
+        # If start of time range is before 00:00, converted to such, so
+        # files of the requested time ranger are included.
+        # This is done because the archive contains daily files.
+        if timerange.start.time() != datetime.time(0, 0):
+            timerange = TimeRange('{:%Y-%m-%d}'.format(timerange.start), timerange.end)
+        eve = Scraper(baseurl)
+        return eve.filelist(timerange)
 
-    def _get_url_for_date(self, date, **kwargs):
-        """
-        Return URL for corresponding date.
-
-        Parameters
-        ----------
-        date : Python datetime object
-
-        Returns
-        -------
-        URL : string
-        """
-        base_url = 'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/'
-        return urljoin(base_url,
-                                date.strftime('%Y/%Y%m%d') + '_EVE_L0CS_DIODES_1m.txt')
+    def _get_time_for_url(self, urls):
+        baseurl = ('http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
+                   'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
+        eve = Scraper(baseurl)
+        times = list()
+        for url in urls:
+            t0 = eve._extractDateURL(url)
+            # hard coded full day as that's the normal.
+            times.append(TimeRange(t0, t0 + datetime.timedelta(days=1)))
+        return times
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -13,6 +13,8 @@ from ..client import GenericClient
 
 
 __all__ = ['EVEClient']
+BASEURL = ('http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
+           'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
 
 
 class EVEClient(GenericClient):
@@ -50,20 +52,17 @@ class EVEClient(GenericClient):
         urls : list
             list of URLs corresponding to the requested time range
         """
-        baseurl = ('http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
-                   'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
+
         # If start of time range is before 00:00, converted to such, so
         # files of the requested time ranger are included.
         # This is done because the archive contains daily files.
         if timerange.start.time() != datetime.time(0, 0):
             timerange = TimeRange('{:%Y-%m-%d}'.format(timerange.start), timerange.end)
-        eve = Scraper(baseurl)
+        eve = Scraper(BASEURL)
         return eve.filelist(timerange)
 
     def _get_time_for_url(self, urls):
-        baseurl = ('http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
-                   'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
-        eve = Scraper(baseurl)
+        eve = Scraper(BASEURL)
         times = list()
         for url in urls:
             t0 = eve._extractDateURL(url)

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -35,7 +35,6 @@ class NoRHClient(GenericClient):
 
         # We allow queries with no Wavelength but error here so that the query
         # does not get passed to VSO and spit out garbage.
-        # NOTE: should not error on the function?
         if 'wavelength' not in kwargs.keys() or not kwargs['wavelength']:
             raise ValueError("Queries to NORH should specify either 17GHz or 34GHz as a Wavelength."
                              "see http://solar.nro.nao.ac.jp/norh/doc/manuale/node65.html")

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -13,6 +13,7 @@ from ..client import GenericClient
 
 __all__ = ['NoRHClient']
 
+BASEURL = 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/{freq}%y%m%d'
 
 class NoRHClient(GenericClient):
 
@@ -30,8 +31,6 @@ class NoRHClient(GenericClient):
         urls : list
             list of URLs corresponding to the requested time range
         """
-
-        baseurl = 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/{freq}%y%m%d'
 
         # We allow queries with no Wavelength but error here so that the query
         # does not get passed to VSO and spit out garbage.
@@ -60,16 +59,15 @@ class NoRHClient(GenericClient):
         # This is done because the archive contains daily files.
         if timerange.start.time() != datetime.time(0, 0):
             timerange = TimeRange('{:%Y-%m-%d}'.format(timerange.start), timerange.end)
-        norh = Scraper(baseurl, freq=freq)
+        norh = Scraper(BASEURL, freq=freq)
         # TODO: warn user that some files may have not been listed, like for example:
         #       tca160504_224657 on ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/05/
         #       as it doesn't follow pattern.
         return norh.filelist(timerange)
 
     def _get_time_for_url(self, urls):
-        baseurl = 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/{freq}%y%m%d'
         freq = urls[0].split('/')[-1][0:3]  # extract the frequency label
-        crawler = Scraper(baseurl, freq=freq)
+        crawler = Scraper(BASEURL, freq=freq)
         times = list()
         for url in urls:
             t0 = crawler._extractDateURL(url)

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -2,6 +2,7 @@
 #  This Module was developed under funding provided by
 #  Google Summer of Code 2014
 
+import datetime
 import astropy.units as u
 
 from sunpy.time import TimeRange
@@ -65,6 +66,17 @@ class NoRHClient(GenericClient):
         #       tca160504_224657 on ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/05/
         #       as it doesn't follow pattern.
         return norh.filelist(timerange)
+
+    def _get_time_for_url(self, urls):
+        baseurl = 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/{freq}%y%m%d'
+        freq = urls[0].split('/')[-1][0:3]  # extract the frequency label
+        crawler = Scraper(baseurl, freq=freq)
+        times = list()
+        for url in urls:
+            t0 = crawler._extractDateURL(url)
+            # hard coded full day as that's the normal.
+            times.append(TimeRange(t0, t0 + datetime.timedelta(days=1)))
+        return times
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -4,7 +4,8 @@
 
 import astropy.units as u
 
-from sunpy.extern.six.moves.urllib.parse import urljoin
+from sunpy.time import TimeRange
+from sunpy.util.scraper import Scraper
 
 from sunpy.net import attrs as a
 from ..client import GenericClient
@@ -28,32 +29,12 @@ class NoRHClient(GenericClient):
         urls : list
             list of URLs corresponding to the requested time range
         """
-        days = timerange.get_dates()
-        urls = []
-        for day in days:
-            urls.append(self._get_url_for_date(day, **kwargs))
-        return urls
 
-    def _get_url_for_date(self, date, **kwargs):
-        """
-        Return URL for corresponding date.
-
-        Parameters
-        ----------
-        date : Python datetime object
-
-        Returns
-        -------
-        string
-            The URL for the corresponding date.
-        """
-
-        # default urllib password anonymous@ is not accepted by the NoRH FTP
-        # server. include an accepted password in base url
-        baseurl = 'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/'
+        baseurl = 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/{freq}%y%m%d'
 
         # We allow queries with no Wavelength but error here so that the query
         # does not get passed to VSO and spit out garbage.
+        # NOTE: should not error on the function?
         if 'wavelength' not in kwargs.keys() or not kwargs['wavelength']:
             raise ValueError("Queries to NORH should specify either 17GHz or 34GHz as a Wavelength."
                              "see http://solar.nro.nao.ac.jp/norh/doc/manuale/node65.html")
@@ -67,16 +48,23 @@ class NoRHClient(GenericClient):
 
         wavelength = wavelength.to(u.GHz, equivalencies=u.spectral())
         if wavelength == 34 * u.GHz:
-            final_url = urljoin(baseurl,
-                                date.strftime('%Y/%m/' + 'tcz' + '%y%m%d'))
+            freq = 'tcz'
         elif wavelength == 17 * u.GHz:
-            final_url = urljoin(baseurl,
-                                date.strftime('%Y/%m/' + 'tca' + '%y%m%d'))
+            freq = 'tca'
         else:
             raise ValueError("NORH Data can be downloaded for 17GHz or 34GHz,"
                              " see http://solar.nro.nao.ac.jp/norh/doc/manuale/node65.html")
 
-        return final_url
+        # If start of time range is before 00:00, converted to such, so
+        # files of the requested time ranger are included.
+        # This is done because the archive contains daily files.
+        if timerange.start.time() != datetime.time(0, 0):
+            timerange = TimeRange('{:%Y-%m-%d}'.format(timerange.start), timerange.end)
+        norh = Scraper(baseurl, freq=freq)
+        # TODO: warn user that some files may have not been listed, like for example:
+        #       tca160504_224657 on ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/05/
+        #       as it doesn't follow pattern.
+        return norh.filelist(timerange)
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/tests/test_eve.py
+++ b/sunpy/net/dataretriever/tests/test_eve.py
@@ -56,7 +56,7 @@ def test_query():
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 2
     assert qr1.time_range().start == parse_time('2012/08/09')
-    assert qr1.time_range().end == parse_time('2012/08/10')
+    assert qr1.time_range().end == parse_time('2012/08/11') # includes end.
 
 
 @pytest.mark.online
@@ -103,4 +103,3 @@ def test_levels(time):
     qr = Fido.search(time, eve_a, a.Level(0) | a.Level(1))
     clients = {type(a.client) for a in qr.responses}
     assert clients.symmetric_difference({VSOClient, eve.EVEClient}) == set()
-

--- a/sunpy/net/dataretriever/tests/test_eve.py
+++ b/sunpy/net/dataretriever/tests/test_eve.py
@@ -17,7 +17,7 @@ from sunpy.net.tests.strategies import time_attr
 
 LCClient = eve.EVEClient()
 
-
+@pytest.mark.online
 @pytest.mark.parametrize("timerange,url_start,url_end", [
     (TimeRange('2012/4/21', '2012/4/21'),
      'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120421_EVE_L0CS_DIODES_1m.txt',
@@ -37,12 +37,6 @@ def test_get_url_for_time_range(timerange, url_start, url_end):
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
-
-
-@pytest.mark.online
-def test_get_url_for_date():
-    url = LCClient._get_url_for_date(datetime.date(2013, 2, 13))
-    assert url == 'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2013/20130213_EVE_L0CS_DIODES_1m.txt'
 
 
 def test_can_handle_query():

--- a/sunpy/net/dataretriever/tests/test_norh.py
+++ b/sunpy/net/dataretriever/tests/test_norh.py
@@ -54,21 +54,16 @@ def test_can_handle_query(time):
 
 
 @pytest.mark.online
-@given(time_attr())
-def test_query(time):
-    qr1 = norh.NoRHClient().query(time, a.Instrument('norh'), a.Wavelength(17 * u.GHz))
+@pytest.mark.parametrize("wave", [a.Wavelength(17*u.GHz), a.Wavelength(34*u.GHz)])
+@given(time=time_attr())
+def test_query(time, wave):
+    qr1 = norh.NoRHClient().query(time, a.Instrument('norh'), wave)
     assert isinstance(qr1, QueryResponse)
-    assert qr1.time_range().start == time.start
-    assert qr1.time_range().end == time.end
-
-
-@pytest.mark.online
-@given(time_attr())
-def test_query_34(time):
-    qr1 = norh.NoRHClient().query(time, a.Instrument('norh'), a.Wavelength(34 * u.GHz))
-    assert isinstance(qr1, QueryResponse)
-    assert qr1.time_range().start == time.start
-    assert qr1.time_range().end == time.end
+    # compare range of time as the smaller of this query is in minutes and
+    # hypothesis may add seconds or milliseconds.
+    assert qr1.time_range().start.date() == time.start.date()
+    # hypothesis can give same start-end, but the query will give you from start to end (so +1)
+    assert time.end <= qr1.time_range().end <= time.end + datetime.timedelta(days=1)
 
 
 # Don't use time_attr here for speed.

--- a/sunpy/net/dataretriever/tests/test_norh.py
+++ b/sunpy/net/dataretriever/tests/test_norh.py
@@ -13,6 +13,8 @@ from sunpy.net import attrs as a
 from hypothesis import given
 from sunpy.net.tests.strategies import time_attr
 
+
+@pytest.mark.online
 @pytest.mark.parametrize("timerange,url_start,url_end", [
     (TimeRange('2012/4/21', '2012/4/21'),
      'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/04/tca120421',
@@ -34,9 +36,10 @@ def test_get_url_for_time_range(timerange, url_start, url_end):
     assert urls[-1] == url_end
 
 
-def test_get_url_for_date():
-    url = norh.NoRHClient()._get_url_for_date(datetime.date(2011, 3, 14), wavelength=17*u.GHz)
-    assert url == 'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2011/03/tca110314'
+# FIXME - Do we need this function? time_range superseeds it, right?
+# def test_get_url_for_date():
+#     url = norh.NoRHClient()._get_url_for_date(datetime.date(2011, 3, 14), wavelength=17*u.GHz)
+#     assert url == 'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2011/03/tca110314'
 
 
 @given(time_attr())
@@ -50,6 +53,7 @@ def test_can_handle_query(time):
     assert ans2 is False
 
 
+@pytest.mark.online
 @given(time_attr())
 def test_query(time):
     qr1 = norh.NoRHClient().query(time, a.Instrument('norh'), a.Wavelength(17 * u.GHz))
@@ -58,6 +62,7 @@ def test_query(time):
     assert qr1.time_range().end == time.end
 
 
+@pytest.mark.online
 @given(time_attr())
 def test_query_34(time):
     qr1 = norh.NoRHClient().query(time, a.Instrument('norh'), a.Wavelength(34 * u.GHz))

--- a/sunpy/net/dataretriever/tests/test_norh.py
+++ b/sunpy/net/dataretriever/tests/test_norh.py
@@ -17,16 +17,16 @@ from sunpy.net.tests.strategies import time_attr
 @pytest.mark.online
 @pytest.mark.parametrize("timerange,url_start,url_end", [
     (TimeRange('2012/4/21', '2012/4/21'),
-     'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/04/tca120421',
-     'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/04/tca120421'
+     'ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/04/tca120421',
+     'ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/04/tca120421'
      ),
     (TimeRange('2012/12/1', '2012/12/2'),
-     'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/12/tca121201',
-     'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/12/tca121202'
+     'ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/12/tca121201',
+     'ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/12/tca121202'
      ),
     (TimeRange('2012/3/7', '2012/3/14'),
-     'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/03/tca120307',
-     'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/03/tca120314'
+     'ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/03/tca120307',
+     'ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/03/tca120314'
      )
 ])
 def test_get_url_for_time_range(timerange, url_start, url_end):
@@ -39,7 +39,7 @@ def test_get_url_for_time_range(timerange, url_start, url_end):
 # FIXME - Do we need this function? time_range superseeds it, right?
 # def test_get_url_for_date():
 #     url = norh.NoRHClient()._get_url_for_date(datetime.date(2011, 3, 14), wavelength=17*u.GHz)
-#     assert url == 'ftp://anonymous:mozilla@example.com@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2011/03/tca110314'
+#     assert url == 'ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2011/03/tca110314'
 
 
 @given(time_attr())

--- a/sunpy/net/tests/strategies.py
+++ b/sunpy/net/tests/strategies.py
@@ -81,8 +81,8 @@ def goes_time(draw, time=datetimes(timezones=[],
     return a.Time(tr)
 
 
-def rhessi_time():
-    time = datetimes(timezones=[], max_year=datetime.datetime.utcnow().year,
-                     min_year=2002)
-    time = time.filter(lambda x: x > parse_time('2002-02-01'))
+def range_time(min_date, max_date=datetime.datetime.utcnow()):
+    time = datetimes(timezones=[], max_year=max_date.year,
+                     min_year=1960)
+    time = time.filter(lambda x: min_date < x < max_date)
     return time_attr(time=time)

--- a/sunpy/net/tests/strategies.py
+++ b/sunpy/net/tests/strategies.py
@@ -27,11 +27,10 @@ def offline_instruments():
     Returns a strategy for any instrument that does not need the internet to do
     a query
     """
-    offline_instr = ['lyra', 'norh', 'noaa-indices', 'noaa-predict', 'goes']
+    offline_instr = ['lyra', 'noaa-indices', 'noaa-predict', 'goes']
     offline_instr = st.builds(a.Instrument, st.sampled_from(offline_instr))
 
-    eve = st.just(a.Instrument('eve') & a.Level(0))
-    return st.one_of(offline_instr, eve)
+    return st.one_of(offline_instr)
 
 
 def online_instruments():

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -95,6 +95,7 @@ Factory Tests
 """
 
 
+@pytest.mark.online
 def test_unified_response():
     start = parse_time("2012/1/1")
     end = parse_time("2012/1/2")

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -17,7 +17,7 @@ from sunpy.time import TimeRange, parse_time
 from sunpy import config
 
 from .strategies import (online_instruments, offline_instruments,
-                         time_attr, rhessi_time, goes_time)
+                         time_attr, range_time, goes_time)
 
 TIMEFORMAT = config.get("general", "time_format")
 
@@ -43,7 +43,7 @@ def online_query(draw, instrument=online_instruments(), time=time_attr()):
     query = draw(instrument)
     # If we have AttrAnd then we don't have RHESSI
     if isinstance(query, a.Instrument) and query.value == 'rhessi':
-        query = query & draw(rhessi_time())
+        query = query & draw(range_time(parse_time('2002-02-01')))
     return query
 
 

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -157,14 +157,14 @@ class Scraper(object):
         for k, v in six.iteritems(TIME_CONVERSIONS):
             re_together = re_together.replace(k, v)
 
-        #   Create new empty lists
+        #   Lists to contain the unique elements of the date and the pattern
         final_date = list()
         final_pattern = list()
         re_together = re_together.replace('[A-Z]', '\\[A-Z]')
         for p, r in zip(pattern_together.split('%')[1:], re_together.split('\\')[1:]):
             if p == 'e':
                 continue
-            regexp = '\\{}'.format(r) if not r.startswith('[') else r
+            regexp = r'\{}'.format(r) if not r.startswith('[') else r
             pattern = '%{}'.format(p)
             date_part = re.search(regexp, date_together)
             date_together = date_together[:date_part.start()] + \

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -65,7 +65,9 @@ class Scraper(object):
         else:
             now = datetime.datetime.now()
             milliseconds_ = int(now.microsecond / 1000.)
-            self.now = now.strftime(self.pattern[0:milliseconds.start()] + str(milliseconds_) + self.pattern[milliseconds.end():])
+            self.now = now.strftime(self.pattern[0:milliseconds.start()] +
+                                    str(milliseconds_) +
+                                    self.pattern[milliseconds.end():])
 
     def matches(self, filepath, date):
         return date.strftime(self.pattern) == filepath
@@ -90,9 +92,9 @@ class Scraper(object):
             range given. Notice that these directories may not exist
             in the archive.
         """
-        #find directory structure - without file names
+        # find directory structure - without file names
         directorypattern = os.path.dirname(self.pattern) + '/'
-        #TODO what if there's not slashes?
+        # TODO what if there's not slashes?
         rangedelta = timerange.dt
         timestep = self._smallerPattern(directorypattern)
         if timestep is None:
@@ -102,13 +104,13 @@ class Scraper(object):
             n_steps = rangedelta.total_seconds()/timestep.total_seconds()
             TotalTimeElements = int(round(n_steps)) + 1
             directories = [(timerange.start + n * timestep).strftime(directorypattern)
-                        for n in range(TotalTimeElements)] #todo if date <= endate
+                           for n in range(TotalTimeElements)]  # TODO if date <= endate
             return directories
 
     def _URL_followsPattern(self, url):
         """Check whether the url provided follows the pattern"""
         pattern = self.pattern
-        for k,v in six.iteritems(TIME_CONVERSIONS):
+        for k, v in six.iteritems(TIME_CONVERSIONS):
             pattern = pattern.replace(k, v)
         matches = re.match(pattern, url)
         if matches:
@@ -154,7 +156,7 @@ class Scraper(object):
         final_date = list()
         final_pattern = list()
         re_together = re_together.replace('[A-Z]', '\\[A-Z]')
-        for p,r in zip(pattern_together.split('%')[1:], re_together.split('\\')[1:]):
+        for p, r in zip(pattern_together.split('%')[1:], re_together.split('\\')[1:]):
             if p == 'e':
                 continue
             regexp = '\\{}'.format(r) if not r.startswith('[') else r
@@ -226,7 +228,7 @@ class Scraper(object):
                 return datetime.timedelta(hours=1)
             elif any(day in directoryPattern for day in ["%d", "%j"]):
                 return datetime.timedelta(days=1)
-            elif any(month in directoryPattern for month in ["%b","%B","%m"]):
+            elif any(month in directoryPattern for month in ["%b", "%B", "%m"]):
                 return datetime.timedelta(days=31)
             elif any(year in directoryPattern for year in ["%Y", "%y"]):
                 return datetime.timedelta(days=365)
@@ -234,4 +236,3 @@ class Scraper(object):
                 return None
         except:
             raise
-

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -120,6 +120,10 @@ class Scraper(object):
 
     def _extractDateURL(self, url):
         """Extracts the date from a particular url following the pattern"""
+
+        # remove the user and passwd from files if there:
+        url = url.replace("anonymous:data@sunpy.org@", "")
+
         # url_to_list substitutes '.' and '_' for '/' to then create
         # a list of all the blocks in times - assuming they are all
         # separated with either '.', '_' or '/'

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -131,6 +131,13 @@ class Scraper(object):
         for pattern_elem, url_elem in zip(pattern_list, url_list):
             time_formats = [x for x in time_order if x in pattern_elem]
             if len(time_formats) > 0:
+                # Find whether there's text that should not be here
+                toremove = re.split('%.', pattern_elem)
+                if len(toremove) > 0:
+                    for bit in toremove:
+                        if bit != '':
+                            url_elem = url_elem.replace(bit, '', 1)
+                            pattern_elem = pattern_elem.replace(bit, '', 1)
                 final_date.append(url_elem)
                 final_pattern.append(pattern_elem)
                 for time_bit in time_formats:

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -189,3 +189,11 @@ def testFilesRange_sameDirectory_months_remote():
     enddate = datetime.datetime(2007, 9, 10)
     timerange = TimeRange(startdate, enddate)
     assert len(s.filelist(timerange)) == 2
+
+
+@pytest.mark.online
+def test_ftp():
+    pattern = 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/tca%y%m%d'
+    s = Scraper(pattern)
+    timerange = TimeRange('2016/5/18 15:28:00', '2016/5/20 16:30:50')
+    assert len(s.filelist(timerange)) == 2

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -99,6 +99,25 @@ def testExtractDates_usingPattern():
     timeURL = datetime.datetime(2014, 5, 14, 20, 1, 35)
     assert s._extractDateURL(testURL) == timeURL
 
+def testExtractDates_notSeparators():
+    s = Scraper('data/%Y/%m/swap%m%d_%H%M%S')
+    testURL = 'data/2014/05/swap0514_200135'
+    timeURL = datetime.datetime(2014, 5, 14, 20, 1, 35)
+    assert s._extractDateURL(testURL) == timeURL
+def testExtractDates_notSeparators_andSimilar():
+    s = Scraper('data/%Y/Jun%b%d_%H%M%S')
+    testURL = 'data/2014/JunJun14_200135'
+    timeURL = datetime.datetime(2014, 6, 14, 20, 1, 35)
+    assert s._extractDateURL(testURL) == timeURL
+    testURL = 'data/2014/JunMay14_200135'
+    timeURL = datetime.datetime(2014, 5, 14, 20, 1, 35)
+    assert s._extractDateURL(testURL) == timeURL
+    # and testing with the month afterwards
+    s = Scraper('data/%Y/%dJun%b_%H%M%S')
+    testURL = 'data/2014/14JunJun_200135'
+    timeURL = datetime.datetime(2014, 6, 14, 20, 1, 35)
+    assert s._extractDateURL(testURL) == timeURL
+
 def testURL_pattern():
     s = Scraper('fd_%Y%m%d_%H%M%S.fts')
     assert s._URL_followsPattern('fd_20130410_231211.fts')
@@ -108,6 +127,8 @@ def testURL_pattern():
 @pytest.mark.xfail
 def testURL_patternMilliseconds():
     s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
+    # NOTE: Seems that if below fails randomly - not understood why
+    #       with `== True` fails a bit less...
     assert s._URL_followsPattern('fd_20130410_231211_119.fts')
     assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
     assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import datetime
-import os
 
-import sunpy.data.test
 from sunpy.time import TimeRange
 from sunpy.util.scraper import Scraper
 
@@ -15,23 +13,27 @@ PATTERN_EXAMPLES = [
     ('%y%b', datetime.timedelta(days=31)),
 ]
 
+
 def testDirectoryDatePattern():
     s = Scraper('%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
     testpath = '2014/03/05/20140305_013000_59.fit.gz'
-    d = datetime.datetime(2014,3,5,1,30)
+    d = datetime.datetime(2014, 3, 5, 1, 30)
     assert s.matches(testpath, d)
+
 
 def testDirectoryDatePatternFalse():
     s = Scraper('%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
     testpath = '2013/03/05/20140305_013000_59.fit.gz'
-    d = datetime.datetime(2014,3,5,1,30)
+    d = datetime.datetime(2014, 3, 5, 1, 30)
     assert not s.matches(testpath, d)
 
+
 def testDirectoryObsPattern():
-    s = Scraper('%y%m%d/{observatory}_%Y%m%d.fits', observatory = 'SDO')
+    s = Scraper('%y%m%d/{observatory}_%Y%m%d.fits', observatory='SDO')
     testpath = '140305/SDO_20140305.fits'
-    d = datetime.datetime(2014,3,5)
+    d = datetime.datetime(2014, 3, 5)
     assert s.matches(testpath, d)
+
 
 def testDirectoryRange():
     s = Scraper('%Y/%m/%d/%Y%m%d_%H.fit.gz')
@@ -40,6 +42,7 @@ def testDirectoryRange():
     timerange = TimeRange('2009-12-30', '2010-01-03')
     assert s.range(timerange) == directory_list
 
+
 def testDirectoryRangeFalse():
     s = Scraper('%Y%m%d/%Y%m%d_%H.fit.gz')
     directory_list = ['20091230/', '20091231/', '20100101/',
@@ -47,38 +50,44 @@ def testDirectoryRangeFalse():
     timerange = TimeRange('2009/12/30', '2010/01/03')
     assert s.range(timerange) != directory_list
 
+
 def testNoDateDirectory():
     s = Scraper('mySpacecraft/myInstrument/xMinutes/aaa%y%b.ext')
     directory_list = ['mySpacecraft/myInstrument/xMinutes/']
     timerange = TimeRange('2009/11/20', '2010/01/03')
     assert s.range(timerange) == directory_list
 
+
 @pytest.mark.parametrize('pattern, mintime', PATTERN_EXAMPLES)
 def test_smallerPattern(pattern, mintime):
-    assert  mintime == Scraper('')._smallerPattern(pattern)
+    assert mintime == Scraper('')._smallerPattern(pattern)
+
 
 def testDirectoryRangeHours():
     s = Scraper('%Y%m%d_%H/%H%M.csv')
     timerange = TimeRange('2009-12-31T23:40:00', '2010-01-01T01:15:00')
-    assert len(s.range(timerange)) == 3 #3 directories (1 per hour)
+    assert len(s.range(timerange)) == 3  # 3 directories (1 per hour)
+
 
 def testDirectoryRange_single():
     s = Scraper('%Y%m%d/%H_%M.csv')
-    startdate = datetime.datetime(2010,10,10,5,00)
-    enddate = datetime.datetime(2010,10,10,7,00)
+    startdate = datetime.datetime(2010, 10, 10, 5, 0)
+    enddate = datetime.datetime(2010, 10, 10, 7, 0)
     timerange = TimeRange(startdate, enddate)
     assert len(s.range(timerange)) == 1
 
+
 def testDirectoryRange_Month():
     s = Scraper('%Y%m/%d/%j_%H.txt')
-    startdate = datetime.datetime(2008, 2,20,10)
+    startdate = datetime.datetime(2008, 2, 20, 10)
     enddate = datetime.datetime(2008, 3, 2, 5)
     timerange = TimeRange(startdate, enddate)
     assert len(s.range(timerange)) == 12
-    startdate = datetime.datetime(2009, 2,20,10)
+    startdate = datetime.datetime(2009, 2, 20, 10)
     enddate = datetime.datetime(2009, 3, 2, 5)
     timerange = TimeRange(startdate, enddate)
     assert len(s.range(timerange)) == 11
+
 
 def testNoDirectory():
     s = Scraper('files/%Y%m%d_%H%M.dat')
@@ -86,6 +95,7 @@ def testNoDirectory():
     enddate = datetime.datetime(2010, 1, 20, 20, 30)
     timerange = TimeRange(startdate, enddate)
     assert len(s.range(timerange)) == 1
+
 
 def testExtractDates_usingPattern():
     # Standard pattern
@@ -99,11 +109,14 @@ def testExtractDates_usingPattern():
     timeURL = datetime.datetime(2014, 5, 14, 20, 1, 35)
     assert s._extractDateURL(testURL) == timeURL
 
+
 def testExtractDates_notSeparators():
     s = Scraper('data/%Y/%m/swap%m%d_%H%M%S')
     testURL = 'data/2014/05/swap0514_200135'
     timeURL = datetime.datetime(2014, 5, 14, 20, 1, 35)
     assert s._extractDateURL(testURL) == timeURL
+
+
 def testExtractDates_notSeparators_andSimilar():
     s = Scraper('data/%Y/Jun%b%d_%H%M%S')
     testURL = 'data/2014/JunJun14_200135'
@@ -118,11 +131,13 @@ def testExtractDates_notSeparators_andSimilar():
     timeURL = datetime.datetime(2014, 6, 14, 20, 1, 35)
     assert s._extractDateURL(testURL) == timeURL
 
+
 def testURL_pattern():
     s = Scraper('fd_%Y%m%d_%H%M%S.fts')
     assert s._URL_followsPattern('fd_20130410_231211.fts')
     assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
     assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
+
 
 @pytest.mark.xfail
 def testURL_patternMilliseconds():
@@ -146,13 +161,14 @@ def testURL_patternMilliseconds():
 #     enddate = datetime.datetime(2010, 1, 20, 20, 30)
 #     assert len(s.filelist(TimeRange(startdate, enddate))) == 0
 
+
 @pytest.mark.xfail
 @pytest.mark.online
 def testFilesRange_sameDirectory_remote():
     pattern = ('http://solarmonitor.org/data/%Y/%m/%d/'
                'fits/{instrument}/'
                '{instrument}_00174_fd_%Y%m%d_%H%M%S.fts.gz')
-    s = Scraper(pattern, instrument = 'swap')
+    s = Scraper(pattern, instrument='swap')
     startdate = datetime.datetime(2014, 5, 14, 0, 0)
     enddate = datetime.datetime(2014, 5, 14, 6, 30)
     timerange = TimeRange(startdate, enddate)
@@ -162,12 +178,13 @@ def testFilesRange_sameDirectory_remote():
     timerange = TimeRange(startdate, enddate)
     assert len(s.filelist(timerange)) == 0
 
+
 @pytest.mark.xfail
 @pytest.mark.online
 def testFilesRange_sameDirectory_months_remote():
     pattern = ('http://www.srl.caltech.edu/{spacecraft}/DATA/{instrument}/'
                'Ahead/1minute/AeH%y%b.1m')
-    s = Scraper(pattern, spacecraft='STEREO', instrument = 'HET')
+    s = Scraper(pattern, spacecraft='STEREO', instrument='HET')
     startdate = datetime.datetime(2007, 8, 1)
     enddate = datetime.datetime(2007, 9, 10)
     timerange = TimeRange(startdate, enddate)


### PR DESCRIPTION
The scraper was failing when asked the time for an URL that contained text in separators, for example in urls like: `data/%Y/%m/swap%m%d_%H%M%S` where it couldn't distinguish between `%mswap` and `%m` as the same time type.