### PR TITLE
[time] Make parse_time return astropy.time.Time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,15 @@ jobs:
       - checkout
       - run: python setup.py egg_info
 
+  astropy-time:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run: *pip-install
+      # Copy and paste this line for every submodule for which the tests pass
+      - run: venv/bin/python setup.py test -P time -w 2> /dev/null
+
   html-docs:
     docker:
       - image: circleci/python:3.6
@@ -67,6 +76,7 @@ workflows:
       - egg-info-36
       - egg-info-35
       - egg-info-27
+      - astropy-time
 
   test-documentation:
     jobs:

--- a/examples/parse_time.py
+++ b/examples/parse_time.py
@@ -5,7 +5,7 @@ Parsing times with sunpy.time.parse_time
 
 Example to show some example usage of parse_time
 """
-
+##############################################################################
 # Import the required modules
 from datetime import datetime, date
 import time
@@ -30,10 +30,9 @@ t2 = parse_time('1995-Dec-31 23:59:60')
 
 ##############################################################################
 # You can mention the scale of the time as keyword parameter if you need
-# The default is utc
-t3 = parse_time('2012:124:21:08:12', scale='tai')
 # Similar to scale you can pass in any astropy Time compatible keywords to
 # parse_time. See all arguments here: http://docs.astropy.org/en/stable/time/#creating-a-time-object
+t3 = parse_time('2012:124:21:08:12', scale='tai')
 
 
 ##############################################################################

--- a/examples/parse_time.py
+++ b/examples/parse_time.py
@@ -18,27 +18,28 @@ from sunpy.time import parse_time
 
 
 ##############################################################################
-# Suppose you want to parse of strings, parse_time can do that.
+# Suppose you want to parse some strings, ``parse_time`` can do that.
 t1 = parse_time('1995-12-31 23:59:60')
 
 ##############################################################################
-# Ofcourse you could do the same with astropy Time.
-# But SunPy parse_time can parse even more time formats.
-# As you see from the examples, thanks to astropy Time, parse_time
+# Of course you could do the same with astropy ``Time``.
+# But SunPy ``parse_time`` can parse even more formats of time strings.
+# And as you see from the examples, thanks to astropy ``Time``, ``parse_time``
 # can handle leap seconds too.
 t2 = parse_time('1995-Dec-31 23:59:60')
 
 
 ##############################################################################
-# You can mention the scale of the time as keyword parameter if you need.
+# You can mention the scale of the time as a keyword parameter if you need.
 # Similar to scale you can pass in any astropy Time compatible keywords to
-# parse_time. See all arguments here: http://docs.astropy.org/en/stable/time/#creating-a-time-object
+# ``parse_time``. See all arguments
+# `here: <http://docs.astropy.org/en/stable/time/#creating-a-time-object>`__
 t3 = parse_time('2012:124:21:08:12', scale='tai')
 
 
 ##############################################################################
-# Now that you are done with strings, let's see other type parse_time handles,
-# tuples. astropy Time doesnot handle tuples but parse_time does
+# Now that you are done with strings, let's see other type ``parse_time`` handles,
+# tuples. astropy ``Time`` doesnot handle tuples but ``parse_time`` does.
 t4 = parse_time((1998, 11, 14))
 t5 = parse_time((2001, 1, 1, 12, 12, 12, 8899))
 
@@ -47,14 +48,14 @@ t5 = parse_time((2001, 1, 1, 12, 12, 12, 8899))
 t6 = parse_time(time.localtime())
 
 ##############################################################################
-# parse_time also parses datetime and date objects.
+# ``parse_time`` also parses ``datetime`` and ``date`` objects.
 t7 = parse_time(datetime.now())
 t8 = parse_time(date.today())
 
 
 ##############################################################################
-# parse_time can return Time objects for pandas.Timestamp, pandas.Series
-# and pandas.DatetimeIndex.
+# ``parse_time`` can return ``Time`` objects for ``pandas.Timestamp``, ``pandas.Series``
+# and ``pandas.DatetimeIndex``.
 t9 = parse_time(pandas.Timestamp(datetime(1966, 2, 3)))
 
 t10 = parse_time(
@@ -73,7 +74,7 @@ t11 = parse_time(
 
 
 ##############################################################################
-# parse_time can parse numpy.datetime64 objects
+# ``parse_time`` can parse numpy.datetime64 objects.
 t12 = parse_time(np.datetime64('2014-02-07T16:47:51.008288123-0500'))
 t13 = parse_time(
     np.array(
@@ -81,13 +82,13 @@ t13 = parse_time(
         dtype='datetime64'))
 
 ##############################################################################
-# Parse time returns astropy.time.Time object for every parsable input that
+# Parse time returns ``astropy.time.Time`` object for every parsable input that
 # you give to it.
-# parse_time can handle all formats that astropy.time.Time can handle.
+# ``parse_time`` can handle all formats that ``astropy.time.Time`` can handle.
 # That is,
 # ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date', 'datetime',
 # 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
 # at the time of writing. This can be used by passing format keyword argument
-# to parse_time
+# to ``parse_time``.
 parse_time(1234.0, format='jd')
 parse_time('B1950.0', format='byear_str')

--- a/examples/parse_time.py
+++ b/examples/parse_time.py
@@ -6,42 +6,29 @@ Parsing times with sunpy.time.parse_time
 Example to show some example usage of parse_time
 """
 
+# Import the required modules
 from datetime import datetime, date
 import time
 
 import numpy as np
 import pandas
 
+# Import parse_time
 from sunpy.time import parse_time
 
 
-# Parse time returns astropy.time.Time object for every parsable input that
-# you give to it
-
 ##############################################################################
-
-
-# parse_time can handle all formats that astropy.time.Time can handle
-# That is,
-# ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date', 'datetime',
-# 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
-# at the time of writing. This can be used by passing format keyword argument
-# to parse_time
-parse_time(1234.0, format='jd')
-parse_time('B1950.0', format='byear_str')
-
-
-##############################################################################
-
-
 # Suppose you want to parse of strings, parse_time can do that.
 t1 = parse_time('1995-12-31 23:59:60')
+
+##############################################################################
 # Ofcourse you could do the same with astropy Time.
 # But SunPy parse_time can parse even more time formats
 t2 = parse_time('1995-Dec-31 23:59:60')
 # As you see from the above examples, thanks to astropy Time, parse_time
 # can handle leap seconds too.
 
+##############################################################################
 # You can mention the scale of the time as keyword parameter if you need
 # The default is utc
 t3 = parse_time('2012:124:21:08:12', scale='tai')
@@ -50,28 +37,23 @@ t3 = parse_time('2012:124:21:08:12', scale='tai')
 
 
 ##############################################################################
-
-
 # Now that you are done with strings, let's see other type parse_time handles,
 # tuples
 # astropy Time doesnot handle tuples but parse_time does
 t4 = parse_time((1998, 11, 14))
 t5 = parse_time((2001, 1, 1, 12, 12, 12, 8899))
-# This also means that you can parse a time struct :D
-t6 = parse_time(time.localtime())
-
 
 ##############################################################################
+# This also means that you can parse a time struct.
+t6 = parse_time(time.localtime())
 
-
+##############################################################################
 # parse_time also parses datetime and date objects
 t7 = parse_time(datetime.now())
 t8 = parse_time(date.today())
 
 
 ##############################################################################
-
-
 # parse_time can return Time objects for pandas.Timestamp, pandas.Series
 # and pandas.DatetimeIndex
 t9 = parse_time(pandas.Timestamp(datetime(1966, 2, 3)))
