### PR TITLE
Deprecation warnings for spectra as moved to gh:sunpy/spectra

### DIFF
--- a/sunpy/spectra/__init__.py
+++ b/sunpy/spectra/__init__.py
@@ -1,0 +1,8 @@
+import warnings
+
+from sunpy.util.exceptions import SunpyDeprecationWarning
+
+deprecation_message = ("As of v0.8.0, the `sunpy.spectra` module is deprecated and will be "
+                       "removed in a future version. This module is being moved to sunpyspectra "
+                       "- https://github.com/sunpy/spectra")
+warnings.warn( deprecation_message, SunpyDeprecationWarning)

--- a/sunpy/spectra/spectrogram.py
+++ b/sunpy/spectra/spectrogram.py
@@ -26,6 +26,7 @@ from sunpy.util.cond_dispatch import ConditionalDispatch
 from sunpy.util.create import Parent
 from sunpy.spectra.spectrum import Spectrum
 from sunpy.extern.six.moves import zip, range
+from sunpy.util.decorators import deprecated
 
 __all__ = ['Spectrogram', 'LinearTimeSpectrogram']
 
@@ -266,6 +267,7 @@ class TimeFreq(object):
         return ret
 
 
+@deprecated("0.8", "this module is being moved to sunpyspectra - https://github.com/sunpy/spectra")
 class Spectrogram(Parent):
     """
     Spectrogram Class.
@@ -885,6 +887,7 @@ class Spectrogram(Parent):
         return format_coord
 
 
+@deprecated("0.8", "this module is being moved to sunpyspectra - https://github.com/sunpy/spectra")
 class LinearTimeSpectrogram(Spectrogram):
     """Spectrogram evenly sampled in time.
 

--- a/sunpy/spectra/spectrogram.py
+++ b/sunpy/spectra/spectrogram.py
@@ -889,7 +889,8 @@ class Spectrogram(Parent):
 
 @deprecated("0.8", "this module is being moved to sunpyspectra - https://github.com/sunpy/spectra")
 class LinearTimeSpectrogram(Spectrogram):
-    """Spectrogram evenly sampled in time.
+    """
+    Spectrogram evenly sampled in time.
 
     Attributes
     ----------

--- a/sunpy/spectra/spectrum.py
+++ b/sunpy/spectra/spectrum.py
@@ -6,9 +6,12 @@ from __future__ import absolute_import
 import numpy as np
 from matplotlib import pyplot as plt
 
+from sunpy.util.decorators import deprecated
+
 __all__ = ['Spectrum']
 
 
+@deprecated("0.8", "this module is being moved to sunpyspectra - https://github.com/sunpy/spectra")
 class Spectrum(np.ndarray):
     """
     Class representing a 1 dimensional spectrum.


### PR DESCRIPTION
spectra module is now available at [sunpy/spectra](/sunpy/spectra). This adds the deprecation notices needed for the people to know the change is happening.

I've only added the warning in the public classes.