### PR TITLE
Fixing CompositeMap object so that it respects masked maps

### DIFF
--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -446,7 +446,7 @@ class CompositeMap(object):
                 if m.mask is None:
                     ret.append(axes.contour(m.data, m.levels, **params))
                 else:
-                    ret.append(axes.contour(np.ma.array(np.asarray(m.data), mask=m.mask), **params))
+                    ret.append(axes.contour(np.ma.array(np.asarray(m.data), mask=m.mask), m.levels, **params))
 
                 # Set the label of the first line so a legend can be created
                 ret[-1].collections[0].set_label(m.name)

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -442,11 +442,13 @@ class CompositeMap(object):
                     ret.append(axes.imshow(m.data, **params))
                 else:
                     ret.append(axes.imshow(np.ma.array(np.asarray(m.data), mask=m.mask), **params))
+            else:
+                # Check for the presence of masked map data
+                if m.mask is None:
+                    ret.append(axes.contour(m.data, m.levels, **params))
+                else:
+                    ret.append(axes.contour(np.ma.array(np.asarray(m.data), mask=m.mask), **params))
 
-            if m.levels is not False:
-                # Set data with values <= 0 to transparent
-                # contour_data = np.ma.masked_array(m, mask=(m <= 0))
-                ret.append(axes.contour(m.data, m.levels, **params))
                 # Set the label of the first line so a legend can be created
                 ret[-1].collections[0].set_label(m.name)
 

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -4,6 +4,8 @@ Author: `Keith Hughitt <keith.hughitt@nasa.gov>`
 """
 from __future__ import absolute_import, print_function, division
 
+import numpy as np
+
 import matplotlib.pyplot as plt
 
 import astropy.units as u
@@ -431,10 +433,16 @@ class CompositeMap(object):
             }
             params.update(matplot_args)
 
+            # The request to show a map layer rendered as a contour is indicated by a
+            # non False levels property.  If levels is False, then the layer is
+            # rendered using imshow.
             if m.levels is False:
-                ret.append(axes.imshow(m.data, **params))
+                # Check for the presence of masked map data
+                if m.mask is None:
+                    ret.append(axes.imshow(m.data, **params))
+                else:
+                    ret.append(axes.imshow(np.ma.array(np.asarray(m.data), mask=m.mask), **params))
 
-            # Use contour for contour data, and imshow otherwise
             if m.levels is not False:
                 # Set data with values <= 0 to transparent
                 # contour_data = np.ma.masked_array(m, mask=(m <= 0))

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -411,7 +411,6 @@ class CompositeMap(object):
                                                    self._maps[0].spatial_units[0]))
             axes.set_ylabel(axis_labels_from_ctype(self._maps[0].coordinate_system[1],
                                                    self._maps[0].spatial_units[1]))
-
             axes.set_title(title)
 
         # Define a list of plotted objects


### PR DESCRIPTION
Issue #2490 notes that masked maps are not rendered when using CompositeMap.  This PR fixes this by using the mask detection mechanism in Map and implementing it in CompositeMap.