### PR TITLE
Remove or document **kwargs in timeseries

### DIFF
--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -397,7 +397,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         Extra keyword arguments are passed through to `sunpy.io.read_file` such
         as `memmap` for FITS files.
         """
-
+        concatenate = kwargs.pop('concatenate', False)
         # Hack to get around Python 2.x not backporting PEP 3102.
         silence_errors = kwargs.pop('silence_errors', False)
 
@@ -475,7 +475,6 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         new_timeseries += already_timeseries
 
         # Concatenate the timeseries into one if specified.
-        concatenate = kwargs.get('concatenate', False)
         if concatenate:
             # Merge all these timeseries into one.
             full_timeseries = new_timeseries.pop(0)
@@ -524,7 +523,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         """
 
         WidgetType = self._get_matching_widget(**kwargs)
-
+        source = kwargs.pop('source', None)
         # Dealing with the fact that timeseries filetypes are less consistent
         # (then maps), we use a _parse_file() method embedded into each
         # instrument subclass.

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -163,7 +163,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         else:
             return False
 
-    def _validate_units(self, units, **kwargs):
+    def _validate_units(self, units):
         """
         Validates the astropy unit-information associated with a TimeSeries.
         Should be a dictionary of some form (but not MetaDict) with only
@@ -185,7 +185,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         # Passed all the tests
         return result
 
-    def _from_table(self, t, **kwargs):
+    def _from_table(self, t):
         """
         Extract the data, metadata and units from an astropy table for use in
         constructing a TimeSeries.

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -134,10 +134,6 @@ class GenericTimeSeries:
         else:
             self.units = units
 
-        # Validate input data
-        #self._validate_meta()
-        #self._validate_units()
-
 # #### Attribute definitions #### #
 
     @property
@@ -167,7 +163,7 @@ class GenericTimeSeries:
 
 # #### Data Access, Selection and Organisation Methods #### #
 
-    def quantity(self, colname, **kwargs):
+    def quantity(self, colname):
         """
         Return a `~astropy.units.quantity.Quantity` for the given column.
 
@@ -181,10 +177,10 @@ class GenericTimeSeries:
         quantity : `~astropy.units.quantity.Quantity`
         """
         values = self.data[colname].values
-        unit   = self.units[colname]
+        unit = self.units[colname]
         return u.Quantity(values, unit)
 
-    def add_column(self, colname, quantity, unit=False, overwrite=True, **kwargs):
+    def add_column(self, colname, quantity, unit=False, overwrite=True):
         """
         Return an new TimeSeries with the given column added or updated.
 
@@ -213,8 +209,8 @@ class GenericTimeSeries:
             unit = u.dimensionless_unscaled
 
         # Make a copy of all the TimeSeries components.
-        data  = copy.copy(self.data)
-        meta  = TimeSeriesMetaData(copy.copy(self.meta.metadata))
+        data = copy.copy(self.data)
+        meta = TimeSeriesMetaData(copy.copy(self.meta.metadata))
         units = copy.copy(self.units)
 
         # Add the unit to the units dictionary if already there.
@@ -234,9 +230,17 @@ class GenericTimeSeries:
         return self.__class__(data, meta, units)
 
     def sort_index(self, **kwargs):
-        """Returns a sorted version of the TimeSeries object.
-        Generally this shouldn't be necessary as most TimeSeries operations sort
-        the data anyway to ensure consistent behaviour when truncating.
+        """
+        Returns a sorted version of the TimeSeries object.
+
+        Generally this shouldn't be necessary as most TimeSeries operations
+        sort the data anyway to ensure consistent behaviour when truncating.
+
+        Parameters
+        ----------
+        **kwargs :
+            All keyword arguments are handed to the `sort_data` method of
+            ``self.data``.
 
         Returns
         -------
@@ -274,7 +278,7 @@ class GenericTimeSeries:
         if isinstance(a, TimeRange):
             # If we have a TimeRange, extract the values
             start = a.start
-            end   = a.end
+            end = a.end
         else:
             # Otherwise we already have the values
             start = a
@@ -338,6 +342,9 @@ class GenericTimeSeries:
 
         same_source : `bool` Optional
             Set to true to check if the sources of the time series match.
+
+        **kwargs :
+            All keyword arguments are handed to `pandas.concat`.
 
         Returns
         -------
@@ -556,7 +563,7 @@ class GenericTimeSeries:
         # Output the table
         return table
 
-    def to_dataframe(self, **kwargs):
+    def to_dataframe(self):
         """
         Return a Pandas DataFrame of the give TimeSeries object.
 

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -112,7 +112,7 @@ class GenericTimeSeries:
     # Class attribute used to specify the source class of the TimeSeries.
     _source = None
 
-    def __init__(self, data, meta=None, units=None, **kwargs):
+    def __init__(self, data, meta=None, units=None):
         self.data = data
         tr = TimeRange(self.data.index.min(), self.data.index.max())
         # Check metadata input
@@ -466,7 +466,7 @@ class GenericTimeSeries:
 
                 warnings.warn("Unknown value for "+meta_property.upper(), Warning)
 
-    def _validate_units(self, units, **kwargs):
+    def _validate_units(self, units):
         """
         Validates the astropy unit-information associated with a TimeSeries.
 
@@ -491,7 +491,7 @@ class GenericTimeSeries:
 
         return result
 
-    def _sanitize_units(self, **kwargs):
+    def _sanitize_units(self):
         """
         Sanitises the collections.OrderedDict used to store the units.
         Primarily this method will:
@@ -516,7 +516,7 @@ class GenericTimeSeries:
         # Now use the amended units Ordered Dictionary
         self.units = units
 
-    def _sanitize_metadata(self, **kwargs):
+    def _sanitize_metadata(self):
         """
         Sanitises the TimeSeriesMetaData object used to store the metadata.
         Primarily this method will:
@@ -538,7 +538,7 @@ class GenericTimeSeries:
 
 # #### Export/Output Methods #### #
 
-    def to_table(self, **kwargs):
+    def to_table(self):
         """
         Return an Astropy Table of the give TimeSeries object.
 


### PR DESCRIPTION
I want to try and clean up `TimeSeries` a bit, before we start using it with a vengeance in HelioPy. This also includes a few PEP8 fixes.