### PR TITLE
Extra tests for `net.attrs`

### DIFF
--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -90,6 +90,33 @@ class DummyAttr(Attr):
         return isinstance(other, DummyAttr)
 
 
+# TODO: Remove _VSOSimpleAttr
+# This is a port of _VSOSimpleAttr.
+class SimpleAttr(Attr):
+    """
+    An attribute that only has a single value.
+
+    This type of attribute is not a composite and has a single value such as
+    ``Instrument('EIT')``.
+
+    Parameters
+    ----------
+    value : `object`
+       The value for the attribute to hold.
+    """
+    def __init__(self, value):
+        Attr.__init__(self)
+
+        self.value = value
+
+    def collides(self, other):
+        return isinstance(other, self.__class__)
+
+    def __repr__(self):
+        return "<{cname!s}({val!r})>".format(
+            cname=self.__class__.__name__, val=self.value)
+
+
 class AttrAnd(Attr):
     """ Attribute representing attributes ANDed together. """
     def __init__(self, attrs):

--- a/sunpy/net/tests/test_attr.py
+++ b/sunpy/net/tests/test_attr.py
@@ -8,11 +8,6 @@ import pytest
 from sunpy.net import attr
 
 
-"""
-Test Attr classes.
-"""
-
-
 class SA1(attr.SimpleAttr):
     pass
 
@@ -117,6 +112,25 @@ def test_dummyattr():
     other = attr.ValueAttr({'a': 'b'})
     assert (one | other) is other
     assert (one & other) is other
+
+
+def test_dummyattr_hash():
+    one = attr.DummyAttr()
+    assert hash(one) == hash(None)
+
+
+def test_dummyattr_collides():
+    one = attr.DummyAttr()
+    two = attr.DummyAttr()
+    assert one.collides(two) is False
+
+
+def test_dummyattr_eq():
+    one = attr.DummyAttr()
+    two = attr.DummyAttr()
+    other = attr.ValueAttr({'a': 'b'})
+    assert one == two
+    assert one != other
 
 
 def test_and_nesting():

--- a/sunpy/net/tests/test_attr.py
+++ b/sunpy/net/tests/test_attr.py
@@ -3,8 +3,114 @@
 
 from __future__ import absolute_import
 
+import pytest
+
 from sunpy.net import attr
-from sunpy.net.vso import attrs
+
+
+"""
+Test Attr classes.
+"""
+
+
+class SA1(attr.SimpleAttr):
+    pass
+
+
+class SA2(attr.SimpleAttr):
+    pass
+
+
+class SA3(attr.SimpleAttr):
+    pass
+
+
+def test_attr_and():
+    a1 = SA1(1)
+    a2 = SA2(2)
+
+    an = a1 & a2
+
+    assert isinstance(an, attr.AttrAnd)
+    assert a1 in an.attrs
+    assert a2 in an.attrs
+    assert len(an.attrs) == 2
+
+
+def test_attr_and_AttrAnd():
+    a1 = SA1(1)
+    a2 = SA2(2)
+    a3 = SA3(3)
+
+    an = a1 & (a2 & a3)
+
+    assert isinstance(an, attr.AttrAnd)
+    assert a1 in an.attrs
+    assert a2 in an.attrs
+    assert a3 in an.attrs
+    assert len(an.attrs) == 3
+
+
+def test_attr_and_AttrOr():
+    a1 = SA1(1)
+    a2 = SA2(2)
+    a3 = SA3(3)
+
+    an = a1 & (a2 | a3)
+
+    assert isinstance(an, attr.AttrOr)
+    for a in an.attrs:
+        assert isinstance(a, attr.AttrAnd)
+    assert len(an.attrs) == 2
+
+
+def test_attr_hash():
+    a1 = SA1(1)
+    a2 = SA1(1)
+    a3 = SA1(3)
+
+    assert hash(a1) == hash(a2)
+    assert hash(a3) != hash(a1)
+
+
+def test_attr_collies():
+    a1 = attr.Attr()
+    with pytest.raises(NotImplementedError):
+        a1.collides(1)
+
+
+def test_attr_or():
+    a1 = SA1(1)
+    a2 = SA2(2)
+
+    an = a1 | a2
+
+    assert isinstance(an, attr.AttrOr)
+    assert a1 in an.attrs
+    assert a2 in an.attrs
+    assert len(an.attrs) == 2
+
+    a1 = SA1(1)
+    a2 = SA2(1)
+
+    an = a1 | a2
+
+    assert an is a1
+
+
+def test_simpleattr_collides():
+    a1 = SA1(1)
+
+    with pytest.raises(TypeError):
+        a1 & a1
+
+
+def test_simple_attr_repr():
+    a1 = SA1("test string")
+
+    assert "test string" in repr(a1)
+    assert "SA1" in repr(a1)
+
 
 def test_dummyattr():
     one = attr.DummyAttr()
@@ -12,16 +118,22 @@ def test_dummyattr():
     assert (one | other) is other
     assert (one & other) is other
 
+
 def test_and_nesting():
-    a = attr.and_(attrs.Level(0),
-                  attr.AttrAnd((attrs.Instrument('EVE'),
-                                attrs.Time("2012/1/1", "2012/01/02"))))
+    a1 = SA1(1)
+    a2 = SA2(2)
+    a3 = SA3(3)
+
+    a = attr.and_(a1, attr.AttrAnd((a2, a3)))
     # Test that the nesting has been removed.
     assert len(a.attrs) == 3
 
+
 def test_or_nesting():
-    a = attr.or_(attrs.Instrument('a'),
-                  attr.AttrOr((attrs.Instrument('b'),
-                               attrs.Instrument('c'))))
+    a1 = SA1(1)
+    a2 = SA2(2)
+    a3 = SA3(3)
+
+    a = attr.or_(a1, attr.AttrOr((a2, a3)))
     # Test that the nesting has been removed.
     assert len(a.attrs) == 3


### PR DESCRIPTION
I am unlikely to get back to this for a little while, so we should just merge this as a straight up improvement.

TODO:

- [ ] Finsh `VSOSimpleAttr` -> `SimpleAttr` conversion.