### PR TITLE
Fido indexing fixes and improvements

### DIFF
--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -305,15 +305,15 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         query = attr.and_(*query)
         return UnifiedResponse(query_walker.create(query, self))
 
-    def fetch(self, query_result, wait=True, progress=True, **kwargs):
+    def fetch(self, *query_results, wait=True, progress=True, **kwargs):
         """
-        Downloads the files pointed at by URLs contained within UnifiedResponse
-        object.
+        Download the records represented by
+        `~sunpy.net.fido_factory.UnifiedResponse` objects.
 
         Parameters
         ----------
-        query_result : `sunpy.net.fido_factory.UnifiedResponse`
-            Container returned by query method.
+        query_results : `sunpy.net.fido_factory.UnifiedResponse`
+            Container returned by query method, or multiple.
 
         wait : `bool`
             fetch will wait until the download is complete before returning.
@@ -333,8 +333,9 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         >>> file_paths = downresp.wait()
         """
         reslist = []
-        for block in query_result.responses:
-            reslist.append(block.client.get(block, **kwargs))
+        for query_result in query_results:
+            for block in query_result.responses:
+                reslist.append(block.client.get(block, **kwargs))
 
         results = DownloadResponse(reslist)
 

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -17,6 +17,7 @@ from sunpy.util.datatype_factory_base import MultipleMatchError
 from sunpy.net.dataretriever.clients import CLIENTS
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.vso import VSOClient, QueryResponse as vsoQueryResponse
+
 from . import attr
 from . import attrs as a
 
@@ -135,7 +136,7 @@ class UnifiedResponse(Sequence):
         else:
             raise IndexError("UnifiedResponse objects must be sliced with integers.")
 
-        return ret
+        return UnifiedResponse(ret)
 
     def get_response(self, i):
         """

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -159,7 +159,11 @@ class UnifiedResponse(Sequence):
         return self._numfile
 
     def _repr_html_(self):
-        ret = 'Number of Providers: <{}>\n'.format(len(self.responses))
+        nprov = len(self)
+        if nprov == 1:
+            ret = 'Results from {} Provider:</br></br>'.format(len(self))
+        else:
+            ret = 'Results from {} Providers:</br></br>'.format(len(self))
         for block in self.responses:
             ret += "{} Results from the {}:</br>".format(len(block), block.client.__class__.__name__)
             ret += block._repr_html_()

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -168,8 +168,9 @@ class UnifiedResponse(MutableSequence):
         return self._numfile
 
     def _repr_html_(self):
-        ret = 'Number of Providers: <{}>\n'.format(len(self.responses))
+        ret = 'Query Returned Results from {} Providers:\n'.format(len(self))
         for block in self.responses:
+            ret += "{} Results from the {}:\n".format(len(block), block.client.__class__.__name__)
             ret += "Results from the {}:\n".format(block.client.__class__.__name__)
             ret += block._repr_html_()
             ret += '\n'
@@ -178,16 +179,17 @@ class UnifiedResponse(MutableSequence):
 
     def __repr__(self):
         ret = super(UnifiedResponse, self).__repr__()
-        ret += str(self)
+        ret += '\n' + str(self)
 
         return ret
 
     def __str__(self):
-        ret += 'Number of Providers: <{}>\n'.format(len(self.responses))
+        ret = 'Query Returned Results from {} Providers:\n\n'.format(len(self))
         for block in self.responses:
-            ret += "Results from the {}:\n".format(block.client.__class__.__name__)
-            ret += repr(block)
-            ret += '\n'
+            ret += "{} Results from the {}:\n".format(len(block), block.client.__class__.__name__)
+            lines = repr(block).split('\n')
+            ret += '\n'.join(lines[1:])
+            ret += '\n\n'
 
         return ret
 

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -159,11 +159,7 @@ class UnifiedResponse(Sequence):
         return self._numfile
 
     def _repr_html_(self):
-        nprov = len(self)
-        if nprov == 1:
-            ret = 'Results from {} Provider:</br></br>'.format(len(self))
-        else:
-            ret = 'Results from {} Providers:</br></br>'.format(len(self))
+        ret = 'Number of Providers: <{}>\n'.format(len(self.responses))
         for block in self.responses:
             ret += "{} Results from the {}:</br>".format(len(block), block.client.__class__.__name__)
             ret += block._repr_html_()
@@ -395,7 +391,8 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         -------
         response : `~sunpy.net.dataretriever.client.QueryResponse`
 
-        client : Instance of client class
+        client : `object`
+		Instance of client class
         """
         candidate_widget_types = self._check_registered_widgets(*query)
         tmpclient = candidate_widget_types[0]()

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -6,9 +6,8 @@ well as defining ``Fido`` which is an instance of
 `~sunpy.net.fido_factory.DownloadResponse` objects are returned by ``Fido.fetch``.
 
 """
-# Author: Rishabh Sharma <rishabh.sharma.gunner@gmail.com>
-# This module was developed under funding provided by
-# Google Summer of Code 2014
+# This module was initially developed under funding provided by Google Summer
+# of Code 2014
 from collections import MutableSequence
 
 from sunpy.util.datatype_factory_base import BasicRegistrationFactory
@@ -17,8 +16,7 @@ from sunpy.util.datatype_factory_base import MultipleMatchError
 
 from sunpy.net.dataretriever.clients import CLIENTS
 from sunpy.net.dataretriever.client import QueryResponse
-import sunpy.net.vso.vso
-from sunpy.net.vso import VSOClient
+from sunpy.net.vso import VSOClient, QueryResponse as vsoQueryResponse
 from . import attr
 from . import attrs as a
 
@@ -27,7 +25,7 @@ __all__ = ['Fido', 'UnifiedResponse', 'UnifiedDownloaderFactory', 'DownloadRespo
 
 class UnifiedResponse(MutableSequence):
     """
