### PR TITLE
Make the database FITS reader be FITS time compliant.

### DIFF
--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -704,23 +704,26 @@ def entries_from_file(file, default_waveunit=None,
 
         entry.instrument = header.get('INSTRUME')
         wave = header.get('WAVELNTH')
-        if wave and unit is None:
+        if wave is None:
+            pass
+        elif unit is None:
             raise WaveunitNotFoundError(file)
         else:
             entry.wavemin = entry.wavemax = unit.to(
-                u.nm, value, u.equivalencies.spectral())
-
-        end_time = header.get('DATE-END', header.get('DATE-END'))
-        entry.observation_time_end = parse_time(
-            end_time,
+                u.nm, wave, u.equivalencies.spectral())
+        end_time = header.get('DATE-END', header.get('DATE_END'))
+        if end_time is None:
+            pass
+        else:
+            entry.observation_time_end = parse_time(end_time,
             _time_string_parse_format=time_string_parse_format
-        )
+            )
 
-        start_time = header.get('DATE-BEG', header.get('DATE-END', header.get('DATE_OBS')))
-        entry.observation_time_start = parse_time(
-            start_time,
-            _time_string_parse_format=time_string_parse_format
-        )
+        start_time = header.get('DATE-BEG', header.get('DATE_OBS', header.get('DATE_OBS')))
+        if start_time is None:
+            entry.observation_time_start = parse_time(start_time,
+                _time_string_parse_format=time_string_parse_format
+            )
 
         yield entry
 

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -704,23 +704,20 @@ def entries_from_file(file, default_waveunit=None,
 
         entry.instrument = header.get('INSTRUME')
         wave = header.get('WAVELNTH')
-        if wave is None:
-            pass
-        elif unit is None:
+        if unit is None:
             raise WaveunitNotFoundError(file)
-        else:
+        elif wave is not None:
             entry.wavemin = entry.wavemax = unit.to(
                 u.nm, wave, u.equivalencies.spectral())
         end_time = header.get('DATE-END', header.get('DATE_END'))
-        if end_time is None:
-            pass
-        else:
+
+        if end_time is not None:
             entry.observation_time_end = parse_time(end_time,
             _time_string_parse_format=time_string_parse_format
             )
 
         start_time = header.get('DATE-BEG', header.get('DATE_OBS', header.get('DATE_OBS')))
-        if start_time is None:
+        if start_time is not None:
             entry.observation_time_start = parse_time(start_time,
                 _time_string_parse_format=time_string_parse_format
             )


### PR DESCRIPTION
This is primarily a bug fix to make the database correctly read `DATE-BEG` and `DATE-END` as specified in the FITS Time spec http://adsabs.harvard.edu/abs/2015A%26A...574A..36R

It needed a little reworking of the FITS reader to make it respect the priorities as required by the standard. I also could not let the units import live.