@@ -92,11 +74,21 @@ t11 = parse_time(
 
 
 ##############################################################################
-
-
 # parse_time can parse numpy.datetime64 objects
 t12 = parse_time(np.datetime64('2014-02-07T16:47:51.008288123-0500'))
 t13 = parse_time(
     np.array(
         ['2014-02-07T16:47:51.008288123', '2014-02-07T18:47:51.008288123'],
         dtype='datetime64'))
+
+##############################################################################
+# Parse time returns astropy.time.Time object for every parsable input that
+# you give to it
+# parse_time can handle all formats that astropy.time.Time can handle
+# That is,
+# ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date', 'datetime',
+# 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
+# at the time of writing. This can be used by passing format keyword argument
+# to parse_time
+parse_time(1234.0, format='jd')
+parse_time('B1950.0', format='byear_str')

--- a/examples/parse_time.py
+++ b/examples/parse_time.py
@@ -1,0 +1,65 @@
+"""
+================================================
+Parsing times with sunpy.time.parse_time
+================================================
+
+Example to show some example usage of parse_time
+"""
+
+from datetime import datetime, date
+import numpy as np
+import pandas
+
+from sunpy.time import parse_time
+
+# dict used for coloring the terminal output
+col = {'y': '\x1b[93m', 'g': '\x1b[92m', 'r': '\x1b[96m', 'bold': '\x1b[1m',
+       'end': '\x1b[0m'}
+
+
+def print_time(*args, **kwargs):
+    '''Parses and pretty prints a parse_time compatible object
+    '''
+
+    # Parse the time
+    time = parse_time(*args, **kwargs)  # Pass all arguments to parse_time
+
+    # Color and print to terminal
+    print(col['r'] + '\nInput string/object: ' + col['end'] +
+          col['bold'] + '{ts!r}'.format(ts=args[0])+col['end'])
+    print(col['r'] + 'Parsed Time: ' + col['end'] + col['y'] + col['bold'] +
+          '{time!r}'.format(time=time) + col['end'])
+
+
+# Strings
+print('\nSTRINGS')
+print_time('2005-08-04T00:18:02.000', scale='tt')
+print_time('20140101000001')
+print_time('2016.05.04_21:08:12_TAI')
+print_time('1995-12-31 23:59:60')  # Leap second
+print_time('1995-Dec-31 23:59:60')
+
+# datetime
+print('\nDATETIME')
+print_time(datetime.now(), scale='tai')
+print_time(date.today())
+
+# numpy
+print('\nnumpy.datetime64')
+print_time(np.datetime64('1995-12-31 18:59:59-0500'))
+print_time(np.arange('2005-02-01T00', '2005-02-01T10', dtype='datetime64'))
+
+# astropy compatible times
+print('\nAstroPy compatible')
+print_time(1234.0, format='jd')
+print_time('B1950.0', format='byear_str')
+print_time('2001-03-22 00:01:44.732327132980', scale='utc',
+           location=('120d', '40d'))  # pass location
+
+# pandas
+print_time(pandas.Timestamp(datetime(1966, 2, 3)))
+print_time(
+    pandas.Series([[datetime(2012, 1, 1, 0, 0),
+                    datetime(2012, 1, 2, 0, 0)],
+                   [datetime(2012, 1, 3, 0, 0),
+                    datetime(2012, 1, 4, 0, 0)]]))

--- a/examples/parse_time.py
+++ b/examples/parse_time.py
@@ -7,59 +7,96 @@ Example to show some example usage of parse_time
 """
 
 from datetime import datetime, date
+import time
+
 import numpy as np
 import pandas
 
 from sunpy.time import parse_time
 
-# dict used for coloring the terminal output
-col = {'y': '\x1b[93m', 'g': '\x1b[92m', 'r': '\x1b[96m', 'bold': '\x1b[1m',
-       'end': '\x1b[0m'}
+
+# Parse time returns astropy.time.Time object for every parsable input that
+# you give to it
+
+##############################################################################
 
 
-def print_time(*args, **kwargs):
-    '''Parses and pretty prints a parse_time compatible object
-    '''
-
-    # Parse the time
-    time = parse_time(*args, **kwargs)  # Pass all arguments to parse_time
-
-    # Color and print to terminal
-    print(col['r'] + '\nInput string/object: ' + col['end'] +
-          col['bold'] + '{ts!r}'.format(ts=args[0])+col['end'])
-    print(col['r'] + 'Parsed Time: ' + col['end'] + col['y'] + col['bold'] +
-          '{time!r}'.format(time=time) + col['end'])
+# parse_time can handle all formats that astropy.time.Time can handle
+# That is,
+# ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date', 'datetime',
+# 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
+# at the time of writing. This can be used by passing format keyword argument
+# to parse_time
+parse_time(1234.0, format='jd')
+parse_time('B1950.0', format='byear_str')
 
 
-# Strings
-print('\nSTRINGS')
-print_time('2005-08-04T00:18:02.000', scale='tt')
-print_time('20140101000001')
-print_time('2016.05.04_21:08:12_TAI')
-print_time('1995-12-31 23:59:60')  # Leap second
-print_time('1995-Dec-31 23:59:60')
+##############################################################################
 
-# datetime
-print('\nDATETIME')
-print_time(datetime.now(), scale='tai')
-print_time(date.today())
 
-# numpy
-print('\nnumpy.datetime64')
-print_time(np.datetime64('1995-12-31 18:59:59-0500'))
-print_time(np.arange('2005-02-01T00', '2005-02-01T10', dtype='datetime64'))
+# Suppose you want to parse of strings, parse_time can do that.
+t1 = parse_time('1995-12-31 23:59:60')
+# Ofcourse you could do the same with astropy Time.
+# But SunPy parse_time can parse even more time formats
+t2 = parse_time('1995-Dec-31 23:59:60')
+# As you see from the above examples, thanks to astropy Time, parse_time
+# can handle leap seconds too.
 
-# astropy compatible times
-print('\nAstroPy compatible')
-print_time(1234.0, format='jd')
-print_time('B1950.0', format='byear_str')
-print_time('2001-03-22 00:01:44.732327132980', scale='utc',
-           location=('120d', '40d'))  # pass location
+# You can mention the scale of the time as keyword parameter if you need
+# The default is utc
+t3 = parse_time('2012:124:21:08:12', scale='tai')
+# Similar to scale you can pass in any astropy Time compatible keywords to
+# parse_time. See all arguments here: http://docs.astropy.org/en/stable/time/#creating-a-time-object
 
-# pandas
-print_time(pandas.Timestamp(datetime(1966, 2, 3)))
-print_time(
+
+##############################################################################
+
+
+# Now that you are done with strings, let's see other type parse_time handles,
+# tuples
+# astropy Time doesnot handle tuples but parse_time does
+t4 = parse_time((1998, 11, 14))
+t5 = parse_time((2001, 1, 1, 12, 12, 12, 8899))
+# This also means that you can parse a time struct :D
+t6 = parse_time(time.localtime())
+
+
+##############################################################################
+
+
+# parse_time also parses datetime and date objects
+t7 = parse_time(datetime.now())
+t8 = parse_time(date.today())
+
+
+##############################################################################
+
+
+# parse_time can return Time objects for pandas.Timestamp, pandas.Series
+# and pandas.DatetimeIndex
+t9 = parse_time(pandas.Timestamp(datetime(1966, 2, 3)))
+
+t10 = parse_time(
     pandas.Series([[datetime(2012, 1, 1, 0, 0),
                     datetime(2012, 1, 2, 0, 0)],
                    [datetime(2012, 1, 3, 0, 0),
                     datetime(2012, 1, 4, 0, 0)]]))
+
+t11 = parse_time(
+    pandas.DatetimeIndex([
+        datetime(2012, 1, 1, 0, 0),
+        datetime(2012, 1, 2, 0, 0),
+        datetime(2012, 1, 3, 0, 0),
+        datetime(2012, 1, 4, 0, 0)
+    ]))
+
+
+##############################################################################
+
+
+# parse_time can parse numpy.datetime64 objects
+t12 = parse_time(np.datetime64('2014-02-07T16:47:51.008288123-0500'))
+t13 = parse_time(
+    np.array(
+        ['2014-02-07T16:47:51.008288123', '2014-02-07T18:47:51.008288123'],
+        dtype='datetime64'))

--- a/examples/parse_time.py
+++ b/examples/parse_time.py
@@ -1,19 +1,20 @@
 """
-================================================
+========================================
 Parsing times with sunpy.time.parse_time
-================================================
+========================================
 
-Example to show some example usage of parse_time
+This is an example to show some possible usage of ``parse_time``.
+``parse_time`` is a function that can be useful to create `~astropy.time.Time`
+objects from various other time objects and strings.
 """
 ##############################################################################
-# Import the required modules
+# Import the required modules.
 from datetime import datetime, date
 import time
 
 import numpy as np
 import pandas
 
-# Import parse_time
 from sunpy.time import parse_time
 
 
@@ -22,9 +23,9 @@ from sunpy.time import parse_time
 t1 = parse_time('1995-12-31 23:59:60')
 
 ##############################################################################
-# Of course you could do the same with astropy ``Time``.
+# Of course you could do the same with `~astropy.time.Time`.
 # But SunPy ``parse_time`` can parse even more formats of time strings.
-# And as you see from the examples, thanks to astropy ``Time``, ``parse_time``
+# And as you see from the examples, thanks to `~astropy.time.Time`, ``parse_time``
 # can handle leap seconds too.
 t2 = parse_time('1995-Dec-31 23:59:60')
 
@@ -39,12 +40,12 @@ t3 = parse_time('2012:124:21:08:12', scale='tai')
 
 ##############################################################################
 # Now that you are done with strings, let's see other type ``parse_time`` handles,
-# tuples. astropy ``Time`` doesnot handle tuples but ``parse_time`` does.
+# tuples. `~astropy.time.Time` doesnot handle tuples but ``parse_time`` does.
 t4 = parse_time((1998, 11, 14))
 t5 = parse_time((2001, 1, 1, 12, 12, 12, 8899))
 
 ##############################################################################
-# This also means that you can parse a time struct.
+# This also means that you can parse a ``time.struct_time``.
 t6 = parse_time(time.localtime())
 
 ##############################################################################
@@ -74,7 +75,7 @@ t11 = parse_time(
 
 
 ##############################################################################
-# ``parse_time`` can parse numpy.datetime64 objects.
+# ``parse_time`` can parse ``numpy.datetime64`` objects.
 t12 = parse_time(np.datetime64('2014-02-07T16:47:51.008288123-0500'))
 t13 = parse_time(
     np.array(
@@ -82,9 +83,9 @@ t13 = parse_time(
         dtype='datetime64'))
 
 ##############################################################################
-# Parse time returns ``astropy.time.Time`` object for every parsable input that
+# Parse time returns `~astropy.time.Time object for every parsable input that
 # you give to it.
-# ``parse_time`` can handle all formats that ``astropy.time.Time`` can handle.
+# ``parse_time`` can handle all formats that `~astropy.time.Time` can handle.
 # That is,
 # ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date', 'datetime',
 # 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']

--- a/sunpy/time/__init__.py
+++ b/sunpy/time/__init__.py
@@ -5,3 +5,4 @@ from sunpy.time.time import *
 from sunpy.time.timerange import *
 from sunpy.time.julian import *
 from sunpy.time.utime import *
+from sunpy.time import astropy_time

--- a/sunpy/time/__init__.py
+++ b/sunpy/time/__init__.py
@@ -5,4 +5,4 @@ from sunpy.time.time import *
 from sunpy.time.timerange import *
 from sunpy.time.julian import *
 from sunpy.time.utime import *
-from sunpy.time import astropy_time
+from sunpy.time.astropy_time import Time

--- a/sunpy/time/astropy_time.py
+++ b/sunpy/time/astropy_time.py
@@ -5,87 +5,91 @@ import numpy as np
 from time import strftime, strptime
 from datetime import date, datetime
 
+__all__ = ['Time']
 
-class Time(astropy.time.Time):
-    @classmethod
-    def strptime(cls, time_string, format_string, **kwargs):
-        """
-        Parse a string to a Time according to a format specification.
-        See `time.strptime` documentation for format specification.
+if hasattr(astropy.time.Time, 'strptime'):
+    from astropy.time import Time
+else:
+    class Time(astropy.time.Time):
+        @classmethod
+        def strptime(cls, time_string, format_string, **kwargs):
+            """
+            Parse a string to a Time according to a format specification.
+            See `time.strptime` documentation for format specification.
 
-        >>> Time.strptime('2012-Jun-30 23:59:60', '%Y-%b-%d %H:%M:%S')
-        <Time object: scale='utc' format='isot' value=2012-06-30T23:59:60.000>
+            >>> Time.strptime('2012-Jun-30 23:59:60', '%Y-%b-%d %H:%M:%S')
+            <Time object: scale='utc' format='isot' value=2012-06-30T23:59:60.000>
 
-        Parameters
-        ----------
-        time_string : string, sequence, ndarray
-            Objects containing time data of type string
-        format_string : string
-            String specifying format of time_string.
-        kwargs : dict
-            Any keyword arguments for ``Time``.  If the ``format`` keyword
-            argument is present, this will be used as the Time format.
+            Parameters
+            ----------
+            time_string : string, sequence, ndarray
+                Objects containing time data of type string
+            format_string : string
+                String specifying format of time_string.
+            kwargs : dict
+                Any keyword arguments for ``Time``.  If the ``format`` keyword
+                argument is present, this will be used as the Time format.
 
-        Returns
-        -------
-        time_obj : `~astropy.time.Time`
-            A new `~astropy.time.Time` object corresponding to the input
-            ``time_string``.
+            Returns
+            -------
+            time_obj : `~astropy.time.Time`
+                A new `~astropy.time.Time` object corresponding to the input
+                ``time_string``.
 
-        """
-        time_array = np.asarray(time_string)
+            """
+            time_array = np.asarray(time_string)
 
-        if time_array.dtype.kind not in ('U', 'S'):
-            err = "Expected type is string, a bytes-like object or a sequence"\
-                  " of these. Got dtype '{}'".format(time_array.dtype.kind)
-            raise TypeError(err)
+            if time_array.dtype.kind not in ('U', 'S'):
+                err = "Expected type is string, a bytes-like object or a sequence"\
+                    " of these. Got dtype '{}'".format(time_array.dtype.kind)
+                raise TypeError(err)
 
-        to_string = (str
-                     if time_array.dtype.kind == 'U' else lambda x: str(x.item(), encoding='ascii'))
-        iterator = np.nditer([time_array, None], op_dtypes=[time_array.dtype, 'U30'])
+            to_string = (str
+                        if time_array.dtype.kind == 'U' else lambda x: str(x.item(), encoding='ascii'))
+            iterator = np.nditer([time_array, None], op_dtypes=[time_array.dtype, 'U30'])
 
-        for time, formatted in iterator:
-            # TODO: Make this same as astropy version
-            if '%f' in format_string:
-                fstring = str(datetime.strptime(to_string(time), format_string))
-                formatted[...] = fstring.replace(' ', 'T')
+            for time, formatted in iterator:
+                # TODO: Make this same as astropy version
+                if '%f' in format_string:
+                    fstring = str(datetime.strptime(to_string(time), format_string))
+                    formatted[...] = fstring.replace(' ', 'T')
+                else:
+                    time_tuple = strptime(to_string(time), format_string)
+                    formatted[...] = '{}-{}-{}T{}:{}:{}'.format(*time_tuple)
+
+            format = kwargs.pop('format', None)
+            out = cls(*iterator.operands[1:], format='isot', **kwargs)
+            if format is not None:
+                out.format = format
+
+            return out
+
+        def strftime(self, format_spec):
+            """
+            Convert Time to a string or a numpy.array of strings according to a
+            format specification.
+            See `time.strftime` documentation for format specification.
+
+            Parameters
+            ----------
+            format_spec : string
+                Format definition of return string.
+
+            Returns
+            -------
+            formatted : string, numpy.array
+                String or numpy.array of strings formatted according to the given
+                format string.
+
+            """
+            formatted_strings = []
+            for sk in self.replicate('iso')._time.str_kwargs():
+                date_tuple = date(sk['year'], sk['mon'], sk['day']).timetuple()
+                datetime_tuple = (sk['year'], sk['mon'], sk['day'], sk['hour'], sk['min'], sk['sec'],
+                                date_tuple[6], date_tuple[7], -1)
+                formatted_strings.append(strftime(format_spec, datetime_tuple))
+
+            if self.isscalar:
+                return formatted_strings[0]
             else:
-                time_tuple = strptime(to_string(time), format_string)
-                formatted[...] = '{}-{}-{}T{}:{}:{}'.format(*time_tuple)
-
-        format = kwargs.pop('format', None)
-        out = cls(*iterator.operands[1:], format='isot', **kwargs)
-        if format is not None:
-            out.format = format
-
-        return out
-
-    def strftime(self, format_spec):
-        """
-        Convert Time to a string or a numpy.array of strings according to a
-        format specification.
-        See `time.strftime` documentation for format specification.
-
-        Parameters
-        ----------
-        format_spec : string
-            Format definition of return string.
-
-        Returns
-        -------
-        formatted : string, numpy.array
-            String or numpy.array of strings formatted according to the given
-            format string.
-
-        """
-        formatted_strings = []
-        for sk in self.replicate('iso')._time.str_kwargs():
-            date_tuple = date(sk['year'], sk['mon'], sk['day']).timetuple()
-            datetime_tuple = (sk['year'], sk['mon'], sk['day'], sk['hour'], sk['min'], sk['sec'],
-                              date_tuple[6], date_tuple[7], -1)
-            formatted_strings.append(strftime(format_spec, datetime_tuple))
-
-        if self.isscalar:
-            return formatted_strings[0]
-        else:
-            return np.array(formatted_strings).reshape(self.shape)
+                return np.array(formatted_strings).reshape(self.shape)

--- a/sunpy/time/astropy_time.py
+++ b/sunpy/time/astropy_time.py
@@ -3,7 +3,7 @@ import astropy.time
 import numpy as np
 
 from time import strftime, strptime
-from datetime import date
+from datetime import date, datetime
 
 
 class Time(astropy.time.Time):
@@ -45,8 +45,13 @@ class Time(astropy.time.Time):
         iterator = np.nditer([time_array, None], op_dtypes=[time_array.dtype, 'U30'])
 
         for time, formatted in iterator:
-            time_tuple = strptime(to_string(time), format_string)
-            formatted[...] = '{}-{}-{}T{}:{}:{}'.format(*time_tuple)
+            # TODO: Make this same as astropy version
+            if '%f' in format_string:
+                fstring = str(datetime.strptime(to_string(time), format_string))
+                formatted[...] = fstring.replace(' ', 'T')
+            else:
+                time_tuple = strptime(to_string(time), format_string)
+                formatted[...] = '{}-{}-{}T{}:{}:{}'.format(*time_tuple)
 
         format = kwargs.pop('format', None)
         out = cls(*iterator.operands[1:], format='isot', **kwargs)

--- a/sunpy/time/astropy_time.py
+++ b/sunpy/time/astropy_time.py
@@ -1,0 +1,86 @@
+import astropy.time
+
+import numpy as np
+
+from time import strftime, strptime
+from datetime import date
+
+
+class Time(astropy.time.Time):
+    @classmethod
+    def strptime(cls, time_string, format_string, **kwargs):
+        """
+        Parse a string to a Time according to a format specification.
+        See `time.strptime` documentation for format specification.
+
+        >>> Time.strptime('2012-Jun-30 23:59:60', '%Y-%b-%d %H:%M:%S')
+        <Time object: scale='utc' format='isot' value=2012-06-30T23:59:60.000>
+
+        Parameters
+        ----------
+        time_string : string, sequence, ndarray
+            Objects containing time data of type string
+        format_string : string
+            String specifying format of time_string.
+        kwargs : dict
+            Any keyword arguments for ``Time``.  If the ``format`` keyword
+            argument is present, this will be used as the Time format.
+
+        Returns
+        -------
+        time_obj : `~astropy.time.Time`
+            A new `~astropy.time.Time` object corresponding to the input
+            ``time_string``.
+
+        """
+        time_array = np.asarray(time_string)
+
+        if time_array.dtype.kind not in ('U', 'S'):
+            err = "Expected type is string, a bytes-like object or a sequence"\
+                  " of these. Got dtype '{}'".format(time_array.dtype.kind)
+            raise TypeError(err)
+
+        to_string = (str
+                     if time_array.dtype.kind == 'U' else lambda x: str(x.item(), encoding='ascii'))
+        iterator = np.nditer([time_array, None], op_dtypes=[time_array.dtype, 'U30'])
+
+        for time, formatted in iterator:
+            time_tuple = strptime(to_string(time), format_string)
+            formatted[...] = '{}-{}-{}T{}:{}:{}'.format(*time_tuple)
+
+        format = kwargs.pop('format', None)
+        out = cls(*iterator.operands[1:], format='isot', **kwargs)
+        if format is not None:
+            out.format = format
+
+        return out
+
+    def strftime(self, format_spec):
+        """
+        Convert Time to a string or a numpy.array of strings according to a
+        format specification.
+        See `time.strftime` documentation for format specification.
+
+        Parameters
+        ----------
+        format_spec : string
+            Format definition of return string.
+
+        Returns
+        -------
+        formatted : string, numpy.array
+            String or numpy.array of strings formatted according to the given
+            format string.
+
+        """
+        formatted_strings = []
+        for sk in self.replicate('iso')._time.str_kwargs():
+            date_tuple = date(sk['year'], sk['mon'], sk['day']).timetuple()
+            datetime_tuple = (sk['year'], sk['mon'], sk['day'], sk['hour'], sk['min'], sk['sec'],
+                              date_tuple[6], date_tuple[7], -1)
+            formatted_strings.append(strftime(format_spec, datetime_tuple))
+
+        if self.isscalar:
+            return formatted_strings[0]
+        else:
+            return np.array(formatted_strings).reshape(self.shape)

--- a/sunpy/time/tests/test_astropy_time.py
+++ b/sunpy/time/tests/test_astropy_time.py
@@ -1,0 +1,106 @@
+from sunpy.time.astropy_time import Time
+
+import numpy as np
+
+import pytest
+
+
+def test_strftime_scalar():
+    """Test of Time.strftime
+    """
+    time_string = '2010-09-03 06:00:00'
+    t = Time(time_string)
+
+    for format in t.FORMATS:
+        t.format = format
+        assert t.strftime('%Y-%m-%d %H:%M:%S') == time_string
+
+
+def test_strftime_array():
+    tstrings = ['2010-09-03 00:00:00', '2005-09-03 06:00:00', '1995-12-31 23:59:60']
+    t = Time(tstrings)
+
+    for format in t.FORMATS:
+        t.format = format
+        assert t.strftime('%Y-%m-%d %H:%M:%S').tolist() == tstrings
+
+
+def test_strftime_array_2():
+    tstrings = [['1998-01-01 00:00:01', '1998-01-01 00:00:02'],
+                ['1998-01-01 00:00:03', '1995-12-31 23:59:60']]
+    tstrings = np.array(tstrings)
+
+    t = Time(tstrings)
+
+    for format in t.FORMATS:
+        t.format = format
+        assert np.all(t.strftime('%Y-%m-%d %H:%M:%S') == tstrings)
+        assert t.strftime('%Y-%m-%d %H:%M:%S').shape == tstrings.shape
+
+
+def test_strftime_leapsecond():
+    time_string = '1995-12-31 23:59:60'
+    t = Time(time_string)
+
+    for format in t.FORMATS:
+        t.format = format
+        assert t.strftime('%Y-%m-%d %H:%M:%S') == time_string
+
+
+def test_strptime_scalar():
+    """Test of Time.strptime
+    """
+    time_string = '2007-May-04 21:08:12'
+    time_object = Time('2007-05-04 21:08:12')
+    t = Time.strptime(time_string, '%Y-%b-%d %H:%M:%S')
+
+    assert t == time_object
+
+
+def test_strptime_array():
+    """Test of Time.strptime
+    """
+    tstrings = [['1998-Jan-01 00:00:01', '1998-Jan-01 00:00:02'],
+                ['1998-Jan-01 00:00:03', '1998-Jan-01 00:00:04']]
+    tstrings = np.array(tstrings)
+
+    time_object = Time([['1998-01-01 00:00:01', '1998-01-01 00:00:02'],
+                        ['1998-01-01 00:00:03', '1998-01-01 00:00:04']])
+    t = Time.strptime(tstrings, '%Y-%b-%d %H:%M:%S')
+
+    assert np.all(t == time_object)
+    assert t.shape == tstrings.shape
+
+
+def test_strptime_badinput():
+    tstrings = [1, 2, 3]
+    with pytest.raises(TypeError):
+        Time.strptime(tstrings, '%S')
+
+
+def test_strptime_input_bytes_scalar():
+    time_string = b'2007-May-04 21:08:12'
+    time_object = Time('2007-05-04 21:08:12')
+    t = Time.strptime(time_string, '%Y-%b-%d %H:%M:%S')
+
+    assert t == time_object
+
+
+def test_strptime_input_bytes_array():
+    tstrings = [[b'1998-Jan-01 00:00:01', b'1998-Jan-01 00:00:02'],
+                [b'1998-Jan-01 00:00:03', b'1998-Jan-01 00:00:04']]
+    tstrings = np.array(tstrings)
+
+    time_object = Time([['1998-01-01 00:00:01', '1998-01-01 00:00:02'],
+                        ['1998-01-01 00:00:03', '1998-01-01 00:00:04']])
+    t = Time.strptime(tstrings, '%Y-%b-%d %H:%M:%S')
+
+    assert np.all(t == time_object)
+    assert t.shape == tstrings.shape
+
+
+def test_strptime_leapsecond():
+    time_obj1 = Time('1995-12-31T23:59:60', format='isot')
+    time_obj2 = Time.strptime('1995-Dec-31 23:59:60', '%Y-%b-%d %H:%M:%S')
+
+    assert time_obj1 == time_obj2

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -42,7 +42,17 @@ def test_parse_time_trailing_zeros():
 def test_parse_time_tuple():
     dt = parse_time((1966, 2, 3))
     assert dt == LANDING
-    assert dt.format == 'iso'
+    assert dt.format == 'isot'
+    assert dt.scale == 'utc'
+
+    dt = parse_time((1966, 2, 3, 12, 2, 3))
+    assert dt == ap.Time('1966-2-3T12:2:3')
+    assert dt.format == 'isot'
+    assert dt.scale == 'utc'
+
+    dt = parse_time((1966, 2, 3, 12, 2, 3, 8266))
+    assert dt == ap.Time('1966-2-3T12:2:3.008266')
+    assert dt.format == 'isot'
     assert dt.scale == 'utc'
 
 

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -170,13 +170,13 @@ def test_parse_time_astropy():
 
 def test_parse_time_datetime():
     dt = datetime(2014, 2, 7, 16, 47, 51, 8288)
-    assert parse_time(dt) == dt
+    assert parse_time(dt) == ap.Time('2014-02-07 16:47:51.008288')
     assert parse_time(dt).format == 'datetime'
 
 
 def test_parse_time_date():
     dt = parse_time(date(1966, 2, 3))
-    assert dt == datetime(1966, 2, 3)
+    assert dt == ap.Time('1966-2-3')
     assert dt.format == 'iso'
 
 

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -5,6 +5,7 @@ import re
 
 from sunpy import time
 from sunpy.time import parse_time, is_time_in_given_format, get_day, find_time
+import sunpy.time.astropy_time as ap
 
 import astropy.time
 import numpy as np
@@ -13,7 +14,7 @@ from sunpy.extern.six.moves import range
 
 import pytest
 
-LANDING = datetime(1966, 2, 3)
+LANDING = ap.Time('1966-02-03', format='isot')
 
 
 def test_parse_time_24():
@@ -34,10 +35,9 @@ def test_parse_time_tuple():
 
 
 def test_parse_time_int():
-    assert parse_time(765548612.0, 'utime') == datetime(2003, 4, 5,
-                                                        12, 23, 32)
-    assert parse_time(1009685652.0, 'utime') == datetime(2010, 12, 30,
-                                                         4, 14, 12)
+    assert parse_time(765548612.0, 'utime').jd == ap.Time('2003-4-5T12:23:32').jd
+
+    assert parse_time(1009685652.0, 'utime').jd == ap.Time('2010-12-30T4:14:12').jd
 
 
 def test_parse_time_pandas_timestamp():
@@ -145,45 +145,47 @@ def test_parse_time_now():
     """
     # TODO: once mocking support is merged in, we can perform a like for like comparison,
     #       the following at least ensures that 'now' is a legal argument.
-    assert isinstance(parse_time('now'), datetime) is True
+    assert isinstance(parse_time('now'), astropy.time.Time) is True
 
 
 def test_parse_time_ISO():
-    assert parse_time('1966-02-03') == LANDING
+    dt1 = ap.Time('1966-02-03T20:17:40')
+    assert parse_time('1966-02-03').jd == LANDING.jd
     assert (
-        parse_time('1966-02-03T20:17:40') == datetime(1966, 2, 3, 20, 17, 40)
+        parse_time('1966-02-03T20:17:40').jd == dt1.jd
     )
     assert (
-        parse_time('19660203T201740') == datetime(1966, 2, 3, 20, 17, 40)
+        parse_time('19660203T201740').jd == dt1.jd
     )
 
+    dt2 = ap.Time('2007-05-04T21:08:12.999999')
+    dt3 = ap.Time('2007-05-04T21:08:12')
+    dt4 = ap.Time('2007-05-04T21:08:00')
+    dt5 = ap.Time('2007-05-04')
+
     lst = [
-        ('2007-05-04T21:08:12.999999',
-         datetime(2007, 5, 4, 21, 8, 12, 999999)),
-        ('20070504T210812.999999',
-         datetime(2007, 5, 4, 21, 8, 12, 999999)),
-        ('2007/05/04 21:08:12.999999',
-         datetime(2007, 5, 4, 21, 8, 12, 999999)),
-        ('2007-05-04 21:08:12.999999',
-         datetime(2007, 5, 4, 21, 8, 12, 999999)),
-        ('2007/05/04 21:08:12', datetime(2007, 5, 4, 21, 8, 12)),
-        ('2007-05-04 21:08:12', datetime(2007, 5, 4, 21, 8, 12)),
-        ('2007-05-04 21:08', datetime(2007, 5, 4, 21, 8)),
-        ('2007-05-04T21:08:12', datetime(2007, 5, 4, 21, 8, 12)),
-        ('20070504T210812', datetime(2007, 5, 4, 21, 8, 12)),
-        ('2007-May-04 21:08:12', datetime(2007, 5, 4, 21, 8, 12)),
-        ('2007-May-04 21:08', datetime(2007, 5, 4, 21, 8)),
-        ('2007-May-04', datetime(2007, 5, 4)),
-        ('2007-05-04', datetime(2007, 5, 4)),
-        ('2007/05/04', datetime(2007, 5, 4)),
-        ('04-May-2007', datetime(2007, 5, 4)),
-        ('04-May-2007 21:08:12.999999', datetime(2007, 5, 4, 21, 8, 12, 999999)),
-        ('20070504_210812', datetime(2007, 5, 4, 21, 8, 12)),
-        ('2007.05.04_21:08:12_TAI', datetime(2007, 5, 4, 21, 8, 12)),
+        ('2007-05-04T21:08:12.999999', dt2),
+        ('20070504T210812.999999', dt2),
+        ('2007/05/04 21:08:12.999999', dt2),
+        ('2007-05-04 21:08:12.999999', dt2),
+        ('2007/05/04 21:08:12', dt3),
+        ('2007-05-04 21:08:12', dt3),
+        ('2007-05-04 21:08', dt4),
+        ('2007-05-04T21:08:12', dt3),
+        ('20070504T210812', dt3),
+        ('2007-May-04 21:08:12', dt3),
+        ('2007-May-04 21:08', dt4),
+        ('2007-May-04', dt5),
+        ('2007-05-04', dt5),
+        ('2007/05/04', dt5),
+        ('04-May-2007', dt5),
+        ('04-May-2007 21:08:12.999999', dt2),
+        ('20070504_210812', dt3),
+        ('2007.05.04_21:08:12_TAI', dt3),
     ]
 
     for k, v in lst:
-        assert parse_time(k) == v
+        assert parse_time(k).jd == v.jd
 
 
 def test_break_time():

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -69,7 +69,7 @@ def test_parse_time_int():
 
 
 def test_parse_time_pandas_timestamp():
-    ts = pandas.Timestamp(datetime(1966, 2, 3))
+    ts = pandas.Timestamp(LANDING.datetime)
 
     dt = parse_time(ts)
 
@@ -118,6 +118,7 @@ def test_parse_time_numpy_date():
     dts = parse_time(inputs)
 
     assert isinstance(dts, astropy.time.Time)
+    assert np.all(dts == ap.Time([str(dt.astype('M8[ns]')) for dt in inputs]))
 
 
 def test_parse_time_numpy_datetime():
@@ -126,6 +127,7 @@ def test_parse_time_numpy_datetime():
     dts = parse_time(inputs)
 
     assert isinstance(dts, astropy.time.Time)
+    assert np.all(dts == ap.Time([str(dt.astype('M8[ns]')) for dt in inputs]))
 
 
 def test_parse_time_individual_numpy_datetime():
@@ -228,7 +230,7 @@ def test_parse_time_ISO():
     for k, v in lst:
         dt = parse_time(k)
         assert dt == v
-        dt.format == 'isot'
+        assert dt.format == 'isot'
 
 
 def test_parse_time_tai():
@@ -244,6 +246,10 @@ def test_parse_time_leap_second():
     dt2 = ap.Time('1995-12-31T23:59:60')
 
     assert dt1.jd == dt2.jd
+
+    dt3 = parse_time('1995-Dec-31 23:59:60')
+
+    assert dt2.jd == dt3.jd
 
 
 @pytest.mark.parametrize("ts,fmt", [

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -43,7 +43,7 @@ def test_parse_time_int():
 
 
 def test_parse_time_pandas_timestamp():
-    ts = pandas.Timestamp(datetime(*(1966, 2, 3)))
+    ts = pandas.Timestamp(datetime(1966, 2, 3))
 
     dt = parse_time(ts)
 
@@ -128,12 +128,10 @@ def test_parse_time_numpy_datetime_ns():
 
     assert dt == ap.Time('2014-02-07T16:47:51.008288123', format='isot')
 
-
-def test_parse_time_numpy_datetime_round():
-    dt64 = np.datetime64('2014-02-07T16:47:51.008288999')
+    dt64 = np.datetime64('2014-02-07T16:47:51.234565999')
     dt = parse_time(dt64)
 
-    assert dt == ap.Time('2014-02-07T16:47:51.008288999')
+    assert dt == ap.Time('2014-02-07T16:47:51.234565999')
 
 
 def test_parse_time_astropy():

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -59,11 +59,11 @@ def test_parse_time_tuple():
 def test_parse_time_int():
     # Once https://github.com/astropy/astropy/issues/6970 is fixed,
     # remove .jd from equality check
-    dt1 = parse_time(765548612.0, 'utime')
+    dt1 = parse_time(765548612.0, format='utime')
     assert dt1.jd == ap.Time('2003-4-5T12:23:32').jd
     assert dt1.format == 'utime'
 
-    dt2 = parse_time(1009685652.0, 'utime')
+    dt2 = parse_time(1009685652.0, format='utime')
     assert dt2.jd == ap.Time('2010-12-30T4:14:12').jd
     assert dt2.format == 'utime'
 

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -208,7 +208,7 @@ def test_break_time():
 
 
 def test_day_of_year():
-    # Note that 2012 is a leap year, 2011 is a standard year
+    # Note that 2008 is a leap year, 2011 is a standard year
     # test that it starts at 1
     assert time.day_of_year('2011/01/01') == 1.0
     # test fractional day
@@ -218,17 +218,27 @@ def test_day_of_year():
     # test correct number of days in a (standard) year
     assert time.day_of_year('2011/12/31') == 365
     # test correct number of days in a (leap) year
-    assert time.day_of_year('2012/12/31') == 366
+    assert time.day_of_year('2008/12/31') == 366
     # test a few extra dates in standard year
     assert time.day_of_year('2011/08/01') == 213
     assert time.day_of_year('2011/04/10') == 100
     assert time.day_of_year('2011/01/31') == 31
     assert time.day_of_year('2011/09/30') == 273
     # test a few extra dates in a leap year
-    assert time.day_of_year('2012/08/01') == 214
-    assert time.day_of_year('2012/04/10') == 101
-    assert time.day_of_year('2012/01/31') == 31
-    assert time.day_of_year('2012/09/30') == 274
+    assert time.day_of_year('2008/08/01') == 214
+    assert time.day_of_year('2008/04/10') == 101
+    assert time.day_of_year('2008/01/31') == 31
+    assert time.day_of_year('2008/09/30') == 274
+
+
+def test_day_of_year_leapsecond():
+    # 2015 had a leap second.
+    # 30/06/2015 23:59:60 was a leap second
+    assert time.day_of_year('2015/01/31') == 31
+    assert time.day_of_year('2015/04/10') == 100
+    assert time.day_of_year('2015/06/30 23:59:60') == 182
+    assert time.day_of_year('2015/08/01') == 213.00001157407408
+    assert time.day_of_year('2015/09/30') == 273.00001157407405
 
 
 def test_time_string_parse_format():

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -18,16 +18,23 @@ LANDING = ap.Time('1966-02-03', format='isot')
 
 
 def test_parse_time_24():
-    assert parse_time("2010-10-10T24:00:00") == datetime(2010, 10, 11)
+    # Once https://github.com/astropy/astropy/issues/6970 is fixed,
+    # remove .jd from equality check
+    assert parse_time("2010-10-10T24:00:00").jd == astropy.time.Time('2010-10-11').jd
 
 
 def test_parse_time_24_2():
-    assert parse_time("2010-10-10T24:00:00.000000") == datetime(2010, 10, 11)
+    # Once https://github.com/astropy/astropy/issues/6970 is fixed,
+    # remove .jd from equality check
+    assert parse_time("2010-10-10T24:00:00.000000").jd == astropy.time.Time('2010-10-11').jd
 
 
 def test_parse_time_trailing_zeros():
     # see issue #289 at https://github.com/sunpy/sunpy/issues/289
-    assert parse_time('2010-10-10T00:00:00.00000000') == datetime(2010, 10, 10)
+
+    # Once https://github.com/astropy/astropy/issues/6970 is fixed,
+    # remove .jd from equality check
+    assert parse_time('2010-10-10T00:00:00.00000000').jd == astropy.time.Time('2010-10-10').jd
 
 
 def test_parse_time_tuple():
@@ -35,40 +42,55 @@ def test_parse_time_tuple():
 
 
 def test_parse_time_int():
+    # Once https://github.com/astropy/astropy/issues/6970 is fixed,
+    # remove .jd from equality check
     assert parse_time(765548612.0, 'utime').jd == ap.Time('2003-4-5T12:23:32').jd
 
     assert parse_time(1009685652.0, 'utime').jd == ap.Time('2010-12-30T4:14:12').jd
 
 
 def test_parse_time_pandas_timestamp():
-    ts = pandas.Timestamp(LANDING)
+    ts = pandas.Timestamp(datetime(*(1966, 2, 3)))
 
     dt = parse_time(ts)
 
-    assert isinstance(dt, datetime)
+    assert isinstance(dt, astropy.time.Time)
     assert dt == LANDING
 
 
 def test_parse_time_pandas_series():
     inputs = [datetime(2012, 1, i) for i in range(1, 13)]
     ind = pandas.Series(inputs)
+    as_inps = ap.Time(inputs)
 
     dts = parse_time(ind)
 
-    assert isinstance(dts, np.ndarray)
-    assert all([isinstance(dt, datetime) for dt in dts])
-    assert list(dts) == inputs
+    assert isinstance(dts, astropy.time.Time)
+    assert np.all(dts == as_inps)
+
+
+def test_parse_time_pandas_series_2():
+    inputs = [[datetime(2012, 1, 1, 0, 0), datetime(2012, 1, 2, 0, 0)],
+              [datetime(2012, 1, 3, 0, 0), datetime(2012, 1, 4, 0, 0)]]
+    ind = pandas.Series(inputs)
+    as_inps = ap.Time(inputs)
+
+    apts = parse_time(ind)
+
+    assert isinstance(apts, astropy.time.Time)
+    assert np.all(apts == as_inps)
+    assert apts.shape == as_inps.shape
 
 
 def test_parse_time_pandas_index():
     inputs = [datetime(2012, 1, i) for i in range(1, 13)]
     ind = pandas.DatetimeIndex(inputs)
+    as_inps = ap.Time(inputs)
 
     dts = parse_time(ind)
 
-    assert isinstance(dts, np.ndarray)
-    assert all([isinstance(dt, datetime) for dt in dts])
-    assert list(dts) == inputs
+    assert isinstance(dts, astropy.time.Time)
+    assert np.all(dts == as_inps)
 
 
 def test_parse_time_numpy_date():
@@ -149,7 +171,7 @@ def test_parse_time_now():
     assert isinstance(parse_time('now'), astropy.time.Time) is True
 
 
-def test_parse_time_ISO():
+def test_ISO():
     dt1 = ap.Time('1966-02-03T20:17:40')
     assert parse_time('1966-02-03').jd == LANDING.jd
     assert (

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -264,6 +264,34 @@ def test_parse_time_astropy_formats(ts, fmt):
     assert dt.format == fmt
 
 
+def test_parse_time_int_float():
+    # int and float values are not unique
+    # The format has to be mentioned
+
+    with pytest.raises(ValueError):
+        parse_time(100)
+
+    with pytest.raises(ValueError):
+        parse_time(100.0)
+
+
+@pytest.mark.parametrize("scale", [
+    'tai',
+    'tcb',
+    'tcg',
+    'tdb',
+    'tt',
+    'ut1',
+    'utc'
+])
+def test_parse_time_scale(scale):
+    dt = parse_time('2007-05-04T21:08:12', scale=scale)
+    dt2 = ap.Time('2007-05-04T21:08:12', scale=scale)
+
+    assert dt == dt2
+    assert dt.scale == scale
+
+
 def test_break_time():
     t = datetime(2007, 5, 4, 21, 8, 12)
     assert time.break_time(t) == '20070504_210812'

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -372,26 +372,6 @@ def test_day_of_year_leapsecond():
     assert time.day_of_year('2015/09/30') == 273.00001157407405
 
 
-def test_time_string_parse_format():
-    assert parse_time('01/06/2012',
-                      _time_string_parse_format='%d/%m/%Y') == datetime(2012, 6, 1, 0, 0)
-    assert parse_time('06/01/2012',
-                      _time_string_parse_format='%d/%m/%Y') == datetime(2012, 1, 6, 0, 0)
-    assert parse_time('06/01/85',
-                      _time_string_parse_format='%d/%m/%y') == datetime(1985, 1, 6, 0, 0)
-    assert parse_time('6/1/85',
-                      _time_string_parse_format='%d/%m/%y') == datetime(1985, 1, 6, 0, 0)
-    with pytest.raises(ValueError):
-        parse_time('01/06/2012')
-    with pytest.raises(ValueError):
-        parse_time('01/06/2012', _time_string_parse_format='%d/%Y/%m')
-    with pytest.raises(re.error):
-        parse_time('01/06/2012', _time_string_parse_format='%d/%m/%m')
-
-    with pytest.raises(ValueError):
-        parse_time('2016', _time_string_parse_format='zz')
-
-
 def test__iter_empty():
 
     class CountDown(object):

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -287,9 +287,39 @@ def test_parse_time_int_float():
 def test_parse_time_scale(scale):
     dt = parse_time('2007-05-04T21:08:12', scale=scale)
     dt2 = ap.Time('2007-05-04T21:08:12', scale=scale)
-
     assert dt == dt2
     assert dt.scale == scale
+
+    dt = parse_time(np.datetime64('2007-05-04T21:08:12'), scale=scale)
+    dt2 = ap.Time('2007-05-04T21:08:12', scale=scale)
+    assert dt == dt2
+    assert dt.scale == scale
+
+    dt = datetime(2014, 2, 7, 16, 47, 51)
+    dt = parse_time(dt, scale=scale)
+    dt2 = ap.Time('2014-02-07T16:47:51', scale=scale)
+    assert dt == dt2
+    assert dt.scale == scale
+
+    dt = date(2014, 2, 7)
+    dt = parse_time(dt, scale=scale)
+    dt2 = ap.Time('2014-02-07', scale=scale)
+    assert dt == dt2
+    assert dt.scale == scale
+
+
+def test_parse_time_list():
+    tstrings = ['2010-09-03 00:00:00', '2005-09-03 06:00:00',
+                '1995-12-31 23:59:60']
+
+    assert np.all(parse_time(tstrings) == ap.Time(tstrings))
+
+
+def test_parse_time_list_2():
+    tstrings = [['1998-01-01 00:00:01', '1998-01-01 00:00:02'],
+                ['1998-01-01 00:00:03', '1995-12-31 23:59:60']]
+
+    assert np.all(parse_time(tstrings) == ap.Time(tstrings))
 
 
 def test_break_time():

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -124,9 +124,10 @@ def test_parse_time_numpy_datetime_round():
 
 
 def test_parse_time_astropy():
-    astropy_time = parse_time(astropy.time.Time(['2016-01-02T23:00:01']))
+    ip = astropy.time.Time(['2016-01-02T23:00:01'])
+    astropy_time = parse_time(ip)
 
-    assert astropy_time == datetime(year=2016, month=1, day=2, hour=23, minute=0, second=1)
+    assert astropy_time == ip
 
 
 def test_parse_time_datetime():

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -184,8 +184,6 @@ def test_parse_time_now():
     """
     Ensure 'parse_time' can be called with 'now' argument to get utc
     """
-    # TODO: once mocking support is merged in, we can perform a like for like comparison,
-    #       the following at least ensures that 'now' is a legal argument.
     now = parse_time('now')
     assert isinstance(now, astropy.time.Time)
     assert now.format == 'datetime'

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -287,10 +287,10 @@ def test__iter_empty():
 
 def test_is_time():
     assert time.is_time(datetime.utcnow()) is True
-    assert time.is_time('2017-02-14 08:08:12.999', "%Y-%m-%d %H:%M:%S.%f") is True
+    assert time.is_time('2017-02-14 08:08:12.999') is True
 
     assert time.is_time(None) is False
-    assert time.is_time('2016-14-14 19:08', "%Y-%b-%d %H:%M:%S") is False
+    assert time.is_time('2016-14-14 19:08') is False
 
 
 def test_is_time_in_given_format():

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -18,23 +18,16 @@ LANDING = ap.Time('1966-02-03', format='isot')
 
 
 def test_parse_time_24():
-    # Once https://github.com/astropy/astropy/issues/6970 is fixed,
-    # remove .jd from equality check
-    assert parse_time("2010-10-10T24:00:00").jd == astropy.time.Time('2010-10-11').jd
+    assert parse_time("2010-10-10T24:00:00") == ap.Time('2010-10-11')
 
 
 def test_parse_time_24_2():
-    # Once https://github.com/astropy/astropy/issues/6970 is fixed,
-    # remove .jd from equality check
-    assert parse_time("2010-10-10T24:00:00.000000").jd == astropy.time.Time('2010-10-11').jd
+    assert parse_time("2010-10-10T24:00:00.000000") == ap.Time('2010-10-11')
 
 
 def test_parse_time_trailing_zeros():
     # see issue #289 at https://github.com/sunpy/sunpy/issues/289
-
-    # Once https://github.com/astropy/astropy/issues/6970 is fixed,
-    # remove .jd from equality check
-    assert parse_time('2010-10-10T00:00:00.00000000').jd == astropy.time.Time('2010-10-10').jd
+    assert parse_time('2010-10-10T00:00:00.00000000') == ap.Time('2010-10-10')
 
 
 def test_parse_time_tuple():
@@ -98,9 +91,7 @@ def test_parse_time_numpy_date():
 
     dts = parse_time(inputs)
 
-    assert isinstance(dts, np.ndarray)
-    assert all([isinstance(dt, datetime) for dt in dts])
-    assert np.all(dts == inputs.astype('M8[s]'))
+    assert isinstance(dts, astropy.time.Time)
 
 
 def test_parse_time_numpy_datetime():
@@ -108,41 +99,41 @@ def test_parse_time_numpy_datetime():
 
     dts = parse_time(inputs)
 
-    assert isinstance(dts, np.ndarray)
-    assert all([isinstance(dt, datetime) for dt in dts])
+    assert isinstance(dts, astropy.time.Time)
 
 
 def test_parse_time_individual_numpy_datetime():
     dt64 = np.datetime64('2005-02-01T00')
     dt = parse_time(dt64)
 
-    assert isinstance(dt, datetime)
+    assert isinstance(dt, astropy.time.Time)
+    assert dt == ap.Time('2005-02-01', format='isot')
 
 
 def test_parse_time_numpy_datetime_timezone():
     dt64 = np.datetime64('2014-02-07T16:47:51-0500')
     dt = parse_time(dt64)
 
-    assert dt == datetime(2014, 2, 7, 21, 47, 51)
+    assert dt == ap.Time('2014-02-07T21:47:51', format='isot')
 
 
 def test_parse_time_numpy_datetime_ns():
     dt64 = np.datetime64('2014-02-07T16:47:51.008288000')
     dt = parse_time(dt64)
 
-    assert dt == datetime(2014, 2, 7, 16, 47, 51, 8288)
+    assert dt == ap.Time('2014-02-07T16:47:51.008288000', format='isot')
 
     dt64 = np.datetime64('2014-02-07T16:47:51.008288123')
     dt = parse_time(dt64)
 
-    assert dt == datetime(2014, 2, 7, 16, 47, 51, 8288)
+    assert dt == ap.Time('2014-02-07T16:47:51.008288123', format='isot')
 
 
 def test_parse_time_numpy_datetime_round():
     dt64 = np.datetime64('2014-02-07T16:47:51.008288999')
     dt = parse_time(dt64)
 
-    assert dt == datetime(2014, 2, 7, 16, 47, 51, 8288)
+    assert dt == ap.Time('2014-02-07T16:47:51.008288999')
 
 
 def test_parse_time_astropy():
@@ -175,10 +166,10 @@ def test_ISO():
     dt1 = ap.Time('1966-02-03T20:17:40')
     assert parse_time('1966-02-03').jd == LANDING.jd
     assert (
-        parse_time('1966-02-03T20:17:40').jd == dt1.jd
+        parse_time('1966-02-03T20:17:40') == dt1
     )
     assert (
-        parse_time('19660203T201740').jd == dt1.jd
+        parse_time('19660203T201740') == dt1
     )
 
     dt2 = ap.Time('2007-05-04T21:08:12.999999')
@@ -208,7 +199,7 @@ def test_ISO():
     ]
 
     for k, v in lst:
-        assert parse_time(k).jd == v.jd
+        assert parse_time(k) == v
 
 
 def test_break_time():

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -187,7 +187,7 @@ def test_parse_time_now():
     # TODO: once mocking support is merged in, we can perform a like for like comparison,
     #       the following at least ensures that 'now' is a legal argument.
     now = parse_time('now')
-    assert isinstance(now, astropy.time.Time) is True
+    assert isinstance(now, astropy.time.Time)
     assert now.format == 'datetime'
     assert now.scale == 'utc'
 
@@ -239,6 +239,13 @@ def test_parse_time_tai():
 
     assert dt == dt2
     assert dt.scale == dt2.scale
+
+
+def test_parse_time_leap_second():
+    dt1 = parse_time('1995-12-31 23:59:60')
+    dt2 = ap.Time('1995-12-31T23:59:60')
+
+    assert dt1.jd == dt2.jd
 
 
 @pytest.mark.parametrize("ts,fmt", [

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -184,10 +184,14 @@ def convert_time_astropy(time_string, **kwargs):
 def convert_time_str(time_string, **kwargs):
     # remove trailing zeros and the final dot to allow any
     # number of zeros. This solves issue #289
-    if 'TAI' in time_string:
-        kwargs['scale'] = 'tai'
     if '.' in time_string:
         time_string = time_string.rstrip("0").rstrip(".")
+
+    if 'TAI' in time_string:
+        kwargs['scale'] = 'tai'
+
+    time_string_parse_format = kwargs.pop('_time_string_parse_format', None)
+
     for time_format in TIME_FORMAT_LIST:
         try:
             try:
@@ -201,7 +205,7 @@ def convert_time_str(time_string, **kwargs):
                                     **kwargs) + time_delta
         except ValueError:
             pass
-    time_string_parse_format = kwargs.pop('_time_string_parse_format', None)
+
     if time_string_parse_format is not None:
         ts, time_delta = _regex_parse_time(time_string,
                                            time_string_parse_format)

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -205,7 +205,7 @@ def convert_time_str(time_string, **kwargs):
             if ts is None:
                 continue
             return ap.Time.strptime(ts, time_format,
-                                    format='isot') + time_delta
+                                    format='isot', **kwargs) + time_delta
         except ValueError:
             pass
     time_string_parse_format = kwargs.pop('_time_string_parse_format', None)
@@ -214,15 +214,15 @@ def convert_time_str(time_string, **kwargs):
                                            time_string_parse_format)
         if ts and time_delta:
             return ap.Time.strptime(ts, time_string_parse_format,
-                                    format='isot') + time_delta
+                                    format='isot', **kwargs) + time_delta
         else:
             return ap.Time.strptime(time_string, time_string_parse_format,
-                                    format='isot')
+                                    format='isot', **kwargs)
     # when no format matches, call default fucntion
     convert_time.dispatch(object)(time_string, **kwargs)
 
 
