### PR TITLE
Map and CompositeMap draw_limb and draw_grid now pass on line properties

### DIFF
--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -301,7 +301,7 @@ class CompositeMap(object):
         """
         self._maps[index].zorder = zorder
 
-    def draw_limb(self, index=None, axes=None):
+    def draw_limb(self, index=None, axes=None, **kwargs):
         """Draws a circle representing the solar limb.
 
         Parameters
@@ -315,6 +315,10 @@ class CompositeMap(object):
         Returns
         -------
         `matplotlib.axes.Axes`
+
+        Notes
+        -----
+        Keyword arguments are passed onto `sunpy.map.mapbase.GenericMap`.
         """
         if index is None:
             for i, amap in enumerate(self._maps):
@@ -326,7 +330,7 @@ class CompositeMap(object):
         if not index_check or index is None:
             raise ValueError("Specified index does not have all the required attributes to draw limb.")
 
-        return self._maps[index].draw_limb(axes=axes)
+        return self._maps[index].draw_limb(axes=axes, **kwargs)
 
     @u.quantity_input(grid_spacing=u.deg)
     def draw_grid(self, index=None, axes=None, grid_spacing=20*u.deg):

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -318,7 +318,7 @@ class CompositeMap(object):
 
         Notes
         -----
-        Keyword arguments are passed onto `sunpy.map.mapbase.GenericMap`.
+        Keyword arguments are passed onto `sunpy.map.mapbase.GenericMap.draw_limb`.
         """
         if index is None:
             for i, amap in enumerate(self._maps):
@@ -333,7 +333,7 @@ class CompositeMap(object):
         return self._maps[index].draw_limb(axes=axes, **kwargs)
 
     @u.quantity_input(grid_spacing=u.deg)
-    def draw_grid(self, index=None, axes=None, grid_spacing=20*u.deg):
+    def draw_grid(self, index=None, axes=None, grid_spacing=20*u.deg, **kwargs):
         """Draws a grid over the surface of the Sun.
 
         Parameters
@@ -350,6 +350,10 @@ class CompositeMap(object):
         Returns
         -------
         `matplotlib.axes.Axes` object
+
+        Notes
+        -----
+        Keyword arguments are passed onto `sunpy.map.mapbase.GenericMap.draw_grid`.
         """
         needed_attrs = ['rsun_meters', 'dsun', 'heliographic_latitude',
                         'heliographic_longitude']
@@ -363,7 +367,7 @@ class CompositeMap(object):
         if not index_check or index is None:
             raise ValueError("Specified index does not have all the required attributes to draw grid.")
 
