### PR TITLE
Change to using pytest-remotedata for our online tests

### DIFF
--- a/docs/dev_guide/tests.rst
+++ b/docs/dev_guide/tests.rst
@@ -41,7 +41,7 @@ working connection to the internet. pytest is configured in a way that it
 iterates over all tests that have been marked as *online* and checks if
 there is an established connection to the internet. If there is none, the
 test is skipped, otherwise it is run. Marking tests is pretty
-straightforward in pytest: use the decorator ``@pytest.mark.online`` to
+straightforward in pytest: use the decorator ``@pytest.mark.remote_data`` to
 mark a test function as needing an internet connection.
 
 Writing a unit test for a figure

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,3 +9,4 @@ pytest
 pytest-cov
 pytest-mock
 pytest-rerunfailures
+pytest-astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ show-response = 1
 minversion = 3.0
 python_files = test_?*.py
 norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "astropy_helpers"
+remote_data_strict = True
 doctest_plus = enabled
 addopts = -p no:warnings -p no:doctest
 markers =

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -4,6 +4,7 @@ from functools import partial
 import os
 import tempfile
 import json
+import socket
 
 # Force MPL to use non-gui backends for testing.
 try:
@@ -44,7 +45,8 @@ def pytest_runtest_setup(item):
     if isinstance(item, item.Function):
         if 'remote_data' in item.keywords and not HAVE_REMOTEDATA:
             pytest.skip("skipping remotedata tests as pytest-remotedata is not installed")
