### PR TITLE
[Doc Fix] SQLAlchemy docs now, not docs2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,7 @@ check_sphinx_version(needs_sphinx)
 # add any custom intersphinx for sunpy
 intersphinx_mapping.pop('h5py', None)
 intersphinx_mapping['astropy'] = ('http://docs.astropy.org/en/stable/', None)
-intersphinx_mapping['sqlalchemy'] = ('http://docs2.sqlalchemy.org/en/latest/', None)
+intersphinx_mapping['sqlalchemy'] = ('http://docs.sqlalchemy.org/en/latest/', None)
 intersphinx_mapping['pandas'] = ('http://pandas.pydata.org/pandas-docs/stable/', None)
 intersphinx_mapping['skimage'] = ('http://scikit-image.org/docs/stable/', None)
 


### PR DESCRIPTION
URL change was creating warnings in doc build. This fixes that.

Let us find out if that is the only issue!