### PR TITLE
Fix Travis Builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 [![Downloads](https://img.shields.io/pypi/dm/sunpy.svg)](https://pypi.python.org/pypi/sunpy/) 
 [![Latest Version](https://img.shields.io/pypi/v/sunpy.svg)](https://pypi.python.org/pypi/sunpy/) 
 [![Build Status](https://secure.travis-ci.org/sunpy/sunpy.svg)](http://travis-ci.org/sunpy/sunpy)
-[![Build status](https://ci.appveyor.com/api/projects/status/xow461iejsjvp9vl?svg=true)](https://ci.appveyor.com/project/sunpy/sunpy)[![Coverage Status](https://coveralls.io/repos/sunpy/sunpy/badge.svg?branch=master)](https://coveralls.io/r/sunpy/sunpy?branch=master) [![Code Health](https://landscape.io/github/sunpy/sunpy/master/landscape.svg)](https://landscape.io/github/sunpy/sunpy/master)
-[![Code Issues](https://www.quantifiedcode.com/api/v1/project/9edd3e28230840038713e1c7dc3eb141/badge.svg)](https://www.quantifiedcode.com/app/project/9edd3e28230840038713e1c7dc3eb141)[![Research software impact](http://depsy.org/api/package/pypi/sunpy/badge.svg)](http://depsy.org/package/python/sunpy)
+[![Build status](https://ci.appveyor.com/api/projects/status/xow461iejsjvp9vl?svg=true)](https://ci.appveyor.com/project/sunpy/sunpy)
+[![Coverage Status](https://coveralls.io/repos/sunpy/sunpy/badge.svg?branch=master)](https://coveralls.io/r/sunpy/sunpy?branch=master)
+[![Research software impact](http://depsy.org/api/package/pypi/sunpy/badge.svg)](http://depsy.org/package/python/sunpy)
+[![DOI](https://zenodo.org/badge/2165383.svg)](https://zenodo.org/badge/latestdoi/2165383)
+
+
 
 SunPy is an open-source Python library for solar physics data analysis. See [sunpy.org](http://sunpy.org) for more information about the project.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://secure.travis-ci.org/sunpy/sunpy.svg)](http://travis-ci.org/sunpy/sunpy)
 [![Build status](https://ci.appveyor.com/api/projects/status/xow461iejsjvp9vl?svg=true)](https://ci.appveyor.com/project/sunpy/sunpy)
 [![Coverage Status](https://coveralls.io/repos/sunpy/sunpy/badge.svg?branch=master)](https://coveralls.io/r/sunpy/sunpy?branch=master)
+[![Code Issues](https://www.quantifiedcode.com/api/v1/project/9edd3e28230840038713e1c7dc3eb141/badge.svg)](https://www.quantifiedcode.com/app/project/9edd3e28230840038713e1c7dc3eb141)
 [![Research software impact](http://depsy.org/api/package/pypi/sunpy/badge.svg)](http://depsy.org/package/python/sunpy)
 [![DOI](https://zenodo.org/badge/2165383.svg)](https://zenodo.org/badge/latestdoi/2165383)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -170,7 +170,7 @@ try:
 
     sphinx_gallery_conf = {
         # path to store the module using example template
-        'mod_example_dir': 'generated{}modules'.format(os.sep),
+        'backreferences_dir': 'generated{}modules'.format(os.sep),
         # execute all examples except those that start with "skip_"
         'filename_pattern': '^((?!skip_).)*$',
         # path to the examples scripts

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -994,7 +994,7 @@ def _calc_rad_loss(temp, em, obstime=None, force_download=False,
         if len(obstime) != n:
             raise IOError("obstime must have same number of elements as "
                           "temp and em.")
-        if type(obstime) == pandas.core.indexes.datetimes.DatetimeIndex:
+        if type(obstime) == pandas.DatetimeIndex:
             obstime = obstime.to_pydatetime
         if any(type(obst) == str for obst in obstime):
             parse_time(obstime)
@@ -1194,7 +1194,7 @@ def _goes_lx(longflux, shortflux, obstime=None, date=None):
         if not len(longflux) == len(shortflux) == len(obstime):
             raise ValueError("longflux, shortflux, and obstime must all have "
                              "same number of elements.")
-        if type(obstime) == pandas.core.indexes.datetimes.DatetimeIndex:
+        if type(obstime) == pandas.DatetimeIndex:
             obstime = obstime.to_pydatetime
         if any(type(obst) == str for obst in obstime):
             parse_time(obstime)

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -994,7 +994,7 @@ def _calc_rad_loss(temp, em, obstime=None, force_download=False,
         if len(obstime) != n:
             raise IOError("obstime must have same number of elements as "
                           "temp and em.")
-        if type(obstime) == pandas.tseries.index.DatetimeIndex:
+        if type(obstime) == pandas.core.indexes.datetimes.DatetimeIndex:
             obstime = obstime.to_pydatetime
         if any(type(obst) == str for obst in obstime):
             parse_time(obstime)
@@ -1194,7 +1194,7 @@ def _goes_lx(longflux, shortflux, obstime=None, date=None):
         if not len(longflux) == len(shortflux) == len(obstime):
             raise ValueError("longflux, shortflux, and obstime must all have "
                              "same number of elements.")
-        if type(obstime) == pandas.tseries.index.DatetimeIndex:
+        if type(obstime) == pandas.core.indexes.datetimes.DatetimeIndex:
             obstime = obstime.to_pydatetime
         if any(type(obst) == str for obst in obstime):
             parse_time(obstime)

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -50,7 +50,7 @@ def test_parse_time_pandas_timestamp():
 
 def test_parse_time_pandas_index():
     inputs = [datetime(2012, 1, i) for i in range(1, 13)]
-    ind = pandas.core.indexes.datetimes.DatetimeIndex(inputs)
+    ind = pandas.DatetimeIndex(inputs)
 
     dts = parse_time(ind)
 

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -50,7 +50,7 @@ def test_parse_time_pandas_timestamp():
 
 def test_parse_time_pandas_index():
     inputs = [datetime(2012, 1, i) for i in range(1, 13)]
-    ind = pandas.tseries.index.DatetimeIndex(inputs)
+    ind = pandas.core.indexes.datetimes.DatetimeIndex(inputs)
 
     dts = parse_time(ind)
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -157,7 +157,7 @@ def parse_time(time_string, time_format='', **kwargs):
         return datetime(*time_string)
     elif time_format == 'utime' or isinstance(time_string, (int, float)):
         return datetime(1979, 1, 1) + timedelta(0, time_string)
-    elif isinstance(time_string, pandas.core.indexes.datetimes.DatetimeIndex):
+    elif isinstance(time_string, pandas.DatetimeIndex):
         return time_string._mpl_repr()
     elif isinstance(time_string, np.ndarray) and 'datetime64' in str(time_string.dtype):
         ii = [ss.astype(datetime) for ss in time_string]

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -157,7 +157,7 @@ def parse_time(time_string, time_format='', **kwargs):
         return datetime(*time_string)
     elif time_format == 'utime' or isinstance(time_string, (int, float)):
         return datetime(1979, 1, 1) + timedelta(0, time_string)
-    elif isinstance(time_string, pandas.tseries.index.DatetimeIndex):
+    elif isinstance(time_string, pandas.core.indexes.datetimes.DatetimeIndex):
         return time_string._mpl_repr()
     elif isinstance(time_string, np.ndarray) and 'datetime64' in str(time_string.dtype):
         ii = [ss.astype(datetime) for ss in time_string]


### PR DESCRIPTION
Fix deprecation warning for sphinx-gallery, stolen from [here](https://github.com/astropy/astropy/commit/5966e5ff10fd63419c85442b198a3250a5a38462).
Seems not to error locally, let us see if Travis agrees.  

Also, we have the occasional error on this:
```python

@example(a.Time("1983-05-01", "1983-05-02"))

E           ValueError: No operational GOES satellites on 1983-05-01 00:00:00
sunpy/net/dataretriever/sources/goes.py:55: ValueError
```
I'm not sure why it  fails but it isn't all the time, it seems random almost.
So my proposed fix would be marking that with a pytest decatator.
@pytest.mark.xfail(raises=ValueError).

What confuses me is the example date is after GOES 2 but before GOES 5 based on the goes_operational dictionary. #Abovemypaygrade