-        ax = self._maps[index].draw_grid(axes=axes, grid_spacing=grid_spacing)
+        ax = self._maps[index].draw_grid(axes=axes, grid_spacing=grid_spacing, **kwargs)
         return ax
 
     def plot(self, axes=None, annotate=True, # pylint: disable=W0613

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -370,7 +370,7 @@ class CompositeMap(object):
         ax = self._maps[index].draw_grid(axes=axes, grid_spacing=grid_spacing, **kwargs)
         return ax
 
-    def plot(self, axes=None, annotate=True, # pylint: disable=W0613
+    def plot(self, axes=None, annotate=True,  # pylint: disable=W0613
              title="SunPy Composite Plot", **matplot_args):
         """Plots the composite map object using matplotlib
 
@@ -476,11 +476,11 @@ class CompositeMap(object):
             axes = plt.Axes(figure, [0., 0., 1., 1.])
             axes.set_axis_off()
             figure.add_axes(axes)
-            matplot_args.update({'annotate':False})
+            matplot_args.update({'annotate': False})
         else:
             axes = figure.add_subplot(111)
 
-        ret = self.plot(axes=axes,**matplot_args)
+        ret = self.plot(axes=axes, **matplot_args)
 
         if not isinstance(colorbar, bool) and isinstance(colorbar, int):
             figure.colorbar(ret[colorbar])

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1374,7 +1374,7 @@ Reference Coord:\t {refcoord}
 # #### Visualization #### #
 
     @u.quantity_input(grid_spacing=u.deg)
-    def draw_grid(self, axes=None, grid_spacing=15*u.deg):
+    def draw_grid(self, axes=None, grid_spacing=15*u.deg, **kwargs):
         """
         Draws a coordinate overlay on the plot in the Heliographic Stonyhurst
         coordinate system.
@@ -1395,6 +1395,10 @@ Reference Coord:\t {refcoord}
         -------
         overlay: `~astropy.visualization.wcsaxes.coordinates_map.CoordinatesMap`
             The wcsaxes coordinate overlay instance.
+
+        Notes
+        -----
+        Keyword arguments are passed onto the `sunpy.visualization.wcsaxes_compat.wcsaxes_heliographic_overlay` object.
         """
 
         if not axes:
@@ -1402,7 +1406,8 @@ Reference Coord:\t {refcoord}
         if not wcsaxes_compat.is_wcsaxes(axes):
             raise TypeError("Overlay grids can only be plotted on WCSAxes plots.")
         return wcsaxes_compat.wcsaxes_heliographic_overlay(axes,
-                                                           grid_spacing=grid_spacing)
+                                                           grid_spacing=grid_spacing,
+                                                           **kwargs)
 
     def draw_limb(self, axes=None, **kwargs):
         """
@@ -1421,7 +1426,7 @@ Reference Coord:\t {refcoord}
 
         Notes
         -----
-        keyword arguments are passed onto the Circle Patch, see:
+        Keyword arguments are passed onto the Circle Patch, see:
         http://matplotlib.org/api/artist_api.html#matplotlib.patches.Patch
         http://matplotlib.org/api/artist_api.html#matplotlib.patches.Circle
         """

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1398,7 +1398,7 @@ Reference Coord:\t {refcoord}
 
         Notes
         -----
-        Keyword arguments are passed onto the `sunpy.visualization.wcsaxes_compat.wcsaxes_heliographic_overlay` object.
+        Keyword arguments are passed onto the `sunpy.visualization.wcsaxes_compat.wcsaxes_heliographic_overlay` function.
         """
 
         if not axes:
@@ -1421,14 +1421,12 @@ Reference Coord:\t {refcoord}
         Returns
         -------
         circ: list
-            A list containing the `matplotlib.patches.Circle` object that
+            A list containing the `~matplotlib.patches.Circle` object that
             has been added to the axes.
 
         Notes
         -----
-        Keyword arguments are passed onto the Circle Patch, see:
-        http://matplotlib.org/api/artist_api.html#matplotlib.patches.Patch
-        http://matplotlib.org/api/artist_api.html#matplotlib.patches.Circle
+        Keyword arguments are passed onto `matplotlib.patches.Circle`.
         """
 
         if not axes:

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -163,7 +163,7 @@ def default_wcs_grid(axes, units, ctypes):
 
 
 @u.quantity_input(grid_spacing=u.deg)
-def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg):
+def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg, **kwargs):
     """
     Create a heliographic overlay using wcsaxes.
 
@@ -181,6 +181,10 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg):
     -------
     overlay : wcsaxes overlay
         The overlay object.
+
+    Notes
+    -----
+    Keywords are passed on to the overlay object.
     """
 
     # Unpack spacing
@@ -205,10 +209,13 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg):
     lon.set_ticks_position('tr')
     lat.set_ticks_position('tr')
 
-    lon.set_ticks(spacing=lon_space, color='white')
-    lat.set_ticks(spacing=lat_space, color='white')
+    grid_kw = {'color': 'white', 'zorder': 100, 'alpha': 0.5}
+    grid_kw.update(kwargs)
 
-    overlay.grid(color='white', alpha=0.5)
+    lon.set_ticks(spacing=lon_space, color=grid_kw['white'])
+    lat.set_ticks(spacing=lat_space, color=grid_kw['white'])
+
+    overlay.grid(grid_kw)
 
     if axes.title:
         x, y = axes.title.get_position()

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -52,8 +52,8 @@ def gca_wcs(wcs, fig=None):
 
     Returns
     -------
-    ax : `matplotlib.axes.Axes` or `wcsaxes.WCSAxes` object.
-        The current axes, or a new one if created.
+    ax : `matplotlib.axes.Axes` or `~astropy.visualization.wcsaxes.WCSAxes`
+        object. The current axes, or a new one if created.
 
     """
 
@@ -76,18 +76,19 @@ def get_world_transform(axes):
     """
     Get the transformation to world coordinates.
 
-    If the axes is a `wcaxes.WCSAxes` instance this returns the transform to
-    the ``'world'`` coordinates, otherwise it returns the transform to the
-    matplotlib data coordinates, which are assumed to be in world coordinates.
+    If the axes is a `~astropy.visualization.wcsaxes.WCSAxes` instance this
+    returns the transform to the ``'world'`` coordinates, otherwise it returns
+    the transform to the matplotlib data coordinates, which are assumed to be in
+    world coordinates.
 
     Parameters
     ----------
-    axes : `wcsaxes.WCSAxes` or `matplotlib.axes.Axes` obejct.
-        The axes to get the transform from.
+    axes : ``~astropy.visualization.wcsaxes.WCSAxes` or `~matplotlib.axes.Axes`
+        object. The axes to get the transform from.
 
     Returns
     -------
-    transform : `matplotlib.transforms.CompositeGenericTransform`
+    transform : `~matplotlib.transforms.CompositeGenericTransform`
         The transformation object.
     """
     if is_wcsaxes(axes):
@@ -123,8 +124,9 @@ def default_wcs_grid(axes, units, ctypes):
 
     Parameters
     ----------
-    axes : `wcsaxes.WCSAxes` object.
-        The `~wcsaxes.WCSAxes` object to draw the world coordinate grid on.
+    axes : ``~astropy.visualization.wcsaxes.WCSAxes` object.
+        The ``~astropy.visualization.wcsaxes.WCSAxes` object to draw the world
+        coordinate grid on.
 
     units : `tuple`
         The axes units axes x y order.
@@ -171,20 +173,21 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg, **kwargs):
 
     Parameters
     ----------