-    The object used to store results from `sunpy.net.Fido`.
+    The object used to store results from `~sunpy.net.UnifiedDownloaderFactory.search`.
 
     The `~sunpy.net.Fido` object returns results from multiple different
     clients. So it is always possible to sub-select these results, you can
@@ -36,20 +34,26 @@ class UnifiedResponse(MutableSequence):
     second index can be used to select records from the results returned from
     that client, for instance if you only want every second result you could
     index the second dimension with ``::2``.
+
+    Parameters
+    ----------
+    lst : `object`
+        A single instance or an iterable of ``(QueryResponse, client)`` pairs
+        or ``QueryResponse`` objects with a ``.client`` attribute.
     """
 
     def __init__(self, lst):
         """
         Input to this constructor can be one of a few things:
 
-        1. A list of one UnifiedResponse object
-        2. A list of tuples (QueryResponse, client)
+        1. A ``QueryResponse`` object
+        2. A list of tuples ``(QueryResponse, client)``
         """
 
         tmplst = []
         # numfile is the number of files not the number of results.
         self._numfile = 0
-        if isinstance(lst, (QueryResponse, sunpy.net.vso.vso.QueryResponse)):
+        if isinstance(lst, (QueryResponse, vsoQueryResponse)):
             if not hasattr(lst, 'client'):
                 raise ValueError(
                     "A {} object is only a valid input to UnifiedResponse if it has a client attribute.".
@@ -267,7 +271,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         Query for data from Nobeyama Radioheliograph and RHESSI
 
         >>> unifresp = Fido.search(a.Time('2012/3/4', '2012/3/6'),
-                                   a.Instrument('norh') | a.Instrument('rhessi'))
+                                   (a.Instrument('norh') & a.Wavelength(17*u.GHz)) | a.Instrument('rhessi'))
 
         Query for 304 Angstrom SDO AIA data with a cadence of 10 minutes
 
@@ -276,7 +280,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         >>> unifresp = Fido.search(a.Time('2012/3/4', '2012/3/6'),
                                    a.Instrument('AIA'),
                                    a.Wavelength(304*u.angstrom, 304*u.angstrom),
-                                   a.Sample(10*u.minute))
+                                   a.vso.Sample(10*u.minute))
 
         Parameters
         ----------

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -319,7 +319,9 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         query = attr.and_(*query)
         return UnifiedResponse(query_walker.create(query, self))
 
-    def fetch(self, *query_results, wait=True, progress=True, **kwargs):
+    # Python 3: this line should be like this
+    # def fetch(self, *query_results, wait=True, progress=True, **kwargs):
+    def fetch(self, *query_results, **kwargs):
         """
         Download the records represented by
         `~sunpy.net.fido_factory.UnifiedResponse` objects.
