### PR TITLE
Run only figure tests on figure test jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,12 +96,14 @@ matrix:
          # Python 2.7 figure tests
          - python: 2.7
            stage: Comprehensive tests
-           env: SETUP_CMD='test --figure --coverage' CONDA_DEPENDENCIES=''
+           env: MAIN_CMD="py.test"
+                SETUP_CMD='-v -m figure' CONDA_DEPENDENCIES=''
 
          # Python 3.5 figure tests
          - python: 3.5
            stage: Comprehensive tests
-           env: SETUP_CMD='test --figure --coverage' CONDA_DEPENDENCIES=''
+           env: MAIN_CMD="py.test"
+                SETUP_CMD='-v -m figure' CONDA_DEPENDENCIES=''
 
          # Python 3.5 with astropy 2
          - python: 3.5


### PR DESCRIPTION
Should shave about 10 minutes of total build time off the travis builds.