### PR TITLE
LightCurve to TimeSeries in instr.lyra

### DIFF
--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -15,23 +15,23 @@ from sunpy.time import parse_time
 from sunpy import config
 from sunpy.util.net import check_download_file
 from sunpy.util.config import get_and_create_download_dir
-from sunpy import lightcurve
+from sunpy import timeseries
 
 from sunpy.extern.six.moves import urllib
 
 LYTAF_REMOTE_PATH = "http://proba2.oma.be/lyra/data/lytaf/"
 
 
-def remove_lytaf_events_from_lightcurve(lc, artifacts=None,
+def remove_lytaf_events_from_timeseries(ts, artifacts=None,
                                         return_artifacts=False,
                                         lytaf_path=None,
                                         force_use_local_lytaf=False):
     """
-    Removes periods of LYRA artifacts defined in LYTAF from a LYRALightCurve.
+    Removes periods of LYRA artifacts defined in LYTAF from a TimeSeries.
 
     Parameters
     ----------
-    lc : `sunpy.lightcurve.LightCurve`
+    ts : `sunpy.timeseries.TimeSeries`
 
      artifacts : list of strings
         Contain the artifact types to be removed.  For list of artifact types
@@ -55,8 +55,8 @@ def remove_lytaf_events_from_lightcurve(lc, artifacts=None,
 
     Returns
     -------
-    lc_new : `sunpy.lightcurve.LightCurve`
-        copy of input LYRALightCurve with periods corresponding to artifacts
+    ts_new : `sunpy.timeseries.TimeSeries`
+        copy of input TimeSeries with periods corresponding to artifacts
         removed.
 
     artifact_status : `dict`
@@ -81,39 +81,37 @@ def remove_lytaf_events_from_lightcurve(lc, artifacts=None,
 
     Examples
     --------
-    Remove LARs (Large Angle Rotations) from LYRALightCurve for 4-Dec-2014:
+    Remove LARs (Large Angle Rotations) from TimeSeries for 4-Dec-2014:
 
-        >>> import sunpy.lightcurve as lc
-        >>> lc = lc.LYRALightCurve.create("2014-12-02")
-        >>> lc_nolars = lc.remove_artifacts_from_lyralightcurve(lc, artifacts=["LAR"])
+        >>> import sunpy.timeseries as ts
+        >>> ts = ts.TimeSeries("2014-12-02")
+        >>> ts_nolars = ts.remove_artifacts_from_timeseries(ts, artifacts=["LAR"])
 
     To also retrieve information on the artifacts during that day:
-        >>> lc_nolars, artifact_status = lc.remove_artifacts_from_lyralightcurve(
-                lc, artifacts=["LAR"], return_artifacts=True)
+        >>> ts_nolars, artifact_status = ts.remove_artifacts_from_timeseries(
+                ts, artifacts=["LAR"], return_artifacts=True)
 
     """
     # Check that input argument is of correct type
     if not lytaf_path:
         lytaf_path = get_and_create_download_dir()
-    if not isinstance(lc, lightcurve.LightCurve):
-        raise TypeError("lc must be a LightCurve object.")
     # Remove artifacts from time series
-    data_columns = lc.data.columns
+    data_columns = ts.data.columns
     time, channels, artifact_status = _remove_lytaf_events(
-        lc.data.index,
-        channels=[np.asanyarray(lc.data[col]) for col in data_columns],
+        ts.data.index,
+        channels=[np.asanyarray(ts.data[col]) for col in data_columns],
         artifacts=artifacts, return_artifacts=True, lytaf_path=lytaf_path,
         force_use_local_lytaf=force_use_local_lytaf)
-    # Create new copy copy of lightcurve and replace data with
+    # Create new copy copy of timeseries and replace data with
     # artifact-free time series.
-    lc_new = copy.deepcopy(lc)
-    lc_new.data = pandas.DataFrame(
+    ts_new = copy.deepcopy(ts)
+    ts_new.data = pandas.DataFrame(
         index=time, data=dict((col, channels[i])
                               for i, col in enumerate(data_columns)))
     if return_artifacts:
-        return lc_new, artifact_status
+        return ts_new, artifact_status
     else:
-        return lc_new
+        return ts_new
 
 
 def _remove_lytaf_events(time, channels=None, artifacts=None,

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -75,6 +75,11 @@ def remove_lytaf_events_from_timeseries(ts, artifacts=None,
             Artifacts listed to be removed by user when defining
             artifacts kwarg which were not found in time series time range.
 
+    Notes
+    -----
+    This function is intended to take TimeSeries objects as input, but the
+    deprecated LightCurve is still supported here.
+
     References
     ----------
     [1] http://proba2.oma.be/data/TARDIS

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -15,11 +15,23 @@ from sunpy.time import parse_time
 from sunpy import config
 from sunpy.util.net import check_download_file
 from sunpy.util.config import get_and_create_download_dir
+from sunpy.util.decorators import deprecated
 from sunpy import timeseries
 
 from sunpy.extern.six.moves import urllib
 
 LYTAF_REMOTE_PATH = "http://proba2.oma.be/lyra/data/lytaf/"
+
+
+@deprecated('v0.8',
+            message="""``remove_lytaf_events_from_lightcurve`` is deprecated as of SunPy v0.8 due to
+            the deprecation of ``LightCurve`` in favour of ``TimeSeries``. You should use
+            ``remove_lytaf_events_from_timeseries`` instead.""",
+            name="remove_lytaf_events_from_lightcurve",
+            alternative="remove_lytaf_events_from_timeseries"
+            )
+def remove_lytaf_events_from_lightcurve(lc, **kwargs):
+    return remove_lytaf_events_from_timeseries(lc, **kwargs)
 
 
 def remove_lytaf_events_from_timeseries(ts, artifacts=None,

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -100,12 +100,12 @@ def remove_lytaf_events_from_timeseries(ts, artifacts=None,
 
         >>> import sunpy.timeseries as ts
         >>> import sunpy.data.sample
-        >>> ts = ts.TimeSeries(sunpy.data.sample.LYRA_LEVEL3_TIMESERIES, source='LYRA')
-        >>> ts_nolars = ts.remove_artifacts_from_timeseries(ts, artifacts=["LAR"])
+        >>> lyrats = ts.TimeSeries(sunpy.data.sample.LYRA_LEVEL3_TIMESERIES, source='LYRA')
+        >>> ts_nolars = ts.remove_artifacts_from_timeseries(lyrats, artifacts=["LAR"])
 
     To also retrieve information on the artifacts during that day:
         >>> ts_nolars, artifact_status = ts.remove_artifacts_from_timeseries(
-                ts, artifacts=["LAR"], return_artifacts=True)
+                lyrats, artifacts=["LAR"], return_artifacts=True)
 
     """
     # Check that input argument is of correct type

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -12,7 +12,6 @@ from astropy.io import fits
 import pandas
 
 from sunpy.time import parse_time
-from sunpy import config
 from sunpy.util.net import check_download_file
 from sunpy.util.config import get_and_create_download_dir
 from sunpy.util.decorators import deprecated

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -89,7 +89,8 @@ def remove_lytaf_events_from_timeseries(ts, artifacts=None,
     Remove LARs (Large Angle Rotations) from TimeSeries for 4-Dec-2014:
 
         >>> import sunpy.timeseries as ts
-        >>> ts = ts.TimeSeries("2014-12-02")
+        >>> import sunpy.data.sample
+        >>> ts = ts.TimeSeries(sunpy.data.sample.LYRA_LEVEL3_TIMESERIES, source='LYRA')
         >>> ts_nolars = ts.remove_artifacts_from_timeseries(ts, artifacts=["LAR"])
 
     To also retrieve information on the artifacts during that day:

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -16,7 +16,6 @@ from sunpy import config
 from sunpy.util.net import check_download_file
 from sunpy.util.config import get_and_create_download_dir
 from sunpy.util.decorators import deprecated
-from sunpy import timeseries
 
 from sunpy.extern.six.moves import urllib
 
@@ -45,11 +44,11 @@ def remove_lytaf_events_from_timeseries(ts, artifacts=None,
     ----------
     ts : `sunpy.timeseries.TimeSeries`
 
-     artifacts : list of strings
-        Contain the artifact types to be removed.  For list of artifact types
-        see reference [1].  For example, if user wants to remove only large
-        angle rotations, listed at reference [1] as LAR, let artifacts=["LAR"].
-        Default=[], i.e. no artifacts will be removed.
+    artifacts : list of strings
+        Sets the artifact types to be removed.  For a list of artifact types
+        see reference [1].  For example, if a user wants to remove only large
+        angle rotations, listed at reference [1] as LAR, set artifacts=["LAR"].
+        The default is that no artifacts will be removed.
 
     return_artifacts : `bool`
         Set to True to return a `numpy.recarray` containing the start time, end

--- a/sunpy/instr/tests/test_lyra.py
+++ b/sunpy/instr/tests/test_lyra.py
@@ -89,7 +89,6 @@ lyralc.data = pandas.DataFrame(index=TIME,
                                      "CHANNEL2": CHANNELS[1],
                                      "CHANNEL3": CHANNELS[0],
                                      "CHANNEL4": CHANNELS[1]})
-
 # Create sample TimeSeries
 lyrats = timeseries.TimeSeries(
         os.path.join(rootdir, 'lyra_20150101-000000_lev3_std_truncated.fits.gz'), source='LYRA')
@@ -98,6 +97,8 @@ lyrats.data = pandas.DataFrame(index=TIME,
                                      "CHANNEL2": CHANNELS[1],
                                      "CHANNEL3": CHANNELS[0],
                                      "CHANNEL4": CHANNELS[1]})
+
+
 @pytest.mark.online
 @pytest.mark.parametrize('ts', [lyrats, lyralc])
 def test_remove_lytaf_events_from_timeseries(ts):
@@ -111,9 +112,9 @@ def test_remove_lytaf_events_from_timeseries(ts):
     # Run remove_artifacts_from_timeseries, returning artifact
     # status
     ts_test, artifact_status_test = \
-      lyra.remove_lytaf_events_from_timeseries(
-          ts, artifacts=["LAR", "Offpoint"], return_artifacts=True,
-          lytaf_path=TEST_DATA_PATH, force_use_local_lytaf=True)
+        lyra.remove_lytaf_events_from_timeseries(
+            ts, artifacts=["LAR", "Offpoint"], return_artifacts=True,
+            lytaf_path=TEST_DATA_PATH, force_use_local_lytaf=True)
     # Generate expected data by calling _remove_lytaf_events and
     # constructing expected dataframe manually.
     time, channels, artifact_status_expected = lyra._remove_lytaf_events(
@@ -138,14 +139,14 @@ def test_remove_lytaf_events_from_timeseries(ts):
     np.testing.assert_array_equal(artifact_status_test["not_removed"],
                                   artifact_status_expected["not_removed"])
     assert artifact_status_test["not_found"] == \
-      artifact_status_expected["not_found"]
+        artifact_status_expected["not_found"]
 
     # Run remove_artifacts_from_timeseries, without returning
     # artifact status
     ts_test = \
-      lyra.remove_lytaf_events_from_timeseries(
-          ts, artifacts=["LAR", "Offpoint"],
-          lytaf_path=TEST_DATA_PATH, force_use_local_lytaf=True)
+        lyra.remove_lytaf_events_from_timeseries(
+            ts, artifacts=["LAR", "Offpoint"],
+            lytaf_path=TEST_DATA_PATH, force_use_local_lytaf=True)
     # Assert expected result is returned
     pandas.util.testing.assert_frame_equal(ts_test.data, dataframe_expected)
 
@@ -154,10 +155,10 @@ def test_remove_lytaf_events_1():
     """Test _remove_lytaf_events() with some artifacts found and others not."""
     # Run _remove_lytaf_events
     time_test, channels_test, artifacts_status_test = \
-      lyra._remove_lytaf_events(
-          TIME, channels=CHANNELS, artifacts=["LAR", "Offpoint"],
-          return_artifacts=True, lytaf_path=TEST_DATA_PATH,
-          force_use_local_lytaf=True)
+        lyra._remove_lytaf_events(
+            TIME, channels=CHANNELS, artifacts=["LAR", "Offpoint"],
+            return_artifacts=True, lytaf_path=TEST_DATA_PATH,
+            force_use_local_lytaf=True)
     # Generated expected result
     bad_indices = np.logical_and(TIME >= LYTAF_TEST["begin_time"][0],
                                  TIME <= LYTAF_TEST["end_time"][0])
@@ -180,16 +181,16 @@ def test_remove_lytaf_events_1():
     np.testing.assert_array_equal(artifacts_status_test["not_removed"],
                                   artifacts_status_expected["not_removed"])
     assert artifacts_status_test["not_found"] == \
-      artifacts_status_expected["not_found"]
+        artifacts_status_expected["not_found"]
 
     # Test that correct values are returned when channels kwarg not
     # supplied.
     # Run _remove_lytaf_events
     time_test, artifacts_status_test = \
-      lyra._remove_lytaf_events(
-          TIME, artifacts=["LAR", "Offpoint"],
-          return_artifacts=True, lytaf_path=TEST_DATA_PATH,
-          force_use_local_lytaf=True)
+        lyra._remove_lytaf_events(
+            TIME, artifacts=["LAR", "Offpoint"],
+            return_artifacts=True, lytaf_path=TEST_DATA_PATH,
+            force_use_local_lytaf=True)
     # Assert test values are same as expected
     assert time_test.all() == time_expected.all()
     assert artifacts_status_test.keys() == artifacts_status_expected.keys()
@@ -200,17 +201,17 @@ def test_remove_lytaf_events_1():
     np.testing.assert_array_equal(artifacts_status_test["not_removed"],
                                   artifacts_status_expected["not_removed"])
     assert artifacts_status_test["not_found"] == \
-      artifacts_status_expected["not_found"]
+        artifacts_status_expected["not_found"]
 
 
 def test_remove_lytaf_events_2():
     """Test _remove_lytaf_events() with no user artifacts found."""
     # Run _remove_lytaf_events
     time_test, channels_test, artifacts_status_test = \
-      lyra._remove_lytaf_events(
-          TIME, channels=CHANNELS, artifacts="Offpoint",
-          return_artifacts=True, lytaf_path=TEST_DATA_PATH,
-          force_use_local_lytaf=True)
+        lyra._remove_lytaf_events(
+            TIME, channels=CHANNELS, artifacts="Offpoint",
+            return_artifacts=True, lytaf_path=TEST_DATA_PATH,
+            force_use_local_lytaf=True)
     # Generated expected result
     time_expected = TIME
     channels_expected = CHANNELS
@@ -229,7 +230,7 @@ def test_remove_lytaf_events_2():
     np.testing.assert_array_equal(artifacts_status_test["not_removed"],
                                   artifacts_status_expected["not_removed"])
     assert artifacts_status_test["not_found"] == \
-      artifacts_status_expected["not_found"]
+        artifacts_status_expected["not_found"]
 
     # Test correct values are returned when return_artifacts kwarg not
     # supplied.
@@ -248,6 +249,7 @@ def test_remove_lytaf_events_2():
         lytaf_path=TEST_DATA_PATH, force_use_local_lytaf=True)
     assert time_test.all() == time_expected.all()
 
+
 def test_remove_lytaf_events_3():
     """Test if correct errors are raised by _remove_lytaf_events()."""
     with pytest.raises(TypeError):
@@ -264,9 +266,10 @@ def test_remove_lytaf_events_3():
                                   force_use_local_lytaf=True)
     with pytest.raises(ValueError):
         lyra._remove_lytaf_events(TIME,
-                                  artifacts=["LAR","incorrect artifact type"],
+                                  artifacts=["LAR", "incorrect artifact type"],
                                   lytaf_path=TEST_DATA_PATH,
                                   force_use_local_lytaf=True)
+
 
 def test_get_lytaf_events():
     """Test if LYTAF events are correctly downloaded and read in."""
@@ -375,7 +378,7 @@ def test_prep_columns():
 
     # Test case when channels supplied by user by not filecolumns
     string_time_test, filecolumns_test = lyra._prep_columns(time_input,
-                                                                channels_input)
+                                                            channels_input)
     np.testing.assert_array_equal(string_time_test, string_time_expected)
     assert filecolumns_test == filecolumns_expected
 
@@ -387,7 +390,7 @@ def test_prep_columns():
     # Test correct exceptions are raised
     with pytest.raises(TypeError):
         string_time_test, filecolumns_test = lyra._prep_columns(
-        time_input, channels_input, ["channel0", 1])
+            time_input, channels_input, ["channel0", 1])
     with pytest.raises(ValueError):
         string_time_test = lyra._prep_columns(time_input,
-                                          filecolumns=filecolumns_input)
+                                              filecolumns=filecolumns_input)


### PR DESCRIPTION
Closes #2239.

Change all the stuff in lyra.py to use TimeSeries instead of LightCurve. All the tests still pass locally so I assume it's all still ok.

LightCurve is dead, long live TimeSeries.