### PR TITLE
Add message about installing suds-jerko for suds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,12 @@ if ON_RTD:
     os.environ['LC_ALL'] = 'C'
 
 try:
+    import suds
+except ImportError:
+    raise ImportError('suds could not be imported, please install the '
+                      '"suds-jerko" package and try again')
+
+try:
     import astropy_helpers
 except ImportError:
     # Building from inside the docs directory?


### PR DESCRIPTION
Had this hanging around for a while; if trying to build the docs without `suds-jerko` installed, it complains about missing `suds`. It took me ages to work out I had to install `suds-jerko` and not the `suds` package, so this is a message that means others don't spend ages working that out.