### PR TITLE
Add an ObserverCoordinateAttribute class to coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ Latest
 * SunPy coordinate frames can now be transformed to and from Astropy coordinate frames
 * `Helioprojective` frame defaults to an Earth observer with correct L0, B0, and distance
 * Ephemeris calculations with higher accuracy are now available under `sunpy.coordinates.ephemeris`
+* Add support for SunPy coordinates to specify observer as a string of a major solar system body.
+* SunPy coordinates observer now defaults to earth if ``obstime`` is set.
+
 
 0.7.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Latest
 * Added SunPy specific warnings under util.
 * SunPy coordinate frames can now be transformed to and from Astropy coordinate frames
 * `Helioprojective` frame defaults to an Earth observer with correct L0, B0, and distance
-* Ephemeris calculations with higher accuracy are now available under `sunpy.coordinates.utilities`
+* Ephemeris calculations with higher accuracy are now available under `sunpy.coordinates.ephemeris`
 
 0.7.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ Latest
   animate N-Dimensional data with the associated WCS object.
 * Moved Docs to docs/ to follow the astropy style
 * Added SunPy specific warnings under util.
+* SunPy coordinate frames can now be transformed to and from Astropy coordinate frames
+* `Helioprojective` frame defaults to an Earth observer with correct L0, B0, and distance
+* Ephemeris calculations with higher accuracy are now available under `sunpy.coordinates.utilities`
 
 0.7.0
 -----

