### PR TITLE
Fix use of self.wcs in plot in mapbase

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1744,7 +1744,7 @@ Reference Coord:\t {refcoord}
 
         if wcsaxes_compat.is_wcsaxes(axes):
             wcsaxes_compat.default_wcs_grid(axes, units=self.spatial_units,
-                                            ctypes=self.coordinate_system)
+                                            ctypes=self.wcs.wcs.ctype)
 
         # Set current image (makes colorbar work)
         plt.sca(axes)


### PR DESCRIPTION
This PR fixes a bug where `self.coordinate_system` was used in `plot()` instead of `self.wcs.wcs.ctype`. This causes a problem if the FITS `CTYPE` keyword is malformed, i.e. `Solar-X/Y` like in XRT map. The `wcs` property fixes these keywords, but are ignored if `wcs.wcs.ctype` is not used.