### PR TITLE
Revert "socket.timeout should xfail now"

### DIFF
--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -4,7 +4,6 @@ from functools import partial
 import os
 import tempfile
 import json
-import socket
 
 # Force MPL to use non-gui backends for testing.
 try:
@@ -43,11 +42,9 @@ def pytest_runtest_setup(item):
     can be requested).
     """
     if isinstance(item, item.Function):
-        if 'remote_data' in item.keywords:
-            if not HAVE_REMOTEDATA:
-                pytest.skip("skipping remotedata tests as pytest-remotedata is not installed")
-            else:
-                item.add_marker(pytest.mark.xfail(raises=socket.timeout))
+        if 'remote_data' in item.keywords and not HAVE_REMOTEDATA:
+            pytest.skip("skipping remotedata tests as pytest-remotedata is not installed")
+
 
 def pytest_unconfigure(config):
     if len(figure_test_pngfiles) > 0:


### PR DESCRIPTION
This reverts commit 8b622a470824dd7b3e07c591f48879eb5189466e.

@nabobalis this did not do what we expected. If the test passes it's now marked as XPASS i.e. it was expected to fail but passed.