### PR TITLE
Fixing 'edit on github' error on generated links.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -161,6 +161,8 @@ edit_on_github_branch = "master"
 edit_on_github_source_root = ""
 edit_on_github_doc_root = "docs"
 
+edit_on_github_skip_regex = '_.*|api/.*'
+
 
 # -- Sphinx Gallery ----------------------------------------------------------
 try:


### PR DESCRIPTION
Issue #2169. `edit_on_github_skip_regex = '_.*|generated/.*'` is used to fix "Edit on Github" error on generated doc links in PR #2166 ([Link](https://github.com/sunpy/sunpy/pull/2166/files#diff-555c472a89566734e0d8567fb205d5dfR194)). But Astropy documentation uses `edit_on_github_skip_regex = '_.*|api/.*'` instead ([link](https://github.com/astropy/astropy/blob/master/docs/conf.py#L203)). This must be preferred following `TODO: make this smart like astropy` ([link](https://github.com/sunpy/sunpy/pull/2166/files#diff-555c472a89566734e0d8567fb205d5dfL158)).