--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -24,7 +24,7 @@ The easiest interface to the coordinates module is through the `~astropy.coordin
   >>> c = SkyCoord(x=-72241.0*u.km, y=361206.1*u.km, z=589951.4*u.km, frame=frames.Heliocentric)
   >>> c = SkyCoord(70*u.deg, -30*u.deg, frame=frames.HeliographicStonyhurst)
   >>> c
-  <SkyCoord (HeliographicStonyhurst: dateobs=None): (lon, lat, rad) in (deg, deg, km)
+  <SkyCoord (HeliographicStonyhurst: obstime=None): (lon, lat, rad) in (deg, deg, km)
       (70.0, -30.0, 695508.0)>
 
 
@@ -37,7 +37,7 @@ astropy coordinates.
   >>> import sunpy.coordinates
   >>> c = SkyCoord(-100*u.arcsec, 500*u.arcsec, frame='helioprojective')
   >>> c
-  <SkyCoord (Helioprojective: D0=149597870.7 km, dateobs=None, L0=0.0 deg, B0=0.0 deg, rsun=695508.0 km): (Tx, Ty) in arcsec
+  <SkyCoord (Helioprojective: D0=149597870.7 km, obstime=None, L0=0.0 deg, B0=0.0 deg, rsun=695508.0 km): (Tx, Ty) in arcsec
     (-100.,  500.)>
 
 
@@ -63,10 +63,10 @@ than a list of `~astropy.coordinates.SkyCoord` objects, because it will be
 
    >>> c = SkyCoord([-500, 400]*u.arcsec, [100, 200]*u.arcsec, frame=frames.Helioprojective)
    >>> c
-   <SkyCoord (HelioProjective: D0=149597870.7 km, dateobs=None, L0=0.0 deg, B0=0.0 deg, rsun=695508.0 km): (Tx, Ty) in arcsec
+   <SkyCoord (HelioProjective: D0=149597870.7 km, obstime=None, L0=0.0 deg, B0=0.0 deg, rsun=695508.0 km): (Tx, Ty) in arcsec
        [(-500.0, 100.0), (400.0, 200.0)]>
    >>> c[0]
-   <SkyCoord (HelioProjective: D0=149597870.7 km, dateobs=None, L0=0.0 deg, B0=0.0 deg, rsun=695508.0 km): (Tx, Ty) in arcsec
+   <SkyCoord (HelioProjective: D0=149597870.7 km, obstime=None, L0=0.0 deg, B0=0.0 deg, rsun=695508.0 km): (Tx, Ty) in arcsec
        (-500.0, 100.0)>
 
 
@@ -167,7 +167,7 @@ themselves and some other usability improvements, for more information see the
 
 The main advantage provided by `~astropy.coordinates.SkyCoord` is the support it
 provides for caching Frame attributes. Frame attributes are extra data specified
-with a frame, some examples in `sunpy.coordinates` are ``dateobs`` or ``L0`` and
+with a frame, some examples in `sunpy.coordinates` are ``obstime`` or ``L0`` and
 ``B0`` for observer location. Only the frames where this data is meaningful have
 these attributes, i.e. only the Helioprojective frames have ``L0`` and ``B0``.
 However, when you transform into another frame and then back to a projective
@@ -209,7 +209,7 @@ If you want to obtain a un-realized coordinate frame corresponding to a
   >>> amap = sunpy.map.Map(AIA_171_IMAGE)
 
   >>> wcs_to_celestial_frame(amap.wcs)
-  <Helioprojective Frame (D0=1.48940609627e+11 m, dateobs=2011-03-1910:54:00.340000, L0=0.0 deg, B0=-7.064078 deg, rsun=695508.0 km)>
+  <Helioprojective Frame (D0=1.48940609627e+11 m, obstime=2011-03-1910:54:00.340000, L0=0.0 deg, B0=-7.064078 deg, rsun=695508.0 km)>
 
 
 

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -3,5 +3,6 @@ from __future__ import absolute_import, division
 from .frames import *
 from .offset_frame import *
 from .transformations import *
+from .utilities import *
 
 from .wcs_utils import *

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -3,6 +3,6 @@ from __future__ import absolute_import, division
 from .frames import *
 from .offset_frame import *
 from .transformations import *
-from .utilities import *
+from .ephemeris import *
 
 from .wcs_utils import *

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+"""
+Ephemeris calculations using SunPy coordinate frames
+
+"""
 from __future__ import absolute_import, division
 import datetime
 import warnings

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -17,6 +17,7 @@ from astropy.coordinates.representation import CartesianRepresentation, Spherica
 from astropy._erfa.core import ErfaWarning
 
 from sunpy.time import parse_time
+from sunpy.time.time import _astropy_time
 
 from .frames import HeliographicStonyhurst as HGS
 from .transformations import _sun_detilt_matrix
@@ -24,13 +25,6 @@ from .transformations import _sun_detilt_matrix
 __all__ = ['get_body_heliographic_stonyhurst', 'get_earth',
            'get_sun_B0', 'get_sun_L0', 'get_sun_P', 'get_sunearth_distance',
            'get_sun_orientation']
-
-
-def _astropy_time(time):
-    """
-    Return an `~astropy.time.Time` instance, running it through `~sunpy.time.parse_time` if needed
-    """
-    return time if isinstance(time, Time) else Time(parse_time(time))
 
 
 def get_body_heliographic_stonyhurst(body, time='now'):

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -146,8 +146,14 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
             # If obstime is not set, we can't work out where an object is.
             return self.fallback_coordinate
 
-        out_icrs = ICRS(get_body_barycentric(out, obstime))
-        return out_icrs.transform_to(HeliographicStonyhurst(obstime=obstime))
+        # Use `get_earth` for earth so lon is always exactly 0
+        if out == "earth":
+            from .utilities import get_earth
+            sc = get_earth(obstime)
+            return sc.frame
+        else:
+            out_icrs = ICRS(get_body_barycentric(out, obstime))
+            return out_icrs.transform_to(HeliographicStonyhurst(obstime=obstime))
 
     def __get__(self, instance, frame_cls=None):
         # If instance is None then we can't get obstime so it doesn't matter.

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -6,8 +6,7 @@ import warnings
 
 import astropy.units as u
 from astropy.time import Time
-from astropy.coordinates import (TimeAttribute, CoordinateAttribute,
-                                 get_body_barycentric, ICRS)
+from astropy.coordinates import TimeAttribute, CoordinateAttribute, get_body_barycentric, ICRS
 
 from sunpy.extern import six
 from sunpy.time import parse_time
@@ -112,12 +111,10 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
             # Import here to prevent circular import
             from .frames import HeliographicStonyhurst
 
-            self.fallback_coordinate = HeliographicStonyhurst(0 * u.deg,
-                                                              0 * u.deg,
-                                                              1 * u.AU)
+            self.fallback_coordinate = HeliographicStonyhurst(0 * u.deg, 0 * u.deg, 1 * u.AU)
 
-        super(ObserverCoordinateAttribute, self).__init__(frame, default=default,
-                                                          secondary_attribute=secondary_attribute)
+        super(ObserverCoordinateAttribute, self).__init__(
+            frame, default=default, secondary_attribute=secondary_attribute)
 
     def convert_input(self, value):
         # If we are reaching here, we do not have an instance, so we fall back
@@ -140,16 +137,17 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
 
         # If no time assume nothing
         if obstime is None:
-            warnings.warn("Can not compute location of object '{}'"
-                          " without obstime attribute being set.".format(out),
-                          SunpyUserWarning, stacklevel=4)
+            warnings.warn(
+                "Can not compute location of object '{}'"
+                " without obstime attribute being set.".format(out),
+                SunpyUserWarning,
+                stacklevel=4)
 
             # If obstime is not set, we can't work out where an object is.
             return self.fallback_coordinate
 
-        out_icrs = get_body_barycentric(out, obstime)
-        return ICRS(out_icrs).transform_to(HeliographicStonyhurst(obstime=obstime))
-
+        out_icrs = ICRS(get_body_barycentric(out, obstime))
+        return out_icrs.transform_to(HeliographicStonyhurst(obstime=obstime))
 
     def __get__(self, instance, frame_cls=None):
         # If instance is None then we can't get obstime so it doesn't matter.

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -146,14 +146,14 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
             # If obstime is not set, we can't work out where an object is.
             return self.fallback_coordinate
 
-        # Use `get_earth` for earth so lon is always exactly 0
+        from .ephemeris import get_body_heliographic_stonyhurst
+        obscoord = get_body_heliographic_stonyhurst(out, obstime)
         if out == "earth":
-            from .utilities import get_earth
-            sc = get_earth(obstime)
-            return sc.frame
-        else:
-            out_icrs = ICRS(get_body_barycentric(out, obstime))
-            return out_icrs.transform_to(HeliographicStonyhurst(obstime=obstime))
+            rep = obscoord.spherical
+            rep.lon[()] = 0*u.deg
+            obscoord = obscoord.realize_frame(rep)
+
+        return obscoord
 
     def __get__(self, instance, frame_cls=None):
         # If instance is None then we can't get obstime so it doesn't matter.

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -51,7 +51,7 @@ class HeliographicStonyhurst(BaseCoordinateFrame):
     radius: `astropy.units.Quantity` object.
         This quantity holds the radial distance. If not specified, it is, by
         default, the radius of the photosphere. Optional.
-    dateobs: SunPy Time
+    obstime: SunPy Time
         The date and time of the observation, used to convert to heliographic
         carrington coordinates.
 
@@ -62,16 +62,16 @@ class HeliographicStonyhurst(BaseCoordinateFrame):
     >>> import astropy.units as u
     >>> sc = SkyCoord(1*u.deg, 1*u.deg, 2*u.km,
     ...               frame="heliographic_stonyhurst",
-    ...               dateobs="2010/01/01T00:00:45")
+    ...               obstime="2010/01/01T00:00:45")
     >>> sc
-    <SkyCoord (HeliographicStonyhurst): dateobs=2010-01-01 00:00:45,
+    <SkyCoord (HeliographicStonyhurst): obstime=2010-01-01 00:00:45,
     lon=1.0 deg, lat=1.0 deg, rad=2.0 km>
     >>> sc.frame
-    <HeliographicStonyhurst Coordinate: dateobs=2010-01-01 00:00:45,
+    <HeliographicStonyhurst Coordinate: obstime=2010-01-01 00:00:45,
     lon=1.0 deg, lat=1.0 deg, rad=2.0 km>
     >>> sc = SkyCoord(HeliographicStonyhurst(-10*u.deg, 2*u.deg))
     >>> sc
-    <SkyCoord (HeliographicStonyhurst): dateobs=None, lon=-10.0 deg,
+    <SkyCoord (HeliographicStonyhurst): obstime=None, lon=-10.0 deg,
     lat=2.0 deg, rad=695508.0 km>
 
     Notes
@@ -95,7 +95,7 @@ class HeliographicStonyhurst(BaseCoordinateFrame):
         ]
     }
 
-    dateobs = TimeFrameAttributeSunPy()
+    obstime = TimeFrameAttributeSunPy()
 
     def __init__(self, *args, **kwargs):
         _rep_kwarg = kwargs.get('representation', None)
@@ -141,7 +141,7 @@ class HeliographicCarrington(HeliographicStonyhurst):
     radius: `astropy.units.Quantity` object, optional, must be keyword.
         This quantity holds the radial distance. If not specified, it is, by
         default, the solar radius. Optional, must be keyword.
-    dateobs: SunPy Time
+    obstime: SunPy Time
         The date and time of the observation, used to convert to heliographic
         carrington coordinates.
 
@@ -152,14 +152,14 @@ class HeliographicCarrington(HeliographicStonyhurst):
     >>> import astropy.units as u
     >>> sc = SkyCoord(1*u.deg, 2*u.deg, 3*u.km,
     ...               frame="heliographic_carrington",
-    ...               dateobs="2010/01/01T00:00:30")
+    ...               obstime="2010/01/01T00:00:30")
     >>> sc
-    <SkyCoord (HelioGraphicCarrington): dateobs=2010-01-01 00:00:30,
+    <SkyCoord (HelioGraphicCarrington): obstime=2010-01-01 00:00:30,
     lon=1.0 deg, lat=2.0 deg, rad=3.0 km>
     >>> sc = SkyCoord([1,2,3]*u.deg, [4,5,6]*u.deg, [5,6,7]*u.km,
-    dateobs="2010/01/01T00:00:45", frame="heliographic_carrington")
+    obstime="2010/01/01T00:00:45", frame="heliographic_carrington")
     >>> sc
-    <SkyCoord (HelioGraphicCarrington): dateobs=2010-01-01 00:00:45,
+    <SkyCoord (HelioGraphicCarrington): obstime=2010-01-01 00:00:45,
     (lon, lat, rad) in (deg, deg, km)
         [(1.0, 4.0, 5.0), (2.0, 5.0, 6.0), (3.0, 6.0, 7.0)]>
     """
@@ -180,7 +180,7 @@ class HeliographicCarrington(HeliographicStonyhurst):
         ]
     }
 
-    dateobs = TimeFrameAttributeSunPy()
+    obstime = TimeFrameAttributeSunPy()
 
 
 class Heliocentric(BaseCoordinateFrame):
@@ -206,7 +206,7 @@ class Heliocentric(BaseCoordinateFrame):
         Z-axis coordinate, optional, must be keyword.
     observer: `~sunpy.coordinates.frames.HeliographicStonyhurst`
         The coordinate of the observer in the solar system.
-    dateobs: SunPy Time
+    obstime: SunPy Time
         The date and time of the observation, used to convert to heliographic
         carrington coordinates.
 
@@ -216,14 +216,14 @@ class Heliocentric(BaseCoordinateFrame):
     >>> import sunpy.coordinates
     >>> import astropy.units as u
     >>> sc = SkyCoord(CartesianRepresentation(10*u.km, 1*u.km, 2*u.km),
-    ...               dateobs="2011/01/05T00:00:50", frame="heliocentric")
+    ...               obstime="2011/01/05T00:00:50", frame="heliocentric")
     >>> sc
-    <SkyCoord (HelioCentric): dateobs=2011-01-05 00:00:50, D0=149597870.7 km,
+    <SkyCoord (HelioCentric): obstime=2011-01-05 00:00:50, D0=149597870.7 km,
     x=10.0 km, y=1.0 km, z=2.0 km>
     >>> sc = SkyCoord([1,2]*u.km, [3,4]*u.m, [5,6]*u.cm, frame="heliocentric",
-    dateobs="2011/01/01T00:00:54")
+    obstime="2011/01/01T00:00:54")
     >>> sc
-    <SkyCoord (HelioCentric): dateobs=2011-01-01 00:00:54, D0=149597870.7 km,
+    <SkyCoord (HelioCentric): obstime=2011-01-01 00:00:54, D0=149597870.7 km,
     (x, y, z) in (km, m, cm)
         [(1.0, 3.0, 5.0), (2.0, 4.0, 6.0)]>
     """
@@ -234,7 +234,7 @@ class Heliocentric(BaseCoordinateFrame):
         'cylindrical': [RepresentationMapping('phi', 'psi', u.deg)]
     }
 
-    dateobs = TimeFrameAttributeSunPy()
+    obstime = TimeFrameAttributeSunPy()
     observer = CoordinateAttribute(HeliographicStonyhurst,
                                    default=HeliographicStonyhurst(0*u.deg,
                                                                   0*u.deg,
@@ -260,7 +260,7 @@ class Helioprojective(BaseCoordinateFrame):
         Y-axis coordinate.
     distance: `~astropy.units.Quantity`
         The radial distance from the observer to the coordinate point.
-    dateobs: SunPy Time
+    obstime: SunPy Time
         The date and time of the observation, used to convert to heliographic
         carrington coordinates.
     observer: `~sunpy.coordinates.frames.HeliographicStonyhurst`
@@ -275,15 +275,15 @@ class Helioprojective(BaseCoordinateFrame):
     >>> from astropy.coordinates import SkyCoord
     >>> import sunpy.coordinates
     >>> import astropy.units as u
-    >>> sc = SkyCoord(0*u.deg, 0*u.deg, 5*u.km, dateobs="2010/01/01T00:00:00",
+    >>> sc = SkyCoord(0*u.deg, 0*u.deg, 5*u.km, obstime="2010/01/01T00:00:00",
     ...               frame="helioprojective")
     >>> sc
-    <SkyCoord (HelioProjective): dateobs=2010-01-01 00:00:00, D0=149597870.7 km
+    <SkyCoord (HelioProjective): obstime=2010-01-01 00:00:00, D0=149597870.7 km
     , Tx=0.0 arcsec, Ty=0.0 arcsec, distance=5.0 km>
-    >>> sc = SkyCoord(0*u.deg, 0*u.deg, dateobs="2010/01/01T00:00:00",
+    >>> sc = SkyCoord(0*u.deg, 0*u.deg, obstime="2010/01/01T00:00:00",
     frame="helioprojective")
     >>> sc
-    <SkyCoord (HelioProjective): dateobs=2010-01-01 00:00:00, D0=149597870.7 km
+    <SkyCoord (HelioProjective): obstime=2010-01-01 00:00:00, D0=149597870.7 km
     , Tx=0.0 arcsec, Ty=0.0 arcsec, distance=149597870.7 km>
     """
 
@@ -310,7 +310,7 @@ class Helioprojective(BaseCoordinateFrame):
         ]
     }
 
-    dateobs = TimeFrameAttributeSunPy()
+    obstime = TimeFrameAttributeSunPy()
     rsun = Attribute(default=RSUN_METERS.to(u.km))
     observer = CoordinateAttribute(HeliographicStonyhurst,
                                    default=HeliographicStonyhurst(0*u.deg,

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -326,7 +326,7 @@ class Helioprojective(BaseCoordinateFrame):
         if 'obstime' not in self._attr_names_with_defaults and \
            'observer' in self._attr_names_with_defaults:
             # Import here to avoid a circular import
-            from .utilities import get_earth
+            from .ephemeris import get_earth
             self._observer = get_earth(self.obstime)
 
         # Convert from Spherical to SphericalWrap180

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -21,7 +21,7 @@ from astropy.coordinates import Attribute, CoordinateAttribute
 from sunpy import sun
 from .representation import (SphericalWrap180Representation, UnitSphericalWrap180Representation)
 
-from .frameattributes import TimeFrameAttributeSunPy
+from .frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribute
 
 RSUN_METERS = sun.constants.get('radius').si.to(u.m)
 DSUN_METERS = sun.constants.get('mean distance').si.to(u.m)
@@ -235,10 +235,7 @@ class Heliocentric(BaseCoordinateFrame):
     }
 
     obstime = TimeFrameAttributeSunPy()
-    observer = CoordinateAttribute(HeliographicStonyhurst,
-                                   default=HeliographicStonyhurst(0*u.deg,
-                                                                  0*u.deg,
-                                                                  1*u.AU))
+    observer = ObserverCoordinateAttribute(HeliographicStonyhurst, default="earth")
 
 
 class Helioprojective(BaseCoordinateFrame):
@@ -312,22 +309,12 @@ class Helioprojective(BaseCoordinateFrame):
 
     obstime = TimeFrameAttributeSunPy()
     rsun = Attribute(default=RSUN_METERS.to(u.km))
-    observer = CoordinateAttribute(HeliographicStonyhurst,
-                                   default=HeliographicStonyhurst(0*u.deg,
-                                                                  0*u.deg,
-                                                                  1*u.AU))
+    observer = ObserverCoordinateAttribute(HeliographicStonyhurst, default="earth")
 
     def __init__(self, *args, **kwargs):
         _rep_kwarg = kwargs.get('representation', None)
 
         BaseCoordinateFrame.__init__(self, *args, **kwargs)
-
-        # If obstime is set, but observer is not, default to Earth observer
-        if 'obstime' not in self._attr_names_with_defaults and \
-           'observer' in self._attr_names_with_defaults:
-            # Import here to avoid a circular import
-            from .ephemeris import get_earth
-            self._observer = get_earth(self.obstime)
 
         # Convert from Spherical to SphericalWrap180
         # If representation was explicitly passed, do not change the rep.

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -322,6 +322,13 @@ class Helioprojective(BaseCoordinateFrame):
 
         BaseCoordinateFrame.__init__(self, *args, **kwargs)
 
+        # If obstime is set, but observer is not, default to Earth observer
+        if 'obstime' not in self._attr_names_with_defaults and \
+           'observer' in self._attr_names_with_defaults:
+            # Import here to avoid a circular import
+            from .utilities import get_earth
+            self._observer = get_earth(self.obstime)
+
         # Convert from Spherical to SphericalWrap180
         # If representation was explicitly passed, do not change the rep.
         if not _rep_kwarg:

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -18,7 +18,7 @@ from astropy.coordinates.baseframe import (BaseCoordinateFrame,
                                            RepresentationMapping)
 from astropy.coordinates import Attribute, CoordinateAttribute
 
-from sunpy import sun  # For Carrington rotation number
+from sunpy import sun
 from .representation import (SphericalWrap180Representation, UnitSphericalWrap180Representation)
 
 from .frameattributes import TimeFrameAttributeSunPy

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -7,6 +7,19 @@ from astropy.coordinates import EarthLocation
 from ..ephemeris import *
 
 
+def test_get_body_barycentric():
+    # Validate against published values from the Astronomical Almanac (2013)
+    e1 = get_body_heliographic_stonyhurst('earth', '2013-Jan-01')
+    assert_quantity_allclose(e1.lon, 0*u.deg, atol=1e-12*u.deg)
+    assert_quantity_allclose(e1.lat, -3.03*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e1.radius, 0.9832947*u.AU, atol=5e-7*u.AU)
+
+    e2 = get_body_heliographic_stonyhurst('earth', '2013-Sep-01')
+    assert_quantity_allclose(e2.lon, 0*u.deg, atol=1e-12*u.deg)
+    assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)
+
+
 def test_get_earth():
     # Validate against published values from the Astronomical Almanac (2013)
     e1 = get_earth('2013-Jan-01')

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -4,7 +4,7 @@ import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import EarthLocation
 
-from ..utilities import *
+from ..ephemeris import *
 
 
 def test_get_earth():

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -4,10 +4,16 @@ import datetime
 
 import pytest
 
+import astropy.units as u
 from astropy.time import Time
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.coordinates import ICRS, get_body_barycentric
 
-from ..frames import Helioprojective
-from ..frameattributes import TimeFrameAttributeSunPy
+from sunpy.time import parse_time
+from ..frames import Helioprojective, HeliographicStonyhurst
+from ..frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribute
+from sunpy.util.exceptions import SunpyUserWarning
+from sunpy.coordinates.utilities import get_earth
 
 
 @pytest.fixture
@@ -31,8 +37,9 @@ def test_none(attr):
     assert not converted
 
 
-@pytest.mark.parametrize('input', [Time('2012-01-01 00:00:00'), '2012/01/01T00:00:00',
-                                   '20120101000000', '2012/01/01 00:00:00'])
+@pytest.mark.parametrize('input', [
+    Time('2012-01-01 00:00:00'), '2012/01/01T00:00:00', '20120101000000', '2012/01/01 00:00:00'
+])
 def test_convert(attr, input):
     result, converted = attr.convert_input(input)
 
@@ -42,8 +49,9 @@ def test_convert(attr, input):
     assert result == output
 
 
-@pytest.mark.parametrize('input', [Time('2012-01-01 00:00:00'), '2012/01/01T00:00:00',
-                                   '20120101000000', '2012/01/01 00:00:00'])
+@pytest.mark.parametrize('input', [
+    Time('2012-01-01 00:00:00'), '2012/01/01T00:00:00', '20120101000000', '2012/01/01 00:00:00'
+])
 def test_on_frame(input):
     hpc1 = Helioprojective(obstime=input)
 
@@ -64,15 +72,78 @@ def test_non_string():
 
 def test_on_frame_error():
     with pytest.raises(ValueError):
-        hpc1 = Helioprojective(obstime='ajshdasjdhk')
+        Helioprojective(obstime='ajshdasjdhk')
 
 
 def test_on_frame_error2():
     with pytest.raises(ValueError):
-        hpc1 = Helioprojective(obstime=17263871263)
+        Helioprojective(obstime=17263871263)
 
 
 def test_array():
     input = Time(['2012-01-01 00:00:00', '2012-01-01 00:00:05'])
     with pytest.raises(ValueError):
-        hpc1 = Helioprojective(obstime=input)
+        Helioprojective(obstime=input)
+
+
+# ObserverCoordinateAttribute
+
+def test_string_coord():
+
+    class dummyframe(object):
+        obstime = Time(parse_time("2011-01-01"))
+
+    finst = dummyframe()
+
+    oca = ObserverCoordinateAttribute(HeliographicStonyhurst)
+
+    coord = oca._convert_string_to_coord("earth", finst)
+
+    assert isinstance(coord, HeliographicStonyhurst)
+
+    assert coord.obstime == parse_time(finst.obstime)
+
+
+def test_string_coord_default():
+
+    class dummyframe(object):
+        obstime = None
+
+    finst = dummyframe()
+
+    oca = ObserverCoordinateAttribute(HeliographicStonyhurst)
+
+    with pytest.warns(SunpyUserWarning):
+        coord = oca._convert_string_to_coord("earth", finst)
+
+    assert isinstance(coord, HeliographicStonyhurst)
+
+
+def test_coord_get():
+
+    # Test default (instance=None)
+    obs = Helioprojective.observer
+    assert isinstance(obs, HeliographicStonyhurst)
+    assert_quantity_allclose(obs.lon, 0*u.deg)
+    assert_quantity_allclose(obs.lat, 0*u.deg)
+    assert_quantity_allclose(obs.radius, 1*u.AU)
+
+    # Test get
+    obstime = "2013-04-01"
+    obs = Helioprojective(observer="earth", obstime=obstime).observer
+    earth = get_earth(obstime)
+    assert isinstance(obs, HeliographicStonyhurst)
+    assert_quantity_allclose(obs.lon, earth.lon)
+    assert_quantity_allclose(obs.lat, earth.lat)
+    assert_quantity_allclose(obs.radius, earth.radius)
+
+    # Test get mars
+    obstime = Time(parse_time("2013-04-01"))
+    obs = Helioprojective(observer="mars", obstime=obstime).observer
+    out_icrs = ICRS(get_body_barycentric("mars", obstime))
+    mars = out_icrs.transform_to(HeliographicStonyhurst(obstime=obstime))
+
+    assert isinstance(obs, HeliographicStonyhurst)
+    assert_quantity_allclose(obs.lon, mars.lon)
+    assert_quantity_allclose(obs.lat, mars.lat)
+    assert_quantity_allclose(obs.radius, mars.radius)

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -9,9 +9,11 @@ from astropy.time import Time
 from ..frames import Helioprojective
 from ..frameattributes import TimeFrameAttributeSunPy
 
+
 @pytest.fixture
 def attr():
     return TimeFrameAttributeSunPy()
+
 
 def test_now(attr):
     """ We can't actually test the value independantly """
@@ -20,12 +22,14 @@ def test_now(attr):
     assert isinstance(result, Time)
     assert converted
 
+
 def test_none(attr):
     """ We can't actually test the value independantly """
     result, converted = attr.convert_input(None)
 
     assert result is None
     assert not converted
+
 
 @pytest.mark.parametrize('input', [Time('2012-01-01 00:00:00'), '2012/01/01T00:00:00',
                                    '20120101000000', '2012/01/01 00:00:00'])
@@ -48,6 +52,7 @@ def test_on_frame(input):
     assert isinstance(hpc1.obstime, Time)
     assert hpc1.obstime == output
 
+
 def test_non_string():
     output = datetime.datetime.now()
 
@@ -56,13 +61,16 @@ def test_non_string():
     assert isinstance(hpc1.obstime, Time)
     assert hpc1.obstime == output
 
+
 def test_on_frame_error():
     with pytest.raises(ValueError):
         hpc1 = Helioprojective(obstime='ajshdasjdhk')
 
+
 def test_on_frame_error2():
     with pytest.raises(ValueError):
         hpc1 = Helioprojective(obstime=17263871263)
+
 
 def test_array():
     input = Time(['2012-01-01 00:00:00', '2012-01-01 00:00:05'])

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -41,30 +41,30 @@ def test_convert(attr, input):
 @pytest.mark.parametrize('input', [Time('2012-01-01 00:00:00'), '2012/01/01T00:00:00',
                                    '20120101000000', '2012/01/01 00:00:00'])
 def test_on_frame(input):
-    hpc1 = Helioprojective(dateobs=input)
+    hpc1 = Helioprojective(obstime=input)
 
     output = Time('2012-01-01 00:00:00')
 
-    assert isinstance(hpc1.dateobs, Time)
-    assert hpc1.dateobs == output
+    assert isinstance(hpc1.obstime, Time)
+    assert hpc1.obstime == output
 
 def test_non_string():
     output = datetime.datetime.now()
 
-    hpc1 = Helioprojective(dateobs=output)
+    hpc1 = Helioprojective(obstime=output)
 
-    assert isinstance(hpc1.dateobs, Time)
-    assert hpc1.dateobs == output
+    assert isinstance(hpc1.obstime, Time)
+    assert hpc1.obstime == output
 
 def test_on_frame_error():
     with pytest.raises(ValueError):
-        hpc1 = Helioprojective(dateobs='ajshdasjdhk')
+        hpc1 = Helioprojective(obstime='ajshdasjdhk')
 
 def test_on_frame_error2():
     with pytest.raises(ValueError):
-        hpc1 = Helioprojective(dateobs=17263871263)
+        hpc1 = Helioprojective(obstime=17263871263)
 
 def test_array():
     input = Time(['2012-01-01 00:00:00', '2012-01-01 00:00:05'])
     with pytest.raises(ValueError):
-        hpc1 = Helioprojective(dateobs=input)
+        hpc1 = Helioprojective(obstime=input)

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -13,7 +13,7 @@ from sunpy.time import parse_time
 from ..frames import Helioprojective, HeliographicStonyhurst
 from ..frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribute
 from sunpy.util.exceptions import SunpyUserWarning
-from sunpy.coordinates.utilities import get_earth
+from sunpy.coordinates import get_earth
 
 
 @pytest.fixture

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -38,20 +38,20 @@ These are common 2D params, kwargs are frame specific
 """
 two_D_parameters = [
     ([0 * u.deg, 0 * u.arcsec], None),
-    ([0 * u.deg, 0 * u.arcsec], {'dateobs': '2011/01/01T00:00:00'}),
+    ([0 * u.deg, 0 * u.arcsec], {'obstime': '2011/01/01T00:00:00'}),
     ([0 * u.deg, 0 * u.arcsec], {'representation': 'unitsphericalwrap180'}),
     ([0 * u.deg, 0 * u.arcsec], {'representation': 'unitspherical'}),
     ([UnitSphericalWrap180Representation(0 * u.deg, 0 * u.arcsec)], None),
     ([UnitSphericalRepresentation(0 * u.deg, 0 * u.arcsec)], None), (
         [UnitSphericalWrap180Representation(0 * u.deg, 0 * u.arcsec)],
-        {'dateobs': '2011/01/01T00:00:00'})
+        {'obstime': '2011/01/01T00:00:00'})
 ]
 """
 These are common 3D params, kwargs are frame specific
 """
 three_D_parameters = [
     ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], None),
-    ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], {'dateobs': '2011/01/01T00:00:00'}),
+    ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], {'obstime': '2011/01/01T00:00:00'}),
     ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], {'representation': 'sphericalwrap180'
                                            }),
     ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], {'representation': 'spherical'}),
@@ -59,7 +59,7 @@ three_D_parameters = [
      None),
     ([SphericalRepresentation(0 * u.deg, 0 * u.arcsec, 1 * u.Mm)], None), (
         [SphericalWrap180Representation(0 * u.deg, 0 * u.arcsec, 1 * u.Mm)],
-        {'dateobs': '2011/01/01T00:00:00'})
+        {'obstime': '2011/01/01T00:00:00'})
 ]
 
 # ==============================================================================
@@ -136,7 +136,7 @@ def test_cart_init():
 # # cylindrical Assuming that that is a vaild representation.
 # cylindrical_parameters = [
 #     ([100 * u.km, 25 * u.deg, 1 * u.Mm], {'representation': 'cylindrical'}), (
-#         [100 * u.km, 25 * u.deg, 1 * u.Mm], {'dateobs': '2011/01/01T00:00:00',
+#         [100 * u.km, 25 * u.deg, 1 * u.Mm], {'obstime': '2011/01/01T00:00:00',
 #                                              'representation': 'cylindrical'}),
 #     ([100 * u.km, 25 * u.deg], {'distance': 1 * u.Mm,
 #                                 'representation': 'cylindrical'}),
@@ -147,7 +147,7 @@ def test_cart_init():
 #     ([CylindricalRepresentation(100 * u.km, 25 * u.deg, 1 * u.Mm)],
 #      {'representation': 'cylindrical'}), (
 #          [CylindricalRepresentation(100 * u.km, 25 * u.deg, 1 * u.Mm)],
-#          {'dateobs': '2011/01/01T00:00:00',
+#          {'obstime': '2011/01/01T00:00:00',
 #           'representation': 'cylindrical'})
 # ]
 #
@@ -344,7 +344,7 @@ def test_hgs_cart_init():
                                                         'z': 10 * u.km}),
      ([CartesianRepresentation(10 * u.km, 10 * u.km, 10 * u.km)], None),
      ([CartesianRepresentation(10 * u.km, 10 * u.km, 10 * u.km)],
-      {'dateobs': '2011/01/01T00:00:00'})])
+      {'obstime': '2011/01/01T00:00:00'})])
 def test_create_hcc_3d(args, kwargs):
     hcc = init_frame(Heliocentric, args, kwargs)
 

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -44,7 +44,8 @@ def test_hpc_hpc_sc():
     observer_in = HeliographicStonyhurst(lat=0*u.deg, lon=0*u.deg, radius=D0)
     observer_out = HeliographicStonyhurst(lat=0*u.deg, lon=L0, radius=D0)
 
-    sc_in = SkyCoord(0*u.arcsec, 0*u.arcsec, rsun=rsun, observer=observer_in, frame='helioprojective')
+    sc_in = SkyCoord(0*u.arcsec, 0*u.arcsec, rsun=rsun, observer=observer_in,
+                     frame='helioprojective')
     hpc_out = Helioprojective(observer=observer_out, rsun=rsun)
 
     hpc_new = sc_in.transform_to(hpc_out)

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -2,9 +2,11 @@ import numpy as np
 
 import astropy.units as u
 from astropy.tests.helper import quantity_allclose
+from astropy.coordinates import SkyCoord, get_body_barycentric
+from astropy.time import Time
 
 from sunpy.coordinates import Helioprojective, HeliographicStonyhurst
-from astropy.coordinates import SkyCoord
+from sunpy.time import parse_time
 
 
 def test_hpc_hpc():
@@ -61,3 +63,19 @@ def test_hpc_hpc_null():
     assert quantity_allclose(hpc_new.Tx, hpc_in.Tx)
     assert quantity_allclose(hpc_new.Ty, hpc_in.Ty)
     assert hpc_out.observer == hpc_new.observer
+
+
+def test_hcrs_hgs():
+    # Get the current Earth location in HCRS
+    now = Time(parse_time('now'))
+    earth_hcrs = SkyCoord(get_body_barycentric('earth', now), frame='icrs', obstime=now).hcrs
+
+    # Convert from HCRS to HGS
+    earth_hgs = earth_hcrs.transform_to(HeliographicStonyhurst)
+
+    # The HGS longitude of the Earth should be zero within numerical error
+    assert quantity_allclose(earth_hgs.lon, 0*u.deg, atol=1e-12*u.deg)
+
+    # The HGS latitude and radius should be within valid ranges
+    assert quantity_allclose(earth_hgs.lat, 0*u.deg, atol=7.3*u.deg)
+    assert quantity_allclose(earth_hgs.radius, 1*u.AU, atol=0.017*u.AU)

--- a/sunpy/coordinates/tests/test_utilities.py
+++ b/sunpy/coordinates/tests/test_utilities.py
@@ -24,6 +24,18 @@ def test_get_sun_B0():
     assert_quantity_allclose(get_sun_B0('2013-Apr-01'), -6.54*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(get_sun_B0('2013-Dec-01'), 0.88*u.deg, atol=5e-3*u.deg)
 
+    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
+    assert_quantity_allclose(get_sun_B0('1992-Oct-13'), 5.99*u.deg, atol=5e-3*u.deg)
+
+
+def test_get_sun_L0():
+    # Validate against published values from the Astronomical Almanac (2013)
+    assert_quantity_allclose(get_sun_L0('2013-Apr-01'), 221.44*u.deg, atol=2e-2*u.deg)
+    assert_quantity_allclose(get_sun_L0('2013-Dec-01'), 237.83*u.deg, atol=2e-2*u.deg)
+
+    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
+    assert_quantity_allclose(get_sun_L0('1992-Oct-13'), 238.6317*u.deg, atol=5e-5*u.deg)
+
 
 def test_get_sun_P():
     # Validate against published values from the Astronomical Almanac (2013)

--- a/sunpy/coordinates/tests/test_utilities.py
+++ b/sunpy/coordinates/tests/test_utilities.py
@@ -3,7 +3,7 @@
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 
-from ..utilities import get_earth
+from ..utilities import *
 
 
 def test_get_earth():
@@ -17,3 +17,15 @@ def test_get_earth():
     assert_quantity_allclose(e2.lon, 0*u.deg, atol=1e-10*u.deg)  # 0 in heliographic Stonyhurst
     assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)
+
+
+def test_get_sun_B0():
+    # Validate against published values from the Astronomical Almanac (2013)
+    assert_quantity_allclose(get_sun_B0('2013-Apr-01'), -6.54*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(get_sun_B0('2013-Dec-01'), 0.88*u.deg, atol=5e-3*u.deg)
+
+
+def test_get_sun_P():
+    # Validate against published values from the Astronomical Almanac (2013)
+    assert_quantity_allclose(get_sun_P('2013-Apr-01'), -26.15*u.deg, atol=1e-2*u.deg)
+    assert_quantity_allclose(get_sun_P('2013-Dec-01'), 16.05*u.deg, atol=1e-2*u.deg)

--- a/sunpy/coordinates/tests/test_utilities.py
+++ b/sunpy/coordinates/tests/test_utilities.py
@@ -2,6 +2,7 @@
 
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.coordinates import EarthLocation
 
 from ..utilities import *
 
@@ -30,8 +31,8 @@ def test_get_sun_B0():
 
 def test_get_sun_L0():
     # Validate against published values from the Astronomical Almanac (2013)
-    assert_quantity_allclose(get_sun_L0('2013-Apr-01'), 221.44*u.deg, atol=2e-2*u.deg)
-    assert_quantity_allclose(get_sun_L0('2013-Dec-01'), 237.83*u.deg, atol=2e-2*u.deg)
+    assert_quantity_allclose(get_sun_L0('2013-Apr-01'), 221.44*u.deg, atol=3e-2*u.deg)
+    assert_quantity_allclose(get_sun_L0('2013-Dec-01'), 237.83*u.deg, atol=3e-2*u.deg)
 
     # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
     assert_quantity_allclose(get_sun_L0('1992-Oct-13'), 238.6317*u.deg, atol=5e-5*u.deg)
@@ -48,8 +49,8 @@ def test_get_sun_orientation():
 
     # Check the Northern Hemisphere
     angle = get_sun_orientation(EarthLocation(lat=40*u.deg, lon=-75*u.deg), '2017-07-18 12:00')
-    assert_quantity_all_close(angle, -59.4*u.deg, atol=0.1*u.deg)
+    assert_quantity_allclose(angle, -59.4*u.deg, atol=0.1*u.deg)
 
     # Check the Southern Hemisphere
     angle = get_sun_orientation(EarthLocation(lat=-40*u.deg, lon=-75*u.deg), '2017-02-18 13:00')
-    assert_quantity_all_close(angle, -110.8*u.deg, atol=0.1*u.deg)
+    assert_quantity_allclose(angle, -110.8*u.deg, atol=0.1*u.deg)

--- a/sunpy/coordinates/tests/test_utilities.py
+++ b/sunpy/coordinates/tests/test_utilities.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+
+from ..utilities import get_earth
+
+
+def test_get_earth():
+    # Validate against published values from the Astronomical Almanac (2013)
+    e1 = get_earth('2013-Jan-01')
+    assert_quantity_allclose(e1.lon, 0*u.deg, atol=1e-10*u.deg)  # 0 in heliographic Stonyhurst
+    assert_quantity_allclose(e1.lat, -3.03*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e1.radius, 0.9832947*u.AU, atol=5e-7*u.AU)
+
+    e2 = get_earth('2013-Sep-01')
+    assert_quantity_allclose(e2.lon, 0*u.deg, atol=1e-10*u.deg)  # 0 in heliographic Stonyhurst
+    assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)

--- a/sunpy/coordinates/tests/test_utilities.py
+++ b/sunpy/coordinates/tests/test_utilities.py
@@ -43,6 +43,18 @@ def test_get_sun_P():
     assert_quantity_allclose(get_sun_P('2013-Apr-01'), -26.15*u.deg, atol=1e-2*u.deg)
     assert_quantity_allclose(get_sun_P('2013-Dec-01'), 16.05*u.deg, atol=1e-2*u.deg)
 
+    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
+    assert_quantity_allclose(get_sun_P('1992-Oct-13'), 26.27*u.deg, atol=5e-3*u.deg)
+
+
+def test_get_sunearth_distance():
+    # Validate against published values from the Astronomical Almanac (2013)
+    assert_quantity_allclose(get_sunearth_distance('2013-Apr-01'), 0.9992311*u.AU, atol=5e-7*u.AU)
+    assert_quantity_allclose(get_sunearth_distance('2013-Dec-01'), 0.9861362*u.AU, atol=5e-7*u.AU)
+
+    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
+    assert_quantity_allclose(get_sunearth_distance('1992-Oct-13'), 0.997608*u.AU, atol=5e-7*u.AU)
+
 
 def test_get_sun_orientation():
     # Not currently aware of a published value to check against, so just self-check for now

--- a/sunpy/coordinates/tests/test_utilities.py
+++ b/sunpy/coordinates/tests/test_utilities.py
@@ -41,3 +41,15 @@ def test_get_sun_P():
     # Validate against published values from the Astronomical Almanac (2013)
     assert_quantity_allclose(get_sun_P('2013-Apr-01'), -26.15*u.deg, atol=1e-2*u.deg)
     assert_quantity_allclose(get_sun_P('2013-Dec-01'), 16.05*u.deg, atol=1e-2*u.deg)
+
+
+def test_get_sun_orientation():
+    # Not currently aware of a published value to check against, so just self-check for now
+
+    # Check the Northern Hemisphere
+    angle = get_sun_orientation(EarthLocation(lat=40*u.deg, lon=-75*u.deg), '2017-07-18 12:00')
+    assert_quantity_all_close(angle, -59.4*u.deg, atol=0.1*u.deg)
+
+    # Check the Southern Hemisphere
+    angle = get_sun_orientation(EarthLocation(lat=-40*u.deg, lon=-75*u.deg), '2017-02-18 13:00')
+    assert_quantity_all_close(angle, -110.8*u.deg, atol=0.1*u.deg)

--- a/sunpy/coordinates/tests/test_utilities.py
+++ b/sunpy/coordinates/tests/test_utilities.py
@@ -9,12 +9,12 @@ from ..utilities import *
 def test_get_earth():
     # Validate against published values from the Astronomical Almanac (2013)
     e1 = get_earth('2013-Jan-01')
-    assert_quantity_allclose(e1.lon, 0*u.deg, atol=1e-10*u.deg)  # 0 in heliographic Stonyhurst
+    assert e1.lon == 0*u.deg
     assert_quantity_allclose(e1.lat, -3.03*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e1.radius, 0.9832947*u.AU, atol=5e-7*u.AU)
 
     e2 = get_earth('2013-Sep-01')
-    assert_quantity_allclose(e2.lon, 0*u.deg, atol=1e-10*u.deg)  # 0 in heliographic Stonyhurst
+    assert e2.lon == 0*u.deg
     assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)
 

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -39,7 +39,7 @@ def _carrington_offset(obstime):
                          " Frame needs a obstime Attribute")
 
     # Import here to avoid a circular import
-    from .utilities import get_sun_L0
+    from .ephemeris import get_sun_L0
     return get_sun_L0(obstime)
 
 # =============================================================================

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -243,8 +243,7 @@ def hcrs_to_hgs(hcrscoord, hgsframe):
     sun_earth_detilt = sun_earth_hcrs.transform(_sun_detilt_matrix)
 
     # Remove the component of the Sun-Earth vector that is parallel to the Sun's north pole
-    z_axis = CartesianRepresentation(0, 0, 1)
-    hgs_x_axis_detilt = sun_earth_detilt - z_axis * sun_earth_detilt.dot(z_axis)
+    hgs_x_axis_detilt = CartesianRepresentation(sun_earth_detilt.xyz * [1, 1, 0])
 
     # The above vector, which is in the Sun's equatorial plane, is also the X axis of HGS
     x_axis = CartesianRepresentation(1, 0, 0)

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -206,8 +206,8 @@ def _make_rotation_matrix(start_representation, end_representation):
     """
     A = start_representation.to_cartesian()
     B = end_representation.to_cartesian()
-    rotation_axis = A.cross(B) / (A.norm() * B.norm())
-    rotation_angle = -np.arcsin(rotation_axis.norm()) # negation is required
+    rotation_axis = A.cross(B)
+    rotation_angle = -np.arccos(A.dot(B) / (A.norm() * B.norm()))  # negation is required
 
     # This line works around some input/output quirks of Astropy's rotation_matrix()
     matrix = np.array(rotation_matrix(rotation_angle, rotation_axis.xyz.value.tolist()))

--- a/sunpy/coordinates/utilities.py
+++ b/sunpy/coordinates/utilities.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division
+import datetime
+
+from astropy.time import Time
+from astropy.coordinates import SkyCoord, get_body_barycentric
+
+from sunpy.time import parse_time
+
+from .frames import HeliographicStonyhurst
+
+__all__ = ['get_earth']
+
+
+def get_earth(time='now'):
+    """
+    Return a SkyCoord for the location of the Earth at a specified time in the
+    HeliographicStonyhurst frame.
+
+    Parameters
+    ----------
+    time : various
+        Time to use in a parse_time-compatible format
+
+    Returns
+    -------
+    out : SkyCoord
+        SkyCoord for the location of the Earth in the HeliographicStonyhurst frame
+    
+    """
+    obstime = Time(parse_time(time))
+
+    return SkyCoord(get_body_barycentric('earth', obstime), obstime=obstime).transform_to(HeliographicStonyhurst)

--- a/sunpy/coordinates/utilities.py
+++ b/sunpy/coordinates/utilities.py
@@ -2,14 +2,17 @@
 from __future__ import absolute_import, division
 import datetime
 
+import numpy as np
+import astropy.units as u
 from astropy.time import Time
-from astropy.coordinates import SkyCoord, get_body_barycentric
+from astropy.coordinates import SkyCoord, get_body_barycentric, PrecessedGeocentric, Angle
+from astropy.coordinates.representation import CartesianRepresentation
 
 from sunpy.time import parse_time
 
-from .frames import HeliographicStonyhurst
+from .frames import HeliographicStonyhurst as HGS
 
-__all__ = ['get_earth']
+__all__ = ['get_earth', 'get_sun_B0', 'get_sun_P']
 
 
 def get_earth(time='now'):
@@ -29,4 +32,60 @@ def get_earth(time='now'):
     """
     obstime = Time(parse_time(time))
     earth = SkyCoord(get_body_barycentric('earth', obstime), frame='icrs', obstime=obstime)
-    return earth.transform_to(HeliographicStonyhurst)
+    return earth.transform_to(HGS)
+
+
+def get_sun_B0(time='now'):
+    """
+    Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
+    Sun-disk center as seen from Earth.  The range of B0 is +/-7.23 degrees.
+
+    Parameters
+    ----------
+    time : various
+        Time to use in a parse_time-compatible format
+
+    Returns
+    -------
+    out : `~astropy.coordinates.Angle`
+        The position angle
+    """
+    return Angle(get_earth(time).lat)
+
+
+def get_sun_P(time='now'):
+    """
+    Return the position (P) angle for the Sun at a specified time, which is the angle between
+    geocentric north and solar north as seen from Earth, measured eastward from geocentric north.
+    The range of P is +/-26.3 degrees.
+
+    Parameters
+    ----------
+    time : various
+        Time to use in a parse_time-compatible format
+
+    Returns
+    -------
+    out : `~astropy.coordinates.Angle`
+        The position angle
+    """
+    obstime = Time(parse_time(time))
+
+    sun_center = SkyCoord(0*u.deg, 0*u.deg, 0*u.km, frame=HGS, obstime=obstime)
+    sun_north_pole = SkyCoord(0*u.deg, 90*u.deg, 690000*u.km, frame=HGS, obstime=obstime)
+
+    # Represent the two north vectors in precessed geocentric coordinates
+    geocentric = PrecessedGeocentric(equinox=obstime, obstime=obstime)
+    sky_normal_vector = sun_center.transform_to(geocentric).data.to_cartesian()
+    sun_north_pole_vector = sun_north_pole.transform_to(geocentric).data.to_cartesian()
+    earth_north_pole_vector = CartesianRepresentation(0, 0, 1)
+
+    # Use cross products to obtain the sky projections of the two north vectors
+    sun_in_sky = sun_north_pole_vector.cross(sky_normal_vector)
+    earth_in_sky = earth_north_pole_vector.cross(sky_normal_vector)
+
+    # Use a cross product to calculate the signed angle between the two projected north vectors
+    cross_vector = sun_in_sky.cross(earth_in_sky) / (sun_in_sky.norm() * earth_in_sky.norm())
+    angle = np.arcsin(cross_vector.dot(sky_normal_vector) / sky_normal_vector.norm()).to('deg')
+
+    return Angle(angle)

--- a/sunpy/coordinates/utilities.py
+++ b/sunpy/coordinates/utilities.py
@@ -16,8 +16,8 @@ from sunpy.time import parse_time
 from .frames import HeliographicStonyhurst as HGS
 from .transformations import _sun_detilt_matrix
 
-__all__ = ['get_earth', 'get_sun_B0', 'get_sun_L0', 'get_sun_P', 'get_sun_orientation']
-
+__all__ = ['get_earth', 'get_sun_B0', 'get_sun_L0', 'get_sun_P', 'get_sunearth_distance',
+           'get_sun_orientation']
 
 
 def _astropy_time(time):
@@ -104,7 +104,7 @@ def get_sun_L0(time='now'):
 
     # Calculate the longitude due to the Sun's rotation relative to the stars
     # A sidereal rotation is defined to be exactly 25.38 days
-    sidereal_lon= Longitude((obstime.jd - _time_first_rotation.jd) / 25.38 * 360 * u.deg)
+    sidereal_lon = Longitude((obstime.jd - _time_first_rotation.jd) / 25.38 * 360*u.deg)
 
     # Calculate the longitude of the Earth in de-tilted HCRS
     lon_obstime = get_earth(obstime).hcrs.cartesian.transform(_sun_detilt_matrix) \
@@ -134,6 +134,23 @@ def get_sun_P(time='now'):
     geocentric = PrecessedGeocentric(equinox=obstime, obstime=obstime)
 
     return _sun_north_angle_to_z(geocentric)
+
+
+def get_sunearth_distance(time='now'):
+    """
+    Return the distance between the Sun and the Earth at a specified time.
+
+    Parameters
+    ----------
+    time : various
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+
+    Returns
+    -------
+    out : `~astropy.coordinates.Distance`
+        The Sun-Earth distance
+    """
+    return get_earth(time).radius
 
 
 def get_sun_orientation(location, time='now'):

--- a/sunpy/coordinates/utilities.py
+++ b/sunpy/coordinates/utilities.py
@@ -19,6 +19,14 @@ from .transformations import _sun_detilt_matrix
 __all__ = ['get_earth', 'get_sun_B0', 'get_sun_L0', 'get_sun_P', 'get_sun_orientation']
 
 
+
+def _astropy_time(time):
+    """
+    Return an `~astropy.time.Time` instance, running it through `~sunpy.time.parse_time` if needed
+    """
+    return time if isinstance(time, Time) else Time(parse_time(time))
+
+
 def get_earth(time='now'):
     """
     Return a SkyCoord for the location of the Earth at a specified time in the
@@ -27,14 +35,14 @@ def get_earth(time='now'):
     Parameters
     ----------
     time : various
-        Time to use in a parse_time-compatible format
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
 
     Returns
     -------
     out : `~astropy.coordinates.SkyCoord`
         SkyCoord for the location of the Earth in the HeliographicStonyhurst frame
     """
-    obstime = Time(parse_time(time))
+    obstime = _astropy_time(time)
 
     earth_icrs = get_body_barycentric('earth', obstime)
     earth = SkyCoord(earth_icrs, frame='icrs', obstime=obstime).transform_to(HGS)
@@ -53,7 +61,7 @@ def get_sun_B0(time='now'):
     Parameters
     ----------
     time : various
-        Time to use in a parse_time-compatible format
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
 
     Returns
     -------
@@ -85,14 +93,14 @@ def get_sun_L0(time='now'):
     Parameters
     ----------
     time : various
-        Time to use in a parse_time-compatible format
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
 
     Returns
     -------
     out : `~astropy.coordinates.Longitude`
         The Carrington longitude
     """
-    obstime = Time(parse_time(time))
+    obstime = _astropy_time(time)
 
     # Calculate the longitude due to the Sun's rotation relative to the stars
     # A sidereal rotation is defined to be exactly 25.38 days
@@ -114,14 +122,14 @@ def get_sun_P(time='now'):
     Parameters
     ----------
     time : various
-        Time to use in a parse_time-compatible format
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
 
     Returns
     -------
     out : `~astropy.coordinates.Angle`
         The position angle
     """
-    obstime = Time(parse_time(time))
+    obstime = _astropy_time(time)
 
     geocentric = PrecessedGeocentric(equinox=obstime, obstime=obstime)
 
@@ -139,14 +147,14 @@ def get_sun_orientation(location, time='now'):
     location : `~astropy.coordinates.EarthLocation`
         Observer location on Earth
     time : various
-        Time to use in a parse_time-compatible format
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
 
     Returns
     -------
     out : `~astropy.coordinates.Angle`
         The orientation of the Sun
     """
-    obstime = Time(parse_time(time))
+    obstime = _astropy_time(time)
 
     local_frame = AltAz(obstime=obstime, location=location)
 

--- a/sunpy/coordinates/utilities.py
+++ b/sunpy/coordinates/utilities.py
@@ -18,7 +18,7 @@ __all__ = ['get_earth', 'get_sun_B0', 'get_sun_P']
 def get_earth(time='now'):
     """
     Return a SkyCoord for the location of the Earth at a specified time in the
-    HeliographicStonyhurst frame.
+    HeliographicStonyhurst frame.  The longitude will be 0 by definition.
 
     Parameters
     ----------
@@ -31,8 +31,14 @@ def get_earth(time='now'):
         SkyCoord for the location of the Earth in the HeliographicStonyhurst frame
     """
     obstime = Time(parse_time(time))
-    earth = SkyCoord(get_body_barycentric('earth', obstime), frame='icrs', obstime=obstime)
-    return earth.transform_to(HGS)
+
+    earth_icrs = get_body_barycentric('earth', obstime)
+    earth = SkyCoord(earth_icrs, frame='icrs', obstime=obstime).transform_to(HGS)
+
+    # Explicitly set the longitude to 0
+    earth = SkyCoord(0*u.deg, earth.lat, earth.radius, frame=earth)
+
+    return earth
 
 
 def get_sun_B0(time='now'):

--- a/sunpy/coordinates/utilities.py
+++ b/sunpy/coordinates/utilities.py
@@ -24,10 +24,9 @@ def get_earth(time='now'):
 
     Returns
     -------
-    out : SkyCoord
+    out : `~astropy.coordinates.SkyCoord`
         SkyCoord for the location of the Earth in the HeliographicStonyhurst frame
-    
     """
     obstime = Time(parse_time(time))
-
-    return SkyCoord(get_body_barycentric('earth', obstime), obstime=obstime).transform_to(HeliographicStonyhurst)
+    earth = SkyCoord(get_body_barycentric('earth', obstime), frame='icrs', obstime=obstime)
+    return earth.transform_to(HeliographicStonyhurst)

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -41,16 +41,16 @@ def solar_wcs_frame_mapping(wcs):
     ycoord = wcs.wcs.ctype[1][0:4]
 
     if xcoord == 'HPLN' and ycoord == 'HPLT':
-        return Helioprojective(dateobs=dateobs, observer=observer, rsun=rsun)
+        return Helioprojective(obstime=dateobs, observer=observer, rsun=rsun)
 
     if xcoord == 'HGLN' and ycoord == 'HGLT':
-        return HeliographicStonyhurst(dateobs=dateobs)
+        return HeliographicStonyhurst(obstime=dateobs)
 
     if xcoord == 'CRLN' and ycoord == 'CRLT':
-        return HeliographicCarrington(dateobs=dateobs)
+        return HeliographicCarrington(obstime=dateobs)
 
     if xcoord == 'SOLX' and ycoord == 'SOLY':
-        return Heliocentric(dateobs=dateobs, observer=observer)
+        return Heliocentric(obstime=dateobs, observer=observer)
 
 
 astropy.wcs.utils.WCS_FRAME_MAPPINGS.append([solar_wcs_frame_mapping])

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -69,6 +69,7 @@ from sunpy import lightcurve
 from sunpy.util.net import check_download_file
 from sunpy.util.config import get_and_create_download_dir
 from sunpy import sun
+from sunpy.coordinates import get_sunearth_distance
 
 GOES_CONVERSION_DICT = {'X': u.Quantity(1e-4, "W/m^2"),
                         'M': u.Quantity(1e-5, "W/m^2"),
@@ -1272,7 +1273,7 @@ def _calc_xraylum(flux, date=None):
     """
     if date is not None:
         date = parse_time(date)
-        xraylum = 4 * np.pi * sun.sun.sunearth_distance(t=date).to("m")**2 * flux
+        xraylum = 4 * np.pi * get_sunearth_distance(date).to("m")**2 * flux
     else:
         xraylum = 4 * np.pi * sun.constants.au.to("m")**2 * flux
     return xraylum

--- a/sunpy/instr/rhessi.py
+++ b/sunpy/instr/rhessi.py
@@ -19,7 +19,7 @@ from astropy import units as u
 
 from sunpy.time import TimeRange, parse_time
 from sunpy.sun.sun import solar_semidiameter_angular_size
-from sunpy.sun.sun import sunearth_distance
+from sunpy.coordinates import get_sunearth_distance
 import sunpy.map
 
 from sunpy.extern.six.moves import urllib
@@ -506,7 +506,7 @@ def backprojection(calibrated_event_list, pixel_size=(1., 1.) * u.arcsec,
         "HGLN_OBS": 0,
         "RSUN_OBS": solar_semidiameter_angular_size(time_range.center).value,
         "RSUN_REF": sunpy.sun.constants.radius.value,
-        "DSUN_OBS": sunearth_distance(time_range.center) * sunpy.sun.constants.au.value
+        "DSUN_OBS": get_sunearth_distance(time_range.center).value * sunpy.sun.constants.au.value
     }
 
     result_map = sunpy.map.Map(image, dict_header)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -31,6 +31,7 @@ from sunpy.time import parse_time, is_time
 from sunpy.image.transform import affine_transform
 from sunpy.image.rescale import reshape_image_to_4d_superpixel
 from sunpy.image.rescale import resample as sunpy_image_resample
+from sunpy.coordinates import get_sun_B0, get_sun_L0, get_sunearth_distance
 
 from astropy.nddata import NDData
 
@@ -427,7 +428,7 @@ Reference Coord:\t {refcoord}
                                    " separation: assuming Sun-Earth distance",
                                    Warning, __file__,
                                    inspect.currentframe().f_back.f_lineno)
-            dsun = sun.sunearth_distance(self.date).to(u.m)
+            dsun = get_sunearth_distance(self.date).to(u.m)
 
         return u.Quantity(dsun, 'm')
 
@@ -579,7 +580,7 @@ Reference Coord:\t {refcoord}
                                    " assuming Earth-based observer",
                                    Warning, __file__,
                                    inspect.currentframe().f_back.f_lineno)
-            carrington_longitude = (sun.heliographic_solar_center(self.date))[0]
+            carrington_longitude = get_sun_L0(self.date)
 
         if isinstance(carrington_longitude, six.string_types):
             carrington_longitude = float(carrington_longitude)
@@ -598,7 +599,7 @@ Reference Coord:\t {refcoord}
                                    " assuming Earth-based observer",
                                    Warning, __file__,
                                    inspect.currentframe().f_back.f_lineno)
-            heliographic_latitude = (sun.heliographic_solar_center(self.date))[1]
+            heliographic_latitude = get_sun_B0(self.date)
 
         if isinstance(heliographic_latitude, six.string_types):
             heliographic_latitude = float(heliographic_latitude)

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -17,6 +17,7 @@ from sunpy.sun import constants
 from sunpy.sun import sun
 from sunpy.cm import cm
 from sunpy.map.sources.source_type import source_stretch
+from sunpy.coordinates import get_sunearth_distance
 
 __all__ = ['EITMap', 'LASCOMap', 'MDIMap']
 
@@ -37,7 +38,7 @@ def _dsunAtSoho(date, rad_d, rad_1au=None):
     """
     if not rad_1au:
         rad_1au = sun.solar_semidiameter_angular_size(date)
-    dsun = sun.sunearth_distance(date) * constants.au * (rad_1au / rad_d)
+    dsun = get_sunearth_distance(date) * constants.au * (rad_1au / rad_d)
     # return scalar value not astropy.quantity
     return dsun.value
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -199,7 +199,7 @@ def test_coordinate_frame(aia171_test_map):
     assert frame.observer.lat == aia171_test_map.observer_coordinate.frame.lat
     assert frame.observer.lon == aia171_test_map.observer_coordinate.frame.lon
     assert frame.observer.radius == aia171_test_map.observer_coordinate.frame.radius
-    assert frame.dateobs == aia171_test_map.date
+    assert frame.obstime == aia171_test_map.date
 
 
 #==============================================================================

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -202,9 +202,9 @@ def test_coordinate_frame(aia171_test_map):
     assert frame.obstime == aia171_test_map.date
 
 
-#==============================================================================
+# ==============================================================================
 # Test Rotation WCS conversion
-#==============================================================================
+# ==============================================================================
 def test_rotation_matrix_pci_j(generic_map):
     np.testing.assert_allclose(generic_map.rotation_matrix, np.matrix([[0., -1.], [1., 0.]]))
 
@@ -645,8 +645,8 @@ def test_hc_warn():
 
 
 def test_more_than_two_dimensions():
-    """Checks to see if an appropriate error is raised when a FITs with more than two dimensions is loaded.
-    We need to load a >2-dim dataset with a TELESCOP header"""
+    """Checks to see if an appropriate error is raised when a FITS with more than two dimensions is
+    loaded.  We need to load a >2-dim dataset with a TELESCOP header"""
 
     # Data crudely represnts 4 stokes, 4 wavelengths with Y,X of 3 and 5.
     bad_data = np.random.rand(4, 4, 3, 5)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -160,7 +160,7 @@ def test_detector(generic_map):
 
 
 def test_dsun(generic_map):
-    assert generic_map.dsun == sunpy.sun.sunearth_distance(generic_map.date).to(u.m)
+    assert generic_map.dsun == sunpy.coordinates.get_sunearth_distance(generic_map.date).to(u.m)
 
 
 def test_rsun_meters(generic_map):
@@ -176,13 +176,11 @@ def test_coordinate_system(generic_map):
 
 
 def test_carrington_longitude(generic_map):
-    assert generic_map.carrington_longitude == (
-        sunpy.sun.heliographic_solar_center(generic_map.date))[0]
+    assert generic_map.carrington_longitude == sunpy.coordinates.get_sun_L0(generic_map.date)
 
 
 def test_heliographic_latitude(generic_map):
-    assert generic_map.heliographic_latitude == (
-        sunpy.sun.heliographic_solar_center(generic_map.date))[1]
+    assert generic_map.heliographic_latitude == sunpy.coordinates.get_sun_B0(generic_map.date)
 
 
 def test_heliographic_longitude(generic_map):

--- a/sunpy/sun/sun.py
+++ b/sunpy/sun/sun.py
@@ -29,6 +29,7 @@ from astropy.coordinates import Angle, Longitude, Latitude
 
 from sunpy.time import parse_time, julian_day, julian_centuries
 from sunpy.sun import constants
+from sunpy.util.decorators import deprecated
 
 __all__ = ["print_params",
            "heliographic_solar_center",
@@ -83,7 +84,9 @@ def solar_semidiameter_angular_size(t='now'):
         Radius_{\odot}[rad]=\frac{<Radius_{\odot}[m]>}{D_{\odot \oplus}(t)[m]}
 
     """
-    solar_semidiameter_rad = (constants.radius.to(u.AU)) / sunearth_distance(t)
+    # Import here to avoid a circular import
+    from sunpy.coordinates import get_sunearth_distance
+    solar_semidiameter_rad = (constants.radius.to(u.AU)) / get_sunearth_distance(t)
     return Angle(solar_semidiameter_rad.to(u.arcsec, equivalencies=u.dimensionless_angles()))
 
 
@@ -165,6 +168,7 @@ def true_anomaly(t='now'):
     return Longitude(result)
 
 
+@deprecated('0.8', 'Use sunpy.coordinates.get_sunearth_distance() for higher accuracy')
 def sunearth_distance(t='now'):
     """Returns the Sun Earth distance (AU). There are a set of higher
     accuracy terms not included here."""
@@ -238,6 +242,7 @@ def apparent_declination(t='now'):
     return Latitude(result.to(u.deg))
 
 
+@deprecated('0.8', 'Use sunpy.coordinates.get_sun_P() for higher accuracy')
 def solar_north(t='now'):
     """Returns the position of the Solar north pole in degrees."""
     T = julian_centuries(t)
@@ -255,6 +260,7 @@ def solar_north(t='now'):
     return Angle(result.to(u.deg))
 
 
+@deprecated('0.8', 'Use sunpy.coordinates.get_sun_L0() and .get_sun_B0() for higher accuracy')
 def heliographic_solar_center(t='now'):
     """Returns the position of the solar center in heliographic coordinates."""
     jd = julian_day(t)

--- a/sunpy/sun/tests/test_sun.py
+++ b/sunpy/sun/tests/test_sun.py
@@ -58,9 +58,9 @@ def test_solar_cycle_number():
 
 
 def test_solar_semidiameter_angular_size():
-    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2012/11/11"), 968.612 * u.arcsec, atol=1e-3 * u.arcsec)
-    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2043/03/01"), 968.042 * u.arcsec, atol=1e-3 * u.arcsec)
-    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2001/07/21"), 943.775 * u.arcsec, atol=1e-3 * u.arcsec)
+    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2012/11/11"), 968.604 * u.arcsec, atol=1e-3 * u.arcsec)
+    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2043/03/01"), 968.059 * u.arcsec, atol=1e-3 * u.arcsec)
+    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2001/07/21"), 943.778 * u.arcsec, atol=1e-3 * u.arcsec)
 
 
 def test_mean_ecliptic_longitude():

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -119,6 +119,13 @@ def _iter_empty(iter):
     return False
 
 
+def _astropy_time(time):
+    """
+    Return an `~astropy.time.Time` instance, running it through `~sunpy.time.parse_time` if needed
+    """
+    return time if isinstance(time, astropy.time.Time) else astropy.time.Time(parse_time(time))
+
+
 def parse_time(time_string, time_format='', **kwargs):
     """Given a time string will parse and return a datetime object.
     Similar to the anytim function in IDL.


### PR DESCRIPTION
This object allows the user to specify the observer of a frame as a string, which if `obstime` is set will be converted to a position.

This is now rebased on #2186, if you want to actually see the diff have a look at ayshih/sunpy#2

Thanks for the advice on the mailing list @taldcroft works like a charm :)

closes #2004

Todo:
- [x] Tests
- [x] Changelog