### PR TITLE
Removed deprecation warnings from pandas and MPL

### DIFF
--- a/sunpy/spectra/spectrum.py
+++ b/sunpy/spectra/spectrum.py
@@ -67,19 +67,7 @@ class Spectrum(np.ndarray):
         params = {}
         params.update(matplot_args)
 
-        # This is taken from mpl.pyplot.plot() as we are trying to
-        # replicate that functionality
-
-        # allow callers to override the hold state by passing hold=True|False
-        washold = axes.ishold()
-        hold = matplot_args.pop('hold', None)
-
-        if hold is not None:
-            axes.hold(hold)
-        try:
-            lines = axes.plot(self.freq_axis, self, **params)
-        finally:
-            axes.hold(washold)
+        lines = axes.plot(self.freq_axis, self, **params)
 
         return lines
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -149,7 +149,7 @@ def parse_time(time_string, time_format='', **kwargs):
     >>> sunpy.time.parse_time('2005-08-04T00:01:02.000Z')
     datetime.datetime(2005, 8, 4, 0, 1, 2)
     """
-    if isinstance(time_string, pandas.tslib.Timestamp):
+    if isinstance(time_string, pandas.Timestamp):
         return time_string.to_pydatetime()
     elif isinstance(time_string, datetime) or time_format == 'datetime':
         return time_string


### PR DESCRIPTION
So we have two extra dep warnings (ignoring the ana one).

One for pandas which is a simple change.
The other is for MPL is that ishold and hold are being removed and is now set to being True as default.

My understanding of the MPL change is hazy but I removed the logic in spectrum.py. 