-def parse_time(time_string, time_format='', time_scale='', **kwargs):
+def parse_time(time_string, time_format='', out_format='isot', **kwargs):
     """Given a time string will parse and return a datetime object.
     Similar to the anytim function in IDL.
     utime -- Time since epoch 1 Jan 1979
@@ -247,11 +247,15 @@ def parse_time(time_string, time_format='', time_scale='', **kwargs):
     datetime.datetime(2005, 8, 4, 0, 1, 2)
     """
     if time_format == 'utime':
-        return convert_time(float(time_string), **kwargs)
+        rt = convert_time(float(time_string), **kwargs)
     elif time_string is 'now':
-        return ap.Time.now()
+        rt = ap.Time.now()
     else:
-        return convert_time(time_string, **kwargs)
+        rt = convert_time(time_string, **kwargs)
+
+    rt = rt.replicate(out_format)
+
+    return rt
 
 
 def is_time(time_string, time_format=''):

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -129,14 +129,6 @@ def _astropy_time(time):
     return time if isinstance(time, astropy.time.Time) else astropy.time.Time(parse_time(time))
 
 
-def _parse_dt64(dt):
-    """
-    Parse a single numpy datetime64 object
-    """
-    # Convert to microsecond precision because datetime cannot handle nanoseconds
-    return dt.astype('M8[us]').astype(datetime)
-
-
 @singledispatch
 def convert_time(time_string, **kwargs):
     # default case when no type matches
