### PR TITLE
Automatically document class members

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,6 +192,10 @@ edit_on_github_skip_regex = '_.*|generated/.*'
 
 github_issues_url = 'https://github.com/sunpy/sunpy/issues/'
 
+# -- Options for autodoc ------------------------------------------------------
+# Make sure members of classes are automatically documented
+autodoc_default_flags = ['members']
+
 # -- Options for the Sphinx gallery -------------------------------------------
 
 if ON_RTD and os.environ.get('READTHEDOCS_PROJECT').lower() != 'sunpy':


### PR DESCRIPTION
Fixes #2348. This causes a lot duplicated description warnings in the doc build (see below); I'm guessing these need to be fixed.

```
/Users/dstansby/github/sunpy/build/lib.macosx-10.7-x86_64-3.6/sunpy/visualization/imageanimator.py:docstring of sunpy.visualization.imageanimator.ImageAnimatorWCS.update_plot:0: WARNING: duplicate object description of sunpy.visualization.imageanimator.ImageAnimatorWCS.update_plot, other instance in /Users/dstansby/github/sunpy/docs/api/sunpy.visualization.imageanimator.ImageAnimatorWCS.rst, use :noindex: for one of them
```