### PR TITLE
Validate that pytest-doctestplus is installed

### DIFF
--- a/sunpy/tests/__init__.py
+++ b/sunpy/tests/__init__.py
@@ -56,7 +56,7 @@ def main(modulename='', coverage=False, cov_report=False,
         raise ImportError("You need to install pytest to run SunPy's tests")
 
     if doctestplus:
-        raise ImportError("Please install 'pytest-astropy' to run SunPy's tests")
+        raise ImportError("You need to install pytest-astropy to run SunPy's tests")
 
     if not modulename:
         module = __import__('sunpy')

--- a/sunpy/tests/__init__.py
+++ b/sunpy/tests/__init__.py
@@ -49,6 +49,14 @@ def main(modulename='', coverage=False, cov_report=False,
     if pytest is None:
         raise ImportError("You need to install pytest to run SunPy's tests")
 
+    try:
+        import pytest_doctestplus
+    except ImportError:
+        raise ImportError(
+            "The 'test' command requires the 'pytest_doctestplus'."
+            " Please install 'pytest-astropy' that provides the"
+            " required plugin.")
+
     if not modulename:
         module = __import__('sunpy')
     else:

--- a/sunpy/tests/__init__.py
+++ b/sunpy/tests/__init__.py
@@ -9,6 +9,12 @@ try:
 except ImportError:
     pytest = None
 
+try:
+    import pytest_doctestplus
+    doctestplus = False
+except ImportError:
+    doctestplus = True
+
 
 def main(modulename='', coverage=False, cov_report=False,
          online=False, offline=True, remote_data=False, figure=False, verbose=False,
@@ -49,13 +55,8 @@ def main(modulename='', coverage=False, cov_report=False,
     if pytest is None:
         raise ImportError("You need to install pytest to run SunPy's tests")
 
-    try:
-        import pytest_doctestplus
-    except ImportError:
-        raise ImportError(
-            "The 'test' command requires the 'pytest_doctestplus'."
-            " Please install 'pytest-astropy' that provides the"
-            " required plugin.")
+    if doctestplus:
+        raise ImportError("Please install 'pytest-astropy' to run SunPy's tests")
 
     if not modulename:
         module = __import__('sunpy')

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -54,12 +54,10 @@ class SunPyTest(AstropyTest):
     ]
 
     user_options = _fix_user_options(user_options)
-
     package_name = ''
 
     def initialize_options(self):
         self.package = ''
-        #self.test_path = None
         self.verbose_results = False
         self.plugins = None
         self.args = None
@@ -88,6 +86,8 @@ class SunPyTest(AstropyTest):
         """
         Build a Python script to run the tests.
         """
+
+        self._validate_required_deps()  # checks if modules are installed
 
         cmd_pre = ''  # Commands to run before the test function
         cmd_post = ''  # Commands to run after the test function


### PR DESCRIPTION
This PR ensures that if the plugin is not installed, then it raises `ImportError` when `pytest-doctestplus` is not installed.
[link](https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder.find_spec)