### PR TITLE
Add net.vso.vso module to API docs

### DIFF
--- a/docs/code_ref/net.rst
+++ b/docs/code_ref/net.rst
@@ -34,6 +34,9 @@ VSO
 .. automodapi:: sunpy.net.vso
    :headings: ^#
 
+.. automodapi:: sunpy.net.vso.vso
+  :headings: ^#
+
 .. automodapi:: sunpy.net.vso.attrs
    :headings: #~
 

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -42,6 +42,8 @@ from sunpy.extern import six
 from sunpy.extern.six import iteritems, text_type
 from sunpy.extern.six.moves import input
 
+__all__ = ['QueryResponse', 'VSOClient']
+
 TIME_FORMAT = config.get("general", "time_format")
 
 DEFAULT_URL_PORT = [{'url': 'http://docs.virtualsolar.org/WSDL/VSOi_rpc_literal.wsdl',


### PR DESCRIPTION
I was looking for VSOClient docs but couldn't find them; looks like `sunpy.net.vso.vso` just needs adding to the `net.rst` file.