### PR TITLE
Fixed Padding values in some of the documentation pages

### DIFF
--- a/examples/2011_06_07_sampledata_overview.py
+++ b/examples/2011_06_07_sampledata_overview.py
@@ -71,7 +71,7 @@ aia_094_map.draw_grid()
 ax = fig.add_subplot(616, projection=aia_1600_map)
 aia_1600_map.plot()
 aia_1600_map.draw_grid()
-plt.tight_layout(pad=1.50)
+plt.tight_layout(pad=6.50)
 plt.show()
 
 ###############################################################################
@@ -94,7 +94,7 @@ ax = fig.add_subplot(514, projection=aia_cutout04_map)
 aia_cutout04_map.plot()
 ax = fig.add_subplot(515, projection=aia_cutout05_map)
 aia_cutout05_map.plot()
-plt.tight_layout(pad=2.50)
+plt.tight_layout(pad=5.50)
 plt.show()
 
 ###############################################################################

--- a/examples/loop_edge_enhance.py
+++ b/examples/loop_edge_enhance.py
@@ -39,7 +39,7 @@ edge_enhanced_im = np.hypot(sx, sy)
 
 edge_map = sunpy.map.Map(edge_enhanced_im, aia_smap.meta)
 
-fig = plt.figure(figsize=(12, 4))
+fig = plt.figure(figsize=(12, 6))
 ax = fig.add_subplot(121, projection=aia_smap)
 aia_smap.plot()
 ax = fig.add_subplot(122, projection=aia_smap)

--- a/examples/submaps_and_cropping.py
+++ b/examples/submaps_and_cropping.py
@@ -45,5 +45,5 @@ top_right = SkyCoord(0*u.arcsec, -200 * u.arcsec, frame=swap_map.coordinate_fram
 bottom_left = SkyCoord(-900 * u.arcsec, -900 * u.arcsec, frame=swap_map.coordinate_frame)
 swap_submap = swap_map.submap(bottom_left, top_right)
 swap_submap.peek(draw_limb=True, draw_grid=True)
-
+plt.tight_layout(pad=1.00)
 plt.show()


### PR DESCRIPTION
This PR is in reference to #2308.
I have gone through each image of the gallery and fixed the error after reading this documentation : https://matplotlib.org/users/tight_layout_guide.html.
![from this ](https://user-images.githubusercontent.com/28241692/36933117-ec212e62-1ef9-11e8-8bef-38dcfac55b7c.png)

to 

![issue1](https://user-images.githubusercontent.com/28241692/36933122-f8c7deb8-1ef9-11e8-8521-276cc4efab85.png)

Also some similar and tight_layout errors were taken care of in another three images.