@@ -346,6 +348,8 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         >>> downresp = Fido.get(unifresp)
         >>> file_paths = downresp.wait()
         """
+        wait = kwargs.pop("wait", True)
+        progress = kwargs.pop("progress", True)
         reslist = []
         for query_result in query_results:
             for block in query_result.responses:

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -168,12 +168,15 @@ class UnifiedResponse(MutableSequence):
         return self._numfile
 
     def _repr_html_(self):
-        ret = 'Query Returned Results from {} Providers:\n'.format(len(self))
+        nprov = len(self)
+        if nprov == 1:
+            ret = 'Results from {} Provider:</br></br>'.format(len(self))
+        else:
+            ret = 'Results from {} Providers:</br></br>'.format(len(self))
         for block in self.responses:
-            ret += "{} Results from the {}:\n".format(len(block), block.client.__class__.__name__)
-            ret += "Results from the {}:\n".format(block.client.__class__.__name__)
+            ret += "{} Results from the {}:</br>".format(len(block), block.client.__class__.__name__)
             ret += block._repr_html_()
-            ret += '\n'
+            ret += '</br>'
 
         return ret
 
@@ -184,7 +187,11 @@ class UnifiedResponse(MutableSequence):
         return ret
 
     def __str__(self):
-        ret = 'Query Returned Results from {} Providers:\n\n'.format(len(self))
+        nprov = len(self)
+        if nprov == 1:
+            ret = 'Results from {} Provider:\n\n'.format(len(self))
+        else:
+            ret = 'Results from {} Providers:\n\n'.format(len(self))
         for block in self.responses:
             ret += "{} Results from the {}:\n".format(len(block), block.client.__class__.__name__)
             lines = repr(block).split('\n')

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -168,7 +168,7 @@ class UnifiedResponse(MutableSequence):
         return self._numfile
 
     def _repr_html_(self):
-        ret = ''
+        ret = 'Number of Providers: <{}>\n'.format(len(self.responses))
         for block in self.responses:
             ret += "Results from the {}:\n".format(block.client.__class__.__name__)
             ret += block._repr_html_()
@@ -178,7 +178,12 @@ class UnifiedResponse(MutableSequence):
 
     def __repr__(self):
         ret = super(UnifiedResponse, self).__repr__()
-        ret += '\n'
+        ret += str(self)
+
+        return ret
+
+    def __str__(self):
+        ret += 'Number of Providers: <{}>\n'.format(len(self.responses))
         for block in self.responses:
             ret += "Results from the {}:\n".format(block.client.__class__.__name__)
             ret += repr(block)

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -8,7 +8,7 @@ well as defining ``Fido`` which is an instance of
 """
 # This module was initially developed under funding provided by Google Summer
 # of Code 2014
-from collections import MutableSequence
+from collections import Sequence
 
 from sunpy.util.datatype_factory_base import BasicRegistrationFactory
 from sunpy.util.datatype_factory_base import NoMatchError
@@ -23,7 +23,7 @@ from . import attrs as a
 __all__ = ['Fido', 'UnifiedResponse', 'UnifiedDownloaderFactory', 'DownloadResponse']
 
 
