### PR TITLE
Correctly handle obstime in coordinate transforms and add HGS>HGS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ API Changes
 
 - ``sunpy.coordinates.representation`` has been removed. Longitude wrapping is
   now done in the constructor of the frames. [#2431]
+- Propagation of ``obstime`` in the coordinate frame transformation has changed,
+  this means in general when transforming directly between frames (not
+  ``SkyCoord``) you will have to specify ``obstime`` in more places. [#2461]
+- Transforming between Heliographic Stonyhurst and Carrington now requires that
+  ``obstime`` be defined and the same on both the input and output frames. [#2461]
 
 Bug Fixes
 ---------

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -166,13 +166,13 @@ of observer is correctly calculated.
 
 def test_default_observer_transform_hcc():
     center = frames.HeliographicStonyhurst(0 * u.deg, 0 * u.deg, obstime="2017-07-11 15:00")
-    hpc = center.transform_to(frames.Heliocentric)
+    hpc = center.transform_to(frames.Heliocentric(obstime="2017-07-11 15:00"))
 
     assert_quantity_allclose(hpc.y, -48471.1283979 * u.km)
 
 
 def test_default_observer_transform_hpc():
     center = frames.HeliographicStonyhurst(0 * u.deg, 0 * u.deg, obstime="2017-07-11 15:00")
-    hpc = center.transform_to(frames.Helioprojective)
+    hpc = center.transform_to(frames.Helioprojective(obstime="2017-07-11 15:00"))
 
     assert_quantity_allclose(hpc.Ty, -66.04425197 * u.arcsec)

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -128,12 +128,12 @@ def test_hgs_hgc_roundtrip():
     obstime = "2011-01-01"
 
     hgsin = HeliographicStonyhurst(lat=0*u.deg, lon=0*u.deg, obstime=obstime)
-    hgcout = hgsin.transform_to(HeliographicCarrington)
+    hgcout = hgsin.transform_to(HeliographicCarrington(obstime=obstime))
 
     assert_quantity_allclose(hgsin.lat, hgcout.lat)
     assert_quantity_allclose(hgcout.lon, get_sun_L0(obstime))
 
-    hgsout = hgcout.transform_to(HeliographicStonyhurst)
+    hgsout = hgcout.transform_to(HeliographicStonyhurst(obstime=obstime))
 
     assert_quantity_allclose(hgsout.lat, hgsin.lat)
     assert_quantity_allclose(hgsout.lon, hgsin.lon)

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -319,4 +319,12 @@ def hgs_to_hcrs(hgscoord, hcrsframe):
     return matrix_transpose(hcrs_to_hgs(hcrsframe, hgscoord))
 
 
+@frame_transform_graph.transform(FunctionTransform, HeliographicStonyhurst, HeliographicStonyhurst)
+def hgs_to_hgs(from_coo, to_frame):
+    if np.all(from_coo.obstime == to_frame.obstime):
+        return to_frame.realize_frame(from_coo.data)
+    else:
+        return from_coo.transform_to(HCRS).transform_to(to_frame)
+
+
 __doc__ += _make_transform_graph_docs()


### PR DESCRIPTION
This fixes the way we handle obstime in the transform functions to be more compliant with what Astropy and SkyCoord in particular are expecting.

It also adds a HGS>HGS transform for different obstime, which does a `HGS - HCRS - ICRS - HCRS - HGS` transform to calculate the new HGS coordinates when the point is fixed relative to the barycentre.

Hopefully, this will not break any code that's using `SkyCoord`. Code using Frames will have to be more explicit about the obstime.