### PR TITLE
Replaced figure.show() with plt.show() to solve instant disapperaing of timeseries plot

### DIFF
--- a/sunpy/lightcurve/lightcurve.py
+++ b/sunpy/lightcurve/lightcurve.py
@@ -254,7 +254,7 @@ class LightCurve(object):
 
         figure = plt.figure()
         self.plot(**kwargs)
-        figure.show()
+        plt.show()
 
         return figure
 

--- a/sunpy/lightcurve/sources/eve.py
+++ b/sunpy/lightcurve/sources/eve.py
@@ -103,7 +103,7 @@ class EVELightCurve(LightCurve):
             if "title" not in kwargs:
                 kwargs['title'] = 'EVE ' + column.replace('_', ' ')
             data.plot(**kwargs)
-        figure.show()
+        plt.show()
         return figure
 
     @staticmethod

--- a/sunpy/lightcurve/sources/goes.py
+++ b/sunpy/lightcurve/sources/goes.py
@@ -99,7 +99,7 @@ class GOESLightCurve(LightCurve):
 
         axes.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M')
         figure.autofmt_xdate()
-        figure.show()
+        plt.show()
 
         return figure
 

--- a/sunpy/lightcurve/sources/lyra.py
+++ b/sunpy/lightcurve/sources/lyra.py
@@ -117,7 +117,7 @@ class LYRALightCurve(LightCurve):
         for axe in axes:
             axe.locator_params(axis='y',nbins=6)
 
-        figure.show()
+        plt.show()
 
         return figure
 

--- a/sunpy/lightcurve/sources/noaa.py
+++ b/sunpy/lightcurve/sources/noaa.py
@@ -105,7 +105,7 @@ class NOAAIndicesLightCurve(LightCurve):
         axes.xaxis.grid(True, 'major')
         axes.legend()
 
-        figure.show()
+        plt.show()
         return figure
 
     @classmethod
@@ -208,7 +208,7 @@ class NOAAPredictIndicesLightCurve(LightCurve):
         axes.xaxis.grid(True, 'major')
         axes.legend()
 
-        figure.show()
+        plt.show()
         return figure
 
     @classmethod

--- a/sunpy/lightcurve/sources/rhessi.py
+++ b/sunpy/lightcurve/sources/rhessi.py
@@ -91,7 +91,7 @@ class RHESSISummaryLightCurve(LightCurve):
 
         axes.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M')
         figure.autofmt_xdate()
-        figure.show()
+        plt.show()
 
     @classmethod
     def _get_default_uri(cls):

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -504,7 +504,7 @@ class CompositeMap(object):
         else:
             raise TypeError("draw_grid should be bool, int, long or float")
 
-        figure.show()
+        plt.show()
 
 
 class OutOfRangeAlphaValue(ValueError):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1658,7 +1658,7 @@ Reference Coord:\t {refcoord}
         else:
             raise TypeError("draw_grid should be a bool or an astropy Quantity.")
 
-        figure.show()
+        plt.show()
 
     @toggle_pylab
     def plot(self, annotate=True, axes=None, title=True, **imshow_kwargs):

--- a/sunpy/spectra/spectrum.py
+++ b/sunpy/spectra/spectrum.py
@@ -99,6 +99,6 @@ class Spectrum(np.ndarray):
 
         figure = plt.figure()
         lines = self.plot(**matplot_args)
-        figure.show()
+        plt.show()
 
         return figure

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -108,7 +108,7 @@ class EVESpWxTimeSeries(GenericTimeSeries):
             if "title" not in kwargs:
                 kwargs['title'] = 'EVE ' + column.replace('_', ' ')
             data.plot(**kwargs)
-        figure.show()
+        plt.show()
         return figure
 
     @classmethod

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -113,7 +113,8 @@ class XRSTimeSeries(GenericTimeSeries):
 
         axes.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M')
         figure.autofmt_xdate()
-        figure.show()
+
+        plt.show()
 
         return figure
 

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -118,7 +118,7 @@ class LYRATimeSeries(GenericTimeSeries):
         for axe in axes:
             axe.locator_params(axis='y',nbins=6)
 
-        figure.show()
+        plt.show()
 
         return figure
 

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -245,7 +245,7 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         axes.xaxis.grid(True, 'major')
         axes.legend()
 
-        figure.show()
+        plt.show()
         return figure
 
     @staticmethod

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -110,7 +110,7 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         axes.xaxis.grid(True, 'major')
         axes.legend()
 
-        figure.show()
+        plt.show()
         return figure
 
     @classmethod

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -112,8 +112,8 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
 
         axes.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M')
         figure.autofmt_xdate()
-        figure.show()
-        return figure
+        plt.show()
+	return figure
 
     @classmethod
     def _parse_file(cls, filepath):

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -420,7 +420,7 @@ class GenericTimeSeries:
         # Now make the plot
         figure = plt.figure()
         self.plot(**kwargs)
-        figure.show()
+        plt.show()
 
         return figure
 


### PR DESCRIPTION
Solves issue #2352 

Replaced ```figure.show()``` with ```plt.show()``` in ```sunpy.timeseries.sources``` .  ```Timeseries.peek``` now holds the plot open.