-    axes : `wcsaxes.WCSAxes` object.
-        The `~wcsaxes.WCSAxes` object to create the HGS overlay on.
+    axes : `~astropy.visualization.wcsaxes.WCSAxes` object.
+        The `~astropy.visualization.wcsaxes.WCSAxes` object to create the HGS overlay on.
 
-    grid_spacing: `astropy.units.Quantity`
+    grid_spacing: `~astropy.units.Quantity`
         Spacing for longitude and latitude grid in degrees.
 
     Returns
     -------
-    overlay : wcsaxes overlay
+    overlay : `~astropy.visualization.wcsaxes.WCSAxes` overlay
         The overlay object.
 
     Notes
     -----
-    Keywords are passed on to the overlay object.
+    Keywords are passed to `~astropy.visualization.wcsaxes.coordinates_map.CoordinatesMap.grid`.
+
     """
 
     # Unpack spacing

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -212,8 +212,8 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg, **kwargs):
     grid_kw = {'color': 'white', 'zorder': 100, 'alpha': 0.5}
     grid_kw.update(kwargs)
 
-    lon.set_ticks(spacing=lon_space, color=grid_kw['white'])
-    lat.set_ticks(spacing=lat_space, color=grid_kw['white'])
+    lon.set_ticks(spacing=lon_space, color=grid_kw['color'])
+    lat.set_ticks(spacing=lat_space, color=grid_kw['color'])
 
     overlay.grid(grid_kw)
 

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -215,10 +215,10 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg, **kwargs):
     lon.set_ticks(spacing=lon_space, color=grid_kw['color'])
     lat.set_ticks(spacing=lat_space, color=grid_kw['color'])
 
-    overlay.grid(grid_kw)
+    overlay.grid(**grid_kw)
 
     if axes.title:
         x, y = axes.title.get_position()
         axes.title.set_position([x, y + 0.05])
 
-    return overlay
+    return

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -83,7 +83,7 @@ def get_world_transform(axes):
 
     Parameters
     ----------
-    axes : ``~astropy.visualization.wcsaxes.WCSAxes` or `~matplotlib.axes.Axes`
+    axes : `~astropy.visualization.wcsaxes.WCSAxes` or `~matplotlib.axes.Axes`
         object. The axes to get the transform from.
 
     Returns
@@ -124,8 +124,8 @@ def default_wcs_grid(axes, units, ctypes):
 
     Parameters
     ----------
-    axes : ``~astropy.visualization.wcsaxes.WCSAxes` object.
-        The ``~astropy.visualization.wcsaxes.WCSAxes` object to draw the world
+    axes : `~astropy.visualization.wcsaxes.WCSAxes` object.
+        The `~astropy.visualization.wcsaxes.WCSAxes` object to draw the world
         coordinate grid on.
 
     units : `tuple`
@@ -224,4 +224,4 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg, **kwargs):
         x, y = axes.title.get_position()
         axes.title.set_position([x, y + 0.05])
 
-    return
+    return overlay


### PR DESCRIPTION
Previously it was not possible to change the properties of the lines drawn using draw_limb and draw_grid in the map and composite map object.  Now you can.