### PR TITLE
Support array values for `obstime` for coordinates and transformations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Bug Fixes
 - Travis CI fix for numpy-dev build [#2340]
 - Updated masking brightest pixel example [#2338]
 - Changed TRAVIS cronjobs [#2338]
+- Support array values for `obstime` for coordinates and transformations [#2342]
 
 0.8.2
 =====

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -215,12 +215,16 @@ def _sun_north_angle_to_z(frame):
     and observation time.
     """
     # Find the Sun center in HGS at the frame's observation time
-    sun_center = SkyCoord(0*u.deg, 0*u.deg, 0*u.km, frame=HGS, obstime=frame.obstime)
+    sun_center_repr = SphericalRepresentation(0*u.deg, 0*u.deg, 0*u.km)
+    sun_center = SkyCoord(sun_center_repr._apply('repeat', frame.obstime.size),
+                          frame=HGS, obstime=frame.obstime)
 
     # Find the Sun north in HGS at the frame's observation time
     # Only a rough value of the solar radius is needed here because, after the cross product,
     #   only the direction from the Sun center to the Sun north pole matters
-    sun_north = SkyCoord(0*u.deg, 90*u.deg, 690000*u.km, frame=HGS, obstime=frame.obstime)
+    sun_north_repr = SphericalRepresentation(0*u.deg, 90*u.deg, 690000*u.km)
+    sun_north = SkyCoord(sun_north_repr._apply('repeat', frame.obstime.size),
+                         frame=HGS, obstime=frame.obstime)
 
     # Find the Sun center and Sun north in the frame's coordinate system
     sky_normal = sun_center.transform_to(frame).data.to_cartesian()
@@ -239,5 +243,8 @@ def _sun_north_angle_to_z(frame):
     cos_theta = sun_north_in_sky.dot(z_in_sky)
     sin_theta = sun_north_in_sky.cross(z_in_sky).dot(sky_normal)
     angle = np.arctan2(sin_theta, cos_theta).to('deg')
+
+    if angle.size == 1:
+        angle = angle[0]
 
     return Angle(angle)

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -214,15 +214,17 @@ def _sun_north_angle_to_z(frame):
     Return the angle between solar north and the Z axis of the provided frame's coordinate system
     and observation time.
     """
-    # Find the Sun center in HGS at the frame's observation time
+    # Find the Sun center in HGS at the frame's observation time(s)
     sun_center_repr = SphericalRepresentation(0*u.deg, 0*u.deg, 0*u.km)
+    # The representation is repeated for as many times as are in obstime prior to transformation
     sun_center = SkyCoord(sun_center_repr._apply('repeat', frame.obstime.size),
                           frame=HGS, obstime=frame.obstime)
 
-    # Find the Sun north in HGS at the frame's observation time
+    # Find the Sun north in HGS at the frame's observation time(s)
     # Only a rough value of the solar radius is needed here because, after the cross product,
     #   only the direction from the Sun center to the Sun north pole matters
     sun_north_repr = SphericalRepresentation(0*u.deg, 90*u.deg, 690000*u.km)
+    # The representation is repeated for as many times as are in obstime prior to transformation
     sun_north = SkyCoord(sun_north_repr._apply('repeat', frame.obstime.size),
                          frame=HGS, obstime=frame.obstime)
 
@@ -244,6 +246,7 @@ def _sun_north_angle_to_z(frame):
     sin_theta = sun_north_in_sky.cross(z_in_sky).dot(sky_normal)
     angle = np.arctan2(sin_theta, cos_theta).to('deg')
 
+    # If there is only one time, this function's output should be scalar rather than array
     if angle.size == 1:
         angle = angle[0]
 

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -79,10 +79,6 @@ class TimeFrameAttributeSunPy(TimeAttribute):
                 raise ValueError('Invalid time input {0}={1!r}\n{2}'.format(self.name, value, err))
             converted = True
 
-        if not out.isscalar:
-            raise ValueError('Time input {0}={1!r} must be a single (scalar) value'
-                             .format(self.name, value))
-
         return out, converted
 
 

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -3,6 +3,7 @@
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import EarthLocation
+from astropy.time import Time
 
 from sunpy.coordinates.ephemeris import *
 
@@ -34,39 +35,51 @@ def test_get_earth():
 
 
 def test_get_sun_B0():
-    # Validate against published values from the Astronomical Almanac (2013)
-    assert_quantity_allclose(get_sun_B0('2013-Apr-01'), -6.54*u.deg, atol=5e-3*u.deg)
-    assert_quantity_allclose(get_sun_B0('2013-Dec-01'), 0.88*u.deg, atol=5e-3*u.deg)
-
     # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
     assert_quantity_allclose(get_sun_B0('1992-Oct-13'), 5.99*u.deg, atol=5e-3*u.deg)
 
 
-def test_get_sun_L0():
+def test_get_sun_B0_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
-    assert_quantity_allclose(get_sun_L0('2013-Apr-01'), 221.44*u.deg, atol=3e-2*u.deg)
-    assert_quantity_allclose(get_sun_L0('2013-Dec-01'), 237.83*u.deg, atol=3e-2*u.deg)
+    sun_B0 = get_sun_B0(Time(['2013-04-01', '2013-12-01']))
+    assert_quantity_allclose(sun_B0[0], -6.54*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(sun_B0[1], 0.88*u.deg, atol=5e-3*u.deg)
 
+
+def test_get_sun_L0():
     # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
     assert_quantity_allclose(get_sun_L0('1992-Oct-13'), 238.6317*u.deg, atol=5e-5*u.deg)
 
 
-def test_get_sun_P():
+def test_get_sun_L0_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
-    assert_quantity_allclose(get_sun_P('2013-Apr-01'), -26.15*u.deg, atol=1e-2*u.deg)
-    assert_quantity_allclose(get_sun_P('2013-Dec-01'), 16.05*u.deg, atol=1e-2*u.deg)
+    sun_L0 = get_sun_L0(Time(['2013-04-01', '2013-12-01']))
+    assert_quantity_allclose(sun_L0[0], 221.44*u.deg, atol=3e-2*u.deg)
+    assert_quantity_allclose(sun_L0[1], 237.83*u.deg, atol=3e-2*u.deg)
 
+
+def test_get_sun_P():
     # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
     assert_quantity_allclose(get_sun_P('1992-Oct-13'), 26.27*u.deg, atol=5e-3*u.deg)
 
 
-def test_get_sunearth_distance():
+def test_get_sun_P_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
-    assert_quantity_allclose(get_sunearth_distance('2013-Apr-01'), 0.9992311*u.AU, atol=5e-7*u.AU)
-    assert_quantity_allclose(get_sunearth_distance('2013-Dec-01'), 0.9861362*u.AU, atol=5e-7*u.AU)
+    sun_P = get_sun_P(Time(['2013-04-01', '2013-12-01']))
+    assert_quantity_allclose(sun_P[0], -26.15*u.deg, atol=1e-2*u.deg)
+    assert_quantity_allclose(sun_P[1], 16.05*u.deg, atol=1e-2*u.deg)
 
+
+def test_get_sunearth_distance():
     # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
     assert_quantity_allclose(get_sunearth_distance('1992-Oct-13'), 0.997608*u.AU, atol=5e-7*u.AU)
+
+
+def test_get_sunearth_distance_array_time():
+    # Validate against published values from the Astronomical Almanac (2013)
+    sunearth_distance = get_sunearth_distance(Time(['2013-04-01', '2013-12-01']))
+    assert_quantity_allclose(sunearth_distance[0], 0.9992311*u.AU, atol=5e-7*u.AU)
+    assert_quantity_allclose(sunearth_distance[1], 0.9861362*u.AU, atol=5e-7*u.AU)
 
 
 def test_get_sun_orientation():

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -79,12 +79,6 @@ def test_on_frame_error2():
         Helioprojective(obstime=17263871263)
 
 
-def test_array():
-    input = Time(['2012-01-01 00:00:00', '2012-01-01 00:00:05'])
-    with pytest.raises(ValueError):
-        Helioprojective(obstime=input)
-
-
 # ObserverCoordinateAttribute
 
 

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -82,6 +82,27 @@ def test_hcrs_hgs():
     assert quantity_allclose(earth_hgs.radius, 1*u.AU, atol=0.017*u.AU)
 
 
+def test_hcrs_hgs_array_obstime():
+    # Get the Earth location in HCRS at two times
+    times = Time(['2017-01-01', '2017-06-01'])
+    earth_hcrs = SkyCoord(get_body_barycentric('earth', times), frame='icrs', obstime=times).hcrs
+
+    # Transform each time in separate calls (uses scalar obstime)
+    earth_hgs_0 = earth_hcrs[0].transform_to(HeliographicStonyhurst)
+    earth_hgs_1 = earth_hcrs[1].transform_to(HeliographicStonyhurst)
+
+    # Transform both times in one call (uses array obstime)
+    earth_hgs = earth_hcrs.transform_to(HeliographicStonyhurst)
+
+    # Confirm that the two approaches produce the same results
+    assert quantity_allclose(earth_hgs_0.lon, earth_hgs[0].lon, rtol=1e-10)
+    assert quantity_allclose(earth_hgs_0.lat, earth_hgs[0].lat, rtol=1e-10)
+    assert quantity_allclose(earth_hgs_0.radius, earth_hgs[0].radius, rtol=1e-10)
+    assert quantity_allclose(earth_hgs_1.lon, earth_hgs[1].lon, rtol=1e-10)
+    assert quantity_allclose(earth_hgs_1.lat, earth_hgs[1].lat, rtol=1e-10)
+    assert quantity_allclose(earth_hgs_1.radius, earth_hgs[1].radius, rtol=1e-10)
+
+
 def test_hgs_hgc_roundtrip():
     obstime = "2011-01-01"
 

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -95,10 +95,10 @@ def test_hcrs_hgs_array_obstime():
     earth_hgs = earth_hcrs.transform_to(HeliographicStonyhurst)
 
     # Confirm that the two approaches produce the same results
-    assert quantity_allclose(earth_hgs_0.lon, earth_hgs[0].lon, rtol=1e-10)
+    assert quantity_allclose(earth_hgs_0.lon, earth_hgs[0].lon, atol=1e-12*u.deg)
     assert quantity_allclose(earth_hgs_0.lat, earth_hgs[0].lat, rtol=1e-10)
     assert quantity_allclose(earth_hgs_0.radius, earth_hgs[0].radius, rtol=1e-10)
-    assert quantity_allclose(earth_hgs_1.lon, earth_hgs[1].lon, rtol=1e-10)
+    assert quantity_allclose(earth_hgs_1.lon, earth_hgs[1].lon, atol=1e-12*u.deg)
     assert quantity_allclose(earth_hgs_1.lat, earth_hgs[1].lat, rtol=1e-10)
     assert quantity_allclose(earth_hgs_1.radius, earth_hgs[1].radius, rtol=1e-10)
 


### PR DESCRIPTION
The use of array values for `obstime` (as opposed to scalar values) is not currently supported for SunPy coordinates.  This PR:

- Allows array values for `obstime`
- Updated the HCRS<->HGS transformation (the glue between Astropy and SunPy frames) to be able to handle array values for `obstime`
- Updated the ephemeris functions to handle array inputs for time

Here's an example of getting the Sun's P angle for a list of times:
```python
>>> from astropy.time import Time
>>> import astropy.units as u
>>> from sunpy.coordinates import get_sun_P

>>> times = Time('2017-06-15 06:00') + range(-24, 25, 4)*u.hour
>>> get_sun_P(times)
<Angle [-10.05231528, -9.9813293 , -9.91026041, -9.8391093 , -9.76787668,
         -9.69656324, -9.6251697 , -9.55369676, -9.48214512, -9.4105155 ,
         -9.33880861, -9.26702517, -9.19516587] deg>
```

Here's an example of using this functionality to easily calculate the position of the Crab Nebula in helioprojective coordinates for a list of times (by a default observer at Earth):
```python
>>> from astropy.time import Time
>>> import astropy.units as u
>>> from astropy.coordinates import SkyCoord
>>> import sunpy.coordinates

>>> times = Time('2017-06-15 06:00') + range(-24, 25, 4) * u.hour
>>> crab = SkyCoord('05h34m31.94s', '+22d00m52.2s', 6500*u.lightyear, frame='icrs', obstime=times)

>>> crab.helioprojective
<SkyCoord (Helioprojective: obstime=['2017-06-14 06:00:00.000' '2017-06-14 10:00:00.000'
 '2017-06-14 14:00:00.000' '2017-06-14 18:00:00.000'
 '2017-06-14 22:00:00.000' '2017-06-15 02:00:00.000'
 '2017-06-15 06:00:00.000' '2017-06-15 10:00:00.000'
 '2017-06-15 14:00:00.000' '2017-06-15 18:00:00.000'
 '2017-06-15 22:00:00.000' '2017-06-16 02:00:00.000'
 '2017-06-16 06:00:00.000'], rsun=695508.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=['2017-06-14 06:00:00.000' '2017-06-14 10:00:00.000'
 '2017-06-14 14:00:00.000' '2017-06-14 18:00:00.000'
 '2017-06-14 22:00:00.000' '2017-06-15 02:00:00.000'
 '2017-06-15 06:00:00.000' '2017-06-15 10:00:00.000'
 '2017-06-15 14:00:00.000' '2017-06-15 18:00:00.000'
 '2017-06-15 22:00:00.000' '2017-06-16 02:00:00.000'
 '2017-06-16 06:00:00.000']): (lon, lat, radius) in (deg, deg, AU)
    [( 0.,  0.93120778,  1.01565833), ( 0.,  0.95113903,  1.01567535),
     ( 0.,  0.97106267,  1.01569227), ( 0.,  0.99097855,  1.01570908),
     ( 0.,  1.01088652,  1.01572579), ( 0.,  1.03078643,  1.01574239),
     ( 0.,  1.05067814,  1.01575888), ( 0.,  1.07056149,  1.01577527),
     ( 0.,  1.09043633,  1.01579154), ( 0.,  1.11030252,  1.0158077 ),
     ( 0.,  1.13015991,  1.01582375), ( 0.,  1.15000835,  1.01583969),
     ( 0.,  1.16984769,  1.01585551)]>): (Tx, Ty, distance) in (arcsec, arcsec, km)
    [(-2821.570214  , -5044.39576901,   6.14947482e+16),
     (-2253.24671907, -4972.53385709,   6.14947482e+16),
     (-1684.93845223, -4900.72103927,   6.14947482e+16),
     (-1116.64475473, -4828.95948339,   6.14947482e+16),
     ( -548.36497281, -4757.2513566 ,   6.14947482e+16),
     (   19.90154201, -4685.59882538,   6.14947482e+16),
     (  588.15543267, -4614.00405543,   6.14947482e+16),
     ( 1156.39733642, -4542.46921163,   6.14947482e+16),
     ( 1724.62788448, -4470.99645799,   6.14947482e+16),
     ( 2292.84770182, -4399.58795763,   6.14947482e+16),
     ( 2861.05740666, -4328.24587269,   6.14947482e+16),
     ( 3429.25761019, -4256.97236434,   6.14947482e+16),
     ( 3997.44891624, -4185.76959271,   6.14947482e+16)]>
```