@@ -181,13 +173,13 @@ def convert_time_float(time_string, **kwargs):
 
 @convert_time.register(np.datetime64)
 def convert_time_npdatetime64(time_string, **kwargs):
-    return _parse_dt64(time_string)
+    return ap.Time(str(time_string.astype('M8[ns]')))
 
 
 @convert_time.register(np.ndarray)
 def convert_time_npndarray(time_string, **kwargs):
     if 'datetime64' in str(time_string.dtype):
-        return np.array([_parse_dt64(dt) for dt in time_string])
+        return ap.Time([str(dt.astype('M8[ns]')) for dt in time_string])
     else:
         return convert_time.dispatch(object)(time_string, **kwargs)
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -7,8 +7,8 @@ import numpy as np
 import pandas
 from sunpy.extern import six
 from sunpy.time.utime import TimeUTime
+from sunpy.time import astropy_time as ap
 
-from . import astropy_time as ap
 import astropy.units as u
 import astropy.time
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -157,7 +157,9 @@ def convert_time_date(time_string, **kwargs):
 
 @convert_time.register(tuple)
 def convert_time_tuple(time_string, **kwargs):
-    return ap.Time('{}-{}-{}'.format(*time_string), **kwargs)
+    # Make sure there are enough values to unpack
+    time_string = (time_string + (0,)*7)[:7]
+    return ap.Time('{}-{}-{}T{}:{}:{}.{:06}'.format(*time_string), **kwargs)
 
 
 @convert_time.register(np.datetime64)

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -208,7 +208,7 @@ def convert_time_str(time_string, **kwargs):
     return convert_time.dispatch(object)(time_string, **kwargs)
 
 
