### PR TITLE
Change import for TimeFrameAttribute

### DIFF
--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division
 import datetime
 
 from astropy.time import Time
-from astropy.coordinates.baseframe import TimeFrameAttribute
+from astropy.coordinates import TimeFrameAttribute
 
 from sunpy.extern import six
 from sunpy.time import parse_time
@@ -80,4 +80,3 @@ class TimeFrameAttributeSunPy(TimeFrameAttribute):
                              .format(self.name, value))
 
         return out, converted
-


### PR DESCRIPTION
We're about to move the `FrameAttribute` classes in astropy to their own module (see astropy/astropy#6175). This import will still work (we import them back in to `baseframe`), but it's safer to import `TimeFrameAttribute` from the top-level `astropy.coordinates` anyways.

cc @eteq @Cadair 