### PR TITLE
Add an attr for goes satellite number

### DIFF
--- a/examples/goes_hek_m25.py
+++ b/examples/goes_hek_m25.py
@@ -17,7 +17,7 @@ from sunpy.net import hek, Fido, attrs as a
 # Let's first grab GOES XRS data for a particular time of interest
 
 tr = TimeRange(['2011-06-07 04:00', '2011-06-07 12:00'])
-results = Fido.search(a.Time(tr), a.Instrument('GOES'))
+results = Fido.search(a.Time(tr), a.Instrument('XRS'))
 results
 
 ###############################################################################

--- a/examples/skip_timeseries_example.py
+++ b/examples/skip_timeseries_example.py
@@ -48,7 +48,7 @@ ts_gbm = sunpy.timeseries.TimeSeries(sunpy.data.sample.GBM_TIMESERIES, source='G
 ##############################################################################
 # You can create a list of TimeSeries objects by using multiple files. First
 # however, we shall download these files using `Fido`.
-goes = Fido.search(a.Time("2012/06/01", "2012/06/04"), a.Instrument("GOES"))
+goes = Fido.search(a.Time("2012/06/01", "2012/06/04"), a.Instrument("XRS"))
 goes_files = Fido.fetch(goes)
 
 # Using these new files you get a list:

--- a/examples/skip_timeseriesmetadata_example.py
+++ b/examples/skip_timeseriesmetadata_example.py
@@ -24,7 +24,7 @@ from sunpy.time import TimeRange, parse_time
 ##############################################################################
 # Search for Data
 
-goes_res = Fido.search(a.Time("2010-11-02", "2010-11-07"), a.Instrument('goes'))
+goes_res = Fido.search(a.Time("2010-11-02", "2010-11-07"), a.Instrument('XRS'))
 goes_res
 
 norh_res = Fido.search(a.Time("2010-11-02", "2010-11-07"), a.Instrument('norh'),

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -67,7 +67,7 @@ def fido_search_result():
     return Fido.search(
         net_attrs.Time("2012/1/1", "2012/1/2"),
         net_attrs.Instrument('lyra') | net_attrs.Instrument('eve') |
-        net_attrs.Instrument('goes') | net_attrs.Instrument('noaa-indices') |
+        net_attrs.Instrument('XRS') | net_attrs.Instrument('noaa-indices') |
         net_attrs.Instrument('noaa-predict') |
         (net_attrs.Instrument('norh') & net_attrs.Wavelength(17*units.GHz)) |
         net_attrs.Instrument('rhessi') |

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -47,7 +47,7 @@ def fido_search_result():
     return Fido.search(
         net_attrs.Time("2012/1/1", "2012/1/2"),
         net_attrs.Instrument('lyra') | net_attrs.Instrument('eve') |
-        net_attrs.Instrument('goes') | net_attrs.Instrument('noaa-indices') |
+        net_attrs.Instrument('XRS') | net_attrs.Instrument('noaa-indices') |
         net_attrs.Instrument('noaa-predict') |
         (net_attrs.Instrument('norh') & net_attrs.Wavelength(17 * u.GHz)) |
         net_attrs.Instrument('rhessi') |

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -2,7 +2,8 @@
 
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
+from .dataretriever.attrs import goes
 
 from .vso.attrs import Time, Instrument, Wavelength, Level
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc']
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'vso', 'jsoc', 'goes']

--- a/sunpy/net/dataretriever/attrs/__init__.py
+++ b/sunpy/net/dataretriever/attrs/__init__.py
@@ -1,0 +1,3 @@
+from . import goes
+
+__all__ = ['goes']

--- a/sunpy/net/dataretriever/attrs/goes.py
+++ b/sunpy/net/dataretriever/attrs/goes.py
@@ -1,0 +1,9 @@
+from ...vso.attrs import _VSOSimpleAttr
+
+__all__ = ['SatelliteNumber']
+
+
+class SatelliteNumber(_VSOSimpleAttr):
+    """
+    The GOES Satellite Number
+    """

--- a/sunpy/net/dataretriever/clients.py
+++ b/sunpy/net/dataretriever/clients.py
@@ -3,7 +3,7 @@
 # Import and register LC sources
 from .sources.eve import EVEClient
 from .sources.lyra import LYRAClient
-from .sources.goes import GOESClient
+from .sources.goes import XRSClient
 from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 from .sources.noaa import NOAAIndicesClient, NOAAPredictClient, SRSClient

--- a/sunpy/net/dataretriever/sources/__init__.py
+++ b/sunpy/net/dataretriever/sources/__init__.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import, division, print_function
-from ..client import GenericClient
 
-__all__ = ['EVEClient','GOESClient','LYRAClient','NOAAIndicesClient',
-           'NOAAPredictClient','NoRHClient','RHESSIClient']
+__all__ = [
+    'EVEClient', 'XRSClient', 'LYRAClient', 'NOAAIndicesClient', 'NOAAPredictClient', 'NoRHClient',
+    'RHESSIClient'
+]
 
 from .eve import EVEClient
-from .goes import GOESClient
+from .goes import XRSClient
 from .lyra import LYRAClient
-from .noaa import NOAAIndicesClient,NOAAPredictClient
+from .noaa import NOAAIndicesClient, NOAAPredictClient
 from .norh import NoRHClient
 from .rhessi import RHESSIClient

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -1,6 +1,6 @@
-#Author: Rishabh Sharma <rishabh.sharma.gunner@gmail.com>
-#This module was developed under funding provided by
-#Google Summer of Code 2014
+# Author: Rishabh Sharma <rishabh.sharma.gunner@gmail.com>
+# This module was developed under funding provided by
+# Google Summer of Code 2014
 
 import datetime
 

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -11,10 +11,10 @@ from ..client import GenericClient
 from sunpy import config
 TIME_FORMAT = config.get("general", "time_format")
 
-__all__ = ['GOESClient']
+__all__ = ['XRSClient']
 
 
-class GOESClient(GenericClient):
+class XRSClient(GenericClient):
     def _get_goes_sat_num(self, date):
         """
         Determines the satellite number for a given date.
@@ -116,6 +116,6 @@ class GOESClient(GenericClient):
         chkattr = ['Time', 'Instrument', 'SatelliteNumber']
         chklist = [x.__class__.__name__ in chkattr for x in query]
         for x in query:
-            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'goes':
+            if x.__class__.__name__ == 'Instrument' and x.value.lower() in ('xrs', 'goes'):
                 return all(chklist)
         return False

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -62,7 +62,7 @@ class GOESClient(GenericClient):
         ----------
         timerange: sunpy.time.TimeRange
             time range for which data is to be downloaded.
-        satellite_number : int
+        satellitenumber : int
             GOES satellite number (default = 15)
         data_type : string
             Data type to return for the particular GOES satellite. Supported
@@ -84,8 +84,9 @@ class GOESClient(GenericClient):
                 regex += "{date:%y%m%d}.fits"
             else:
                 regex += "{date:%Y%m%d}.fits"
+            satellitenumber = kwargs.get('satellitenumber', self._get_goes_sat_num(date))
             url = base_url + regex.format(
-                date=date, sat=self._get_goes_sat_num(date))
+                date=date, sat=satellitenumber)
             result.append(url)
         return result
 
@@ -112,7 +113,7 @@ class GOESClient(GenericClient):
         boolean
             answer as to whether client can service the query
         """
-        chkattr = ['Time', 'Instrument']
+        chkattr = ['Time', 'Instrument', 'SatelliteNumber']
         chklist = [x.__class__.__name__ in chkattr for x in query]
         for x in query:
             if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'goes':

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -11,7 +11,7 @@ from sunpy.net import attrs as a
 from hypothesis import given, example
 from sunpy.net.tests.strategies import goes_time
 
-LCClient = goes.GOESClient()
+LCClient = goes.XRSClient()
 
 
 @pytest.mark.parametrize(
@@ -31,11 +31,11 @@ def test_get_url_for_time_range(timerange, url_start, url_end):
 
 @given(goes_time())
 def test_can_handle_query(time):
-    ans1 = goes.GOESClient._can_handle_query(time, Instrument('XRS'))
+    ans1 = goes.XRSClient._can_handle_query(time, Instrument('XRS'))
     assert ans1 is True
-    ans2 = goes.GOESClient._can_handle_query(time)
+    ans2 = goes.XRSClient._can_handle_query(time)
     assert ans2 is False
-    ans3 = goes.GOESClient._can_handle_query(time, Instrument('eve'))
+    ans3 = goes.XRSClient._can_handle_query(time, Instrument('eve'))
     assert ans3 is False
 
 

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -43,6 +43,22 @@ def test_no_satellite():
     with pytest.raises(ValueError):
         LCClient.search(Time("1950/01/01", "1950/02/02"), Instrument('goes'))
 
+
+def test_fixed_satellite():
+    ans1 = LCClient.search(a.Time("2017/01/01", "2017/01/02"),
+                           a.Instrument('goes'))
+
+    for resp in ans1:
+        assert "go15" in resp.url
+
+    ans1 = LCClient.search(a.Time("2017/01/01", "2017/01/02"),
+                           a.Instrument('goes'),
+                           a.goes.SatelliteNumber(13))
+
+    for resp in ans1:
+        assert "go13" in resp.url
+
+
 @example(a.Time("2006-08-01", "2006-08-01"))
 @example(a.Time("1983-05-01", "1983-05-02"))
 # This example tests a time range with a satellite jump and no overlap

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -31,7 +31,7 @@ def test_get_url_for_time_range(timerange, url_start, url_end):
 
 @given(goes_time())
 def test_can_handle_query(time):
-    ans1 = goes.GOESClient._can_handle_query(time, Instrument('goes'))
+    ans1 = goes.GOESClient._can_handle_query(time, Instrument('XRS'))
     assert ans1 is True
     ans2 = goes.GOESClient._can_handle_query(time)
     assert ans2 is False
@@ -41,18 +41,18 @@ def test_can_handle_query(time):
 
 def test_no_satellite():
     with pytest.raises(ValueError):
-        LCClient.search(Time("1950/01/01", "1950/02/02"), Instrument('goes'))
+        LCClient.search(Time("1950/01/01", "1950/02/02"), Instrument('XRS'))
 
 
 def test_fixed_satellite():
     ans1 = LCClient.search(a.Time("2017/01/01", "2017/01/02"),
-                           a.Instrument('goes'))
+                           a.Instrument('XRS'))
 
     for resp in ans1:
         assert "go15" in resp.url
 
     ans1 = LCClient.search(a.Time("2017/01/01", "2017/01/02"),
-                           a.Instrument('goes'),
+                           a.Instrument('XRS'),
                            a.goes.SatelliteNumber(13))
 
     for resp in ans1:
@@ -68,9 +68,9 @@ def test_query(time):
     tr = TimeRange(time.start, time.end)
     if parse_time("1983-05-01") in tr:
         with pytest.raises(ValueError):
-            LCClient.search(time, Instrument('goes'))
+            LCClient.search(time, Instrument('XRS'))
     else:
-        qr1 = LCClient.search(time, Instrument('goes'))
+        qr1 = LCClient.search(time, Instrument('XRS'))
         assert isinstance(qr1, QueryResponse)
         assert qr1.time_range().start == time.start
         assert qr1.time_range().end == time.end
@@ -78,8 +78,8 @@ def test_query(time):
 
 @pytest.mark.online
 @pytest.mark.parametrize("time, instrument", [
-    (Time('1983/06/17', '1983/06/18'), Instrument('goes')),
-    (Time('2012/10/4', '2012/10/6'), Instrument('goes')),
+    (Time('1983/06/17', '1983/06/18'), Instrument('XRS')),
+    (Time('2012/10/4', '2012/10/6'), Instrument('XRS')),
 ])
 def test_get(time, instrument):
     qr1 = LCClient.search(time, instrument)
@@ -90,7 +90,7 @@ def test_get(time, instrument):
 
 @pytest.mark.online
 def test_new_logic():
-    qr = LCClient.search(Time('2012/10/4', '2012/10/6'), Instrument('goes'))
+    qr = LCClient.search(Time('2012/10/4', '2012/10/6'), Instrument('XRS'))
     res = LCClient.fetch(qr)
     download_list = res.wait(progress=False)
     assert len(download_list) == len(qr)
@@ -102,7 +102,7 @@ def test_new_logic():
     [(a.Time("2012/10/4", "2012/10/6"), a.Instrument("goes")),
      (a.Time('2013/10/5', '2013/10/7'), a.Instrument("goes"))])
 def test_fido(time, instrument):
-    qr = Fido.search(a.Time('2012/10/4', '2012/10/6'), Instrument('goes'))
+    qr = Fido.search(a.Time('2012/10/4', '2012/10/6'), Instrument('XRS'))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile


### PR DESCRIPTION
This is a fix to the issue raised on the mailinglist. It adds client specific attrs for inside dataretriver for the first time. It can be used like:

```python
from sunpy.net import Fido, attrs as a

Fido.search(a.Time("2017/01/01", "2017/01/02"), a.Instrument("goes"),
            a.goes.SatelliteNumber(13))
```