-
+        if 'remote_data' in item.keywords:
+            item.add_marker(pytest.mark.xfail(raises=socket.timeout)
 
 def pytest_unconfigure(config):
     if len(figure_test_pngfiles) > 0:

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -15,6 +15,35 @@ else:
 
 from sunpy.tests.hash import HASH_LIBRARY_NAME
 from sunpy.tests.helpers import new_hash_library, figure_test_pngfiles
+from sunpy.extern import six
+
+import pytest
+
+
+# Don't actually import pytest_remotedata because that can do things to the
+# entrypoints code in pytest.
+if six.PY2:
+    import imp
+    try:
+        imp.find_module('pytest_remotedata')
+        HAVE_REMOTEDATA = True
+    except ImportError:
+        HAVE_REMOTEDATA = False
+else:
+    import importlib
+    remotedata_spec = importlib.util.find_spec("pytest_remotedata")
+    HAVE_REMOTEDATA = remotedata_spec is not None
+
+
+def pytest_runtest_setup(item):
+    """
+    pytest hook to skip all tests that have the mark 'online' if the
+    client is online (simply detected by checking whether http://www.google.com
+    can be requested).
+    """
+    if isinstance(item, item.Function):
+        if 'remote_data' in item.keywords and not HAVE_REMOTEDATA:
+            pytest.skip("skipping remotedata tests as pytest-remotedata is not installed")
 
 
 def pytest_unconfigure(config):

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -43,10 +43,11 @@ def pytest_runtest_setup(item):
     can be requested).
     """
     if isinstance(item, item.Function):
-        if 'remote_data' in item.keywords and not HAVE_REMOTEDATA:
-            pytest.skip("skipping remotedata tests as pytest-remotedata is not installed")
         if 'remote_data' in item.keywords:
-            item.add_marker(pytest.mark.xfail(raises=socket.timeout)
+            if not HAVE_REMOTEDATA:
+                pytest.skip("skipping remotedata tests as pytest-remotedata is not installed")
+            else:
+                item.add_marker(pytest.mark.xfail(raises=socket.timeout))
 
 def pytest_unconfigure(config):
     if len(figure_test_pngfiles) > 0:

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -2,14 +2,8 @@ from __future__ import absolute_import, print_function
 from functools import partial
 
 import os
-import socket
 import tempfile
 import json
-
-from sunpy.extern.six.moves.urllib.request import urlopen
-from sunpy.extern.six.moves.urllib.error import URLError
-
-import pytest
 
 # Force MPL to use non-gui backends for testing.
 try:
@@ -19,42 +13,8 @@ except ImportError:
 else:
     matplotlib.use('Agg')
 
-from astropy.tests import disable_internet
 from sunpy.tests.hash import HASH_LIBRARY_NAME
 from sunpy.tests.helpers import new_hash_library, figure_test_pngfiles
-
-GOOGLE_URL = 'http://www.google.com'
-
-
-def site_reachable(url):
-    try:
-        urlopen(url, timeout=1)
-    except (URLError, socket.timeout):
-        return False
-    else:
-        return True
-
-
-is_online = partial(site_reachable, GOOGLE_URL)
-
-
-def pytest_runtest_setup(item):
-    """
-    pytest hook to skip all tests that have the mark 'online' if the
-    client is online (simply detected by checking whether http://www.google.com
-    can be requested).
-    """
-    if isinstance(item, item.Function):
-        if 'online' in item.keywords and not is_online():
-            msg = 'skipping test {0} (reason: client seems to be offline)'
-            pytest.skip(msg.format(item.name))
-
-        if 'online' not in item.keywords:
-            disable_internet.turn_off_internet()
-
-
-def pytest_runtest_teardown(item, nextitem):
-    disable_internet.turn_on_internet()
 
 
 def pytest_unconfigure(config):

--- a/sunpy/database/tests/test_attrs.py
+++ b/sunpy/database/tests/test_attrs.py
@@ -404,7 +404,7 @@ def test_walker_create_fitsheader_inverted(session):
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_walker_create_vso_instrument(vso_session):
     entries = walker.create(vso.attrs.Instrument('RHESSI'), vso_session)
     assert entries == [
@@ -423,7 +423,7 @@ def test_walker_create_vso_instrument(vso_session):
             instrument=u'RHESSI', size=-1.0, wavemin=0.4132806579880238,
             wavemax=7.293188082141598e-05)]
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_walker_create_wave(vso_session):
     entries = walker.create(vso.attrs.Wavelength(0 * u.AA, 10 * u.AA), vso_session)
     assert len(entries) == 2
@@ -432,7 +432,7 @@ def test_walker_create_wave(vso_session):
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_walker_create_time(vso_session):
     time = vso.attrs.Time(
         datetime(2011, 9, 17, 0, 0, 0), datetime(2011, 9, 20, 0, 0, 0))

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -434,7 +434,7 @@ def test_add_already_existing_entry_ignore(database):
     assert entry.id == 1
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_add_entry_from_hek_qr(database):
     hek_res = hek.HEKClient().search(
         hek.attrs.Time('2011/08/09 07:23:56', '2011/08/09 07:24:00'),
@@ -456,7 +456,7 @@ def num_entries_from_vso_query(db, query, path=None, file_pattern='',
     return num_of_fits_headers
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_vso_query_block_caching(database, download_qr, tmpdir):
 
     assert len(database) == 0
@@ -497,7 +497,7 @@ def test_vso_query_block_caching(database, download_qr, tmpdir):
     assert num_of_fits_headers_1 + num_of_fits_headers_2 == num_of_fits_headers
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_vso_query_block_caching_with_overwrite_true_flag(database,
                                                           download_qr, tmpdir):
 
@@ -525,7 +525,7 @@ def test_vso_query_block_caching_with_overwrite_true_flag(database,
     assert len(database) > 0
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_download_from_qr(database, download_qr, tmpdir):
     assert len(database) == 0
     database.download_from_vso_query_result(
@@ -542,7 +542,7 @@ def test_download_from_qr(database, download_qr, tmpdir):
     assert len(database) == num_of_fits_headers > 0
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_add_entry_from_qr(database, query_result):
     assert len(database) == 0
     database.add_from_vso_query_result(query_result)
@@ -553,7 +553,7 @@ def test_add_entry_from_qr(database, query_result):
     assert len(database) == 16
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_add_entries_from_qr_duplicates(database, query_result):
     assert len(database) == 0
     database.add_from_vso_query_result(query_result)
@@ -562,7 +562,7 @@ def test_add_entries_from_qr_duplicates(database, query_result):
         database.add_from_vso_query_result(query_result)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_add_entries_from_qr_ignore_duplicates(database, query_result):
     assert len(database) == 0
     database.add_from_vso_query_result(query_result)
@@ -571,7 +571,7 @@ def test_add_entries_from_qr_ignore_duplicates(database, query_result):
     assert len(database) == 32
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_add_entry_fido_search_result(database, fido_search_result):
     assert len(database) == 0
     database.add_from_fido_search_result(fido_search_result)
@@ -582,7 +582,7 @@ def test_add_entry_fido_search_result(database, fido_search_result):
     assert len(database) == 65
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_add_entries_from_fido_search_result_JSOC_client(database):
     assert len(database) == 0
     search_result = Fido.search(
@@ -594,7 +594,7 @@ def test_add_entries_from_fido_search_result_JSOC_client(database):
         database.add_from_fido_search_result(search_result)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_add_entries_from_fido_search_result_duplicates(database, fido_search_result):
     assert len(database) == 0
     database.add_from_fido_search_result(fido_search_result)
@@ -603,7 +603,7 @@ def test_add_entries_from_fido_search_result_duplicates(database, fido_search_re
         database.add_from_fido_search_result(fido_search_result)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_add_entries_from_fido_search_result_ignore_duplicates(database, fido_search_result):
     assert len(database) == 0
     database.add_from_fido_search_result(fido_search_result)
@@ -879,7 +879,7 @@ def test_fetch_missing_arg(database):
         database.fetch()
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_fetch_empty_query_result(database, empty_query):
     database.fetch(*empty_query)
     with pytest.raises(EmptyCommandStackError):
@@ -887,7 +887,7 @@ def test_fetch_empty_query_result(database, empty_query):
     assert len(database) == 0
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_fetch(database, download_query, tmpdir):
     assert len(database) == 0
     database.default_waveunit = 'angstrom'
@@ -905,7 +905,7 @@ def test_fetch(database, download_query, tmpdir):
     assert len(database) == 4
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_fetch_duplicates(database, download_query, tmpdir):
     assert len(database) == 0
     database.default_waveunit = 'angstrom'
@@ -925,7 +925,7 @@ def test_fetch_missing_arg(database):
         database.fetch()
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_fetch(database, download_query, tmpdir):
     assert len(database) == 0
     database.default_waveunit = 'angstrom'
@@ -937,7 +937,7 @@ def test_fetch(database, download_query, tmpdir):
     assert database[0].download_time == download_time
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_fetch_separate_filenames():
     # Setup
     db = Database('sqlite:///')
@@ -974,7 +974,7 @@ def test_fetch_separate_filenames():
     shutil.rmtree(tmp_test_dir)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_disable_undo(database, download_query, tmpdir):
     entry = DatabaseEntry()
     with disable_undo(database) as db:

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -112,7 +112,7 @@ def test_tag_hashability():
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_entries_from_fido_search_result(fido_search_result):
     entries = list(entries_from_fido_search_result(fido_search_result))
     # 65 entries for 8 instruments in fido_search_result
@@ -186,7 +186,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         instrument='eve')
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_entries_from_fido_search_result_JSOC():
     search_result = Fido.search(
         net_attrs.jsoc.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'),
@@ -200,7 +200,7 @@ def test_entries_from_fido_search_result_JSOC():
         list(entries_from_fido_search_result(search_result))
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_from_fido_search_result_block(fido_search_result):
     entry = DatabaseEntry._from_fido_search_result_block(
         fido_search_result[0, 0][0].get_response(0)[0])
@@ -214,7 +214,7 @@ def test_from_fido_search_result_block(fido_search_result):
     assert entry == expected_entry
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_entry_from_qr_block(query_result):
     entry = DatabaseEntry._from_query_result_block(query_result[0])
     expected_entry = DatabaseEntry(
@@ -226,7 +226,7 @@ def test_entry_from_qr_block(query_result):
     assert entry == expected_entry
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_entry_from_qr_block_with_missing_physobs(qr_block_with_missing_physobs):
     entry = DatabaseEntry._from_query_result_block(
         qr_block_with_missing_physobs)
@@ -240,7 +240,7 @@ def test_entry_from_qr_block_with_missing_physobs(qr_block_with_missing_physobs)
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_entry_from_qr_block_kev(qr_block_with_kev_unit):
     # See issue #766.
     entry = DatabaseEntry._from_query_result_block(qr_block_with_kev_unit)
@@ -416,7 +416,7 @@ def test_entries_from_dir_recursively_false():
     assert len(entries) == 80
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_entries_from_query_result(query_result):
     entries = list(entries_from_query_result(query_result))
     assert len(entries) == 122
@@ -430,14 +430,14 @@ def test_entries_from_query_result(query_result):
     assert snd_entry == expected_entry
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_entry_from_query_results_with_none_wave(qr_with_none_waves):
     # does not raise WaveunitNotFoundError because neither wavemin nor wavemax
     # are given
     list(entries_from_query_result(qr_with_none_waves))
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_entry_from_query_results_with_none_wave_and_default_unit(
         qr_with_none_waves):
     entries = list(entries_from_query_result(qr_with_none_waves, 'nm'))

--- a/sunpy/instr/tests/test_fermi.py
+++ b/sunpy/instr/tests/test_fermi.py
@@ -5,7 +5,7 @@ from sunpy.time import parse_time
 from sunpy.extern import six
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_download_weekly_pointing_file():
     # set a test date
     date = parse_time('2011-10-01')
@@ -14,7 +14,7 @@ def test_download_weekly_pointing_file():
     assert afile.endswith('.fits')
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_detector_angles():
     # set a test date
     date = parse_time('2012-02-15')

--- a/sunpy/instr/tests/test_goes.py
+++ b/sunpy/instr/tests/test_goes.py
@@ -21,7 +21,7 @@ LONGFLUX = Quantity([7e-6], unit="W/m**2")
 SHORTFLUX = Quantity([7e-7], unit="W/m**2")
 DATE = "2014-04-16"
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_event_list():
     # Set a time range to search
     trange = TimeRange('2011-06-07 00:00', '2011-06-08 00:00')
@@ -63,7 +63,7 @@ def test_goes_event_list():
     assert result[0]['noaa_active_region'] == 11226
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_calculate_temperature_em():
     # Create GOESLightcurve object, then create new one with
     # temperature & EM using with calculate_temperature_em().
@@ -89,7 +89,7 @@ def test_calculate_temperature_em():
     del goeslc_revert.data["em"]
     assert_frame_equal(goeslc_revert.data, goeslc.data)
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_errors():
     # Define input variables.
     ratio = SHORTFLUX/LONGFLUX
@@ -133,7 +133,7 @@ def test_goes_chianti_tem_errors():
     with pytest.raises(ValueError):
         em = goes._goes_get_chianti_em(LONGFLUX, temp_test_toobig)
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_case1():
     # test case 1: satellite > 7, abundances = coronal
     temp1, em1 = goes._goes_chianti_tem(LONGFLUX, SHORTFLUX, satellite=15,
@@ -142,7 +142,7 @@ def test_goes_chianti_tem_case1():
     assert all(em1 < Quantity([4.79e+48], unit="1/cm**3")) and \
       em1 > Quantity([4.78e+48], unit="1/cm**3")
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_case2():
     # test case 2: satellite > 7, abundances = photospheric
     temp2, em2 = goes._goes_chianti_tem(LONGFLUX, SHORTFLUX, satellite=15,
@@ -152,7 +152,7 @@ def test_goes_chianti_tem_case2():
     assert all(em2 < Quantity([1.12e+49], unit="1/cm**3")) and \
       all(em2 > Quantity([1.11e+49], unit="1/cm**3"))
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_case3():
     # test case 3: satellite < 8 and != 6, abundances = coronal
     temp3, em3 = goes._goes_chianti_tem(LONGFLUX, SHORTFLUX, satellite=5,
@@ -163,7 +163,7 @@ def test_goes_chianti_tem_case3():
     assert all(em3 < Quantity([3.85e+48], unit="1/cm**3")) and \
       all(em3 > Quantity([3.84e+48], unit="1/cm**3"))
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_case4():
     # test case 4: satellite < 8 and != 6, abundances = photospheric
     temp4, em4 = goes._goes_chianti_tem(LONGFLUX, SHORTFLUX, satellite=5,
@@ -174,7 +174,7 @@ def test_goes_chianti_tem_case4():
     assert all(em4 < Quantity(8.81e+48, unit="1/cm**3")) and \
       all(em4 > Quantity(8.80e+48, unit="1/cm**3"))
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_case5():
     # test case 5: satellite = 6, date < 1983-06-28, abundances = coronal
     temp5, em5 = goes._goes_chianti_tem(LONGFLUX, SHORTFLUX, satellite=6,
@@ -185,7 +185,7 @@ def test_goes_chianti_tem_case5():
     assert all(em5 < Quantity(3.13e+48, unit="1/cm**3")) and \
       all(em5 > Quantity(3.12e+48, unit="1/cm**3"))
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_case6():
     # test case 6: satellite = 6, date < 1983-06-28, abundances = photospheric
     temp6, em6 = goes._goes_chianti_tem(LONGFLUX, SHORTFLUX, satellite=6,
@@ -196,7 +196,7 @@ def test_goes_chianti_tem_case6():
     assert all(em6 < Quantity(6.74e+48, unit="1/cm**3")) and \
       all(em6 > Quantity(6.73e+48, unit="1/cm**3"))
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_case7():
     # test case 7: satellite = 6, date > 1983-06-28, abundances = coronal
     temp7, em7 = goes._goes_chianti_tem(LONGFLUX, SHORTFLUX, satellite=6,
@@ -207,7 +207,7 @@ def test_goes_chianti_tem_case7():
     assert all(em7 < Quantity(4.08e+48, unit="1/cm**3")) and \
       all(em7 > Quantity(4.07e+48, unit="1/cm**3"))
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_goes_chianti_tem_case8():
     # test case 8: satellite = 6, date > 1983-06-28, abundances = photospheric
     temp8, em8 = goes._goes_chianti_tem(LONGFLUX, SHORTFLUX, satellite=6,
@@ -218,7 +218,7 @@ def test_goes_chianti_tem_case8():
     assert all(em8 < Quantity(9.39e+48, unit="1/cm**3")) and \
       all(em8 > Quantity(9.38e+48, unit="1/cm**3"))
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_calculate_radiative_loss_rate():
     # Define input variables.
     goeslc_input = lightcurve.GOESLightCurve.create("2014-01-01 00:00:00",
@@ -245,7 +245,7 @@ def test_calculate_radiative_loss_rate():
     goes_test = goes.calculate_radiative_loss_rate(goeslc_no_em)
     assert_frame_equal(goeslc_test.data, goeslc_expected.data)
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_calc_rad_loss_errors():
     # Define input variables
     temp = 11.0 * Quantity(np.ones(6), unit="MK")
@@ -282,7 +282,7 @@ def test_calc_rad_loss_errors():
     with pytest.raises(ValueError):
         rad_loss_test = goes._calc_rad_loss(temp, em, obstime_nonchrono)
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_calc_rad_loss_nokwags():
     # Define input variables
     temp = Quantity([11.0, 11.0, 11.0, 11.0, 11.0, 11.0], unit="MK")
@@ -302,7 +302,7 @@ def test_calc_rad_loss_nokwags():
     assert_quantity_allclose(rad_loss_test["rad_loss_rate"],
                        rad_loss_expected["rad_loss_rate"], rtol=0.01)
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_calc_rad_loss_obstime():
     # Define input variables
     temp = Quantity([11.0, 11.0, 11.0, 11.0, 11.0, 11.0], unit="MK")
@@ -331,7 +331,7 @@ def test_calc_rad_loss_obstime():
     assert_quantity_allclose(rad_loss_test["rad_loss_cumul"],
                        rad_loss_expected["rad_loss_cumul"], rtol=0.0001)
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_calculate_xray_luminosity():
     # Check correct exceptions are raised to incorrect inputs
     not_goeslc = []

--- a/sunpy/instr/tests/test_lyra.py
+++ b/sunpy/instr/tests/test_lyra.py
@@ -47,7 +47,7 @@ LYTAF_TEST = np.append(
              dtype=LYTAF_TEST.dtype))
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_split_series_using_lytaf():
     '''test the downloading of the LYTAF file and subsequent queries'''
     tmp_dir = tempfile.mkdtemp()
@@ -105,7 +105,7 @@ def get_lyradata(dtype):
     return lyrats
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize('dtype', ['ts', 'lc'])
 def test_remove_lytaf_events_from_timeseries(dtype):
     """Test if artefacts are correctly removed from a TimeSeries.

