### PR TITLE
Add HCC --> HGS test

### DIFF
--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -5,9 +5,26 @@ from astropy.tests.helper import quantity_allclose, assert_quantity_allclose
 from astropy.coordinates import SkyCoord, get_body_barycentric, HeliocentricTrueEcliptic, Angle
 from astropy.time import Time
 
-from sunpy.coordinates import (Helioprojective, HeliographicStonyhurst, HeliographicCarrington,
+from sunpy.coordinates import (Helioprojective, HeliographicStonyhurst,
+                               HeliographicCarrington, Heliocentric,
                                get_sun_L0, get_earth)
 from sunpy.time import parse_time
+
+
+def test_hcc_to_hgs():
+    '''
+    Check that a coordinate pointing to the observer in Heliocentric
+    coordinates maps to the lattitude/longitude of the observer in
+    HeliographicStonyhurst coordinates.
+    '''
+    lat = 10 * u.deg
+    lon = 20 * u.deg
+    observer = HeliographicStonyhurst(lat=lat, lon=lon)
+    hcc_in = Heliocentric(x=0*u.km, y=0*u.km, z=1*u.km, observer=observer)
+    hgs_out = hcc_in.transform_to(HeliographicStonyhurst)
+
+    assert_quantity_allclose(hgs_out.lat, lat)
+    assert_quantity_allclose(hgs_out.lon, lon)
 
 
 def test_hpc_hpc():


### PR DESCRIPTION
This is split out of #2439 to run the test on the current transformation method. A couple of things:

- The coordinate transformations in general don't seem to have many meaningful tests.
- Would it be possible to add some kind of coverage checker to PRs? I notice coveralls runs on the master branch, but it would be good to have some indication on PRs of whether new code is covered by tests.