### PR TITLE
Don't use conda-forge as numpy-dev is not building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='astropy astropy-ci-extras conda-forge'
-        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock pyyaml pandas nomkl pytest-cov coverage glymur'
+        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock pyyaml pandas nomkl glymur'
         - PIP_DEPENDENCIES='hypothesis suds-jurko sphinx-gallery pytest-sugar pytest-rerunfailures sunpy-sphinx-theme'
         - EVENT_TYPE='pull_request push'
 
@@ -56,6 +56,7 @@ matrix:
          - python: 3.6
            env: NUMPY_VERSION='dev' ASTROPY_VERSION='dev'
                 EVENT_TYPE='push pull_request cron'
+                CONDA_CHANNELS='astropy'
 
          - python: 2.7
            env: SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ env:
         - ASTROPY_VERSION='stable'
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
-        - CONDA_CHANNELS='astropy astropy-ci-extras conda-forge'
-        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock pyyaml pandas nomkl glymur'
-        - PIP_DEPENDENCIES='hypothesis suds-jurko sphinx-gallery pytest-sugar pytest-rerunfailures sunpy-sphinx-theme'
+        - CONDA_CHANNELS='astropy astropy-ci-extras'
+        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock pyyaml pandas nomkl'
+        - PIP_DEPENDENCIES='hypothesis suds-jurko sphinx-gallery pytest-sugar pytest-rerunfailures sunpy-sphinx-theme glymur'
         - EVENT_TYPE='pull_request push'
 
     matrix:
@@ -56,7 +56,6 @@ matrix:
          - python: 3.6
            env: NUMPY_VERSION='dev' ASTROPY_VERSION='dev'
                 EVENT_TYPE='push pull_request cron'
-                CONDA_CHANNELS='astropy'
 
          - python: 2.7
            env: SETUP_CMD='test'


### PR DESCRIPTION
conda-forge is used to get glymur, but installing numpy-dev is started to fail due to one of the packages pull from there, thus it's removed from the channel list and glymur is installed with pip.

This PR also removed the coverage dependencies, as ci-helpers installs them anyway when ``--coverage`` is used in the test command.