### PR TITLE
Fix matplotlib / pandas 0.21 bug in examples

### DIFF
--- a/sunpy/timeseries/__init__.py
+++ b/sunpy/timeseries/__init__.py
@@ -18,7 +18,11 @@ from sunpy.timeseries.sources.norh import NoRHTimeSeries
 from sunpy.timeseries.sources.rhessi import RHESSISummaryTimeSeries
 from sunpy.timeseries.sources.fermi_gbm import GBMSummaryTimeSeries
 
-# register pandas datetime converter with matplotlib
-# This is to work around the change in pandas-dev/pandas#17710
-import pandas.plotting._converter
-pandas.plotting._converter.register()
+
+try:
+    # register pandas datetime converter with matplotlib
+    # This is to work around the change in pandas-dev/pandas#17710
+    import pandas.plotting._converter
+    pandas.plotting._converter.register()
+except ImportError:
+    pass

--- a/sunpy/timeseries/__init__.py
+++ b/sunpy/timeseries/__init__.py
@@ -14,3 +14,8 @@ from sunpy.timeseries.sources.lyra import LYRATimeSeries
 from sunpy.timeseries.sources.norh import NoRHTimeSeries
 from sunpy.timeseries.sources.rhessi import RHESSISummaryTimeSeries
 from sunpy.timeseries.sources.fermi_gbm import GBMSummaryTimeSeries
+
+# register pandas datetime converter with matplotlib
+# This is to work around the change in pandas-dev/pandas#17710
+import pandas.plotting._converter
+pandas.plotting._converter.register()

--- a/sunpy/timeseries/__init__.py
+++ b/sunpy/timeseries/__init__.py
@@ -1,7 +1,10 @@
 """
-SunPy's TimeSeries module provides a datatype for 1D time series data, replacing the SunPy LightCurve module.
+SunPy's TimeSeries module provides a datatype for 1D time series data, replacing
+the SunPy LightCurve module.
 
-Currently the objects can be instansiated from files (such as CSV and FITS) and urls to these files, but don't include data downloaders for their specific instruments as this will become part of the universal downloader.
+Currently the objects can be instansiated from files (such as CSV and FITS) and
+urls to these files, but don't include data downloaders for their specific
+instruments as this will become part of the universal downloader.
 """
 from __future__ import absolute_import
 from sunpy.timeseries.metadata import TimeSeriesMetaData


### PR DESCRIPTION
Here we manually register the pandas matplotlib converters so people doing manual plotting with pandas works under pandas 0.21