### PR TITLE
Fix the output units of pixel_to_world

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -4,10 +4,10 @@ Map is a generic Map class from which all other Map classes inherit from.
 from __future__ import absolute_import, division, print_function
 from sunpy.extern.six.moves import range
 
+import copy
 import warnings
 import inspect
 from abc import ABCMeta
-from copy import deepcopy
 from collections import OrderedDict, namedtuple
 
 import numpy as np
@@ -855,15 +855,17 @@ Reference Coord:\t {refcoord}
             A coordinate object representing the output coordinate.
 
         """
-        x, y = self.wcs.wcs_pix2world(x, y, origin)
 
-        # If the wcs is celestial it is output in degress
-        if self.wcs.is_celestial:
-            x = u.Quantity(x, u.deg)
-            y = u.Quantity(y, u.deg)
-        else:
-            x = u.Quantity(x, self.spatial_units[0])
-            y = u.Quantity(y, self.spatial_units[1])
+        # Hold the WCS instance here so we can inspect the output units after
+        # the pix2world call
+        temp_wcs = self.wcs
+
+        x, y = temp_wcs.wcs_pix2world(x, y, origin)
+
+        out_units = list(map(u.Unit, temp_wcs.wcs.cunit))
+
+        x = u.Quantity(x, out_units[0])
+        y = u.Quantity(y, out_units[1])
 
         return SkyCoord(x, y, frame=self.coordinate_frame)
 
@@ -1703,7 +1705,7 @@ Reference Coord:\t {refcoord}
                               Warning)
 
         # Normal plot
-        imshow_args = deepcopy(self.plot_settings)
+        imshow_args = copy.deepcopy(self.plot_settings)
         if 'title' in imshow_args:
             plot_settings_title = imshow_args.pop('title')
         else:

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -266,9 +266,9 @@ def test_data_range(generic_map):
 
     # the weird unit-de-unit thing here is to work around and inconsistency in
     # the way np.average works with astropy 1.3 and 2.0dev
-    assert_quantity_allclose(np.average(u.Quantity(generic_map.xrange).value) * u.deg,
+    assert_quantity_allclose(np.average(u.Quantity(generic_map.xrange).value) * u.arcsec,
                              generic_map.center.Tx)
-    assert_quantity_allclose(np.average(u.Quantity(generic_map.yrange).value) * u.deg,
+    assert_quantity_allclose(np.average(u.Quantity(generic_map.yrange).value) * u.arcsec,
                              generic_map.center.Ty)
 
 
@@ -550,6 +550,12 @@ def test_as_mpl_axes_aia171(aia171_test_map):
     assert all([ct1 == ct2 for ct1, ct2 in zip(ax.wcs.wcs.ctype, aia171_test_map.wcs.wcs.ctype)])
     # Map adds these attributes, so we use them to check.
     assert hasattr(ax.wcs, 'heliographic_observer')
+
+
+def test_pixel_to_world_no_projection(generic_map):
+    out = generic_map.pixel_to_world(*u.Quantity(generic_map.reference_pixel)+1*u.pix, origin=1)
+    assert_quantity_allclose(out.Tx, -10*u.arcsec)
+    assert_quantity_allclose(out.Ty, 10*u.arcsec)
 
 
 def test_validate_meta(generic_map):


### PR DESCRIPTION
This correctly infers the output units of `WCS.wcs_pix2world` by copying the WCS object and asking it what the units are after the transformation.

closes #2324