--- a/sunpy/instr/tests/test_rhessi.py
+++ b/sunpy/instr/tests/test_rhessi.py
@@ -30,14 +30,14 @@ def test_get_obssumm_dbase_file():
         rhessi.get_obssumm_dbase_file(['2002/01/01', '2002/04/01'])
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_get_obssum_filename():
     file_name = rhessi.get_obssum_filename(('2011/04/04', '2011/04/05'))
     # Irregardless of mirror server the osbsum file name should match
     assert file_name[0].split('metadata/catalog/')[1] == 'hsi_obssumm_20110404_042.fits'
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_parse_obssum_dbase_file():
     file = rhessi.get_obssumm_dbase_file(('2011/04/04', '2011/04/05'))
     obssum = rhessi.parse_obssumm_dbase_file(file[0])
@@ -64,7 +64,7 @@ def test_parse_obssum_dbase_file():
     assert obssum['npackets'][-1] == 0
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_get_parse_obssum_file():
     f = rhessi.get_obssumm_file(('2011/04/04', '2011/04/05'))  # doctest: +SKIP
     header, _data = rhessi.parse_obssumm_file(f[0])

--- a/sunpy/lightcurve/tests/test_eve.py
+++ b/sunpy/lightcurve/tests/test_eve.py
@@ -12,12 +12,12 @@ from sunpy.data.test import get_test_filepath
 
 EVE_AVERAGES_CSV = get_test_filepath("EVE_He_II_304_averages.csv")
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_eve():
     eve = sunpy.lightcurve.EVELightCurve.create('2013/04/15')
     assert isinstance(eve, sunpy.lightcurve.EVELightCurve)
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_txt():
     """Check support for parsing EVE TXT files """
     eve = sunpy.lightcurve.EVELightCurve.create(

--- a/sunpy/lightcurve/tests/test_goes.py
+++ b/sunpy/lightcurve/tests/test_goes.py
@@ -23,25 +23,25 @@ class TestGOESLightCurve(object):
     def timerange_c(self):
         return TimeRange('1980/01/05', '1980/01/06')
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_goes_range(self, timerange_a):
         """Test creation with two times"""
         lc1 = sunpy.lightcurve.GOESLightCurve.create(timerange_a.start, timerange_a.end)
         assert isinstance(lc1, sunpy.lightcurve.GOESLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_goes_timerange(self, timerange_a):
         """Test creation with a TimeRange"""
         lc1 = sunpy.lightcurve.GOESLightCurve.create(timerange_a)
         assert isinstance(lc1, sunpy.lightcurve.GOESLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_goes_default(self):
         """Test creation with no input"""
         lc1 = sunpy.lightcurve.GOESLightCurve.create()
         assert isinstance(lc1, sunpy.lightcurve.GOESLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_data(self, timerange_a, timerange_b):
         """Test presence of data"""
         lc1 = sunpy.lightcurve.GOESLightCurve.create(timerange_b)
@@ -49,7 +49,7 @@ class TestGOESLightCurve(object):
         assert lc1.data.empty == False
         assert lc2.data.empty == False
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_header(self, timerange_a, timerange_b):
         """Test presence of GOES satellite number in header"""
         lc1 = sunpy.lightcurve.GOESLightCurve.create(timerange_b)
@@ -57,21 +57,21 @@ class TestGOESLightCurve(object):
         assert lc1.header['TELESCOP'] == 'GOES 7'
         assert lc2.header['TELESCOP'] == 'GOES 10'
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_goes_url(self):
         """Test creation with url"""
         url = 'http://umbra.nascom.nasa.gov/goes/fits/1995/go07950603.fits'
         lc1 = sunpy.lightcurve.GOESLightCurve.create(url)
         assert isinstance(lc1, sunpy.lightcurve.GOESLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def compare(self, lc1, lc2):
         try:
             (lc1.data == lc2.data)
         except:
             raise Exception
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_filename(self, timerange_a, timerange_b):
         """Compare data from two different time ranges to make
         sure they are not the same"""

--- a/sunpy/lightcurve/tests/test_lyra.py
+++ b/sunpy/lightcurve/tests/test_lyra.py
@@ -9,7 +9,7 @@ import sunpy
 from sunpy.time import parse_time
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("date,level,start,end",
                          [('2012/06/03', 3, '2012-06-03 00:00:00.047000',
                            '2012-06-03 23:59:00.047000'),
@@ -22,7 +22,7 @@ def test_lyra_level(date, level, start, end):
     assert lyra.time_range().end == parse_time(end)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize(("url, start, end"), [(
     'http://proba2.oma.be/lyra/data/bsd/2012/02/04/lyra_20120204-000000_lev3_std.fits',
     '2012-02-04 00:00:00.004000', '2012-02-04 23:59:00.004000'

--- a/sunpy/lightcurve/tests/test_noaa.py
+++ b/sunpy/lightcurve/tests/test_noaa.py
@@ -11,24 +11,24 @@ timerange_a = TimeRange('2004/01/01', '2007/01/01')
 
 class TestNOAAIndicesLightCurve(object):
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_create(self):
         lc = sunpy.lightcurve.NOAAIndicesLightCurve.create()
         assert isinstance(lc, sunpy.lightcurve.NOAAIndicesLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_isempty(self):
         lc = sunpy.lightcurve.NOAAIndicesLightCurve.create()
         assert lc.data.empty == False
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_url(self):
         """Test creation with url"""
         url = 'ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt'
         lc1 = sunpy.lightcurve.NOAAIndicesLightCurve.create(url)
         assert isinstance(lc1, sunpy.lightcurve.NOAAIndicesLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_goes_timerange(self):
         """Test creation with a TimeRange"""
         lc1 = sunpy.lightcurve.NOAAIndicesLightCurve.create(timerange_a)
@@ -39,7 +39,7 @@ class TestNOAAIndicesLightCurve(object):
         g = sunpy.lightcurve.NOAAIndicesLightCurve
         assert g._get_url_for_date_range(timerange_a) == 'ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt'
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_header(self):
         """Test presence of GOES satellite number in header"""
         lc1 = sunpy.lightcurve.NOAAIndicesLightCurve.create()
@@ -48,25 +48,25 @@ class TestNOAAIndicesLightCurve(object):
 
 class TestNOAAPredictIndicesLightCurve(object):
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_create(self):
         """Test creation with no input"""
         lc = sunpy.lightcurve.NOAAPredictIndicesLightCurve.create()
         assert isinstance(lc, sunpy.lightcurve.NOAAPredictIndicesLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_isempty(self):
         """Test presence of data"""
         lc = sunpy.lightcurve.NOAAPredictIndicesLightCurve.create()
         assert lc.data.empty == False
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_goes_timerange(self):
         """Test creation with a TimeRange"""
         lc1 = sunpy.lightcurve.NOAAPredictIndicesLightCurve.create(timerange_a)
         assert isinstance(lc1, sunpy.lightcurve.NOAAPredictIndicesLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_url(self):
         """Test creation with url"""
         url = 'http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt'
@@ -78,7 +78,7 @@ class TestNOAAPredictIndicesLightCurve(object):
         g = sunpy.lightcurve.NOAAPredictIndicesLightCurve
         assert g._get_url_for_date_range(timerange_a) == 'http://services.swpc.noaa.gov/text/predicted-sunspot-radio-flux.txt'
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_header(self):
         """Test presence of GOES satellite number in header"""
         lc1 = sunpy.lightcurve.NOAAPredictIndicesLightCurve.create()

--- a/sunpy/lightcurve/tests/test_norh.py
+++ b/sunpy/lightcurve/tests/test_norh.py
@@ -7,7 +7,7 @@ import pytest
 import sunpy
 import pandas
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_norh():
     norh=sunpy.lightcurve.NoRHLightCurve.create('2012-07-06')
     assert isinstance(norh, sunpy.lightcurve.NoRHLightCurve)

--- a/sunpy/lightcurve/tests/test_rhessi.py
+++ b/sunpy/lightcurve/tests/test_rhessi.py
@@ -20,25 +20,25 @@ class TestRHESSISummaryLightCurve(object):
     def timerange_b(self):
         return TimeRange('2004/06/03', '2004/06/04')
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_hsi_range(self, timerange_a):
         """Test creation with two times"""
         lc1 = sunpy.lightcurve.RHESSISummaryLightCurve.create(timerange_a.start, timerange_a.end)
         assert isinstance(lc1, sunpy.lightcurve.RHESSISummaryLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_hsi_timerange(self, timerange_a):
         """Test creation with a TimeRange"""
         lc1 = sunpy.lightcurve.RHESSISummaryLightCurve.create(timerange_a)
         assert isinstance(lc1, sunpy.lightcurve.RHESSISummaryLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_hsi_default(self):
         """Test creation with no input"""
         lc1 = sunpy.lightcurve.RHESSISummaryLightCurve.create()
         assert isinstance(lc1, sunpy.lightcurve.RHESSISummaryLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_data(self, timerange_a, timerange_b):
         """Test presence of data"""
         lc1 = sunpy.lightcurve.RHESSISummaryLightCurve.create(timerange_b)
@@ -46,20 +46,20 @@ class TestRHESSISummaryLightCurve(object):
         assert not lc1.data.empty
         assert not lc2.data.empty
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_header(self, timerange_b):
         """Test presence of TELESCOP in header"""
         lc1 = sunpy.lightcurve.RHESSISummaryLightCurve.create(timerange_b)
         assert lc1.header['TELESCOP'] == 'HESSI'
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_hsi_url(self):
         """Test creation with url"""
         url = 'http://soleil.i4ds.ch/hessidata/metadata/catalog/hsi_obssumm_20030302_146.fits'
         lc1 = sunpy.lightcurve.RHESSISummaryLightCurve.create(url)
         assert isinstance(lc1, sunpy.lightcurve.RHESSISummaryLightCurve)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_filename(self, timerange_a, timerange_b):
         """Compare data from two different time ranges to make
         sure they are not the same"""
@@ -68,7 +68,7 @@ class TestRHESSISummaryLightCurve(object):
         with pytest.raises(AssertionError):
             np.testing.assert_allclose(lc1, lc2)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_get_url(self, timerange_a, timerange_b):
         """Test the getting of urls"""
         g = sunpy.lightcurve.RHESSISummaryLightCurve

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -95,7 +95,7 @@ class TestMap(object):
         db_map = sunpy.map.Map(res)
         assert isinstance(db_map, sunpy.map.GenericMap)
 
-    @pytest.mark.online
+    @pytest.mark.remote_data
     def test_url_pattern(self):
         # A URL
         amap = sunpy.map.Map("http://data.sunpy.org/sample-data/AIA20110319_105400_0171.fits")

--- a/sunpy/net/dataretriever/tests/test_eve.py
+++ b/sunpy/net/dataretriever/tests/test_eve.py
@@ -17,7 +17,7 @@ from sunpy.net.tests.strategies import time_attr
 
 LCClient = eve.EVEClient()
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("timerange,url_start,url_end", [
     (TimeRange('2012/4/21', '2012/4/21'),
      'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120421_EVE_L0CS_DIODES_1m.txt',
@@ -50,7 +50,7 @@ def test_can_handle_query():
     assert ans3 is False
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_query():
     qr1 = LCClient.search(Time('2012/8/9', '2012/8/10'), Instrument('eve'))
     assert isinstance(qr1, QueryResponse)
@@ -59,7 +59,7 @@ def test_query():
     assert qr1.time_range().end == parse_time('2012/08/11') # includes end.
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("time,instrument", [
     (Time('2012/11/27', '2012/11/27'), Instrument('eve')),
 ])
@@ -70,7 +70,7 @@ def test_get(time, instrument):
     assert len(download_list) == len(qr1)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize(
     'query',
     [(a.Time('2012/10/4', '2012/10/6') & a.Instrument('eve') & a.Level(0))])
@@ -83,7 +83,7 @@ def test_fido(query):
     assert len(response) == qr._numfile
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @given(time_attr(time=datetimes(timezones=[], max_year=datetime.datetime.utcnow().year, min_year=2010)))
 @settings(max_examples=2, timeout=240)
 def test_levels(time):

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -78,7 +78,7 @@ def test_query_error():
 
 
 @pytest.mark.skip(reason="Hangs with pytest only")
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("time, instrument", [
     (Time('1983/06/17', '1983/06/18'), Instrument('XRS')),
     (Time('2012/10/4', '2012/10/6'), Instrument('XRS')),
@@ -91,7 +91,7 @@ def test_get(time, instrument):
 
 
 @pytest.mark.skip(reason="Hangs with pytest only")
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_new_logic():
     qr = LCClient.search(Time('2012/10/4', '2012/10/6'), Instrument('XRS'))
     res = LCClient.fetch(qr)
@@ -99,7 +99,7 @@ def test_new_logic():
     assert len(download_list) == len(qr)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize(
     "time, instrument",
     [(a.Time("2012/10/4", "2012/10/6"), a.Instrument("goes")),

--- a/sunpy/net/dataretriever/tests/test_lyra_ud.py
+++ b/sunpy/net/dataretriever/tests/test_lyra_ud.py
@@ -58,7 +58,7 @@ def test_query(time):
     assert qr1.time_range().end == time.end
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("time,instrument", [
     (Time('2013/8/27', '2013/8/27'), Instrument('lyra')),
     (Time('2013/2/4', '2013/2/6'), Instrument('lyra')),
@@ -70,7 +70,7 @@ def test_get(time, instrument):
     assert len(download_list) == len(qr1)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize(
     "time, instrument",
     [(a.Time('2012/10/4', '2012/10/6'), a.Instrument('lyra')),

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -38,7 +38,7 @@ def test_can_handle_query():
     assert ans3 == False
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_query():
     qr1 = LCClient.search(
         Time('2012/8/9', '2012/8/10'), Instrument('noaa-indices'))
@@ -48,7 +48,7 @@ def test_query():
     assert qr1.time_range().end == parse_time('2012/08/10')
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("time, instrument", [
     (Time('2012/11/27', '2012/11/27'), Instrument('noaa-indices')),
     (Time('2012/10/4', '2012/10/6'), Instrument('noaa-indices')),
@@ -60,7 +60,7 @@ def test_get(time, instrument):
     assert len(download_list) == len(qr1)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize(
     "time, instrument",
     [(a.Time("2012/10/4", "2012/10/6"), a.Instrument('noaa-indices')),

--- a/sunpy/net/dataretriever/tests/test_norh.py
+++ b/sunpy/net/dataretriever/tests/test_norh.py
@@ -15,7 +15,7 @@ from hypothesis import given
 from sunpy.net.tests.strategies import time_attr, range_time
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("timerange,url_start,url_end", [
     (TimeRange('2012/4/21', '2012/4/21'),
      'ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/04/tca120421',
@@ -48,7 +48,7 @@ def test_can_handle_query(time):
     assert ans2 is False
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("wave", [a.Wavelength(17*u.GHz), a.Wavelength(34*u.GHz)])
 @given(time=range_time(datetime.datetime(1992, 6, 1)))
 def test_query(time, wave):
@@ -86,7 +86,7 @@ def test_query_wrong_wave():
                 a.Wavelength(50*u.GHz))
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("time,instrument,wave", [
     (a.Time('2012/10/4', '2012/10/6'), a.Instrument('norh'), a.Wavelength(17*u.GHz)),
     (a.Time('2013/10/5', '2013/10/7'), a.Instrument('norh'), a.Wavelength(34*u.GHz))])
@@ -98,7 +98,7 @@ def test_get(time, instrument, wave):
     assert len(download_list) == len(qr1)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize(
     "time, instrument, wave",
     [(a.Time('2012/10/4', '2012/10/6'), a.Instrument('norh'), a.Wavelength(17*u.GHz)),

--- a/sunpy/net/dataretriever/tests/test_rhessi.py
+++ b/sunpy/net/dataretriever/tests/test_rhessi.py
@@ -12,7 +12,7 @@ from sunpy.net.fido_factory import UnifiedResponse
 LCClient = rhessi.RHESSIClient()
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("timerange,url_start", [
     (TimeRange('2012/7/1', '2012/7/2'),
      'hessidata/metadata/catalog/hsi_obssumm_20120701_050.fits'),
@@ -35,7 +35,7 @@ def test_can_handle_query():
     assert ans2 is False
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_query():
     qr1 = LCClient.search(Time('2011/4/9', '2011/4/10'), Instrument('rhessi'))
     assert isinstance(qr1, QueryResponse)
@@ -44,7 +44,7 @@ def test_query():
     assert qr1.time_range().end == parse_time('2011/04/10')
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize("time,instrument", [
     (Time('2012/11/27', '2012/11/28'), Instrument('rhessi')),
     (Time('2012/10/4', '2012/10/5'), Instrument('rhessi')),
@@ -56,7 +56,7 @@ def test_get(time, instrument):
     assert len(download_list) == len(qr1)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.parametrize(
     "time, instrument",
     [(a.Time('2012/10/4', '2012/10/6'), a.Instrument('rhessi')),

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -135,7 +135,7 @@ def test_process_time_astropy_tai():
     assert start == datetime.datetime(year=2012, month=1, day=1, second=0)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_status_request():
     r = client._request_status('none')
     assert r.json() == {
@@ -155,7 +155,7 @@ def test_empty_jsoc_response():
     assert len(Jresp) == 0
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_query():
     Jresp = client.search(
         attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:01:30'),
@@ -165,7 +165,7 @@ def test_query():
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_post_pass():
     responses = client.search(
         attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
@@ -177,7 +177,7 @@ def test_post_pass():
     assert tmpresp['method'] == 'url'
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_post_wavelength():
     responses = client.search(
         attrs.Time('2010/07/30T13:30:00', '2010/07/30T14:00:00'),
@@ -196,7 +196,7 @@ def test_post_wavelength():
     assert tmpresp['rcount'] == 151
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_post_notify_fail():
     responses = client.search(
         attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
@@ -205,7 +205,7 @@ def test_post_notify_fail():
         client.request_data(responses, return_resp=True)
 
 
-@pytest.mark.online()
+@pytest.mark.remote_data()
 def test_post_wave_series():
     with pytest.raises(TypeError):
         client.search(
@@ -214,7 +214,7 @@ def test_post_wave_series():
             attrs.Wavelength(193 * u.AA) | attrs.Wavelength(335 * u.AA))
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_post_fail(recwarn):
     res = client.search(
         attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
@@ -228,7 +228,7 @@ def test_post_fail(recwarn):
     assert w.lineno
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_request_status_fail():
     resp = client._request_status('none')
     assert resp.json() == {
@@ -244,7 +244,7 @@ def test_request_status_fail():
     }
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_wait_get():
     responses = client.search(
         attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
@@ -255,7 +255,7 @@ def test_wait_get():
     assert res.total == 1
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_get_request():
     responses = client.search(
         attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
@@ -267,7 +267,7 @@ def test_get_request():
     assert isinstance(aa, Results)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_results_filenames():
     responses = client.search(
         attrs.Time('2014/1/1T1:00:36', '2014/1/1T01:01:38'),
@@ -281,7 +281,7 @@ def test_results_filenames():
         assert os.path.isfile(hmiurl)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_invalid_query():
     with pytest.raises(ValueError):
         client.search(attrs.Time('2012/1/1T01:00:00', '2012/1/1T01:00:45'))

--- a/sunpy/net/tests/test_download.py
+++ b/sunpy/net/tests/test_download.py
@@ -62,7 +62,7 @@ def get_and_create_temp_directory(tmpdir):
 
     return sunpy.config.get('downloads', 'download_dir')
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_path_exception():
     x = threading.Event()
     dw = Downloader(1, 2)
@@ -76,7 +76,7 @@ def test_path_exception():
     assert x.isSet()
     dw.stop()
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_download_http():
     items = []
     lck = threading.Lock()
@@ -114,7 +114,7 @@ def test_download_http():
     for item in items:
         assert os.path.exists(item['path'])
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_download_default_dir():
     _config = sunpy.config
 
@@ -145,7 +145,7 @@ def test_download_default_dir():
     finally:
         sunpy.config = _config
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_download_dir():
     tmpdir = tempfile.mkdtemp()
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -55,7 +55,7 @@ def test_offline_fido(query):
     check_response(query, unifiedresp)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @given(online_query())
 def test_online_fido(query):
     unifiedresp = Fido.search(query)
@@ -82,7 +82,7 @@ def check_response(query, unifiedresp):
             assert query_instr.lower() == res.instrument.lower()
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_save_path():
     with tempfile.TemporaryDirectory() as target_dir:
         qr = Fido.search(a.Instrument('EVE'), a.Time("2016/10/01", "2016/10/02"), a.Level(0))
@@ -97,7 +97,7 @@ Factory Tests
 """
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_unified_response():
     start = parse_time("2012/1/1")
     end = parse_time("2012/1/2")
@@ -155,7 +155,7 @@ def test_multiple_match():
     Fido.registry = CLIENTS
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_no_wait_fetch():
         qr = Fido.search(a.Instrument('EVE'),
                          a.Time("2016/10/01", "2016/10/02"),

--- a/sunpy/net/tests/test_hek2vso.py
+++ b/sunpy/net/tests/test_hek2vso.py
@@ -40,7 +40,7 @@ def hek_client():
 def vso_client():
     vso.VSOClient()
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_translate_results_to_query():
     """Make sure that conversion of HEK results to VSO queries is accurate"""
     h = hek.HEKClient()
@@ -53,7 +53,7 @@ def test_translate_results_to_query():
         #Comparing types of both queries
         assert type(hek_query) == type(vso_query)
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_vso_attribute_parse():
     """Make sure that Parsing of VSO attributes from HEK queries is accurate"""
     h = hek.HEKClient()

--- a/sunpy/net/tests/test_helio.py
+++ b/sunpy/net/tests/test_helio.py
@@ -87,7 +87,7 @@ def test_suds_unwrapper():
     assert hec.suds_unwrapper(suds_output) == expected_output
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_webservice_parser():
     result = webservice_parser()
     assert isinstance(result, list)

--- a/sunpy/net/tests/test_helioviewer.py
+++ b/sunpy/net/tests/test_helioviewer.py
@@ -26,7 +26,7 @@ def client():
         pytest.skip("HTTP error {}".format(e.code))
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 class TestHelioviewerClient:
     """Tests the Helioviewer.org API Client class"""
 

--- a/sunpy/net/tests/test_vso.py
+++ b/sunpy/net/tests/test_vso.py
@@ -94,7 +94,7 @@ def test_input_error():
         va.Time('2012/1/1')
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_simpleattr_create(client):
     a = attr.ValueAttr({('instrument', ): 'eit'})
     assert va.walker.create(a, client.api)[0].instrument == 'eit'
@@ -127,7 +127,7 @@ def test_complexattr_apply():
     assert dct['test'] == {'foo': 'a', 'bar': 'b'}
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_complexattr_create(client):
     a = attr.ValueAttr({('time', 'start'): 'test'})
     assert va.walker.create(a, client.api)[0].time.start == 'test'
@@ -262,7 +262,7 @@ def test_repr():
     assert "Start Time End Time  Source Instrument   Type" in repr(qr)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_path(client):
     """
     Test that '{file}' is automatically appended to the end of a custom path if

--- a/sunpy/spectra/tests/test_callisto.py
+++ b/sunpy/spectra/tests/test_callisto.py
@@ -50,7 +50,7 @@ def test_read(CALLISTO_IMAGE):
     assert ca.dtype == np.uint8
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_query():
     URL = 'http://soleil.i4ds.ch/solarradio/data/2002-20yy_Callisto/2011/09/22/'
 
@@ -74,7 +74,7 @@ def test_query():
         assert URL + item in result
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.xfail
 def test_query_number():
     URL = 'http://soleil.i4ds.ch/solarradio/data/2002-20yy_Callisto/2011/09/22/'
@@ -95,7 +95,7 @@ def test_query_number():
     assert len(result) == len(RESULTS)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 @pytest.mark.xfail
 def test_download():
     directory = mkdtemp()
@@ -125,7 +125,7 @@ def test_create_file_kw(CALLISTO_IMAGE):
     assert np.array_equal(ca.data, CallistoSpectrogram.read(CALLISTO_IMAGE).data)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_create_url():
     URL = (
         "http://soleil.i4ds.ch/solarradio/data/2002-20yy_Callisto/2011/09/22/"
@@ -135,7 +135,7 @@ def test_create_url():
     assert np.array_equal(ca.data, CallistoSpectrogram.read(URL).data)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_create_url_kw():
     URL = (
         "http://soleil.i4ds.ch/solarradio/data/2002-20yy_Callisto/2011/09/22/"
@@ -400,7 +400,7 @@ def test_homogenize_rightfq():
     assert_array_almost_equal(factors[0] * b + constants[0], a)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_extend(CALLISTO_IMAGE):
     im = CallistoSpectrogram.create(CALLISTO_IMAGE)
     im2 = im.extend()

--- a/sunpy/tests/__init__.py
+++ b/sunpy/tests/__init__.py
@@ -68,12 +68,9 @@ def main(modulename='', coverage=False, cov_report=False,
         all_args.extend(['--cov', path])
     if cov_report:
         all_args.extend(['--cov-report', cov_report])
-    if online or remote_data:
+    if online or remote_data or not offline:
         all_args.append('--remote-data')
-    if not online:
-        all_args.append('-k-remote_data')
     if not offline:
-        all_args.append('--remote-data')
         all_args.append('-k remote_data')
     if not figure:
         all_args.append('-m not figure')
@@ -105,6 +102,4 @@ def main(modulename='', coverage=False, cov_report=False,
 
         all_args.extend(['-n', str(parallel)])
 
-    # de-duplicate
-    all_args = list(set(all_args))
     return pytest.main(all_args)

--- a/sunpy/tests/__init__.py
+++ b/sunpy/tests/__init__.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 def main(modulename='', coverage=False, cov_report=False,
-         online=False, offline=True, figure=False, verbose=False,
+         online=False, offline=True, remote_data=False, figure=False, verbose=False,
          parallel=0, args=None):
     """
     Execute the test suite of the sunpy package. The parameters may be
@@ -37,6 +37,9 @@ def main(modulename='', coverage=False, cov_report=False,
 
     offline: bool
         Run the tests that don't require an internet connection.
+
+    remote_data : bool
+        Run the tests that require an internet connection.
 
     figure: bool
         Include the figure tests in the test run.
@@ -65,10 +68,13 @@ def main(modulename='', coverage=False, cov_report=False,
         all_args.extend(['--cov', path])
     if cov_report:
         all_args.extend(['--cov-report', cov_report])
+    if online or remote_data:
+        all_args.append('--remote-data')
     if not online:
-        all_args.append('-k-online')
+        all_args.append('-k-remote_data')
     if not offline:
-        all_args.append('-k online')
+        all_args.append('--remote-data')
+        all_args.append('-k remote_data')
     if not figure:
         all_args.append('-m not figure')
 
@@ -99,4 +105,6 @@ def main(modulename='', coverage=False, cov_report=False,
 
         all_args.extend(['-n', str(parallel)])
 
+    # de-duplicate
+    all_args = list(set(all_args))
     return pytest.main(all_args)

--- a/sunpy/tests/figure_tests_env_2.7.yml
+++ b/sunpy/tests/figure_tests_env_2.7.yml
@@ -73,3 +73,5 @@ dependencies:
 - wheel=0.29.0=py27_0
 - xz=5.2.2=1
 - zlib=1.2.8=3
+- pip:
+    - pytest-astropy

--- a/sunpy/tests/figure_tests_env_2.7.yml
+++ b/sunpy/tests/figure_tests_env_2.7.yml
@@ -53,7 +53,7 @@ dependencies:
 - pycairo=1.10.0=py27_0
 - pyparsing=2.1.4=py27_0
 - pyqt=5.6.0=py27_2
-- pytest=3.0.5=py27_0
+- pytest
 - pytest-mock=1.5.0=py27_0
 - python=2.7.11=0
 - python-dateutil=2.6.0=py27_0

--- a/sunpy/tests/figure_tests_env_3.5.yml
+++ b/sunpy/tests/figure_tests_env_3.5.yml
@@ -45,7 +45,7 @@ dependencies:
 - py=1.4.32=py35_0
 - pyparsing=2.1.4=py35_0
 - pyqt=5.6.0=py35_2
-- pytest=3.0.5=py35_0
+- pytest
 - pytest-mock=1.5.0=py35_0
 - python=3.5.2=0
 - python-dateutil=2.6.0=py35_0

--- a/sunpy/tests/figure_tests_env_3.5.yml
+++ b/sunpy/tests/figure_tests_env_3.5.yml
@@ -65,3 +65,5 @@ dependencies:
 - wheel=0.29.0=py35_0
 - xz=5.2.2=1
 - zlib=1.2.8=3
+- pip:
+    - pytest-astropy

--- a/sunpy/tests/tests/test_main.py
+++ b/sunpy/tests/tests/test_main.py
@@ -24,22 +24,22 @@ def test_main_stdlib_module():
 def test_main_noargs(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main()
-    assert args in (['-k-online', '-m not figure', '-p no:warnings', 'sunpy'],
-                    ['-k-online', '-m not figure', '-p no:warnings', root_dir])
+    assert args in (['-k-remote_data', '-m not figure', '-p no:warnings', 'sunpy'],
+                    ['-k-remote_data', '-m not figure', '-p no:warnings', root_dir])
 
 
 def test_main_submodule_map(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map')
-    assert args in (['-k-online', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['-k-online', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
+    assert args in (['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
+                    ['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
 def test_main_submodule_jsoc(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('net.jsoc')
-    assert args in (['-k-online', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'net', 'jsoc')],
-                    ['-k-online', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'net', 'jsoc')])
+    assert args in (['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'net', 'jsoc')],
+                    ['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'net', 'jsoc')])
 
 
 def test_main_with_cover(monkeypatch):
@@ -47,41 +47,41 @@ def test_main_with_cover(monkeypatch):
     args = sunpy.tests.main('map', coverage=True)
     covpath = os.path.abspath(
         os.path.join(sunpy.tests.testdir, os.path.join(os.pardir, 'map')))
-    assert args in (['--cov', covpath, '-k-online', '-m not figure',
+    assert args in (['--cov', covpath, '-k-remote_data', '-m not figure',
                      '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['--cov', os.path.join('sunpy', 'map'), '-k-online',
+                    ['--cov', os.path.join('sunpy', 'map'), '-k-remote_data',
                      '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')],
-                    ['--cov', os.path.join('sunpy', 'map'), '-k-online', '-m not figure',
+                    ['--cov', os.path.join('sunpy', 'map'), '-k-remote_data', '-m not figure',
                      '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['--cov', covpath, '-k-online', '-m not figure',
+                    ['--cov', covpath, '-k-remote_data', '-m not figure',
                      '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
 def test_main_with_show_uncovered_lines(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map', cov_report='term-missing')
-    assert args in (['--cov-report', 'term-missing', '-k-online', '-m not figure',
+    assert args in (['--cov-report', 'term-missing', '-k-remote_data', '-m not figure',
                      '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['--cov-report', 'term-missing', '-k-online', '-m not figure',
+                    ['--cov-report', 'term-missing', '-k-remote_data', '-m not figure',
                      '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
-def test_main_exclude_online(monkeypatch):
+def test_main_exclude_remote_data(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
-    args = sunpy.tests.main('map', online=False)
-    assert args in (['-k-online', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['-k-online', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
+    args = sunpy.tests.main('map', remote_data=False)
+    assert args in (['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
+                    ['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
-def test_main_only_online(monkeypatch):
+def test_main_only_remote_data(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
-    args = sunpy.tests.main('map', offline=False, online=True)
-    assert args in (['-k online', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['-k online', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
+    args = sunpy.tests.main('map', offline=False, remote_data=True)
+    assert args in (['-k remote_data', '--remote-data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
+                    ['-k remote_data', '--remote-data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
 def test_main_figures(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main(figure=True)
-    assert args in (['-k-online', '-p no:warnings', 'sunpy'],
-                    ['-k-online', '-p no:warnings', root_dir])
+    assert args in (['-k-remote_data', '-p no:warnings', 'sunpy'],
+                    ['-k-remote_data', '-p no:warnings', root_dir])

--- a/sunpy/tests/tests/test_main.py
+++ b/sunpy/tests/tests/test_main.py
@@ -24,22 +24,22 @@ def test_main_stdlib_module():
 def test_main_noargs(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main()
-    assert args in (['-k-remote_data', '-m not figure', '-p no:warnings', 'sunpy'],
-                    ['-k-remote_data', '-m not figure', '-p no:warnings', root_dir])
+    assert args in (['-m not figure', '-p no:warnings', 'sunpy'],
+                    ['-m not figure', '-p no:warnings', root_dir])
 
 
 def test_main_submodule_map(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map')
-    assert args in (['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
+    assert args in (['-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
+                    ['-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
 def test_main_submodule_jsoc(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('net.jsoc')
-    assert args in (['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'net', 'jsoc')],
-                    ['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'net', 'jsoc')])
+    assert args in (['-m not figure', '-p no:warnings', os.path.join('sunpy', 'net', 'jsoc')],
+                    ['-m not figure', '-p no:warnings', os.path.join(root_dir, 'net', 'jsoc')])
 
 
 def test_main_with_cover(monkeypatch):
@@ -47,41 +47,41 @@ def test_main_with_cover(monkeypatch):
     args = sunpy.tests.main('map', coverage=True)
     covpath = os.path.abspath(
         os.path.join(sunpy.tests.testdir, os.path.join(os.pardir, 'map')))
-    assert args in (['--cov', covpath, '-k-remote_data', '-m not figure',
+    assert args in (['--cov', covpath, '-m not figure',
                      '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['--cov', os.path.join('sunpy', 'map'), '-k-remote_data',
+                    ['--cov', os.path.join('sunpy', 'map'),
                      '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')],
-                    ['--cov', os.path.join('sunpy', 'map'), '-k-remote_data', '-m not figure',
+                    ['--cov', os.path.join('sunpy', 'map'), '-m not figure',
                      '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['--cov', covpath, '-k-remote_data', '-m not figure',
+                    ['--cov', covpath, '-m not figure',
                      '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
 def test_main_with_show_uncovered_lines(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map', cov_report='term-missing')
-    assert args in (['--cov-report', 'term-missing', '-k-remote_data', '-m not figure',
+    assert args in (['--cov-report', 'term-missing', '-m not figure',
                      '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['--cov-report', 'term-missing', '-k-remote_data', '-m not figure',
+                    ['--cov-report', 'term-missing', '-m not figure',
                      '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
 def test_main_exclude_remote_data(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map', remote_data=False)
-    assert args in (['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['-k-remote_data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
+    assert args in (['-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
+                    ['-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
 def test_main_only_remote_data(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main('map', offline=False, remote_data=True)
-    assert args in (['-k remote_data', '--remote-data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
-                    ['-k remote_data', '--remote-data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
+    assert args in (['--remote-data', '-k remote_data', '-m not figure', '-p no:warnings', os.path.join('sunpy', 'map')],
+                    ['--remote-data', '-k remote_data', '-m not figure', '-p no:warnings', os.path.join(root_dir, 'map')])
 
 
 def test_main_figures(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda x: x)
     args = sunpy.tests.main(figure=True)
-    assert args in (['-k-remote_data', '-p no:warnings', 'sunpy'],
-                    ['-k-remote_data', '-p no:warnings', root_dir])
+    assert args in (['-p no:warnings', 'sunpy'],
+                    ['-p no:warnings', root_dir])

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -163,7 +163,7 @@ def testURL_patternMilliseconds():
 
 
 @pytest.mark.xfail
-@pytest.mark.online
+@pytest.mark.remote_data
 def testFilesRange_sameDirectory_remote():
     pattern = ('http://solarmonitor.org/data/%Y/%m/%d/'
                'fits/{instrument}/'
@@ -180,7 +180,7 @@ def testFilesRange_sameDirectory_remote():
 
 
 @pytest.mark.xfail
-@pytest.mark.online
+@pytest.mark.remote_data
 def testFilesRange_sameDirectory_months_remote():
     pattern = ('http://www.srl.caltech.edu/{spacecraft}/DATA/{instrument}/'
                'Ahead/1minute/AeH%y%b.1m')
@@ -191,7 +191,7 @@ def testFilesRange_sameDirectory_months_remote():
     assert len(s.filelist(timerange)) == 2
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_ftp():
     pattern = 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/tca%y%m%d'
     s = Scraper(pattern)


### PR DESCRIPTION
This simplifies our code by making use of `pytest-remotedata` while keeping `sunpy.self_test` and the behaviour of our `python setup.py test` commands the same. (Future PRs changing that behavior are likely)

cc @drdavella