### PR TITLE
Fix our handling of "Unit Spherical" where distance is dimensionless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,10 @@ matrix:
            stage: Comprehensive tests
            env: SETUP_CMD='test'
 
+         - python: 3.5
+           stage: Comprehensive tests
+           env: ASTROPY_VERSION='lts'
+
          - os: osx
            stage: Cron tests
            language: generic

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ API Changes
 Bug Fixes
 ---------
 
+- Fix HGS frame constructor and HPC ``calculate_distance`` with SkyCoord constructor. [#2463]
 - removed `wavelnth` keyword in meta desc of Maps to avoid using non standard FITS keyword like `nan` [#2427]
 - `~sunpy.net.dataretriever.clients.XRSClient` now reports time ranges of files correctly. [#2364]
 - Make parse_time work with datetime64s and pandas series [#2370]

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -19,7 +19,8 @@ from astropy.coordinates.representation import (CartesianRepresentation,
 from astropy.coordinates.baseframe import (BaseCoordinateFrame,
                                            RepresentationMapping)
 
-from astropy.coordinates import Attribute, CoordinateAttribute, ConvertError
+from astropy.coordinates import Attribute, ConvertError
+from astropy.tests.helper import quantity_allclose
 
 from sunpy import sun
 
@@ -103,6 +104,10 @@ class HeliographicStonyhurst(BaseCoordinateFrame):
     def __init__(self, *args, **kwargs):
         _rep_kwarg = kwargs.get('representation', None)
         wrap = kwargs.pop('wrap_longitude', True)
+
+        if ('radius' in kwargs and kwargs['radius'].unit is u.one and
+                quantity_allclose(kwargs['radius'], 1*u.one)):
+            kwargs['radius'] = RSUN_METERS.to(u.km)
 
         super(HeliographicStonyhurst, self).__init__(*args, **kwargs)
 
@@ -358,7 +363,8 @@ class Helioprojective(BaseCoordinateFrame):
             now with a third coordinate.
         """
         # Skip if we already are 3D
-        if isinstance(self._data, SphericalRepresentation):
+        if (isinstance(self._data, SphericalRepresentation) and
+                not (self.distance.unit is u.one and quantity_allclose(self.distance, 1*u.one))):
             return self
 
         if not isinstance(self.observer, BaseCoordinateFrame):

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -370,7 +370,12 @@ def test_skycoord_hpc(args, kwargs):
     still works.
     """
 
-    sc = SkyCoord(*args, **kwargs, frame="helioprojective", obstime="2011-01-01T00:00:00")
+    # Python 3: These should just be keywords in the `SkyCoord` constructor
+    kwargs.update({
+        "frame": "helioprojective",
+        "obstime": "2011-01-01T00:00:00"
+        })
+    sc = SkyCoord(*args, **kwargs)
     # Test the transform to HGS because it will force a `calculate_distance` call.
     hgs = sc.transform_to("heliographic_stonyhurst")
 
@@ -388,6 +393,12 @@ def test_skycoord_hgs(args, kwargs):
     """
 
     RSUN_METERS = sun.constants.get('radius').si
-    sc = SkyCoord(*args, **kwargs, frame="heliographic_stonyhurst", obstime="2011-01-01T00:00:00")
+
+    # Python 3: These should just be keywords in the `SkyCoord` constructor
+    kwargs.update({
+        "frame": "heliographic_stonyhurst",
+        "obstime": "2011-01-01T00:00:00"
+        })
+    sc = SkyCoord(*args, **kwargs)
 
     assert_quantity_allclose(sc.radius, RSUN_METERS)


### PR DESCRIPTION
Sometimes when using the SkyCoord constructor the frame will be created with a `SphericalRepresentation` with `distance=1*u.one` rather than an `UnitSphericalRepresentation`. 

This fixes our detection of this case in our frames.

(This is needed for Astropy 3.0 compatibility, so we should get this out of the door asap)

Todo:
- [x] Tests

ping @eteq