### PR TITLE
Added a subclass of astropy.time to support utime

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ API Changes
 Bug Fixes
 ---------
 
+- Added TimeUTime class to support utime. [#2409]
 - Fix HGS frame constructor and HPC ``calculate_distance`` with SkyCoord constructor. [#2463]
 - removed `wavelnth` keyword in meta desc of Maps to avoid using non standard FITS keyword like `nan` [#2427]
 - `~sunpy.net.dataretriever.clients.XRSClient` now reports time ranges of files correctly. [#2364]
@@ -40,7 +41,6 @@ Bug Fixes
 - Updates MapCube to access the correct properties of the namedtuple SpatialPair [#2297]
 - Fixed TimeSeries test failures due to missing test files [#2273]
 - Refactored a GOES test to avoid a Py3.6 issue [#2276]
-
 
 0.8.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@
 New Features
 ------------
 
+- Added TimeUTime class to support utime. [#2409]
+
 API Changes
 -----------
 
@@ -18,7 +20,6 @@ API Changes
 Bug Fixes
 ---------
 
-- Added TimeUTime class to support utime. [#2409]
 - Fix HGS frame constructor and HPC ``calculate_distance`` with SkyCoord constructor. [#2463]
 - removed `wavelnth` keyword in meta desc of Maps to avoid using non standard FITS keyword like `nan` [#2427]
 - `~sunpy.net.dataretriever.clients.XRSClient` now reports time ranges of files correctly. [#2364]

--- a/sunpy/time/__init__.py
+++ b/sunpy/time/__init__.py
@@ -4,3 +4,4 @@ from __future__ import absolute_import
 from sunpy.time.time import *
 from sunpy.time.timerange import *
 from sunpy.time.julian import *
+from sunpy.time.utime import *

--- a/sunpy/time/tests/test_utime.py
+++ b/sunpy/time/tests/test_utime.py
@@ -3,7 +3,7 @@ import pytest
 from astropy.time import Time
 
 # Ignore PEP8 F401 warning here, this registers TimeUTime in astropy.time.Time
-from utime import TimeUTime
+from sunpy.time import TimeUTime
 
 
 def test_utime_t0():

--- a/sunpy/time/tests/test_utime.py
+++ b/sunpy/time/tests/test_utime.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
+from astropy.time import Time
+
+
+def test_utime_t0():
+    t = Time('1979-01-01T00:00:00')
+    assert t.utime == 0.0
+
+
+def test_utime_random_date():
+    t = Time('2018-01-13T13:32:56')
+    assert t.utime == 1231853576.0

--- a/sunpy/time/tests/test_utime.py
+++ b/sunpy/time/tests/test_utime.py
@@ -4,10 +4,8 @@ from astropy.time import Time
 
 
 def test_utime_t0():
-    t = Time('1979-01-01T00:00:00')
-    assert t.utime == 0.0
+    assert Time('1979-01-01T00:00:00').utime == 0.0
 
 
 def test_utime_random_date():
-    t = Time('2018-01-13T13:32:56')
-    assert t.utime == 1231853576.0
+    assert Time('2018-01-13T13:32:56').utime == 1231853576.0

--- a/sunpy/time/tests/test_utime.py
+++ b/sunpy/time/tests/test_utime.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, print_function
-
+import pytest
 from astropy.time import Time
+
+# Ignore PEP8 F401 warning here, this registers TimeUTime in astropy.time.Time
+from utime import TimeUTime
 
 
 def test_utime_t0():
@@ -9,3 +12,12 @@ def test_utime_t0():
 
 def test_utime_random_date():
     assert Time('2018-01-13T13:32:56').utime == 1231853576.0
+
+
+@pytest.mark.xfail
+def test_conversion_from_utime():
+    """
+    This is expected to fail until astropy issue 7092 is resolved.
+    """
+    t2 = Time(1231853576.0, format='utime')
+    assert t2.iso == '2018-01-13T13:32:56.000'

--- a/sunpy/time/utime.py
+++ b/sunpy/time/utime.py
@@ -11,12 +11,15 @@ class TimeUTime(TimeFromEpoch):
     This time format is included for historical reasons. Some
     people in solar physics prefer using this epoch.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy.time import Time
     >>> t = Time('2000-01-01T13:53:23')
     >>> print(t.utime)
     662738003.0
+    >>> t2 = Time('1979-01-01T00:00:00')
+    >>> print(t2.utime)
+    0.0
     """
     name = 'utime'
     unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)

--- a/sunpy/time/utime.py
+++ b/sunpy/time/utime.py
@@ -10,7 +10,8 @@ class TimeUTime(TimeFromEpoch):
     This time format is included for historical reasons. Some
     people in solar physics prefer using this epoch.
 
-    Example:
+    Example
+    -------
         >>> from astropy.time import Time
         >>> t = Time('2000-01-01T13:53:23')
         >>> print(t.utime)

--- a/sunpy/time/utime.py
+++ b/sunpy/time/utime.py
@@ -4,7 +4,8 @@ from astropy.time.formats import erfa, TimeFromEpoch
 
 
 class TimeUTime(TimeFromEpoch):
-    """Seconds from 1979-01-01 00:00:00 UTC. Same as Unix time
+    """
+    Seconds from 1979-01-01 00:00:00 UTC. Same as Unix time
     but this starts 9 years later.
 
     This time format is included for historical reasons. Some

--- a/sunpy/time/utime.py
+++ b/sunpy/time/utime.py
@@ -12,10 +12,10 @@ class TimeUTime(TimeFromEpoch):
 
     Example
     -------
-        >>> from astropy.time import Time
-        >>> t = Time('2000-01-01T13:53:23')
-        >>> print(t.utime)
-        662738003.0
+    >>> from astropy.time import Time
+    >>> t = Time('2000-01-01T13:53:23')
+    >>> print(t.utime)
+    662738003.0
     """
     name = 'utime'
     unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)

--- a/sunpy/time/utime.py
+++ b/sunpy/time/utime.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from astropy.time.formats import erfa, TimeFromEpoch
 
+__all__ = ['TimeUTime']
+
 
 class TimeUTime(TimeFromEpoch):
     """

--- a/sunpy/time/utime.py
+++ b/sunpy/time/utime.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from astropy.time.formats import erfa, TimeFromEpoch
+
+
+class TimeUTime(TimeFromEpoch):
+    """Seconds from 1979-01-01 00:00:00 UTC. Same as Unix time
+    but this starts 9 years later.
+
+    This time format is included for historical reasons. Some
+    people in solar physics prefer using this epoch.
+
+    Example:
+        from astropy.time import Time
+        t = Time('2000-01-01T13:53:23')
+        print(t.utime)
+        >>> 662738003.0
+    """
+    name = 'utime'
+    unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)
+    epoch_val = '1979-01-01 00:00:00'
+    epoch_val2 = None
+    epoch_scale = 'utc'  # Scale for epoch_val class attribute
+    epoch_format = 'iso'  # Format for epoch_val class attribute

--- a/sunpy/time/utime.py
+++ b/sunpy/time/utime.py
@@ -11,10 +11,10 @@ class TimeUTime(TimeFromEpoch):
     people in solar physics prefer using this epoch.
 
     Example:
-        from astropy.time import Time
-        t = Time('2000-01-01T13:53:23')
-        print(t.utime)
-        >>> 662738003.0
+        >>> from astropy.time import Time
+        >>> t = Time('2000-01-01T13:53:23')
+        >>> print(t.utime)
+        662738003.0
     """
     name = 'utime'
     unit = 1.0 / erfa.DAYSEC  # in days (1 day == 86400 seconds)


### PR DESCRIPTION
Implemented handling of utime by creating a custom subclass of ```astropy.time.Time```, which uses the [third code example from their documentation](http://docs.astropy.org/en/stable/time/#writing-a-custom-format) as a template. 