### PR TITLE
Skip figure tests if hash file not present

### DIFF
--- a/sunpy/tests/hash.py
+++ b/sunpy/tests/hash.py
@@ -8,10 +8,11 @@ import json
 import matplotlib.pyplot as plt
 
 HASH_LIBRARY_NAME = 'figure_hashes_py{0}{1}.json'.format(version_info.major, version_info.minor)
+HASH_LIBRARY_FILE = os.path.join(os.path.dirname(__file__), HASH_LIBRARY_NAME)
 
 # Load the hash library if it exists
 try:
-    with open(os.path.join(os.path.dirname(__file__), HASH_LIBRARY_NAME)) as infile:
+    with open(HASH_LIBRARY_FILE) as infile:
         hash_library = json.load(infile)
 except IOError:
     hash_library = {}

--- a/sunpy/tests/helpers.py
+++ b/sunpy/tests/helpers.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 import warnings
 import tempfile
 import platform
+import os
 
 import pytest
 import numpy as np
@@ -74,6 +75,10 @@ def figure_test(test_function):
     @pytest.mark.figure
     @wraps(test_function)
     def wrapper(*args, **kwargs):
+        if not os.path.exists(hash.HASH_LIBRARY_FILE):
+            pytest.skip('Could not find a figure hash library at '
+                        '{}, skipping map plotting tests'.format(hash.HASH_LIBRARY_FILE),
+                        allow_module_level=True)
         plt.figure()
         name = "{0}.{1}".format(test_function.__module__, test_function.__name__)
         pngfile = tempfile.NamedTemporaryFile(delete=False)

--- a/sunpy/tests/helpers.py
+++ b/sunpy/tests/helpers.py
@@ -76,9 +76,7 @@ def figure_test(test_function):
     @wraps(test_function)
     def wrapper(*args, **kwargs):
         if not os.path.exists(hash.HASH_LIBRARY_FILE):
-            pytest.skip('Could not find a figure hash library at '
-                        '{}, skipping map plotting tests'.format(hash.HASH_LIBRARY_FILE),
-                        allow_module_level=True)
+            pytest.xfail('Could not find a figure hash library at {}'.format(hash.HASH_LIBRARY_FILE))
         plt.figure()
         name = "{0}.{1}".format(test_function.__module__, test_function.__name__)
         pngfile = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
Currently only python 2.7 and 3.5 has figure hashes, so this skips doing the figure tests if testing on e.g. python 3.6.

As a side note, shouldn't the hashes depend on the Matplotlib version as well as the python version?