-def parse_time(time_string, format=None, **kwargs):
+def parse_time(time_string, *, format=None, **kwargs):
     """Given a time string will parse and return a datetime object.
     Similar to the anytim function in IDL.
     utime -- Time since epoch 1 Jan 1979
@@ -291,7 +291,7 @@ def is_time(time_string, time_format=None):
         return True
 
     try:
-        parse_time(time_string, time_format)
+        parse_time(time_string, format=time_format)
     except ValueError:
         return False
     else:
@@ -331,7 +331,7 @@ def day_of_year(time_string):
 def break_time(t='now', time_format=None):
     """Given a time returns a string. Useful for naming files."""
     # TODO: should be able to handle a time range
-    return parse_time(t, time_format).strftime("%Y%m%d_%H%M%S")
+    return parse_time(t, format=time_format).strftime("%Y%m%d_%H%M%S")
 
 
 def get_day(dt):

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -173,7 +173,7 @@ def convert_time_date(time_string, **kwargs):
 
 @convert_time.register(tuple)
 def convert_time_tuple(time_string, **kwargs):
-    return datetime(*time_string)
+    return ap.Time('{}-{}-{}'.format(*time_string))
 
 
 @convert_time.register(float)
@@ -197,7 +197,7 @@ def convert_time_npndarray(time_string, **kwargs):
 
 @convert_time.register(astropy.time.Time)
 def convert_time_astropy(time_string, **kwargs):
-    return time_string.datetime
+    return time_string
 
 
 @convert_time.register(str)

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import re
-from datetime import datetime, date, time, timedelta
+from datetime import datetime, date
 from functools import singledispatch
 
 import numpy as np
@@ -307,6 +307,7 @@ def is_time(time_string, time_format=None):
 
 def day_of_year(time_string):
     """Returns the (fractional) day of year.
