### PR TITLE
Add link to list of all allowed attributes when searching for data

### DIFF
--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -22,6 +22,8 @@ Searching for Data Using Fido
 -----------------------------
 
 To search for data with Fido, you need to specify attributes to search against.
+The full list of allowed attributes can be found in the
+`vso.attrs <sunpy.net.vso.attrs>` module.
 Examples of these attributes are `a.Time <sunpy.net.vso.attrs.Time>`,
 `a.Instrument <sunpy.net.vso.attrs.Instrument>`,
 `a.Wavelength <sunpy.net.vso.attrs.Wavelength>`, some of these attributes are


### PR DESCRIPTION
I spent a while recently trying to work out exactly what the different attributes are allowed by `Fido.search`; after a while I found them! This adds a link from the guide to searching for data to a list of all the allowed attributes.