### PR TITLE
fix formatting of multiline examples on docs

### DIFF
--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -57,7 +57,7 @@ passbands can be searched for by supplying an `~astropy.units.Quantity` to the
 
     >>> import astropy.units as u
     >>> result = Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument('norh'),
-                             a.Wavelength(17*u.GHz))
+    ...                      a.Wavelength(17*u.GHz))
 
 Data of a given cadence can also be specified using the Sample attribute. To
 search for data at a given cadence use the
@@ -69,17 +69,17 @@ like this which are client specific will result in
 client for results, in this case VSO.::
 
     >>> result = Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument('aia'),
-                             a.Wavelength(171*u.angstrom), a.vso.Sample(10*u.minute))
+    ...                      a.Wavelength(171*u.angstrom), a.vso.Sample(10*u.minute))
 
 To search for data from multiple instruments, wavelengths, times etc., use the
 pipe ``|`` operator. This joins queries together just as the logical ``OR``
 operator would::
 
     >>> result = Fido.search(a.Time('2012/3/4', '2012/3/6'),
-                             a.Instrument('lyra') | a.Instrument('rhessi'))
+    ...                      a.Instrument('lyra') | a.Instrument('rhessi'))
 
     >>> result = Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument('aia'),
-                             a.Wavelength(171*u.angstrom) | a.Wavelength(94*u.angstrom))
+    ...                      a.Wavelength(171*u.angstrom) | a.Wavelength(94*u.angstrom))
 
 
 Indexing search results

--- a/docs/guide/tour.rst
+++ b/docs/guide/tour.rst
@@ -157,7 +157,7 @@ a short bit of code to get you started: ::
     >>> from sunpy.sun import constants as con
 
     # one astronomical unit (the average distance between the Sun and Earth)
-    >>> print con.au
+    >>> print(con.au)
       Name   = Astronomical Unit
       Value  = 1.495978707e+11
       Error  = 0.0
@@ -165,7 +165,7 @@ a short bit of code to get you started: ::
       Reference = IAU 2012 Resolution B2
 
     # the solar radius
-    >>> print con.radius
+    >>> print(con.radius)
       Name   = Solar radius
       Value  = 695508000.0
       Error  = 26000.0
@@ -350,7 +350,7 @@ A simple example of this is shown below::
 
   >>> db = Database()
   >>> db.fetch(a.Time("2011-09-20T01:00:00", "2011-09-20T02:00:00"),
-               a.Instrument('AIA'), a.vso.Sample(15*u.min))
+  ...          a.Instrument('AIA'), a.vso.Sample(15*u.min))
   >>> db.commit()
 
   >>> db


### PR DESCRIPTION
And also a couple of old lonely old `print`

This is related with #2315 - as seen in [FIDO's documentation](http://docs.sunpy.org/en/stable/guide/acquiring_data/fido.html).

I've not checked all the docstrings, but the ones I've checked randomly seems all right.