+    Note: This function takes into account leap seconds.
 
     Parameters
     ----------
@@ -324,7 +325,7 @@ def day_of_year(time_string):
     >>> sunpy.time.day_of_year('2012/01/01')
     1.0
     >>> sunpy.time.day_of_year('2012/08/01')
-    214.0
+    214.00001157407408
     >>> sunpy.time.day_of_year('2005-08-04T00:18:02.000Z')
     216.01252314814815
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -330,10 +330,9 @@ def day_of_year(time_string):
     216.01252314814815
 
     """
-    SECONDS_IN_DAY = 60 * 60 * 24.0
     time = parse_time(time_string)
-    time_diff = time - datetime(time.year, 1, 1, 0, 0, 0)
-    return time_diff.days + time_diff.seconds / SECONDS_IN_DAY + 1
+    time_diff = time - ap.Time.strptime(time.strftime('%Y'), '%Y')
+    return time_diff.jd + 1
 
 
 def break_time(t='now', time_format=''):

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -140,45 +140,45 @@ def convert_time(time_string, format=None, **kwargs):
 
 @convert_time.register(pandas.Series)
 def convert_time_pandasSeries(time_string, **kwargs):
-    return ap.Time(time_string.tolist())
+    return ap.Time(time_string.tolist(), **kwargs)
 
 
 @convert_time.register(pandas.DatetimeIndex)
 def convert_time_pandasDatetimeIndex(time_string, **kwargs):
-    return ap.Time(time_string.tolist())
+    return ap.Time(time_string.tolist(), **kwargs)
 
 
 @convert_time.register(pandas.Timestamp)
 @convert_time.register(datetime)
 def convert_time_datetime(time_string, **kwargs):
-    return ap.Time(time_string)
+    return ap.Time(time_string, **kwargs)
 
 
 @convert_time.register(date)
 def convert_time_date(time_string, **kwargs):
-    return ap.Time(time_string.isoformat())
+    return ap.Time(time_string.isoformat(), **kwargs)
 
 
 @convert_time.register(tuple)
 def convert_time_tuple(time_string, **kwargs):
-    return ap.Time('{}-{}-{}'.format(*time_string))
+    return ap.Time('{}-{}-{}'.format(*time_string), **kwargs)
 
 
 @convert_time.register(float)
 @convert_time.register(int)
 def convert_time_float(time_string, **kwargs):
-    return ap.Time(time_string, format='utime')
+    return ap.Time(time_string, format='utime', **kwargs)
 
 
 @convert_time.register(np.datetime64)
 def convert_time_npdatetime64(time_string, **kwargs):
-    return ap.Time(str(time_string.astype('M8[ns]')))
+    return ap.Time(str(time_string.astype('M8[ns]')), **kwargs)
 
 
 @convert_time.register(np.ndarray)
 def convert_time_npndarray(time_string, **kwargs):
     if 'datetime64' in str(time_string.dtype):
-        return ap.Time([str(dt.astype('M8[ns]')) for dt in time_string])
+        return ap.Time([str(dt.astype('M8[ns]')) for dt in time_string], **kwargs)
     else:
         return convert_time.dispatch(object)(time_string, **kwargs)
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -145,30 +145,27 @@ def convert_time(time_string, **kwargs):
 
 @convert_time.register(pandas.Timestamp)
 def convert_time_pandasTimestamp(time_string, **kwargs):
-    return time_string.to_pydatetime()
+    return ap.Time(time_string)
 
 
 @convert_time.register(pandas.Series)
 def convert_time_pandasSeries(time_string, **kwargs):
-    if 'datetime64' in str(time_string.dtype):
-        return np.array([dt.to_pydatetime() for dt in time_string])
-    else:
-        convert_time.dispatch(object)(time_string, **kwargs)
+    return ap.Time(time_string.tolist())
 
 
 @convert_time.register(pandas.DatetimeIndex)
 def convert_time_pandasDatetimeIndex(time_string, **kwargs):
-    return time_string._mpl_repr()
+    return ap.Time(time_string.tolist())
 
 
 @convert_time.register(datetime)
 def convert_time_datetime(time_string, **kwargs):
-    return time_string
+    return ap.Time(time_string)
 
 
 @convert_time.register(date)
 def convert_time_date(time_string, **kwargs):
-    return datetime.combine(time_string, time())
+    return ap.Time(datetime.combine(time_string, time()))
 
 
 @convert_time.register(tuple)

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -190,8 +190,6 @@ def convert_time_str(time_string, **kwargs):
     if 'TAI' in time_string:
         kwargs['scale'] = 'tai'
 
-    time_string_parse_format = kwargs.pop('_time_string_parse_format', None)
-
     for time_format in TIME_FORMAT_LIST:
         try:
             try:
@@ -206,15 +204,6 @@ def convert_time_str(time_string, **kwargs):
         except ValueError:
             pass
 
-    if time_string_parse_format is not None:
-        ts, time_delta = _regex_parse_time(time_string,
-                                           time_string_parse_format)
-        if ts and time_delta:
-            return ap.Time.strptime(ts, time_string_parse_format,
-                                    **kwargs) + time_delta
-        else:
-            return ap.Time.strptime(time_string, time_string_parse_format,
-                                    **kwargs)
     # when no format matches, call default fucntion
     return convert_time.dispatch(object)(time_string, **kwargs)
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -219,25 +219,35 @@ def parse_time(time_string, format=None, **kwargs):
     """Given a time string will parse and return a datetime object.
     Similar to the anytim function in IDL.
     utime -- Time since epoch 1 Jan 1979
