### PR TITLE
Convert hcc --> hgs transformation to a matrix

### DIFF
--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -32,6 +32,22 @@ def test_new_hcc_to_hgs():
         assert_quantity_allclose(out1.radius, out2.radius)
 
 
+def test_hcc_to_hgs():
+    '''
+    Check that a coordinate pointing to the observer in Heliocentric
+    coordinates maps to the lattitude/longitude of the observer in
+    HeliographicStonyhurst coordinates.
+    '''
+    lat = 10 * u.deg
+    lon = 20 * u.deg
+    observer = HeliographicStonyhurst(lat=lat, lon=lon)
+    hcc_in = Heliocentric(x=0*u.km, y=0*u.km, z=1*u.km, observer=observer)
+    hgs_out = hcc_in.transform_to(HeliographicStonyhurst)
+
+    assert_quantity_allclose(hgs_out.lat, lat)
+    assert_quantity_allclose(hgs_out.lon, lon)
+
+
 def test_hpc_hpc():
     # Use some unphysical values for solar parameters for testing, to make it
     # easier to calculate expected results.

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -14,10 +14,10 @@ from sunpy.time import parse_time
 
 def test_new_hcc_to_hgs():
     # Generate 10 random coordinates
-    for i in range(10):
-        x = np.random.rand() * u.km
-        y = np.random.rand() * u.km
-        z = np.random.rand() * u.km
+    for i in range(50):
+        x = (np.random.rand() - 0.5) * u.km
+        y = (np.random.rand() - 0.5) * u.km
+        z = (np.random.rand() - 0.5) * u.km
         time = '2007-05-04T21:08:12'
         hcc = Heliocentric(x=x, y=y, z=z, obstime=time)
         hgs_frame = HeliographicStonyhurst(obstime=time)
@@ -27,7 +27,8 @@ def test_new_hcc_to_hgs():
         # Old function based transformation
         out2 = trans.old_hcc_to_hgs(hcc, hgs_frame)
         # Check that they give the same results
-        assert_quantity_allclose(out1.lon, out2.lon)
+        assert_quantity_allclose(np.mod(out1.lon, 360 * u.deg),
+                                 np.mod(out2.lon, 360 * u.deg))
         assert_quantity_allclose(out1.lat, out2.lat)
         assert_quantity_allclose(out1.radius, out2.radius)
 

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -20,10 +20,10 @@ def test_new_hcc_to_hgs():
         z = np.random.rand() * u.km
         time = '2007-05-04T21:08:12'
         hcc = Heliocentric(x=x, y=y, z=z, obstime=time)
-        hgs_frame = HeliographicCarrington(obstime=time)
+        hgs_frame = HeliographicStonyhurst(obstime=time)
 
         # New matrix based transformation
-        out1 = hcc.transform_to(HeliographicStonyhurst)
+        out1 = hcc.transform_to(hgs_frame)
         # Old function based transformation
         out2 = trans.old_hcc_to_hgs(hcc, hgs_frame)
         # Check that they give the same results

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -5,8 +5,31 @@ from astropy.tests.helper import quantity_allclose, assert_quantity_allclose
 from astropy.coordinates import SkyCoord, get_body_barycentric
 from astropy.time import Time
 
-from sunpy.coordinates import Helioprojective, HeliographicStonyhurst, HeliographicCarrington, get_sun_L0
+import sunpy.coordinates.transformations as trans
+from sunpy.coordinates import (Helioprojective, HeliographicStonyhurst,
+                               HeliographicCarrington, get_sun_L0,
+                               Heliocentric)
 from sunpy.time import parse_time
+
+
+def test_new_hcc_to_hgs():
+    # Generate 10 random coordinates
+    for i in range(10):
+        x = np.random.rand() * u.km
+        y = np.random.rand() * u.km
+        z = np.random.rand() * u.km
+        time = '2007-05-04T21:08:12'
+        hcc = Heliocentric(x=x, y=y, z=z, obstime=time)
+        hgs_frame = HeliographicCarrington(obstime=time)
+
+        # New matrix based transformation
+        out1 = hcc.transform_to(HeliographicStonyhurst)
+        # Old function based transformation
+        out2 = trans.old_hcc_to_hgs(hcc, hgs_frame)
+        # Check that they give the same results
+        assert_quantity_allclose(out1.lon, out2.lon)
+        assert_quantity_allclose(out1.lat, out2.lat)
+        assert_quantity_allclose(out1.radius, out2.radius)
 
 
 def test_hpc_hpc():

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -187,16 +187,23 @@ def hcc_to_hgs(hcc_coord, hgs_frame):
     z = hcc_coord.z.to(u.km)
 
     # Get observer longitude/lattitude with respect to Earth
-    l0_rad = hcc_coord.observer.lon
-    b0_deg = hcc_coord.observer.lat
+    l0 = np.deg2rad(hcc_coord.observer.lon)
+    b0 = np.deg2rad(hcc_coord.observer.lat)
 
-    cosb = np.cos(np.deg2rad(b0_deg))
-    sinb = np.sin(np.deg2rad(b0_deg))
+    cosl = np.cos(l0)
+    sinl = np.sin(l0)
+    cosb = np.cos(b0)
+    sinb = np.sin(b0)
 
-    R = np.array([[0, -sinb, cosb],
-                  [1, 0, 0],
-                  [0, cosb, sinb]])
-    return R
+    # Take into account lattitude, and swap axes
+    R1 = np.array([[0, -sinb, cosb],
+                   [1, 0, 0],
+                   [0, cosb, sinb]])
+    # Take into account longitude
+    R2 = np.array([[cosl, -sinl, 0],
+                   [sinl, cosl, 0],
+                   [0, 0, 1]])
+    return matrix_product(R2, R1)
 
 
 @frame_transform_graph.transform(FunctionTransform, HeliographicStonyhurst,

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -182,10 +182,6 @@ def hcc_to_hgs(hcc_coord, hgs_frame):
                            "heliographic coordinates for observer '{}' "
                            "without `obstime` being specified.".format(hcc_coord.observer))
 
-    x = hcc_coord.x.to(u.km)
-    y = hcc_coord.y.to(u.km)
-    z = hcc_coord.z.to(u.km)
-
     # Get observer longitude/lattitude with respect to Earth
     l0 = np.deg2rad(hcc_coord.observer.lon)
     b0 = np.deg2rad(hcc_coord.observer.lat)

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -183,8 +183,8 @@ def hcc_to_hgs(hcc_coord, hgs_frame):
                            "without `obstime` being specified.".format(hcc_coord.observer))
 
     # Get observer longitude/lattitude with respect to Earth
-    l0 = np.deg2rad(hcc_coord.observer.lon)
-    b0 = np.deg2rad(hcc_coord.observer.lat)
+    l0 = hcc_coord.observer.lon
+    b0 = hcc_coord.observer.lat
 
     cosl = np.cos(l0)
     sinl = np.sin(l0)


### PR DESCRIPTION
This changes the `hgs -> hcc` transformation to a matrix, instead of a function transform. Hopefully this makes it simpler, and more readable as just a simple rotation matrix.

**Note**: I have left in the old transformation, and added a test to make sure the new transformation is identical to the old one. Once this has been reviewed I can remove the test, and the old transformation code.