### PR TITLE
Make parse_time work with individual dt64s and pandas series

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Bug Fixes
 - Updated masking brightest pixel example [#2338]
 - Changed TRAVIS cronjobs [#2338]
 - Support array values for `obstime` for coordinates and transformations [#2342]
+- Make parse_time work with datetime64s and pandas series [#2370]
 
 0.8.2
 =====

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -77,6 +77,13 @@ def test_parse_time_numpy_datetime():
     assert all([isinstance(dt, datetime) for dt in dts])
 
 
+def test_parse_time_individual_numpy_datetime():
+    dt64 = np.datetime64('2005-02-01T00')
+    dt = parse_time(dt64)
+
+    assert isinstance(dt, datetime)
+
+
 def test_parse_time_astropy():
     astropy_time = parse_time(astropy.time.Time(['2016-01-02T23:00:01']))
 

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -48,6 +48,17 @@ def test_parse_time_pandas_timestamp():
     assert dt == LANDING
 
 
+def test_parse_time_pandas_series():
+    inputs = [datetime(2012, 1, i) for i in range(1, 13)]
+    ind = pandas.Series(inputs)
+
+    dts = parse_time(ind)
+
+    assert isinstance(dts, np.ndarray)
+    assert all([isinstance(dt, datetime) for dt in dts])
+    assert list(dts) == inputs
+
+
 def test_parse_time_pandas_index():
     inputs = [datetime(2012, 1, i) for i in range(1, 13)]
     ind = pandas.DatetimeIndex(inputs)

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -164,6 +164,10 @@ def parse_time(time_string, time_format='', **kwargs):
     """
     if isinstance(time_string, pandas.Timestamp):
         return time_string.to_pydatetime()
+    elif isinstance(time_string, pandas.Series) and 'datetime64' in str(time_string.dtype):
+        return np.array([dt.to_pydatetime() for dt in time_string])
+    elif isinstance(time_string, pandas.DatetimeIndex):
+        return time_string._mpl_repr()
     elif isinstance(time_string, datetime) or time_format == 'datetime':
         return time_string
     elif isinstance(time_string, tuple):


### PR DESCRIPTION
- First commit makes individual `datetime64` objects be parsed (previously only arrays of these worked)
- Second commit makes a pandas `Series` of `datetime64` objects be parsed.