### PR TITLE
removed wavelnth keyword in meta desc of maps to avoid using non standard FITS keyword - nan

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ New Features
 Bug Fixes
 ---------
 
+- removed `wavelnth` keyword in meta desc of Maps to avoid using non standard FITS keyword like `nan` [#2427]
 - `~sunpy.net.dataretriever.clients.XRSClient` now reports time ranges of files correctly. [#2364]
 - Make parse_time work with datetime64s and pandas series [#2370]
 - CompositeMap axes scaling now uses map spatial units [#2310]

--- a/sunpy/map/sources/hinode.py
+++ b/sunpy/map/sources/hinode.py
@@ -64,8 +64,7 @@ class XRTMap(GenericMap):
 
         self.meta['detector'] = "XRT"
 #        self.meta['instrume'] = "XRT"
-        self.meta['telescop'] = "Hinode"
-        self.meta['wavelnth'] = np.nan
+        self.meta['telescop'] = "Hinode"        
         self.meta['waveunit'] = 'keV'
         self.plot_settings['cmap'] = cm.get_cmap(name='hinodexrt')
 

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -128,8 +128,7 @@ class LASCOMap(GenericMap):
 
         # If non-standard Keyword is present, correct it too, for compatibility.
         if 'date_obs' in self.meta:
-            self.meta['date_obs'] = self.meta['date-obs']
-        self.meta['wavelnth'] = np.nan
+            self.meta['date_obs'] = self.meta['date-obs']        
         self.meta['waveunit'] = 'nm'
         self._nickname = self.instrument + "-" + self.detector
         self.plot_settings['cmap'] = cm.get_cmap('soholasco{det!s}'.format(det=self.detector[1]))
@@ -180,8 +179,7 @@ class MDIMap(GenericMap):
 
         # Fill in some missing or broken info
         self.meta['detector'] = "MDI"
-        self._fix_dsun()
-        self.meta['wavelnth'] = np.nan
+        self._fix_dsun()        
         self.meta['waveunit'] = 'nm'
         self._nickname = self.detector + " " + self.measurement
         vmin = np.nanmin(self.data)

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -86,8 +86,7 @@ class CORMap(GenericMap):
 
         GenericMap.__init__(self, data, header, **kwargs)
 
-        self._nickname = "{0}-{1}".format(self.detector, self.observatory[-1])
-        self.meta['wavelnth'] = np.nan
+        self._nickname = "{0}-{1}".format(self.detector, self.observatory[-1])        
         self.meta['waveunit'] = 'nm'
         self.plot_settings['cmap'] = cm.get_cmap('stereocor{det!s}'.format(det=self.detector[-1]))
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)))
@@ -131,8 +130,7 @@ class HIMap(GenericMap):
     """
     def __init__(self, data, header, **kwargs):
 
-        GenericMap.__init__(self, data, header, **kwargs)
-        self.meta['wavelnth'] = np.nan
+        GenericMap.__init__(self, data, header, **kwargs)        
         self.meta['waveunit'] = 'nm'
         self._nickname = "{0}-{1}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = cm.get_cmap('stereohi{det!s}'.format(det=self.detector[-1]))


### PR DESCRIPTION
removed wavelnth (not in use currently) keyword in meta desc of Maps to avoid using non standard FITS keyword - nan for issue #2405