+
     Parameters
     ----------
-    time_string : [ int, float, time_string, datetime ]
-        Date to parse which can be either time_string, int, datetime object.
-    time_format : [ basestring, utime, datetime ]
+    time_string : [ int, float, string, datetime, astropy.time.Time,
+                    numpy.datetime64, pandas.Timestamp ]
+        Time to parse.
+
+    format : [ 'jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps',
+               'plot_date', 'datetime', 'iso', 'isot', 'yday', 'fits',
+               'byear', 'jyear', 'byear_str', 'jyear_str', 'utime']
+
         Specifies the format user has provided the time_string in.
+        Same as format of `astropy.time.Time`
+
+    kwargs : dict
+        Additional keyword arguments that can be passed to `astropy.time.Time`
+
     Returns
     -------
-    out : datetime
-        DateTime corresponding to input date string
-    Note:
-    If time_string is an instance of float, then it is assumed to be in utime format.
+    out : Time
+        `astropy.time.Time` corresponding to input time string
+
     Examples
     --------
     >>> import sunpy.time
     >>> sunpy.time.parse_time('2012/08/01')
-    datetime.datetime(2012, 8, 1, 0, 0)
-    >>> sunpy.time.parse_time('2005-08-04T00:01:02.000Z')
-    datetime.datetime(2005, 8, 4, 0, 1, 2)
+    <Time object: scale='utc' format='isot' value=2012-08-01T00:00:00.000>
+    >>> sunpy.time.parse_time('2016.05.04_21:08:12_TAI')
+    <Time object: scale='tai' format='isot' value=2016-05-04T21:08:12.000>
     """
     if time_string is 'now':
         rt = ap.Time.now()

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -145,6 +145,11 @@ def convert_time_pandasDatetimeIndex(time_string, **kwargs):
     return ap.Time(time_string.tolist(), **kwargs)
 
 
+@convert_time.register(datetime)
+def convert_time_datetime(time_string, **kwargs):
+    return ap.Time(time_string, **kwargs)
+
+
 @convert_time.register(date)
 def convert_time_date(time_string, **kwargs):
     return ap.Time(time_string.isoformat(), **kwargs)
@@ -177,6 +182,8 @@ def convert_time_astropy(time_string, **kwargs):
 def convert_time_str(time_string, **kwargs):
     # remove trailing zeros and the final dot to allow any
     # number of zeros. This solves issue #289
+    if 'TAI' in time_string:
+        kwargs['scale'] = 'tai'
     if '.' in time_string:
         time_string = time_string.rstrip("0").rstrip(".")
     for time_format in TIME_FORMAT_LIST:

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -82,7 +82,7 @@ def _regex_parse_time(inp, format):
     try:
         hour = match.group("hour")
     except IndexError:
-        return inp, astropy.time.TimeDelta(u.day*0)
+        return inp, astropy.time.TimeDelta(0*u.day)
     if match.group("hour") == "24":
         if not all(
                    _n_or_eq(_group_or_none(match, g, int), 00)
@@ -90,8 +90,8 @@ def _regex_parse_time(inp, format):
                   ):
             raise ValueError
         from_, to = match.span("hour")
-        return inp[:from_] + "00" + inp[to:], astropy.time.TimeDelta(u.day*1)
-    return inp, astropy.time.TimeDelta(u.day*0)
+        return inp[:from_] + "00" + inp[to:], astropy.time.TimeDelta(1*u.day)
+    return inp, astropy.time.TimeDelta(0*u.day)
 
 
 def find_time(string, format):
@@ -135,11 +135,6 @@ def convert_time(time_string, **kwargs):
     raise ValueError("'{tstr!s}' is not a valid time string!".format(tstr=time_string))
 
 
-@convert_time.register(pandas.Timestamp)
-def convert_time_pandasTimestamp(time_string, **kwargs):
-    return ap.Time(time_string)
-
-
 @convert_time.register(pandas.Series)
 def convert_time_pandasSeries(time_string, **kwargs):
     return ap.Time(time_string.tolist())
@@ -150,6 +145,7 @@ def convert_time_pandasDatetimeIndex(time_string, **kwargs):
     return ap.Time(time_string.tolist())
 
 
+@convert_time.register(pandas.Timestamp)
 @convert_time.register(datetime)
 def convert_time_datetime(time_string, **kwargs):
     return ap.Time(time_string)
@@ -157,7 +153,7 @@ def convert_time_datetime(time_string, **kwargs):
 
 @convert_time.register(date)
 def convert_time_date(time_string, **kwargs):
-    return ap.Time(datetime.combine(time_string, time()))
+    return ap.Time(time_string.isoformat())
 
 
 @convert_time.register(tuple)


### PR DESCRIPTION
`parse_time` now returns `Time`. The test for `parse_time` are fixed too.

---
## Notes to reviewers

This PR is against the "time" branch of SunPy, where we will be doing incremental PRs as we refactor the whole code base to use Astropy Time. The plan is to review each PR to the time branch in detail, so the massive merge PR dosen't require a massive review at the end.

This PR is (hopefully) the only massive API change (beyond everything returning `Time`), so it's important we get this right. Also the tests will fail until we have completed the migration across much more of the code.

Here is a summary of the API:

### Strings
```
parse_time call: parse_time('2005-08-04T00:18:02.000', scale='tt')
Parsed Time: <Time object: scale='tt' format='isot' value=2005-08-04T00:18:02.000>

parse_time call: parse_time('20140101000001')
Parsed Time: <Time object: scale='utc' format='isot' value=2014-01-01T00:00:01.000>

parse_time call: parse_time('2016.05.04_21:08:12_TAI')
Parsed Time: <Time object: scale='tai' format='isot' value=2016-05-04T21:08:12.000>

parse_time call: parse_time('1995-12-31 23:59:60')
Parsed Time: <Time object: scale='utc' format='isot' value=1995-12-31T23:59:60.000>

parse_time call: parse_time('1995-Dec-31 23:59:60')
Parsed Time: <Time object: scale='utc' format='isot' value=1995-12-31T23:59:60.000>
```

### Datetime

```
parse_time call: parse_time(datetime.datetime(2018, 5, 13, 15, 46, 26, 317773), scale='tai')
Parsed Time: <Time object: scale='tai' format='datetime' value=2018-05-13 15:46:26.317773>

parse_time call: parse_time(datetime.date(2018, 5, 13))
Parsed Time: <Time object: scale='utc' format='iso' value=2018-05-13 00:00:00.000>
```

### numpy.datetime64

```
parse_time call: parse_time(numpy.datetime64('1995-12-31T23:59:59'))
Parsed Time: <Time object: scale='utc' format='isot' value=1995-12-31T23:59:59.000>

parse_time call: parse_time(array(['2005-02-01T00', '2005-02-01T01', '2005-02-01T02', '2005-02-01T03',
       '2005-02-01T04', '2005-02-01T05', '2005-02-01T06', '2005-02-01T07',
       '2005-02-01T08', '2005-02-01T09'], dtype='datetime64[h]'))
Parsed Time: <Time object: scale='utc' format='isot' value=['2005-02-01T00:00:00.000' '2005-02-01T01:00:00.000'
 '2005-02-01T02:00:00.000' '2005-02-01T03:00:00.000'
 '2005-02-01T04:00:00.000' '2005-02-01T05:00:00.000'
 '2005-02-01T06:00:00.000' '2005-02-01T07:00:00.000'
 '2005-02-01T08:00:00.000' '2005-02-01T09:00:00.000']>
```

### AstroPy compatible

```
parse_time call: parse_time(1234.0, format=jd)
Parsed Time: <Time object: scale='utc' format='jd' value=1234.0>

parse_time call: parse_time('B1950.0', format=byear_str)
Parsed Time: <Time object: scale='utc' format='byear_str' value=B1950.000>

parse_time call: parse_time('2001-03-22 00:01:44.732327132980', scale='utc', location=('120d', '40d'))
Parsed Time: <Time object: scale='utc' format='iso' value=2001-03-22 00:01:44.732>
```

### Pandas

```
parse_time call: parse_time(pandas.Timestamp('1966-02-03 00:00:00'))
Parsed Time: <Time object: scale='utc' format='datetime' value=1966-02-03 00:00:00>

parse_time call: parse_time(pandas.Series([[2012-01-01 00:00:00, 2012-01-02 00:00:00]
                                           [2012-01-03 00:00:00, 2012-01-04 00:00:00]]))
Parsed Time: <Time object: scale='utc' format='datetime' value=[[datetime.datetime(2012, 1, 1, 0, 0) datetime.datetime(2012, 1, 2, 0, 0)]
 [datetime.datetime(2012, 1, 3, 0, 0) datetime.datetime(2012, 1, 4, 0, 0)]]>
```