### PR TITLE
Fix for obstime propagation in HGC->HGS transformation

### DIFF
--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -77,14 +77,11 @@ def hgc_to_hgs(hgccoord, hgsframe):
     """
     Convert from Heliograpic Carrington to Heliographic Stonyhurst.
     """
-    if hgccoord.obstime:
-        obstime = hgccoord.obstime
-    else:
-        obstime = hgsframe.obstime
-    s_lon = hgccoord.spherical.lon - _carrington_offset(obstime).to(
+    s_lon = hgccoord.spherical.lon - _carrington_offset(hgccoord.obstime).to(
         u.deg)
     representation = SphericalWrap180Representation(s_lon, hgccoord.lat,
                                                     hgccoord.radius)
+    hgsframe = hgsframe.__class__(obstime=hgccoord.obstime)
     return hgsframe.realize_frame(representation)
 
 


### PR DESCRIPTION
Currently, the propagation of `obstime` in the HGC->HGS transformation relies on implicit propagation that might not happen depending on how the transformation is called, so this PR fixes it so the propagation is explicit.  We will need to do add more "smarts" to our handling of `obstime`, but this PR handles the immediate bug.