-class UnifiedResponse(MutableSequence):
+class UnifiedResponse(Sequence):
     """
     The object used to store results from `~sunpy.net.UnifiedDownloaderFactory.search`.
 
@@ -77,6 +77,9 @@ class UnifiedResponse(MutableSequence):
 
     def __len__(self):
         return len(self._list)
+
+    def __iter__(self):
+        return self.responses
 
     def _handle_record_slice(self, client_resp, record_slice):
         """
@@ -132,20 +135,7 @@ class UnifiedResponse(MutableSequence):
         else:
             raise IndexError("UnifiedResponse objects must be sliced with integers.")
 
-        # Construct a new UnifiedResponse object and return
-        return type(self)(ret)
-
-    def __delitem__(self, i):
-        del self._list[i]
-
-    def __setitem__(self, aslice, v):
-        self._list[aslice] = v
-
-    def __iter__(self):
-        return self.responses
-
-    def insert(self, i, v):
-        self._list.insert(i, v)
+        return ret
 
     def get_response(self, i):
         """

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -201,5 +201,5 @@ def test_repr():
 
     rep = repr(results)
     rep = rep.split('\n')
-    # 6 header lines, the results table and a blank line at the end
-    assert len(rep) == 6 + len(list(results.responses)[0]) + 1
+    # 6 header lines, the results table and two blank lines at the end
+    assert len(rep) == 7 + len(list(results.responses)[0]) + 2

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -214,10 +214,9 @@ def test_repr():
     assert len(rep) == 7 + len(list(results.responses)[0]) + 2
 
 
-@given(offline_query(), offline_query())
-def test_fido_indexing(query1, query2):
-    # If the queries are the same then it don't work.
-    assume(query1.attrs[1] != query2.attrs[1])
+@given(st.tuples(offline_query(), offline_query()).filter(lambda x: x[0] != x[1]))
+def test_fido_indexing(queries):
+    query1, query2 = queries
 
     res = Fido.search(query1 | query2)
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -178,6 +178,15 @@ def test_unifiedresponse_slicing():
     assert isinstance(results[0], UnifiedResponse)
 
 
+def test_unifiedresponse_slicing_reverse():
+    results = Fido.search(
+        a.Time("2012/1/1", "2012/1/5"), a.Instrument("lyra"))
+    assert isinstance(results[::-1], UnifiedResponse)
+    assert len(results[::-1]) == len(results)
+    assert isinstance(results[0, ::-1], UnifiedResponse)
+    assert results[0, ::-1]._list[0] == results._list[0][::-1]
+
+
 def test_vso_unifiedresponse():
     vrep = vsoQueryResponse([])
     vrep.client = True

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -10,6 +10,7 @@ import astropy.units as u
 
 from sunpy.net import attr
 from sunpy.net import Fido, attrs as a
+from sunpy.net.vso.vso import QueryResponse as vsoQueryResponse
 from sunpy.net.fido_factory import DownloadResponse, UnifiedResponse
 from sunpy.net.dataretriever.client import CLIENTS, QueryResponse
 from sunpy.util.datatype_factory_base import NoMatchError, MultipleMatchError
@@ -175,6 +176,13 @@ def test_unifiedresponse_slicing():
         a.Time("2012/1/1", "2012/1/5"), a.Instrument("lyra"))
     assert isinstance(results[0:2], UnifiedResponse)
     assert isinstance(results[0], UnifiedResponse)
+
+
+def test_vso_unifiedresponse():
+    vrep = vsoQueryResponse([])
+    vrep.client = True
+    uresp = UnifiedResponse(vrep)
+    assert isinstance(uresp, UnifiedResponse)
 
 
 def test_responses():

--- a/sunpy/net/vso/__init__.py
+++ b/sunpy/net/vso/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 # for exposure to from sunpy.net.vso import *
-from sunpy.net.vso.vso import VSOClient, InteractiveVSOClient
+from sunpy.net.vso.vso import VSOClient, InteractiveVSOClient, QueryResponse
 
 # for, e.g.,
 # >>> from sunpy.net import vso
@@ -9,4 +9,4 @@ from sunpy.net.vso.vso import VSOClient, InteractiveVSOClient
 # >>> vso.get(...)
 from sunpy.net.vso.vso import search, get
 
-__all__ = ['VSOClient', 'InteractiveVSOClient']
+__all__ = ['VSOClient', 'InteractiveVSOClient', 'QueryResponse']

--- a/sunpy/net/vso/__init__.py
+++ b/sunpy/net/vso/__init__.py
@@ -9,4 +9,4 @@ from sunpy.net.vso.vso import VSOClient, InteractiveVSOClient, QueryResponse
 # >>> vso.get(...)
 from sunpy.net.vso.vso import search, get
 
-__all__ = ['VSOClient', 'InteractiveVSOClient', 'QueryResponse']
+__all__ = ['VSOClient', 'InteractiveVSOClient']

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -119,6 +119,9 @@ def get_online_vso_url(api, url, port):
 
 # TODO: Python 3 this should subclass from UserList
 class QueryResponse(list):
+    """
+    A container for VSO Records returned from VSO Searches.
+    """
 
     def __init__(self, lst, queryresult=None, table=None):
         super(QueryResponse, self).__init__(lst)


### PR DESCRIPTION
This fixes #2140 and proposes a solution to close #2157.

The proposed solution to #2157 is to support two dimensional indexing for `UnifiedResponse` (the things that `Fido.search` returns) objects. The first index is for the client (must always be present) and the second index is for the records that client responded.

See example:
```python
In [8]: from sunpy.net import Fido, attrs as a

In [9]: uresp = Fido.search(a.Time("2012/1/1", "2012/1/2"),
                            a.Instrument("lyra") | a.Instrument("eve"))

In [10]: uresp[0]
```
```
Out[10]: 
<sunpy.net.fido_factory.UnifiedResponse object at 0x7f1ba8650cf8>
Results from the LYRAClient:
<class 'sunpy.net.dataretriever.client.QueryResponse'><Table length=2>
     Start Time           End Time      Source Instrument Wavelength
       str19               str19         str6     str4       str3   
------------------- ------------------- ------ ---------- ----------
2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
```
```python
In [11]: uresp[1, ::5]
```
```
Out[11]: 
<sunpy.net.fido_factory.UnifiedResponse object at 0x7f1ba8490668>
Results from the VSOClient:
<QTable length=11>
   Start Time [1]       End Time [1]    Source Instrument   Type   Wavelength [2]
                                                                      Angstrom   
       str19               str19         str3     str3      str8      float64    
------------------- ------------------- ------ ---------- -------- --------------
2012-01-01 00:00:00 2012-01-02 00:00:00    SDO        EVE FULLDISK   1.0 .. 304.0
2012-01-01 03:00:00 2012-01-01 04:00:00    SDO        EVE FULLDISK 93.0 .. 1033.0
2012-01-01 08:00:00 2012-01-01 09:00:00    SDO        EVE FULLDISK 93.0 .. 1033.0
2012-01-01 13:00:00 2012-01-01 14:00:00    SDO        EVE FULLDISK 93.0 .. 1033.0
2012-01-01 18:00:00 2012-01-01 19:00:00    SDO        EVE FULLDISK 93.0 .. 1033.0
2012-01-01 23:00:00 2012-01-02 00:00:00    SDO        EVE FULLDISK 93.0 .. 1033.0
2012-01-01 03:00:00 2012-01-01 04:00:00    SDO        EVE FULLDISK 60.0 .. 1060.0
2012-01-01 08:00:00 2012-01-01 09:00:00    SDO        EVE FULLDISK 60.0 .. 1060.0
2012-01-01 13:00:00 2012-01-01 14:00:00    SDO        EVE FULLDISK 60.0 .. 1060.0
2012-01-01 18:00:00 2012-01-01 19:00:00    SDO        EVE FULLDISK 60.0 .. 1060.0
2012-01-01 23:00:00 2012-01-02 00:00:00    SDO        EVE FULLDISK 60.0 .. 1060.0
```

The new slicing behaviour still needs tests, but I wanted to get some feedback on the idea first.