### PR TITLE
Better information when reporting parse time error and PEP8 nags

### DIFF
--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -185,12 +185,18 @@ def parse_time(time_string, time_format='', **kwargs):
 
         time_string_parse_format = kwargs.pop('_time_string_parse_format', None)
         if time_string_parse_format is not None:
-            ts, time_delta = _regex_parse_time(time_string,
-                                                   time_string_parse_format)
-            if ts and time_delta:
-                return datetime.strptime(ts, time_string_parse_format) + time_delta
-            else:
-                return datetime.strptime(time_string, time_string_parse_format)
+            # Following a comment by the Lead Developer, the Try / except clause
+            # is replaced.  The Lead Developer thinks that this the try/except
+            # clause is related to SunPy's database module.
+            try:
+                ts, time_delta = _regex_parse_time(time_string,
+                                                       time_string_parse_format)
+                if ts and time_delta:
+                    return datetime.strptime(ts, time_string_parse_format) + time_delta
+                else:
+                    return datetime.strptime(time_string, time_string_parse_format)
+            except Exception:
+                pass
         raise ValueError("'{tstr!s}' is not a valid time string!".format(tstr=time_string))
 
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -196,7 +196,7 @@ def parse_time(time_string, time_format='', **kwargs):
                     return datetime.strptime(time_string, time_string_parse_format)
             except:
                 pass
-        raise ValueError("{tstr!s} is not a valid time string!".format(tstr=time_string))
+        raise ValueError("'{tstr!s}' is not a valid time string!".format(tstr=time_string))
 
 
 def is_time(time_string, time_format=''):

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -185,15 +185,12 @@ def parse_time(time_string, time_format='', **kwargs):
 
         time_string_parse_format = kwargs.pop('_time_string_parse_format', None)
         if time_string_parse_format is not None:
-            try:
-                ts, time_delta = _regex_parse_time(time_string,
+            ts, time_delta = _regex_parse_time(time_string,
                                                    time_string_parse_format)
-                if ts and time_delta:
-                    return datetime.strptime(ts, time_string_parse_format) + time_delta
-                else:
-                    return datetime.strptime(time_string, time_string_parse_format)
-            except:
-                pass
+            if ts and time_delta:
+                return datetime.strptime(ts, time_string_parse_format) + time_delta
+            else:
+                return datetime.strptime(time_string, time_string_parse_format)
         raise ValueError("'{tstr!s}' is not a valid time string!".format(tstr=time_string))
 
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -119,8 +119,6 @@ def _iter_empty(iter):
     return False
 
 
-
-
 def parse_time(time_string, time_format='', **kwargs):
     """Given a time string will parse and return a datetime object.
     Similar to the anytim function in IDL.


### PR DESCRIPTION
I came across a FITS file with a date-obs string that had a single leading white space.  Such a string is not parseable by parse_time.  This PR changes the report of the failure by putting quotation marks around the failed string, making the presence of leading and trailing whitespace more explicit.
I also fixed a couple of PEP8 nags.