### PR TITLE
Improve Map Peek when using draw_grid

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1643,7 +1643,11 @@ Reference Coord:\t {refcoord}
         im = self.plot(axes=axes, **matplot_args)
 
         if colorbar and not basic_plot:
-            figure.colorbar(im)
+            if draw_grid:
+                pad = 0.12  # Pad to compensate for ticks and axes labels
+            else:
+                pad = 0.05  # Default value for vertical colorbar
+            figure.colorbar(im, pad=pad)
 
         if draw_limb:
             self.draw_limb(axes=axes)

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -230,8 +230,8 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg, **kwargs):
     lon.coord_wrap = 180
     lon.set_major_formatter('dd')
 
-    lon.set_axislabel('Solar Longitude')
-    lat.set_axislabel('Solar Latitude')
+    lon.set_axislabel('Solar Longitude', minpad=0.8)
+    lat.set_axislabel('Solar Latitude', minpad=0.9)
 
     lon.set_ticks_position('tr')
     lat.set_ticks_position('tr')
@@ -246,6 +246,6 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing=10*u.deg, **kwargs):
 
     if axes.title:
         x, y = axes.title.get_position()
-        axes.title.set_position([x, y + 0.07])
+        axes.title.set_position([x, y + 0.08])
 
     return overlay


### PR DESCRIPTION
This makes a few tweaks to our plots, to reduce the amount of drawing over things that happens when using `draw_grid` with tick labels.

Before:
![before](https://user-images.githubusercontent.com/1391051/35546103-bad9d4e6-052f-11e8-86d4-1f2fea844132.png)


After:
![after](https://user-images.githubusercontent.com/1391051/35546108-c0c0bdac-052f-11e8-874c-286d60c9be6c.png)

It should also be noted that in astropy 3.0 the axis labels will not be shown until there are ticks to be drawn (see astropy/astropy#6774):

Astropy 2.0:
![apy2](https://user-images.githubusercontent.com/1391051/35546189-5da3f63e-0530-11e8-9c73-6f43cdd75c09.png)


Astropy 3.0:
![apy3](https://user-images.githubusercontent.com/1391051/35546198-6c9fee5e-0530-11e8-9435-c46dad84ed3f.png)

