### PR TITLE
Output sphinx warnings to stdout.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ jobs:
     docker:
       - image: circleci/python:3.6
     steps:
+      - restore_cache:
+          keys: sample-data-v1
+
       - checkout
       - run: *apt-install
       - run: *pip-install
@@ -49,6 +52,11 @@ jobs:
       - run:
           name: "Built documentation is available at:"
           command: DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/_build/html/index.html"; echo $DOCS_URL
+
+      - save_cache:
+          key: sample-data-v1
+          paths:
+            - ~/sunpy/data/sample_data
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ pip-run: &pip-install
   command: |
     python3 -m venv venv
     . venv/bin/activate
-    pip install -r requirements/docs.txt
+    pip install -q -r requirements/docs.txt
 
 version: 2
 jobs:
@@ -35,16 +35,13 @@ jobs:
       - run: python setup.py egg_info
 
   html-docs:
-    environment:
-      - MAIN_CMD: "venv/bin/python setup.py"
-      - SETUP_CMD: "build_docs -w"
     docker:
       - image: circleci/python:3.6
     steps:
       - checkout
       - run: *apt-install
       - run: *pip-install
-      - run: $MAIN_CMD $SETUP_CMD
+      - run: venv/bin/python setup.py build_docs -w 2> /dev/null
 
       - store_artifacts:
           path: docs/_build/html

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,1 +1,6 @@
 comment: off
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "astropy_helpers"]
 	path = astropy_helpers
-	url = https://github.com/astropy/astropy-helpers.git
+	url = https://github.com/Cadair/astropy-helpers.git

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,19 @@ import os
 import datetime
 import sys
 
+
+# -- Convert Sphinx Warnings to output to stdout not stderr---------------------
+
+import logging
+from sphinx.util.logging import NAMESPACE, WarningStreamHandler, SafeEncodingWriter
+
+sphinxlogger = logging.getLogger(NAMESPACE)
+handlers = sphinxlogger.handlers
+warninghandler = list(filter(lambda x: isinstance(x, WarningStreamHandler), handlers))[0]
+warninghandler.stream = SafeEncodingWriter(stream=sys.stdout)
+
+# -- Import Base config from sphinx-astropy ------------------------------------
+
 try:
     from sphinx_astropy.conf.v1 import *
 except ImportError:


### PR DESCRIPTION
This allows us to silence stderr on CircleCI to make it more obvious what are actually warnings.