### PR TITLE
Vso client fix

### DIFF
--- a/sunpy/net/tests/test_vso.py
+++ b/sunpy/net/tests/test_vso.py
@@ -412,3 +412,15 @@ def test_vso_hmi(client, tmpdir):
     files = client.fetch(res, path=tmpdir).wait()
 
     assert len(files) == len(res)
+
+
+@pytest.mark.remote_data
+def test_vso_hmi2(client, tmpdir):
+    """
+    This is a regression test for https://github.com/sunpy/sunpy/issues/2284
+    """
+    res = client.search(va.Time('2017-09-02 23:52:00', '2017-09-02 23:52:30'),
+                        va.Instrument('HMI') | (va.Instrument('AIA') & va.Wavelength(304*u.AA, 304*u.AA)))
+    files = client.fetch(res, path=tmpdir).wait()
+
+    assert len(files) == len(res)

--- a/sunpy/net/tests/test_vso.py
+++ b/sunpy/net/tests/test_vso.py
@@ -401,3 +401,10 @@ def test_QueryResponse_build_table_with_no_end_time():
     end_time_ = table['End Time']
     assert len(end_time_) == 1
     assert end_time_[0] == 'None'
+
+
+def test_vso_hmi(client, tmpdir):
+    res = client.search(va.Time('2017-09-02 23:52:00', '2017-09-02 23:52:30'), va.Instrument('HMI'))
+    files = client.fetch(res, path=tmpdir)
+
+    assert len(files) == len(res)

--- a/sunpy/net/tests/test_vso.py
+++ b/sunpy/net/tests/test_vso.py
@@ -403,8 +403,12 @@ def test_QueryResponse_build_table_with_no_end_time():
     assert end_time_[0] == 'None'
 
 
+@pytest.mark.remote_data
 def test_vso_hmi(client, tmpdir):
+    """
+    This is a regression test for https://github.com/sunpy/sunpy/issues/2284
+    """
     res = client.search(va.Time('2017-09-02 23:52:00', '2017-09-02 23:52:30'), va.Instrument('HMI'))
-    files = client.fetch(res, path=tmpdir)
+    files = client.fetch(res, path=tmpdir).wait()
 
     assert len(files) == len(res)

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -8,8 +8,8 @@
 from __future__ import absolute_import, division, print_function
 
 """
-This module provides a wrapper around the VSO API.
-"""
+    This module provides a wrapper around the VSO API.
+    """
 
 import re
 import os
@@ -45,7 +45,7 @@ from sunpy.extern.six.moves import input
 TIME_FORMAT = config.get("general", "time_format")
 
 DEFAULT_URL_PORT = [{'url': 'http://docs.virtualsolar.org/WSDL/VSOi_rpc_literal.wsdl',
-                     'port': 'nsoVSOi', 'transport': WellBehavedHttpTransport}]
+                    'port': 'nsoVSOi', 'transport': WellBehavedHttpTransport}]
 
 RANGE = re.compile(r'(\d+)(\s*-\s*(\d+))?(\s*([a-zA-Z]+))?')
 
@@ -57,16 +57,16 @@ suds_log.setLevel(50)
 
 # TODO: Name
 class NoData(Exception):
-
+    
     """ Risen for callbacks of VSOClient that are unable to supply
-    information for the request. """
+        information for the request. """
     pass
 
 
 class _Str(str):
-
+    
     """ Subclass of string that contains a meta attribute for the
-    record_item associated with the file. """
+        record_item associated with the file. """
     pass
 
 
@@ -78,7 +78,7 @@ def _parse_waverange(string):
         'wave_wavemin': min_,
         'wave_wavemax': min_ if max_ is None else max_,
         'wave_waveunit': 'Angstrom' if unit is None else unit,
-    }
+}
 
 
 def _parse_date(string):
@@ -105,7 +105,7 @@ def check_connection(url):
         return requests.get(url).status_code == 200
     except (socket.error, socket.timeout) as e:
         warnings.warn(
-            "Connection failed with error {}. \n Retrying with different url and port.".format(e))
+                      "Connection failed with error {}. \n Retrying with different url and port.".format(e))
 
 
 def get_online_vso_url(api, url, port):
@@ -113,72 +113,72 @@ def get_online_vso_url(api, url, port):
         for mirror in DEFAULT_URL_PORT:
             if check_connection(mirror['url']):
                 api = client.Client(
-                    mirror['url'], transport=mirror['transport']())
-                api.set_options(port=mirror['port'])
-                return api
+                                    mirror['url'], transport=mirror['transport']())
+                                    api.set_options(port=mirror['port'])
+                                    return api
 
 
 # TODO: Python 3 this should subclass from UserList
 class QueryResponse(list):
     """
-    A container for VSO Records returned from VSO Searches.
-    """
-
+        A container for VSO Records returned from VSO Searches.
+        """
+    
     def __init__(self, lst, queryresult=None, table=None):
         super(QueryResponse, self).__init__(lst)
         self.queryresult = queryresult
         self.errors = []
         self.table = None
-
+    
     def search(self, *query):
         """ Furtherly reduce the query response by matching it against
-        another query, e.g. response.search(attrs.Instrument('aia')). """
+            another query, e.g. response.search(attrs.Instrument('aia')). """
         query = and_(*query)
         return QueryResponse(
-            attrs.filter_results(query, self), self.queryresult
-        )
-
+                             attrs.filter_results(query, self), self.queryresult
+                             )
+    
     @deprecated('0.8', alternative='QueryResponse.search')
     def query(self, *query):
         """
-        See `~sunpy.net.vso.vso.QueryResponse.search`
-        """
+            See `~sunpy.net.vso.vso.QueryResponse.search`
+            """
         return self.search(*query)
-
+    
     @classmethod
     def create(cls, queryresult):
         return cls(iter_records(queryresult), queryresult)
-
+    
     def total_size(self):
         """ Total size of data in KB. May be less than the actual
-        size because of inaccurate data providers. """
+            size because of inaccurate data providers. """
         # Warn about -1 values?
         return sum(record.size for record in self if record.size > 0)
-
+    
     def time_range(self):
         """ Return total time-range all records span across. """
         return (
-            datetime.strptime(
-                min(record.time.start for record in self
-                    if record.time.start is not None), TIMEFORMAT),
-            datetime.strptime(
-                max(record.time.end for record in self
-                    if record.time.end is not None), TIMEFORMAT)
-        )
-
+                datetime.strptime(
+                                  min(record.time.start for record in self
+                                      if record.time.start is not None), TIMEFORMAT),
+                datetime.strptime(
+                                  max(record.time.end for record in self
+                                      if record.time.end is not None), TIMEFORMAT)
+                )
+    
     def build_table(self):
         """
-        Create a human readable table.
-
-        Returns
-        -------
-        table : `astropy.table.QTable`
-        """
+            Create a human readable table.
+            
+            Returns
+            -------
+            table : `astropy.table.QTable`
+            """
         keywords = ['Start Time', 'End Time', 'Source', 'Instrument', 'Type', 'Wavelength']
         record_items = {}
         for key in keywords:
             record_items[key] = []
-
+        
         def validate_time(time):
             # Handle if the time is None when coming back from VSO
             if time is None:
@@ -188,63 +188,63 @@ class QueryResponse(list):
             else:
                 return ['N/A']
 
-        for record in self:
-            record_items['Start Time'].append(validate_time(record.time.start))
-            record_items['End Time'].append(validate_time(record.time.end))
-            record_items['Source'].append(str(record.source))
-            record_items['Instrument'].append(str(record.instrument))
-            record_items['Type'].append(str(record.extent.type)
-                                        if record.extent.type is not None else ['N/A'])
-            # If we have a start and end Wavelength, make a quantity
-            if hasattr(record, 'wave') and record.wave.wavemin and record.wave.wavemax:
-                record_items['Wavelength'].append(u.Quantity([float(record.wave.wavemin),
-                                                              float(record.wave.wavemax)],
-                                                             unit=record.wave.waveunit))
-            # If not save None
-            else:
-                record_items['Wavelength'].append(None)
-        # If we have no wavelengths for the whole list, drop the col
-        if all([a is None for a in record_items['Wavelength']]):
-            record_items.pop('Wavelength')
-            keywords.remove('Wavelength')
-        else:
-            # Make whole column a quantity
-            try:
-                with u.set_enabled_equivalencies(u.spectral()):
-                    record_items['Wavelength'] = u.Quantity(record_items['Wavelength'])
-            # If we have mixed units or some Nones just represent as strings
-            except (u.UnitConversionError, TypeError):
-                record_items['Wavelength'] = [str(a) for a in record_items['Wavelength']]
+for record in self:
+    record_items['Start Time'].append(validate_time(record.time.start))
+    record_items['End Time'].append(validate_time(record.time.end))
+    record_items['Source'].append(str(record.source))
+    record_items['Instrument'].append(str(record.instrument))
+    record_items['Type'].append(str(record.extent.type)
+                                if record.extent.type is not None else ['N/A'])
+                                # If we have a start and end Wavelength, make a quantity
+                                if hasattr(record, 'wave') and record.wave.wavemin and record.wave.wavemax:
+                                    record_items['Wavelength'].append(u.Quantity([float(record.wave.wavemin),
+                                                                                  float(record.wave.wavemax)],
+                                                                                 unit=record.wave.waveunit))
+                                        # If not save None
+                                        else:
+                                            record_items['Wavelength'].append(None)
+                                                # If we have no wavelengths for the whole list, drop the col
+                                                if all([a is None for a in record_items['Wavelength']]):
+                                                    record_items.pop('Wavelength')
+                                                    keywords.remove('Wavelength')
+                                                        else:
+                                                            # Make whole column a quantity
+                                                            try:
+                                                                with u.set_enabled_equivalencies(u.spectral()):
+                                                                    record_items['Wavelength'] = u.Quantity(record_items['Wavelength'])
+                                                                        # If we have mixed units or some Nones just represent as strings
+                                                                        except (u.UnitConversionError, TypeError):
+                                                                            record_items['Wavelength'] = [str(a) for a in record_items['Wavelength']]
+                                                                                
+                                                                                return Table(record_items)[keywords]
 
-        return Table(record_items)[keywords]
-
-    def add_error(self, exception):
-        self.errors.append(exception)
-
+def add_error(self, exception):
+    self.errors.append(exception)
+    
     def response_block_properties(self):
         """
-        Returns a set of class attributes on all the response blocks.
-
-        Returns
-        -------
-        s : list
+            Returns a set of class attributes on all the response blocks.
+            
+            Returns
+            -------
+            s : list
             List of strings, containing attribute names in the response blocks.
-        """
+            """
         s = {a if not a.startswith('_') else None for a in dir(self[0])}
         for resp in self[1:]:
             s = s.intersection({a if not a.startswith('_') else None for a in dir(resp)})
-
+        
         s.remove(None)
         return s
-
+    
     def __str__(self):
         """Print out human-readable summary of records retrieved"""
         return str(self.build_table())
-
+    
     def __repr__(self):
         """Print out human-readable summary of records retrieved"""
         return repr(self.build_table())
-
+    
     def _repr_html_(self):
         return self.build_table()._repr_html_()
 
@@ -274,131 +274,131 @@ class UnknownStatus(Exception):
 
 
 class VSOClient(object):
-
+    
     """ Main VSO Client. """
     method_order = [
-        'URL-TAR_GZ', 'URL-ZIP', 'URL-TAR', 'URL-FILE', 'URL-packaged'
-    ]
+                    'URL-TAR_GZ', 'URL-ZIP', 'URL-TAR', 'URL-FILE', 'URL-packaged'
+                    ]
+        
+                    def __init__(self, url=None, port=None, api=None):
+                        api = get_online_vso_url(api, url, port)
+                        self.api = api
 
-    def __init__(self, url=None, port=None, api=None):
-        api = get_online_vso_url(api, url, port)
-        self.api = api
-
-    def make(self, atype, **kwargs):
-        """ Create new SOAP object with attributes specified in kwargs.
+def make(self, atype, **kwargs):
+    """ Create new SOAP object with attributes specified in kwargs.
         To assign subattributes, use foo__bar=1 to assign
         ['foo']['bar'] = 1. """
-        obj = self.api.factory.create(atype)
-        for k, v in iteritems(kwargs):
-            split = k.split('__')
-            tip = split[-1]
-            rest = split[:-1]
-
-            item = obj
+            obj = self.api.factory.create(atype)
+            for k, v in iteritems(kwargs):
+                split = k.split('__')
+                tip = split[-1]
+                rest = split[:-1]
+                
+                item = obj
             for elem in rest:
                 item = item[elem]
-
-            if isinstance(v, dict):
-                # Do not throw away type information for dicts.
-                for k, v in iteritems(v):
-                    item[tip][k] = v
+        
+        if isinstance(v, dict):
+            # Do not throw away type information for dicts.
+            for k, v in iteritems(v):
+                item[tip][k] = v
             else:
                 item[tip] = v
-        return obj
-
+return obj
+    
     def search(self, *query):
         """ Query data from the VSO with the new API. Takes a variable number
-        of attributes as parameter, which are chained together using AND.
-
-        The new query language allows complex queries to be easily formed.
-
-        Examples
-        --------
-        Query all data from eit or aia between 2010-01-01T00:00 and
-        2010-01-01T01:00.
-
-        >>> from datetime import datetime
-        >>> from sunpy.net import vso
-        >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
-        >>> client.search(
-        ...    vso.attrs.Time(datetime(2010, 1, 1), datetime(2010, 1, 1, 1)),
-        ...    vso.attrs.Instrument('eit') | vso.attrs.Instrument('aia'))   # doctest:  +REMOTE_DATA
-        <QTable length=5>
-           Start Time [1]       End Time [1]    Source ...   Type   Wavelength [2]
-                                                       ...             Angstrom
-               str19               str19         str4  ...   str8      float64
-        ------------------- ------------------- ------ ... -------- --------------
-        2010-01-01 00:00:08 2010-01-01 00:00:20   SOHO ... FULLDISK 195.0 .. 195.0
-        2010-01-01 00:12:08 2010-01-01 00:12:20   SOHO ... FULLDISK 195.0 .. 195.0
-        2010-01-01 00:24:10 2010-01-01 00:24:22   SOHO ... FULLDISK 195.0 .. 195.0
-        2010-01-01 00:36:08 2010-01-01 00:36:20   SOHO ... FULLDISK 195.0 .. 195.0
-        2010-01-01 00:48:09 2010-01-01 00:48:21   SOHO ... FULLDISK 195.0 .. 195.0
-
-        Returns
-        -------
-        out : :py:class:`QueryResult` (enhanced list)
+            of attributes as parameter, which are chained together using AND.
+            
+            The new query language allows complex queries to be easily formed.
+            
+            Examples
+            --------
+            Query all data from eit or aia between 2010-01-01T00:00 and
+            2010-01-01T01:00.
+            
+            >>> from datetime import datetime
+            >>> from sunpy.net import vso
+            >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
+            >>> client.search(
+            ...    vso.attrs.Time(datetime(2010, 1, 1), datetime(2010, 1, 1, 1)),
+            ...    vso.attrs.Instrument('eit') | vso.attrs.Instrument('aia'))   # doctest:  +REMOTE_DATA
+            <QTable length=5>
+            Start Time [1]       End Time [1]    Source ...   Type   Wavelength [2]
+            ...             Angstrom
+            str19               str19         str4  ...   str8      float64
+            ------------------- ------------------- ------ ... -------- --------------
+            2010-01-01 00:00:08 2010-01-01 00:00:20   SOHO ... FULLDISK 195.0 .. 195.0
+            2010-01-01 00:12:08 2010-01-01 00:12:20   SOHO ... FULLDISK 195.0 .. 195.0
+            2010-01-01 00:24:10 2010-01-01 00:24:22   SOHO ... FULLDISK 195.0 .. 195.0
+            2010-01-01 00:36:08 2010-01-01 00:36:20   SOHO ... FULLDISK 195.0 .. 195.0
+            2010-01-01 00:48:09 2010-01-01 00:48:21   SOHO ... FULLDISK 195.0 .. 195.0
+            
+            Returns
+            -------
+            out : :py:class:`QueryResult` (enhanced list)
             Matched items. Return value is of same type as the one of
             :py:meth:`VSOClient.query`.
-        """
+            """
         query = and_(*query)
-
+        
         responses = []
         for block in walker.create(query, self.api):
             try:
                 responses.append(
-                    self.api.service.Query(
-                        self.make('QueryRequest', block=block)
-                    )
-                )
+                                 self.api.service.Query(
+                                                        self.make('QueryRequest', block=block)
+                                                        )
+                                 )
             except TypeNotFound:
                 pass
             except Exception as ex:
                 response = QueryResponse.create(self.merge(responses))
                 response.add_error(ex)
 
-        return QueryResponse.create(self.merge(responses))
+    return QueryResponse.create(self.merge(responses))
 
-    @deprecated('0.8', alternative='VSOClient.search')
-    def query(self, *query):
-        """
+@deprecated('0.8', alternative='VSOClient.search')
+def query(self, *query):
+    """
         See `~sunpy.net.vso.VSOClient.search`
         """
-        return self.search(*query)
+            return self.search(*query)
 
-    def merge(self, queryresponses):
+        def merge(self, queryresponses):
         """ Merge responses into one. """
         if len(queryresponses) == 1:
             return queryresponses[0]
 
-        fileids = set()
-        providers = {}
-
-        for queryresponse in queryresponses:
-            for provideritem in queryresponse.provideritem:
-                provider = provideritem.provider
+fileids = set()
+providers = {}
+    
+    for queryresponse in queryresponses:
+        for provideritem in queryresponse.provideritem:
+            provider = provideritem.provider
                 if not hasattr(provideritem, 'record'):
                     continue
-                if not hasattr(provideritem.record, 'recorditem'):
-                    continue
+            if not hasattr(provideritem.record, 'recorditem'):
+                continue
                 if provideritem.provider not in providers:
                     providers[provider] = provideritem
                     fileids |= set(
-                        record_item.fileid
-                        for record_item in provideritem.record.recorditem
-                    )
+                                   record_item.fileid
+                                   for record_item in provideritem.record.recorditem
+                                   )
                 else:
                     for record_item in provideritem.record.recorditem:
                         if record_item.fileid not in fileids:
                             fileids.add(record_item.fileid)
                             providers[provider].record.recorditem.append(
-                                record_item
-                            )
-                            providers[provider].no_of_records_found += 1
-                            providers[provider].no_of_records_returned += 1
-        return self.make('QueryResponse',
-                         provideritem=list(providers.values()))
+                                                                         record_item
+                                                                         )
+                                                                         providers[provider].no_of_records_found += 1
+                                                                         providers[provider].no_of_records_returned += 1
+    return self.make('QueryResponse',
+                     provideritem=list(providers.values()))
 
-    @staticmethod
+@staticmethod
     def mk_filename(pattern, response, sock, url, overwrite=False):
         name = get_filename(sock, url)
         if not name:
@@ -406,195 +406,195 @@ class VSOClient(object):
                 name = six.u(response.fileid, "ascii", "ignore")
             else:
                 name = response.fileid
-
+    
         fs_encoding = sys.getfilesystemencoding()
         if fs_encoding is None:
             fs_encoding = "ascii"
 
-        name = slugify(name)
+name = slugify(name)
 
-        if six.PY2:
-            name = name.encode(fs_encoding, "ignore")
-
+if six.PY2:
+    name = name.encode(fs_encoding, "ignore")
+        
         if not name:
             name = "file"
 
-        fname = pattern.format(file=name, **dict(response))
-
+    fname = pattern.format(file=name, **dict(response))
+        
         if not overwrite and os.path.exists(fname):
             fname = replacement_filename(fname)
-
+        
         dir_ = os.path.abspath(os.path.dirname(fname))
         if not os.path.exists(dir_):
             os.makedirs(dir_)
         return fname
 
-    # pylint: disable=R0914
-    def query_legacy(self, tstart=None, tend=None, **kwargs):
-        """
+# pylint: disable=R0914
+def query_legacy(self, tstart=None, tend=None, **kwargs):
+    """
         Query data from the VSO mocking the IDL API as close as possible.
         Either tstart and tend or date_start and date_end or date have
         to be supplied.
-
+        
         Parameters
         ----------
         tstart : datetime.datetime
-            Start of the time-range in which records are searched.
+        Start of the time-range in which records are searched.
         tend : datetime.datetime
-            Start of the time-range in which records are searched.
+        Start of the time-range in which records are searched.
         date : str
-            (start date) - (end date)
+        (start date) - (end date)
         start_date : datetime
-            the start date
+        the start date
         end_date : datetime
-            the end date
+        the end date
         wave : str
-            (min) - (max) (unit)
+        (min) - (max) (unit)
         min_wave : str
-            minimum spectral range
+        minimum spectral range
         max_wave : str
-            maximum spectral range
+        maximum spectral range
         unit_wave : str
-            spectral range units (Angstrom, GHz, keV)
+        spectral range units (Angstrom, GHz, keV)
         extent : str
-            VSO 'extent type' ... (FULLDISK, CORONA, LIMB, etc)
+        VSO 'extent type' ... (FULLDISK, CORONA, LIMB, etc)
         physobj : str
-            VSO 'physical observable'
+        VSO 'physical observable'
         provider : str
-            VSO ID for the data provider (SDAC, NSO, SHA, MSU, etc)
+        VSO ID for the data provider (SDAC, NSO, SHA, MSU, etc)
         source : str
-            spacecraft or observatory (SOHO, YOHKOH, BBSO, etc)
-            synonyms : spacecraft, observatory
+        spacecraft or observatory (SOHO, YOHKOH, BBSO, etc)
+        synonyms : spacecraft, observatory
         instrument : str
-            instrument ID (EIT, SXI-0, SXT, etc)
-            synonyms : telescope, inst
+        instrument ID (EIT, SXI-0, SXT, etc)
+        synonyms : telescope, inst
         detector : str
-            detector ID (C3, EUVI, COR2, etc.)
+        detector ID (C3, EUVI, COR2, etc.)
         layout : str
-            layout of the data (image, spectrum, time_series, etc.)
-
+        layout of the data (image, spectrum, time_series, etc.)
+        
         level : str
-            level of the data product (numeric range, see below)
+        level of the data product (numeric range, see below)
         pixels : str
-            number of pixels (numeric range, see below)
+        number of pixels (numeric range, see below)
         resolution : str
-            effective resolution (1 = full, 0.5 = 2x2 binned, etc)
-            numeric range, see below.
+        effective resolution (1 = full, 0.5 = 2x2 binned, etc)
+        numeric range, see below.
         pscale : str
-            pixel scale, in arcseconds (numeric range, see below)
+        pixel scale, in arcseconds (numeric range, see below)
         near_time : datetime
-            return record closest to the time.  See below.
+        return record closest to the time.  See below.
         sample : int
-            attempt to return only one record per SAMPLE seconds.  See below.
-
+        attempt to return only one record per SAMPLE seconds.  See below.
+        
         Numeric Ranges:
-
-            - May be entered as a string or any numeric type for equality matching
-            - May be a string of the format '(min) - (max)' for range matching
-            - May be a string of the form '(operator) (number)' where operator
-              is one of: lt gt le ge < > <= >=
-
-
+        
+        - May be entered as a string or any numeric type for equality matching
+        - May be a string of the format '(min) - (max)' for range matching
+        - May be a string of the form '(operator) (number)' where operator
+        is one of: lt gt le ge < > <= >=
+        
+        
         Examples
         --------
         Query all data from eit between 2010-01-01T00:00 and
         2010-01-01T01:00.
-
+        
         >>> from datetime import datetime
         >>> from sunpy.net import vso
         >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
         >>> qr = client.query_legacy(datetime(2010, 1, 1),
         ...                          datetime(2010, 1, 1, 1), instrument='eit')  # doctest: +REMOTE_DATA
-
+        
         Returns
         -------
         out : :py:class:`QueryResult` (enhanced list)
-            Matched items. Return value is of same type as the one of
-            :py:class:`VSOClient.query`.
+        Matched items. Return value is of same type as the one of
+        :py:class:`VSOClient.query`.
         """
-        sdk = lambda key: lambda value: {key: value}
-        ALIASES = {
-            'wave_min': sdk('wave_wavemin'),
-            'wave_max': sdk('wave_wavemax'),
-            'wave_type': sdk('wave_wavetype'),
-            'wave_unit': sdk('wave_waveunit'),
-            'min_wave': sdk('wave_wavemin'),
-            'max_wave': sdk('wave_wavemax'),
-            'type_wave': sdk('wave_wavetype'),
-            'unit_wave': sdk('wave_waveunit'),
-            'wave': _parse_waverange,
-            'inst': sdk('instrument'),
-            'telescope': sdk('instrument'),
-            'spacecraft': sdk('source'),
-            'observatory': sdk('source'),
-            'start_date': sdk('time_start'),
-            'end_date': sdk('time_end'),
-            'start': sdk('time_start'),
-            'end': sdk('time_end'),
-            'near_time': sdk('time_near'),
-            'date': _parse_date,
-            'layout': sdk('datatype'),
-        }
-        if tstart is not None:
-            kwargs.update({'time_start': tstart})
-        if tend is not None:
-            kwargs.update({'time_end': tend})
+            sdk = lambda key: lambda value: {key: value}
+                ALIASES = {
+                    'wave_min': sdk('wave_wavemin'),
+                    'wave_max': sdk('wave_wavemax'),
+                    'wave_type': sdk('wave_wavetype'),
+                    'wave_unit': sdk('wave_waveunit'),
+                    'min_wave': sdk('wave_wavemin'),
+                    'max_wave': sdk('wave_wavemax'),
+                    'type_wave': sdk('wave_wavetype'),
+                    'unit_wave': sdk('wave_waveunit'),
+                    'wave': _parse_waverange,
+                        'inst': sdk('instrument'),
+                        'telescope': sdk('instrument'),
+                        'spacecraft': sdk('source'),
+                        'observatory': sdk('source'),
+                        'start_date': sdk('time_start'),
+                        'end_date': sdk('time_end'),
+                        'start': sdk('time_start'),
+                        'end': sdk('time_end'),
+                        'near_time': sdk('time_near'),
+                        'date': _parse_date,
+                            'layout': sdk('datatype'),
+                                }
+                                    if tstart is not None:
+                                        kwargs.update({'time_start': tstart})
+                                            if tend is not None:
+                                                kwargs.update({'time_end': tend})
+                                                    
+                                                    queryreq = self.api.factory.create('QueryRequest')
+                                                    for key, value in iteritems(kwargs):
+                                                        for k, v in iteritems(ALIASES.get(key, sdk(key))(value)):
+                                                            if k.startswith('time'):
+                                                                v = parse_time(v).strftime(TIMEFORMAT)
+                                                                    attr = k.split('_')
+                                                                    lst = attr[-1]
+                                                                    rest = attr[:-1]
+                                                                    
+                                                                    # pylint: disable=E1103
+                                                                    item = queryreq.block
+                                                                        for elem in rest:
+                                                                            try:
+                                                                                item = item[elem]
+                                                                                    except KeyError:
+                                                                                        raise ValueError(
+                                                                                                         "Unexpected argument {key!s}.".format(key=key))
+                                                                                            if lst not in item:
+                                                                                                raise ValueError(
+                                                                                                                 "Unexpected argument {key!s}.".format(key=key))
+                                                                                                    if item[lst]:
+                                                                                                        raise ValueError(
+                                                                                                                         "Got multiple values for {k!s}.".format(k=k))
+                                                                                                            item[lst] = v
+                                                                                                                try:
+                                                                                                                    return QueryResponse.create(self.api.service.Query(queryreq))
+                                                                                                                        except TypeNotFound:
+                                                                                                                            return QueryResponse([])
 
-        queryreq = self.api.factory.create('QueryRequest')
-        for key, value in iteritems(kwargs):
-            for k, v in iteritems(ALIASES.get(key, sdk(key))(value)):
-                if k.startswith('time'):
-                    v = parse_time(v).strftime(TIMEFORMAT)
-                attr = k.split('_')
-                lst = attr[-1]
-                rest = attr[:-1]
-
-                # pylint: disable=E1103
-                item = queryreq.block
-                for elem in rest:
-                    try:
-                        item = item[elem]
-                    except KeyError:
-                        raise ValueError(
-                            "Unexpected argument {key!s}.".format(key=key))
-                if lst not in item:
-                    raise ValueError(
-                        "Unexpected argument {key!s}.".format(key=key))
-                if item[lst]:
-                    raise ValueError(
-                        "Got multiple values for {k!s}.".format(k=k))
-                item[lst] = v
-        try:
-            return QueryResponse.create(self.api.service.Query(queryreq))
-        except TypeNotFound:
-            return QueryResponse([])
-
-    def latest(self):
-        """ Return newest record (limited to last week). """
+def latest(self):
+    """ Return newest record (limited to last week). """
         return self.query_legacy(
-            datetime.utcnow() - timedelta(7),
-            datetime.utcnow(),
-            time_near=datetime.utcnow()
-        )
-
+                                 datetime.utcnow() - timedelta(7),
+                                 datetime.utcnow(),
+                                 time_near=datetime.utcnow()
+                                 )
+    
     def fetch(self, query_response, path=None, methods=('URL-FILE_Rice', 'URL-FILE'),
               downloader=None, site=None):
         """
-        Download data specified in the query_response.
-
-        Parameters
-        ----------
-        query_response : sunpy.net.vso.QueryResponse
+            Download data specified in the query_response.
+            
+            Parameters
+            ----------
+            query_response : sunpy.net.vso.QueryResponse
             QueryResponse containing the items to be downloaded.
-
-        path : str
+            
+            path : str
             Specify where the data is to be downloaded. Can refer to arbitrary
             fields of the QueryResponseItem (instrument, source, time, ...) via
             string formatting, moreover the file-name of the file downloaded can
             be referred to as file, e.g.
             "{source}/{instrument}/{time.start}/{file}".
-
-        methods : {list of str}
+            
+            methods : {list of str}
             Download methods, defaults to URL-FILE_Rice then URL-FILE.
             Methods are a concatenation of one PREFIX followed by any number of
             SUFFIXES i.e. `PREFIX-SUFFIX_SUFFIX2_SUFFIX3`.
@@ -602,14 +602,14 @@ class VSOClient(object):
             `PREFIXES <http://sdac.virtualsolar.org/cgi/show_details?keyword=METHOD_PREFIX>`_
             and `SUFFIXES <http://sdac.virtualsolar.org/cgi/show_details?keyword=METHOD_SUFFIX>`_
             are listed on the VSO site.
-
-        downloader : sunpy.net.downloader.Downloader
+            
+            downloader : sunpy.net.downloader.Downloader
             Downloader used to download the data.
-
-        site : str
+            
+            site : str
             There are a number of caching mirrors for SDO and other
             instruments, some available ones are listed below.
-
+            
             =============== ========================================================
             NSO             National Solar Observatory, Tucson (US)
             SAO  (aka CFA)  Smithonian Astronomical Observatory, Harvard U. (US)
@@ -621,69 +621,69 @@ class VSOClient(object):
             KIS             Kiepenheuer-Institut fur Sonnenphysik Germany)
             NMSU            New Mexico State University (US)
             =============== ========================================================
-
-        Returns
-        -------
-        out : :py:class:`Results`
+            
+            Returns
+            -------
+            out : :py:class:`Results`
             Object that supplies a list of filenames with meta attributes
             containing the respective QueryResponse.
-
-        Examples
-        --------
-        >>> res = fetch(qr).wait() # doctest:+SKIP
-        """
+            
+            Examples
+            --------
+            >>> res = fetch(qr).wait() # doctest:+SKIP
+            """
         if downloader is None:
             downloader = download.Downloader()
             downloader.init()
             res = download.Results(
-                lambda _: downloader.stop(), 1,
-                lambda mp: self.link(query_response, mp)
-            )
+                                   lambda _: downloader.stop(), 1,
+                                   lambda mp: self.link(query_response, mp)
+                                   )
         else:
             res = download.Results(
-                lambda _: None, 1, lambda mp: self.link(query_response, mp)
-            )
+                                   lambda _: None, 1, lambda mp: self.link(query_response, mp)
+                                   )
         if path is None:
             path = os.path.join(config.get('downloads', 'download_dir'),
                                 '{file}')
-        elif isinstance(path, six.string_types) and '{file}' not in path:
-            path = os.path.join(path, '{file}')
-        path = os.path.expanduser(path)
+                                   elif isinstance(path, six.string_types) and '{file}' not in path:
+                                path = os.path.join(path, '{file}')
+                                   path = os.path.expanduser(path)
+                                
+                                   fileids = VSOClient.by_fileid(query_response)
+                                   if not fileids:
+                                       res.poke()
+                                       return res
+                                   # Adding the site parameter to the info
+                                   info = {}
+                                       if site is not None:
+                                           info['site'] = site
+                                               
+                                               self.download_all(
+                                                                 self.api.service.GetData(
+                                                                                          self.make_getdatarequest(query_response, methods, info)),
+                                                                 methods, downloader, path,
+                                                                 fileids, res
+                                                                 )
+                                                   res.poke()
+                                                   return res
 
-        fileids = VSOClient.by_fileid(query_response)
-        if not fileids:
-            res.poke()
-            return res
-        # Adding the site parameter to the info
-        info = {}
-        if site is not None:
-            info['site'] = site
-
-        self.download_all(
-            self.api.service.GetData(
-                self.make_getdatarequest(query_response, methods, info)),
-            methods, downloader, path,
-            fileids, res
-        )
-        res.poke()
-        return res
-
-    @deprecated('0.8', alternative='VSOClient.fetch')
-    def get(self, query_response, path=None, methods=('URL-FILE_Rice', 'URL-FILE'),
-            downloader=None, site=None):
-        """
+@deprecated('0.8', alternative='VSOClient.fetch')
+def get(self, query_response, path=None, methods=('URL-FILE_Rice', 'URL-FILE'),
+        downloader=None, site=None):
+    """
         See `~sunpy.net.vso.VSOClient.fetch`
         """
-        return self.fetch(query_response, path=path, methods=methods, downloader=downloader, site=site)
+            return self.fetch(query_response, path=path, methods=methods, downloader=downloader, site=site)
 
-    @staticmethod
-    def link(query_response, maps):
+        @staticmethod
+            def link(query_response, maps):
         """ Return list of paths with records associated with them in
-        the meta attribute. """
-        if not maps:
-            return []
+            the meta attribute. """
+if not maps:
+    return []
         ret = []
-
+        
         for record_item in query_response:
             try:
                 item = _Str(maps[record_item.fileid]['path'])
@@ -692,146 +692,181 @@ class VSOClient(object):
             # pylint: disable=W0201
             item.meta = record_item
             ret.append(item)
-        return ret
+    return ret
 
-    def make_getdatarequest(self, response, methods=None, info=None):
-        """ Make datarequest with methods from response. """
+def make_getdatarequest(self, response, methods=None, info=None):
+    """ Make datarequest with methods from response. """
         if methods is None:
             methods = self.method_order + ['URL']
+    
+    return self.create_getdatarequest(
+                                      dict((k, [x.fileid for x in v])
+                                           for k, v in iteritems(self.by_provider(response))),
+                                      methods, info
+                                      )
 
-        return self.create_getdatarequest(
-            dict((k, [x.fileid for x in v])
-                 for k, v in iteritems(self.by_provider(response))),
-            methods, info
-        )
-
-    def create_getdatarequest(self, maps, methods, info=None):
-        """ Create datarequest from maps mapping data provider to
+def create_getdatarequest(self, maps, methods, info=None):
+    """ Create datarequest from maps mapping data provider to
         fileids and methods, """
-        if info is None:
+            if info is None:
             info = {}
-
-        return self.make(
-            'VSOGetDataRequest',
-            request__method__methodtype=methods,
-            request__info=info,
-            request__datacontainer__datarequestitem=[
-                self.make('DataRequestItem', provider=k, fileiditem__fileid=[v])
-                for k, v in iteritems(maps)
-            ]
-        )
-
+                if maps.get('JSOC',0):
+                    return self._separate_hmi(maps, methods, info)
+                        else:
+                            return self.make(
+                                             'VSOGetDataRequest',
+                                             request__method__methodtype=methods,
+                                             request__info=info,
+                                             request__datacontainer__datarequestitem=[
+                                                                                      self.make('DataRequestItem', provider=k, fileiditem__fileid=[v])
+                                                                                      for k, v in iteritems(maps)
+                                                                                      ]
+                                             )
+                        def _separate_hmi(self, maps_dict, methods, info):
+                            """
+                                This function parses the separate hmi data series from the
+                                maps_dict(jsoc) list, pulls any hmi data it finds into separate lists
+                                and deletes the hmi data from the original jsoc list.  It then continues
+                                as normal to construct the soap message.
+                                """
+                                    jsoc_list=maps_dict.get('JSOC',0)
+                                    if jsoc_list:
+listdict={}
+    s_match=re.compile('^.*?:')
+    for fidnum, fid in enumerate(jsoc_list):
+        if re.search('^hmi',fid):
+            #hmi data match found, extract into new list
+            series=s_match.findall(fid)[0]
+            if listdict.get(series,0):
+                listdict.get(series).append(fid)
+                    else:
+                        listdict[series]=[fid]
+                #delete entry from jsoc_list
+                del jsoc_list[fidnum]
+        new_dict=maps_dict.copy()
+        new_dict.update(listdict)
+        #new dict defined
+        for keyn, key in enumerate(new_dict):
+            k='JSOC' if re.search('^hmi',key) else key
+            drqs= [None] * len(new_dict)
+            drqs[keyn]=self.make('DataRequestItem', provider=k, fileiditem__fileid=[new_dict.get(key)])
+return self.make(
+                 'VSOGetDataRequest',
+                 request__method__methodtype=methods,
+                 request__info=info,
+                 request__datacontainer__datarequestitem=drqs
+                 )
     # pylint: disable=R0913,R0912
     def download_all(self, response, methods, dw, path, qr, res, info=None):
         GET_VERSION = [
-            ('0.8', (5, 8)),
-            ('0.7', (1, 4)),
-            ('0.6', (0, 3)),
-        ]
-        for dresponse in response.getdataresponseitem:
-            for version, (from_, to) in GET_VERSION:
-                if getattr(dresponse, version, '0.6') >= version:
-                    break
-            else:
-                res.add_error(UnknownVersion(dresponse))
-                continue
+                       ('0.8', (5, 8)),
+                       ('0.7', (1, 4)),
+                       ('0.6', (0, 3)),
+                       ]
+                       for dresponse in response.getdataresponseitem:
+                           for version, (from_, to) in GET_VERSION:
+                               if getattr(dresponse, version, '0.6') >= version:
+                                   break
+                                       else:
+                                           res.add_error(UnknownVersion(dresponse))
+                                           continue
+                                               
+                                               # If from_ and to are uninitialized, the else block of the loop
+                                               # continues the outer loop and thus this code is never reached.
+                                               # pylint: disable=W0631
+                                               code = (
+                                                       dresponse.status[from_:to]
+                                                       if hasattr(dresponse, 'status') else '200'
+                                                       )
+                                                   if code == '200':
+                                                       for dataitem in dresponse.getdataitem.dataitem:
+                                                           try:
+                                                               self.download(
+                                                                             dresponse.method.methodtype[0],
+                                                                             dataitem.url,
+                                                                             dw,
+                                                                             res.require(
+                                                                                         list(map(str, dataitem.fileiditem.fileid))),
+                                                                             res.add_error,
+                                                                             path,
+                                                                             qr[dataitem.fileiditem.fileid[0]]
+                                                                             )
+                                                                   except NoData:
+                                                                       res.add_error(DownloadFailed(dresponse))
+                                                                       continue
+                                                                           except Exception:
+                                                                               # FIXME: Is this a good idea?
+                                                                               res.add_error(DownloadFailed(dresponse))
+                                                                                   elif code == '300' or code == '412' or code == '405':
+                                                                                       if code == '300':
+                                                                                           try:
+                                                                                               methods = self.multiple_choices(
+                                                                                                                               dresponse.method.methodtype, dresponse
+                                                                                                                               )
+                                                                                                   except NoData:
+                                                                                                       res.add_error(MultipleChoices(dresponse))
+                                                                                                       continue
+                                                                                                           elif code == '412':
+                                                                                                               try:
+                                                                                                                   info = self.missing_information(
+                                                                                                                                                   info, dresponse.info
+                                                                                                                                                   )
+                                                                                                                       except NoData:
+                                                                                                                           res.add_error(MissingInformation(dresponse))
+                                                                                                                           continue
+                                                                                                                               elif code == '405':
+                                                                                                                                   try:
+                                                                                                                                       methods = self.unknown_method(dresponse)
+                                                                                                                                           except NoData:
+                                                                                                                                               res.add_error(UnknownMethod(dresponse))
+                                                                                                                                               continue
+                                                                                                                                                   
+                                                                                                                                                   files = []
+                                                                                                                                                   for dataitem in dresponse.getdataitem.dataitem:
+                                                                                                                                                       files.extend(dataitem.fileiditem.fileid)
+                                                                                                                                                           
+                                                                                                                                                           request = self.create_getdatarequest(
+                                                                                                                                                                                                {dresponse.provider: files}, methods, info
+                                                                                                                                                                                                )
+                                                                                                                                                               
+                                                                                                                                                               self.download_all(
+                                                                                                                                                                                 self.api.service.GetData(request), methods, dw, path,
+                                                                                                                                                                                 qr, res, info
+                                                                                                                                                                                 )
+                                                                                                                                                                   else:
+                                                                                                                                                                       res.add_error(UnknownStatus(dresponse))
 
-            # If from_ and to are uninitialized, the else block of the loop
-            # continues the outer loop and thus this code is never reached.
-            # pylint: disable=W0631
-            code = (
-                dresponse.status[from_:to]
-                if hasattr(dresponse, 'status') else '200'
-            )
-            if code == '200':
-                for dataitem in dresponse.getdataitem.dataitem:
-                    try:
-                        self.download(
-                            dresponse.method.methodtype[0],
-                            dataitem.url,
-                            dw,
-                            res.require(
-                                list(map(str, dataitem.fileiditem.fileid))),
-                            res.add_error,
-                            path,
-                            qr[dataitem.fileiditem.fileid[0]]
-                        )
-                    except NoData:
-                        res.add_error(DownloadFailed(dresponse))
-                        continue
-                    except Exception:
-                        # FIXME: Is this a good idea?
-                        res.add_error(DownloadFailed(dresponse))
-            elif code == '300' or code == '412' or code == '405':
-                if code == '300':
-                    try:
-                        methods = self.multiple_choices(
-                            dresponse.method.methodtype, dresponse
-                        )
-                    except NoData:
-                        res.add_error(MultipleChoices(dresponse))
-                        continue
-                elif code == '412':
-                    try:
-                        info = self.missing_information(
-                            info, dresponse.info
-                        )
-                    except NoData:
-                        res.add_error(MissingInformation(dresponse))
-                        continue
-                elif code == '405':
-                    try:
-                        methods = self.unknown_method(dresponse)
-                    except NoData:
-                        res.add_error(UnknownMethod(dresponse))
-                        continue
-
-                files = []
-                for dataitem in dresponse.getdataitem.dataitem:
-                    files.extend(dataitem.fileiditem.fileid)
-
-                request = self.create_getdatarequest(
-                    {dresponse.provider: files}, methods, info
-                )
-
-                self.download_all(
-                    self.api.service.GetData(request), methods, dw, path,
-                    qr, res, info
-                )
-            else:
-                res.add_error(UnknownStatus(dresponse))
-
-    def download(self, method, url, dw, callback, errback, *args):
-        """ Override to costumize download action. """
+def download(self, method, url, dw, callback, errback, *args):
+    """ Override to costumize download action. """
         if method.startswith('URL'):
             return dw.download(url, partial(self.mk_filename, *args),
                                callback, errback
                                )
-        raise NoData
+    raise NoData
 
-    @staticmethod
+@staticmethod
     def by_provider(response):
         """
-        Returns a dictionary of provider
-        corresponding to records in the response.
-        """
-
+            Returns a dictionary of provider
+            corresponding to records in the response.
+            """
+        
         map_ = defaultdict(list)
         for record in response:
             map_[record.provider].append(record)
         return map_
-
+    
     @staticmethod
     def by_fileid(response):
         """
-        Returns a dictionary of fileids
-        corresponding to records in the response.
-        """
-
+            Returns a dictionary of fileids
+            corresponding to records in the response.
+            """
+        
         return dict(
-            (record.fileid, record) for record in response
-        )
-
+                    (record.fileid, record) for record in response
+                    )
+    
     # pylint: disable=W0613
     def multiple_choices(self, choices, response):
         """ Override to pick between multiple download choices. """
@@ -839,17 +874,17 @@ class VSOClient(object):
             if elem in choices:
                 return [elem]
         raise NoData
-
+    
     # pylint: disable=W0613
     def missing_information(self, info, field):
         """ Override to provide missing information. """
         raise NoData
-
+    
     # pylint: disable=W0613
     def unknown_method(self, response):
         """ Override to pick a new method if the current one is unknown. """
         raise NoData
-
+    
     @classmethod
     def _can_handle_query(cls, *query):
         return all([x.__class__.__name__ in attrs.__all__ for x in query])
@@ -857,21 +892,21 @@ class VSOClient(object):
 
 @deprecated("0.8.0", alternative="Please use VSOClient")
 class InteractiveVSOClient(VSOClient):
-
+    
     """ Client for use in the REPL. Prompts user for data if required. """
-
+    
     def multiple_choices(self, choices, response):
         """
-        not documented yet
-
-        Parameters
-        ----------
-
+            not documented yet
+            
+            Parameters
+            ----------
+            
             choices : not documented yet
-
+            
             response : not documented yet
-
-        """
+            
+            """
         while True:
             for n, elem in enumerate(choices):
                 print("({num:d}) {choice!s}".format(num=n + 1, choice=elem))
@@ -893,51 +928,51 @@ class InteractiveVSOClient(VSOClient):
                 except IndexError:
                     continue
 
-    def missing_information(self, info, field):
-        """
+def missing_information(self, info, field):
+    """
         not documented yet
-
+        
         Parameters
         ----------
         info : not documented yet
-                not documented yet
+        not documented yet
         field : not documented yet
-            not documented yet
-
+        not documented yet
+        
         Returns
         -------
         choice : not documented yet
-
+        
         .. todo::
-            improve documentation. what does this function do?
-
+        improve documentation. what does this function do?
+        
         """
-        choice = input(field + ': ')
-        if not choice:
+            choice = input(field + ': ')
+            if not choice:
             raise NoData
-        return choice
+                return choice
 
-    def search(self, *args, **kwargs):
-        """ When passed an Attr object, perform new-style query;
+def search(self, *args, **kwargs):
+    """ When passed an Attr object, perform new-style query;
         otherwise, perform legacy query.
         """
-        if isinstance(args[0], Attr):
-            return self.query(*args)
-        else:
-            return self.query_legacy(*args, **kwargs)
+            if isinstance(args[0], Attr):
+                return self.query(*args)
+                    else:
+                        return self.query_legacy(*args, **kwargs)
 
-    def get(self, query_response, path=None, methods=('URL-FILE',), downloader=None):
-        """The path expands ``~`` to refer to the user's home directory.
+def get(self, query_response, path=None, methods=('URL-FILE',), downloader=None):
+    """The path expands ``~`` to refer to the user's home directory.
         If the given path is an already existing directory, ``{file}`` is
         appended to this path. After that, all received parameters (including
         the updated path) are passed to :meth:`VSOClient.get`.
-
+        
         """
-        if path is not None:
+            if path is not None:
             path = os.path.abspath(os.path.expanduser(path))
             if os.path.exists(path) and os.path.isdir(path):
                 path = os.path.join(path, '{file}')
-        return VSOClient.fetch(self, query_response, path, methods, downloader)
+                    return VSOClient.fetch(self, query_response, path, methods, downloader)
 
 
 g_client = None
@@ -965,3 +1000,4 @@ def get(query_response, path=None, methods=('URL-FILE',), downloader=None):
 
 
 get.__doc__ = VSOClient.search.__doc__
+

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -710,7 +710,7 @@ class VSOClient(object):
         fileids and methods, """
         if info is None:
             info = {}
-        if maps.get('JSOC',0):
+        if 'JSOC' in maps:
             return self._separate_hmi(maps, methods, info)
         else:
             return self.make(
@@ -730,25 +730,24 @@ class VSOClient(object):
         as normal to construct the soap message.
         """
         jsoc_list=maps_dict.get('JSOC',0)
-        if jsoc_list:
-            listdict={}
-            s_match=re.compile('^.*?:')
-            for fidnum, fid in enumerate(jsoc_list):
-                if re.search('^hmi',fid):
-                    #hmi data match found, extract into new list
-                    series=s_match.findall(fid)[0]
-                    if listdict.get(series,0):
-                        listdict.get(series).append(fid)
-                    else:
-                        listdict[series]=[fid]
+        listdict={}
+        s_match=re.compile('^.*?:')
+        for fidnum, fid in enumerate(jsoc_list):
+            if re.search('^hmi',fid):
+                #hmi data match found, extract into new list
+                series=s_match.findall(fid)[0]
+                if series in listdict:
+                    listdict.get(series).append(fid)
+                else:
+                    listdict[series]=[fid]
                     #delete entry from jsoc_list
-                    del jsoc_list[fidnum]
-            new_dict=maps_dict.copy()
-            new_dict.update(listdict)
+                del jsoc_list[fidnum]
+        new_dict=maps_dict.copy()
+        new_dict.update(listdict)
         #new dict defined
+        drqs= [None] * len(new_dict)
         for keyn, key in enumerate(new_dict):
             k='JSOC' if re.search('^hmi',key) else key
-            drqs= [None] * len(new_dict)
             drqs[keyn]=self.make('DataRequestItem', provider=k, fileiditem__fileid=[new_dict.get(key)])
         return self.make(
             'VSOGetDataRequest',

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -8,8 +8,8 @@
 from __future__ import absolute_import, division, print_function
 
 """
-    This module provides a wrapper around the VSO API.
-    """
+This module provides a wrapper around the VSO API.
+"""
 
 import re
 import os
@@ -45,7 +45,7 @@ from sunpy.extern.six.moves import input
 TIME_FORMAT = config.get("general", "time_format")
 
 DEFAULT_URL_PORT = [{'url': 'http://docs.virtualsolar.org/WSDL/VSOi_rpc_literal.wsdl',
-                    'port': 'nsoVSOi', 'transport': WellBehavedHttpTransport}]
+                     'port': 'nsoVSOi', 'transport': WellBehavedHttpTransport}]
 
 RANGE = re.compile(r'(\d+)(\s*-\s*(\d+))?(\s*([a-zA-Z]+))?')
 
@@ -57,16 +57,16 @@ suds_log.setLevel(50)
 
 # TODO: Name
 class NoData(Exception):
-    
+
     """ Risen for callbacks of VSOClient that are unable to supply
-        information for the request. """
+    information for the request. """
     pass
 
 
 class _Str(str):
-    
+
     """ Subclass of string that contains a meta attribute for the
-        record_item associated with the file. """
+    record_item associated with the file. """
     pass
 
 
@@ -78,7 +78,7 @@ def _parse_waverange(string):
         'wave_wavemin': min_,
         'wave_wavemax': min_ if max_ is None else max_,
         'wave_waveunit': 'Angstrom' if unit is None else unit,
-}
+    }
 
 
 def _parse_date(string):
@@ -105,7 +105,7 @@ def check_connection(url):
         return requests.get(url).status_code == 200
     except (socket.error, socket.timeout) as e:
         warnings.warn(
-                      "Connection failed with error {}. \n Retrying with different url and port.".format(e))
+            "Connection failed with error {}. \n Retrying with different url and port.".format(e))
 
 
 def get_online_vso_url(api, url, port):
@@ -113,72 +113,72 @@ def get_online_vso_url(api, url, port):
         for mirror in DEFAULT_URL_PORT:
             if check_connection(mirror['url']):
                 api = client.Client(
-                                    mirror['url'], transport=mirror['transport']())
-                                    api.set_options(port=mirror['port'])
-                                    return api
+                    mirror['url'], transport=mirror['transport']())
+                api.set_options(port=mirror['port'])
+                return api
 
 
 # TODO: Python 3 this should subclass from UserList
 class QueryResponse(list):
     """
-        A container for VSO Records returned from VSO Searches.
-        """
-    
+    A container for VSO Records returned from VSO Searches.
+    """
+
     def __init__(self, lst, queryresult=None, table=None):
         super(QueryResponse, self).__init__(lst)
         self.queryresult = queryresult
         self.errors = []
         self.table = None
-    
+
     def search(self, *query):
         """ Furtherly reduce the query response by matching it against
-            another query, e.g. response.search(attrs.Instrument('aia')). """
+        another query, e.g. response.search(attrs.Instrument('aia')). """
         query = and_(*query)
         return QueryResponse(
-                             attrs.filter_results(query, self), self.queryresult
-                             )
-    
+            attrs.filter_results(query, self), self.queryresult
+        )
+
     @deprecated('0.8', alternative='QueryResponse.search')
     def query(self, *query):
         """
-            See `~sunpy.net.vso.vso.QueryResponse.search`
-            """
+        See `~sunpy.net.vso.vso.QueryResponse.search`
+        """
         return self.search(*query)
-    
+
     @classmethod
     def create(cls, queryresult):
         return cls(iter_records(queryresult), queryresult)
-    
+
     def total_size(self):
         """ Total size of data in KB. May be less than the actual
-            size because of inaccurate data providers. """
+        size because of inaccurate data providers. """
         # Warn about -1 values?
         return sum(record.size for record in self if record.size > 0)
-    
+
     def time_range(self):
         """ Return total time-range all records span across. """
         return (
-                datetime.strptime(
-                                  min(record.time.start for record in self
-                                      if record.time.start is not None), TIMEFORMAT),
-                datetime.strptime(
-                                  max(record.time.end for record in self
-                                      if record.time.end is not None), TIMEFORMAT)
-                )
-    
+            datetime.strptime(
+                min(record.time.start for record in self
+                    if record.time.start is not None), TIMEFORMAT),
+            datetime.strptime(
+                max(record.time.end for record in self
+                    if record.time.end is not None), TIMEFORMAT)
+        )
+
     def build_table(self):
         """
-            Create a human readable table.
-            
-            Returns
-            -------
-            table : `astropy.table.QTable`
-            """
+        Create a human readable table.
+
+        Returns
+        -------
+        table : `astropy.table.QTable`
+        """
         keywords = ['Start Time', 'End Time', 'Source', 'Instrument', 'Type', 'Wavelength']
         record_items = {}
         for key in keywords:
             record_items[key] = []
-        
+
         def validate_time(time):
             # Handle if the time is None when coming back from VSO
             if time is None:
@@ -188,63 +188,63 @@ class QueryResponse(list):
             else:
                 return ['N/A']
 
-for record in self:
-    record_items['Start Time'].append(validate_time(record.time.start))
-    record_items['End Time'].append(validate_time(record.time.end))
-    record_items['Source'].append(str(record.source))
-    record_items['Instrument'].append(str(record.instrument))
-    record_items['Type'].append(str(record.extent.type)
-                                if record.extent.type is not None else ['N/A'])
-                                # If we have a start and end Wavelength, make a quantity
-                                if hasattr(record, 'wave') and record.wave.wavemin and record.wave.wavemax:
-                                    record_items['Wavelength'].append(u.Quantity([float(record.wave.wavemin),
-                                                                                  float(record.wave.wavemax)],
-                                                                                 unit=record.wave.waveunit))
-                                        # If not save None
-                                        else:
-                                            record_items['Wavelength'].append(None)
-                                                # If we have no wavelengths for the whole list, drop the col
-                                                if all([a is None for a in record_items['Wavelength']]):
-                                                    record_items.pop('Wavelength')
-                                                    keywords.remove('Wavelength')
-                                                        else:
-                                                            # Make whole column a quantity
-                                                            try:
-                                                                with u.set_enabled_equivalencies(u.spectral()):
-                                                                    record_items['Wavelength'] = u.Quantity(record_items['Wavelength'])
-                                                                        # If we have mixed units or some Nones just represent as strings
-                                                                        except (u.UnitConversionError, TypeError):
-                                                                            record_items['Wavelength'] = [str(a) for a in record_items['Wavelength']]
-                                                                                
-                                                                                return Table(record_items)[keywords]
+        for record in self:
+            record_items['Start Time'].append(validate_time(record.time.start))
+            record_items['End Time'].append(validate_time(record.time.end))
+            record_items['Source'].append(str(record.source))
+            record_items['Instrument'].append(str(record.instrument))
+            record_items['Type'].append(str(record.extent.type)
+                                        if record.extent.type is not None else ['N/A'])
+            # If we have a start and end Wavelength, make a quantity
+            if hasattr(record, 'wave') and record.wave.wavemin and record.wave.wavemax:
+                record_items['Wavelength'].append(u.Quantity([float(record.wave.wavemin),
+                                                              float(record.wave.wavemax)],
+                                                             unit=record.wave.waveunit))
+            # If not save None
+            else:
+                record_items['Wavelength'].append(None)
+        # If we have no wavelengths for the whole list, drop the col
+        if all([a is None for a in record_items['Wavelength']]):
+            record_items.pop('Wavelength')
+            keywords.remove('Wavelength')
+        else:
+            # Make whole column a quantity
+            try:
+                with u.set_enabled_equivalencies(u.spectral()):
+                    record_items['Wavelength'] = u.Quantity(record_items['Wavelength'])
+            # If we have mixed units or some Nones just represent as strings
+            except (u.UnitConversionError, TypeError):
+                record_items['Wavelength'] = [str(a) for a in record_items['Wavelength']]
 
-def add_error(self, exception):
-    self.errors.append(exception)
-    
+        return Table(record_items)[keywords]
+
+    def add_error(self, exception):
+        self.errors.append(exception)
+
     def response_block_properties(self):
         """
-            Returns a set of class attributes on all the response blocks.
-            
-            Returns
-            -------
-            s : list
+        Returns a set of class attributes on all the response blocks.
+
+        Returns
+        -------
+        s : list
             List of strings, containing attribute names in the response blocks.
-            """
+        """
         s = {a if not a.startswith('_') else None for a in dir(self[0])}
         for resp in self[1:]:
             s = s.intersection({a if not a.startswith('_') else None for a in dir(resp)})
-        
+
         s.remove(None)
         return s
-    
+
     def __str__(self):
         """Print out human-readable summary of records retrieved"""
         return str(self.build_table())
-    
+
     def __repr__(self):
         """Print out human-readable summary of records retrieved"""
         return repr(self.build_table())
-    
+
     def _repr_html_(self):
         return self.build_table()._repr_html_()
 
@@ -274,131 +274,131 @@ class UnknownStatus(Exception):
 
 
 class VSOClient(object):
-    
+
     """ Main VSO Client. """
     method_order = [
-                    'URL-TAR_GZ', 'URL-ZIP', 'URL-TAR', 'URL-FILE', 'URL-packaged'
-                    ]
-        
-                    def __init__(self, url=None, port=None, api=None):
-                        api = get_online_vso_url(api, url, port)
-                        self.api = api
+        'URL-TAR_GZ', 'URL-ZIP', 'URL-TAR', 'URL-FILE', 'URL-packaged'
+    ]
 
-def make(self, atype, **kwargs):
-    """ Create new SOAP object with attributes specified in kwargs.
+    def __init__(self, url=None, port=None, api=None):
+        api = get_online_vso_url(api, url, port)
+        self.api = api
+
+    def make(self, atype, **kwargs):
+        """ Create new SOAP object with attributes specified in kwargs.
         To assign subattributes, use foo__bar=1 to assign
         ['foo']['bar'] = 1. """
-            obj = self.api.factory.create(atype)
-            for k, v in iteritems(kwargs):
-                split = k.split('__')
-                tip = split[-1]
-                rest = split[:-1]
-                
-                item = obj
+        obj = self.api.factory.create(atype)
+        for k, v in iteritems(kwargs):
+            split = k.split('__')
+            tip = split[-1]
+            rest = split[:-1]
+
+            item = obj
             for elem in rest:
                 item = item[elem]
-        
-        if isinstance(v, dict):
-            # Do not throw away type information for dicts.
-            for k, v in iteritems(v):
-                item[tip][k] = v
+
+            if isinstance(v, dict):
+                # Do not throw away type information for dicts.
+                for k, v in iteritems(v):
+                    item[tip][k] = v
             else:
                 item[tip] = v
-return obj
-    
+        return obj
+
     def search(self, *query):
         """ Query data from the VSO with the new API. Takes a variable number
-            of attributes as parameter, which are chained together using AND.
-            
-            The new query language allows complex queries to be easily formed.
-            
-            Examples
-            --------
-            Query all data from eit or aia between 2010-01-01T00:00 and
-            2010-01-01T01:00.
-            
-            >>> from datetime import datetime
-            >>> from sunpy.net import vso
-            >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
-            >>> client.search(
-            ...    vso.attrs.Time(datetime(2010, 1, 1), datetime(2010, 1, 1, 1)),
-            ...    vso.attrs.Instrument('eit') | vso.attrs.Instrument('aia'))   # doctest:  +REMOTE_DATA
-            <QTable length=5>
-            Start Time [1]       End Time [1]    Source ...   Type   Wavelength [2]
-            ...             Angstrom
-            str19               str19         str4  ...   str8      float64
-            ------------------- ------------------- ------ ... -------- --------------
-            2010-01-01 00:00:08 2010-01-01 00:00:20   SOHO ... FULLDISK 195.0 .. 195.0
-            2010-01-01 00:12:08 2010-01-01 00:12:20   SOHO ... FULLDISK 195.0 .. 195.0
-            2010-01-01 00:24:10 2010-01-01 00:24:22   SOHO ... FULLDISK 195.0 .. 195.0
-            2010-01-01 00:36:08 2010-01-01 00:36:20   SOHO ... FULLDISK 195.0 .. 195.0
-            2010-01-01 00:48:09 2010-01-01 00:48:21   SOHO ... FULLDISK 195.0 .. 195.0
-            
-            Returns
-            -------
-            out : :py:class:`QueryResult` (enhanced list)
+        of attributes as parameter, which are chained together using AND.
+
+        The new query language allows complex queries to be easily formed.
+
+        Examples
+        --------
+        Query all data from eit or aia between 2010-01-01T00:00 and
+        2010-01-01T01:00.
+
+        >>> from datetime import datetime
+        >>> from sunpy.net import vso
+        >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
+        >>> client.search(
+        ...    vso.attrs.Time(datetime(2010, 1, 1), datetime(2010, 1, 1, 1)),
+        ...    vso.attrs.Instrument('eit') | vso.attrs.Instrument('aia'))   # doctest:  +REMOTE_DATA
+        <QTable length=5>
+           Start Time [1]       End Time [1]    Source ...   Type   Wavelength [2]
+                                                       ...             Angstrom
+               str19               str19         str4  ...   str8      float64
+        ------------------- ------------------- ------ ... -------- --------------
+        2010-01-01 00:00:08 2010-01-01 00:00:20   SOHO ... FULLDISK 195.0 .. 195.0
+        2010-01-01 00:12:08 2010-01-01 00:12:20   SOHO ... FULLDISK 195.0 .. 195.0
+        2010-01-01 00:24:10 2010-01-01 00:24:22   SOHO ... FULLDISK 195.0 .. 195.0
+        2010-01-01 00:36:08 2010-01-01 00:36:20   SOHO ... FULLDISK 195.0 .. 195.0
+        2010-01-01 00:48:09 2010-01-01 00:48:21   SOHO ... FULLDISK 195.0 .. 195.0
+
+        Returns
+        -------
+        out : :py:class:`QueryResult` (enhanced list)
             Matched items. Return value is of same type as the one of
             :py:meth:`VSOClient.query`.
-            """
+        """
         query = and_(*query)
-        
+
         responses = []
         for block in walker.create(query, self.api):
             try:
                 responses.append(
-                                 self.api.service.Query(
-                                                        self.make('QueryRequest', block=block)
-                                                        )
-                                 )
+                    self.api.service.Query(
+                        self.make('QueryRequest', block=block)
+                    )
+                )
             except TypeNotFound:
                 pass
             except Exception as ex:
                 response = QueryResponse.create(self.merge(responses))
                 response.add_error(ex)
 
-    return QueryResponse.create(self.merge(responses))
+        return QueryResponse.create(self.merge(responses))
 
-@deprecated('0.8', alternative='VSOClient.search')
-def query(self, *query):
-    """
+    @deprecated('0.8', alternative='VSOClient.search')
+    def query(self, *query):
+        """
         See `~sunpy.net.vso.VSOClient.search`
         """
-            return self.search(*query)
+        return self.search(*query)
 
-        def merge(self, queryresponses):
+    def merge(self, queryresponses):
         """ Merge responses into one. """
         if len(queryresponses) == 1:
             return queryresponses[0]
 
-fileids = set()
-providers = {}
-    
-    for queryresponse in queryresponses:
-        for provideritem in queryresponse.provideritem:
-            provider = provideritem.provider
+        fileids = set()
+        providers = {}
+
+        for queryresponse in queryresponses:
+            for provideritem in queryresponse.provideritem:
+                provider = provideritem.provider
                 if not hasattr(provideritem, 'record'):
                     continue
-            if not hasattr(provideritem.record, 'recorditem'):
-                continue
+                if not hasattr(provideritem.record, 'recorditem'):
+                    continue
                 if provideritem.provider not in providers:
                     providers[provider] = provideritem
                     fileids |= set(
-                                   record_item.fileid
-                                   for record_item in provideritem.record.recorditem
-                                   )
+                        record_item.fileid
+                        for record_item in provideritem.record.recorditem
+                    )
                 else:
                     for record_item in provideritem.record.recorditem:
                         if record_item.fileid not in fileids:
                             fileids.add(record_item.fileid)
                             providers[provider].record.recorditem.append(
-                                                                         record_item
-                                                                         )
-                                                                         providers[provider].no_of_records_found += 1
-                                                                         providers[provider].no_of_records_returned += 1
-    return self.make('QueryResponse',
-                     provideritem=list(providers.values()))
+                                record_item
+                            )
+                            providers[provider].no_of_records_found += 1
+                            providers[provider].no_of_records_returned += 1
+        return self.make('QueryResponse',
+                         provideritem=list(providers.values()))
 
-@staticmethod
+    @staticmethod
     def mk_filename(pattern, response, sock, url, overwrite=False):
         name = get_filename(sock, url)
         if not name:
@@ -406,195 +406,195 @@ providers = {}
                 name = six.u(response.fileid, "ascii", "ignore")
             else:
                 name = response.fileid
-    
+
         fs_encoding = sys.getfilesystemencoding()
         if fs_encoding is None:
             fs_encoding = "ascii"
 
-name = slugify(name)
+        name = slugify(name)
 
-if six.PY2:
-    name = name.encode(fs_encoding, "ignore")
-        
+        if six.PY2:
+            name = name.encode(fs_encoding, "ignore")
+
         if not name:
             name = "file"
 
-    fname = pattern.format(file=name, **dict(response))
-        
+        fname = pattern.format(file=name, **dict(response))
+
         if not overwrite and os.path.exists(fname):
             fname = replacement_filename(fname)
-        
+
         dir_ = os.path.abspath(os.path.dirname(fname))
         if not os.path.exists(dir_):
             os.makedirs(dir_)
         return fname
 
-# pylint: disable=R0914
-def query_legacy(self, tstart=None, tend=None, **kwargs):
-    """
+    # pylint: disable=R0914
+    def query_legacy(self, tstart=None, tend=None, **kwargs):
+        """
         Query data from the VSO mocking the IDL API as close as possible.
         Either tstart and tend or date_start and date_end or date have
         to be supplied.
-        
+
         Parameters
         ----------
         tstart : datetime.datetime
-        Start of the time-range in which records are searched.
+            Start of the time-range in which records are searched.
         tend : datetime.datetime
-        Start of the time-range in which records are searched.
+            Start of the time-range in which records are searched.
         date : str
-        (start date) - (end date)
+            (start date) - (end date)
         start_date : datetime
-        the start date
+            the start date
         end_date : datetime
-        the end date
+            the end date
         wave : str
-        (min) - (max) (unit)
+            (min) - (max) (unit)
         min_wave : str
-        minimum spectral range
+            minimum spectral range
         max_wave : str
-        maximum spectral range
+            maximum spectral range
         unit_wave : str
-        spectral range units (Angstrom, GHz, keV)
+            spectral range units (Angstrom, GHz, keV)
         extent : str
-        VSO 'extent type' ... (FULLDISK, CORONA, LIMB, etc)
+            VSO 'extent type' ... (FULLDISK, CORONA, LIMB, etc)
         physobj : str
-        VSO 'physical observable'
+            VSO 'physical observable'
         provider : str
-        VSO ID for the data provider (SDAC, NSO, SHA, MSU, etc)
+            VSO ID for the data provider (SDAC, NSO, SHA, MSU, etc)
         source : str
-        spacecraft or observatory (SOHO, YOHKOH, BBSO, etc)
-        synonyms : spacecraft, observatory
+            spacecraft or observatory (SOHO, YOHKOH, BBSO, etc)
+            synonyms : spacecraft, observatory
         instrument : str
-        instrument ID (EIT, SXI-0, SXT, etc)
-        synonyms : telescope, inst
+            instrument ID (EIT, SXI-0, SXT, etc)
+            synonyms : telescope, inst
         detector : str
-        detector ID (C3, EUVI, COR2, etc.)
+            detector ID (C3, EUVI, COR2, etc.)
         layout : str
-        layout of the data (image, spectrum, time_series, etc.)
-        
+            layout of the data (image, spectrum, time_series, etc.)
+
         level : str
-        level of the data product (numeric range, see below)
+            level of the data product (numeric range, see below)
         pixels : str
-        number of pixels (numeric range, see below)
+            number of pixels (numeric range, see below)
         resolution : str
-        effective resolution (1 = full, 0.5 = 2x2 binned, etc)
-        numeric range, see below.
+            effective resolution (1 = full, 0.5 = 2x2 binned, etc)
+            numeric range, see below.
         pscale : str
-        pixel scale, in arcseconds (numeric range, see below)
+            pixel scale, in arcseconds (numeric range, see below)
         near_time : datetime
-        return record closest to the time.  See below.
+            return record closest to the time.  See below.
         sample : int
-        attempt to return only one record per SAMPLE seconds.  See below.
-        
+            attempt to return only one record per SAMPLE seconds.  See below.
+
         Numeric Ranges:
-        
-        - May be entered as a string or any numeric type for equality matching
-        - May be a string of the format '(min) - (max)' for range matching
-        - May be a string of the form '(operator) (number)' where operator
-        is one of: lt gt le ge < > <= >=
-        
-        
+
+            - May be entered as a string or any numeric type for equality matching
+            - May be a string of the format '(min) - (max)' for range matching
+            - May be a string of the form '(operator) (number)' where operator
+              is one of: lt gt le ge < > <= >=
+
+
         Examples
         --------
         Query all data from eit between 2010-01-01T00:00 and
         2010-01-01T01:00.
-        
+
         >>> from datetime import datetime
         >>> from sunpy.net import vso
         >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
         >>> qr = client.query_legacy(datetime(2010, 1, 1),
         ...                          datetime(2010, 1, 1, 1), instrument='eit')  # doctest: +REMOTE_DATA
-        
+
         Returns
         -------
         out : :py:class:`QueryResult` (enhanced list)
-        Matched items. Return value is of same type as the one of
-        :py:class:`VSOClient.query`.
+            Matched items. Return value is of same type as the one of
+            :py:class:`VSOClient.query`.
         """
-            sdk = lambda key: lambda value: {key: value}
-                ALIASES = {
-                    'wave_min': sdk('wave_wavemin'),
-                    'wave_max': sdk('wave_wavemax'),
-                    'wave_type': sdk('wave_wavetype'),
-                    'wave_unit': sdk('wave_waveunit'),
-                    'min_wave': sdk('wave_wavemin'),
-                    'max_wave': sdk('wave_wavemax'),
-                    'type_wave': sdk('wave_wavetype'),
-                    'unit_wave': sdk('wave_waveunit'),
-                    'wave': _parse_waverange,
-                        'inst': sdk('instrument'),
-                        'telescope': sdk('instrument'),
-                        'spacecraft': sdk('source'),
-                        'observatory': sdk('source'),
-                        'start_date': sdk('time_start'),
-                        'end_date': sdk('time_end'),
-                        'start': sdk('time_start'),
-                        'end': sdk('time_end'),
-                        'near_time': sdk('time_near'),
-                        'date': _parse_date,
-                            'layout': sdk('datatype'),
-                                }
-                                    if tstart is not None:
-                                        kwargs.update({'time_start': tstart})
-                                            if tend is not None:
-                                                kwargs.update({'time_end': tend})
-                                                    
-                                                    queryreq = self.api.factory.create('QueryRequest')
-                                                    for key, value in iteritems(kwargs):
-                                                        for k, v in iteritems(ALIASES.get(key, sdk(key))(value)):
-                                                            if k.startswith('time'):
-                                                                v = parse_time(v).strftime(TIMEFORMAT)
-                                                                    attr = k.split('_')
-                                                                    lst = attr[-1]
-                                                                    rest = attr[:-1]
-                                                                    
-                                                                    # pylint: disable=E1103
-                                                                    item = queryreq.block
-                                                                        for elem in rest:
-                                                                            try:
-                                                                                item = item[elem]
-                                                                                    except KeyError:
-                                                                                        raise ValueError(
-                                                                                                         "Unexpected argument {key!s}.".format(key=key))
-                                                                                            if lst not in item:
-                                                                                                raise ValueError(
-                                                                                                                 "Unexpected argument {key!s}.".format(key=key))
-                                                                                                    if item[lst]:
-                                                                                                        raise ValueError(
-                                                                                                                         "Got multiple values for {k!s}.".format(k=k))
-                                                                                                            item[lst] = v
-                                                                                                                try:
-                                                                                                                    return QueryResponse.create(self.api.service.Query(queryreq))
-                                                                                                                        except TypeNotFound:
-                                                                                                                            return QueryResponse([])
+        sdk = lambda key: lambda value: {key: value}
+        ALIASES = {
+            'wave_min': sdk('wave_wavemin'),
+            'wave_max': sdk('wave_wavemax'),
+            'wave_type': sdk('wave_wavetype'),
+            'wave_unit': sdk('wave_waveunit'),
+            'min_wave': sdk('wave_wavemin'),
+            'max_wave': sdk('wave_wavemax'),
+            'type_wave': sdk('wave_wavetype'),
+            'unit_wave': sdk('wave_waveunit'),
+            'wave': _parse_waverange,
+            'inst': sdk('instrument'),
+            'telescope': sdk('instrument'),
+            'spacecraft': sdk('source'),
+            'observatory': sdk('source'),
+            'start_date': sdk('time_start'),
+            'end_date': sdk('time_end'),
+            'start': sdk('time_start'),
+            'end': sdk('time_end'),
+            'near_time': sdk('time_near'),
+            'date': _parse_date,
+            'layout': sdk('datatype'),
+        }
+        if tstart is not None:
+            kwargs.update({'time_start': tstart})
+        if tend is not None:
+            kwargs.update({'time_end': tend})
 
-def latest(self):
-    """ Return newest record (limited to last week). """
+        queryreq = self.api.factory.create('QueryRequest')
+        for key, value in iteritems(kwargs):
+            for k, v in iteritems(ALIASES.get(key, sdk(key))(value)):
+                if k.startswith('time'):
+                    v = parse_time(v).strftime(TIMEFORMAT)
+                attr = k.split('_')
+                lst = attr[-1]
+                rest = attr[:-1]
+
+                # pylint: disable=E1103
+                item = queryreq.block
+                for elem in rest:
+                    try:
+                        item = item[elem]
+                    except KeyError:
+                        raise ValueError(
+                            "Unexpected argument {key!s}.".format(key=key))
+                if lst not in item:
+                    raise ValueError(
+                        "Unexpected argument {key!s}.".format(key=key))
+                if item[lst]:
+                    raise ValueError(
+                        "Got multiple values for {k!s}.".format(k=k))
+                item[lst] = v
+        try:
+            return QueryResponse.create(self.api.service.Query(queryreq))
+        except TypeNotFound:
+            return QueryResponse([])
+
+    def latest(self):
+        """ Return newest record (limited to last week). """
         return self.query_legacy(
-                                 datetime.utcnow() - timedelta(7),
-                                 datetime.utcnow(),
-                                 time_near=datetime.utcnow()
-                                 )
-    
+            datetime.utcnow() - timedelta(7),
+            datetime.utcnow(),
+            time_near=datetime.utcnow()
+        )
+
     def fetch(self, query_response, path=None, methods=('URL-FILE_Rice', 'URL-FILE'),
               downloader=None, site=None):
         """
-            Download data specified in the query_response.
-            
-            Parameters
-            ----------
-            query_response : sunpy.net.vso.QueryResponse
+        Download data specified in the query_response.
+
+        Parameters
+        ----------
+        query_response : sunpy.net.vso.QueryResponse
             QueryResponse containing the items to be downloaded.
-            
-            path : str
+
+        path : str
             Specify where the data is to be downloaded. Can refer to arbitrary
             fields of the QueryResponseItem (instrument, source, time, ...) via
             string formatting, moreover the file-name of the file downloaded can
             be referred to as file, e.g.
             "{source}/{instrument}/{time.start}/{file}".
-            
-            methods : {list of str}
+
+        methods : {list of str}
             Download methods, defaults to URL-FILE_Rice then URL-FILE.
             Methods are a concatenation of one PREFIX followed by any number of
             SUFFIXES i.e. `PREFIX-SUFFIX_SUFFIX2_SUFFIX3`.
@@ -602,14 +602,14 @@ def latest(self):
             `PREFIXES <http://sdac.virtualsolar.org/cgi/show_details?keyword=METHOD_PREFIX>`_
             and `SUFFIXES <http://sdac.virtualsolar.org/cgi/show_details?keyword=METHOD_SUFFIX>`_
             are listed on the VSO site.
-            
-            downloader : sunpy.net.downloader.Downloader
+
+        downloader : sunpy.net.downloader.Downloader
             Downloader used to download the data.
-            
-            site : str
+
+        site : str
             There are a number of caching mirrors for SDO and other
             instruments, some available ones are listed below.
-            
+
             =============== ========================================================
             NSO             National Solar Observatory, Tucson (US)
             SAO  (aka CFA)  Smithonian Astronomical Observatory, Harvard U. (US)
@@ -621,69 +621,69 @@ def latest(self):
             KIS             Kiepenheuer-Institut fur Sonnenphysik Germany)
             NMSU            New Mexico State University (US)
             =============== ========================================================
-            
-            Returns
-            -------
-            out : :py:class:`Results`
+
+        Returns
+        -------
+        out : :py:class:`Results`
             Object that supplies a list of filenames with meta attributes
             containing the respective QueryResponse.
-            
-            Examples
-            --------
-            >>> res = fetch(qr).wait() # doctest:+SKIP
-            """
+
+        Examples
+        --------
+        >>> res = fetch(qr).wait() # doctest:+SKIP
+        """
         if downloader is None:
             downloader = download.Downloader()
             downloader.init()
             res = download.Results(
-                                   lambda _: downloader.stop(), 1,
-                                   lambda mp: self.link(query_response, mp)
-                                   )
+                lambda _: downloader.stop(), 1,
+                lambda mp: self.link(query_response, mp)
+            )
         else:
             res = download.Results(
-                                   lambda _: None, 1, lambda mp: self.link(query_response, mp)
-                                   )
+                lambda _: None, 1, lambda mp: self.link(query_response, mp)
+            )
         if path is None:
             path = os.path.join(config.get('downloads', 'download_dir'),
                                 '{file}')
-                                   elif isinstance(path, six.string_types) and '{file}' not in path:
-                                path = os.path.join(path, '{file}')
-                                   path = os.path.expanduser(path)
-                                
-                                   fileids = VSOClient.by_fileid(query_response)
-                                   if not fileids:
-                                       res.poke()
-                                       return res
-                                   # Adding the site parameter to the info
-                                   info = {}
-                                       if site is not None:
-                                           info['site'] = site
-                                               
-                                               self.download_all(
-                                                                 self.api.service.GetData(
-                                                                                          self.make_getdatarequest(query_response, methods, info)),
-                                                                 methods, downloader, path,
-                                                                 fileids, res
-                                                                 )
-                                                   res.poke()
-                                                   return res
+        elif isinstance(path, six.string_types) and '{file}' not in path:
+            path = os.path.join(path, '{file}')
+        path = os.path.expanduser(path)
 
-@deprecated('0.8', alternative='VSOClient.fetch')
-def get(self, query_response, path=None, methods=('URL-FILE_Rice', 'URL-FILE'),
-        downloader=None, site=None):
-    """
+        fileids = VSOClient.by_fileid(query_response)
+        if not fileids:
+            res.poke()
+            return res
+        # Adding the site parameter to the info
+        info = {}
+        if site is not None:
+            info['site'] = site
+
+        self.download_all(
+            self.api.service.GetData(
+                self.make_getdatarequest(query_response, methods, info)),
+            methods, downloader, path,
+            fileids, res
+        )
+        res.poke()
+        return res
+
+    @deprecated('0.8', alternative='VSOClient.fetch')
+    def get(self, query_response, path=None, methods=('URL-FILE_Rice', 'URL-FILE'),
+            downloader=None, site=None):
+        """
         See `~sunpy.net.vso.VSOClient.fetch`
         """
-            return self.fetch(query_response, path=path, methods=methods, downloader=downloader, site=site)
+        return self.fetch(query_response, path=path, methods=methods, downloader=downloader, site=site)
 
-        @staticmethod
-            def link(query_response, maps):
+    @staticmethod
+    def link(query_response, maps):
         """ Return list of paths with records associated with them in
-            the meta attribute. """
-if not maps:
-    return []
+        the meta attribute. """
+        if not maps:
+            return []
         ret = []
-        
+
         for record_item in query_response:
             try:
                 item = _Str(maps[record_item.fileid]['path'])
@@ -692,181 +692,181 @@ if not maps:
             # pylint: disable=W0201
             item.meta = record_item
             ret.append(item)
-    return ret
+        return ret
 
-def make_getdatarequest(self, response, methods=None, info=None):
-    """ Make datarequest with methods from response. """
+    def make_getdatarequest(self, response, methods=None, info=None):
+        """ Make datarequest with methods from response. """
         if methods is None:
             methods = self.method_order + ['URL']
-    
-    return self.create_getdatarequest(
-                                      dict((k, [x.fileid for x in v])
-                                           for k, v in iteritems(self.by_provider(response))),
-                                      methods, info
-                                      )
 
-def create_getdatarequest(self, maps, methods, info=None):
-    """ Create datarequest from maps mapping data provider to
+        return self.create_getdatarequest(
+            dict((k, [x.fileid for x in v])
+                 for k, v in iteritems(self.by_provider(response))),
+            methods, info
+        )
+
+    def create_getdatarequest(self, maps, methods, info=None):
+        """ Create datarequest from maps mapping data provider to
         fileids and methods, """
-            if info is None:
+        if info is None:
             info = {}
-                if maps.get('JSOC',0):
-                    return self._separate_hmi(maps, methods, info)
-                        else:
-                            return self.make(
-                                             'VSOGetDataRequest',
-                                             request__method__methodtype=methods,
-                                             request__info=info,
-                                             request__datacontainer__datarequestitem=[
-                                                                                      self.make('DataRequestItem', provider=k, fileiditem__fileid=[v])
-                                                                                      for k, v in iteritems(maps)
-                                                                                      ]
-                                             )
-                        def _separate_hmi(self, maps_dict, methods, info):
-                            """
-                                This function parses the separate hmi data series from the
-                                maps_dict(jsoc) list, pulls any hmi data it finds into separate lists
-                                and deletes the hmi data from the original jsoc list.  It then continues
-                                as normal to construct the soap message.
-                                """
-                                    jsoc_list=maps_dict.get('JSOC',0)
-                                    if jsoc_list:
-listdict={}
-    s_match=re.compile('^.*?:')
-    for fidnum, fid in enumerate(jsoc_list):
-        if re.search('^hmi',fid):
-            #hmi data match found, extract into new list
-            series=s_match.findall(fid)[0]
-            if listdict.get(series,0):
-                listdict.get(series).append(fid)
+        if maps.get('JSOC',0):
+            return self._separate_hmi(maps, methods, info)
+        else:
+            return self.make(
+                'VSOGetDataRequest',
+                request__method__methodtype=methods,
+                request__info=info,
+                request__datacontainer__datarequestitem=[
+                    self.make('DataRequestItem', provider=k, fileiditem__fileid=[v])
+                    for k, v in iteritems(maps)
+                ]
+            )
+    def _separate_hmi(self, maps_dict, methods, info):
+        """
+        This function parses the separate hmi data series from the
+        maps_dict(jsoc) list, pulls any hmi data it finds into separate lists
+        and deletes the hmi data from the original jsoc list.  It then continues
+        as normal to construct the soap message.
+        """
+        jsoc_list=maps_dict.get('JSOC',0)
+        if jsoc_list:
+            listdict={}
+            s_match=re.compile('^.*?:')
+            for fidnum, fid in enumerate(jsoc_list):
+                if re.search('^hmi',fid):
+                    #hmi data match found, extract into new list
+                    series=s_match.findall(fid)[0]
+                    if listdict.get(series,0):
+                        listdict.get(series).append(fid)
                     else:
                         listdict[series]=[fid]
-                #delete entry from jsoc_list
-                del jsoc_list[fidnum]
-        new_dict=maps_dict.copy()
-        new_dict.update(listdict)
+                    #delete entry from jsoc_list
+                    del jsoc_list[fidnum]
+            new_dict=maps_dict.copy()
+            new_dict.update(listdict)
         #new dict defined
         for keyn, key in enumerate(new_dict):
             k='JSOC' if re.search('^hmi',key) else key
             drqs= [None] * len(new_dict)
             drqs[keyn]=self.make('DataRequestItem', provider=k, fileiditem__fileid=[new_dict.get(key)])
-return self.make(
-                 'VSOGetDataRequest',
-                 request__method__methodtype=methods,
-                 request__info=info,
-                 request__datacontainer__datarequestitem=drqs
-                 )
+        return self.make(
+            'VSOGetDataRequest',
+            request__method__methodtype=methods,
+            request__info=info,
+            request__datacontainer__datarequestitem=drqs
+        )
     # pylint: disable=R0913,R0912
     def download_all(self, response, methods, dw, path, qr, res, info=None):
         GET_VERSION = [
-                       ('0.8', (5, 8)),
-                       ('0.7', (1, 4)),
-                       ('0.6', (0, 3)),
-                       ]
-                       for dresponse in response.getdataresponseitem:
-                           for version, (from_, to) in GET_VERSION:
-                               if getattr(dresponse, version, '0.6') >= version:
-                                   break
-                                       else:
-                                           res.add_error(UnknownVersion(dresponse))
-                                           continue
-                                               
-                                               # If from_ and to are uninitialized, the else block of the loop
-                                               # continues the outer loop and thus this code is never reached.
-                                               # pylint: disable=W0631
-                                               code = (
-                                                       dresponse.status[from_:to]
-                                                       if hasattr(dresponse, 'status') else '200'
-                                                       )
-                                                   if code == '200':
-                                                       for dataitem in dresponse.getdataitem.dataitem:
-                                                           try:
-                                                               self.download(
-                                                                             dresponse.method.methodtype[0],
-                                                                             dataitem.url,
-                                                                             dw,
-                                                                             res.require(
-                                                                                         list(map(str, dataitem.fileiditem.fileid))),
-                                                                             res.add_error,
-                                                                             path,
-                                                                             qr[dataitem.fileiditem.fileid[0]]
-                                                                             )
-                                                                   except NoData:
-                                                                       res.add_error(DownloadFailed(dresponse))
-                                                                       continue
-                                                                           except Exception:
-                                                                               # FIXME: Is this a good idea?
-                                                                               res.add_error(DownloadFailed(dresponse))
-                                                                                   elif code == '300' or code == '412' or code == '405':
-                                                                                       if code == '300':
-                                                                                           try:
-                                                                                               methods = self.multiple_choices(
-                                                                                                                               dresponse.method.methodtype, dresponse
-                                                                                                                               )
-                                                                                                   except NoData:
-                                                                                                       res.add_error(MultipleChoices(dresponse))
-                                                                                                       continue
-                                                                                                           elif code == '412':
-                                                                                                               try:
-                                                                                                                   info = self.missing_information(
-                                                                                                                                                   info, dresponse.info
-                                                                                                                                                   )
-                                                                                                                       except NoData:
-                                                                                                                           res.add_error(MissingInformation(dresponse))
-                                                                                                                           continue
-                                                                                                                               elif code == '405':
-                                                                                                                                   try:
-                                                                                                                                       methods = self.unknown_method(dresponse)
-                                                                                                                                           except NoData:
-                                                                                                                                               res.add_error(UnknownMethod(dresponse))
-                                                                                                                                               continue
-                                                                                                                                                   
-                                                                                                                                                   files = []
-                                                                                                                                                   for dataitem in dresponse.getdataitem.dataitem:
-                                                                                                                                                       files.extend(dataitem.fileiditem.fileid)
-                                                                                                                                                           
-                                                                                                                                                           request = self.create_getdatarequest(
-                                                                                                                                                                                                {dresponse.provider: files}, methods, info
-                                                                                                                                                                                                )
-                                                                                                                                                               
-                                                                                                                                                               self.download_all(
-                                                                                                                                                                                 self.api.service.GetData(request), methods, dw, path,
-                                                                                                                                                                                 qr, res, info
-                                                                                                                                                                                 )
-                                                                                                                                                                   else:
-                                                                                                                                                                       res.add_error(UnknownStatus(dresponse))
+            ('0.8', (5, 8)),
+            ('0.7', (1, 4)),
+            ('0.6', (0, 3)),
+        ]
+        for dresponse in response.getdataresponseitem:
+            for version, (from_, to) in GET_VERSION:
+                if getattr(dresponse, version, '0.6') >= version:
+                    break
+            else:
+                res.add_error(UnknownVersion(dresponse))
+                continue
 
-def download(self, method, url, dw, callback, errback, *args):
-    """ Override to costumize download action. """
+            # If from_ and to are uninitialized, the else block of the loop
+            # continues the outer loop and thus this code is never reached.
+            # pylint: disable=W0631
+            code = (
+                dresponse.status[from_:to]
+                if hasattr(dresponse, 'status') else '200'
+            )
+            if code == '200':
+                for dataitem in dresponse.getdataitem.dataitem:
+                    try:
+                        self.download(
+                            dresponse.method.methodtype[0],
+                            dataitem.url,
+                            dw,
+                            res.require(
+                                list(map(str, dataitem.fileiditem.fileid))),
+                            res.add_error,
+                            path,
+                            qr[dataitem.fileiditem.fileid[0]]
+                        )
+                    except NoData:
+                        res.add_error(DownloadFailed(dresponse))
+                        continue
+                    except Exception:
+                        # FIXME: Is this a good idea?
+                        res.add_error(DownloadFailed(dresponse))
+            elif code == '300' or code == '412' or code == '405':
+                if code == '300':
+                    try:
+                        methods = self.multiple_choices(
+                            dresponse.method.methodtype, dresponse
+                        )
+                    except NoData:
+                        res.add_error(MultipleChoices(dresponse))
+                        continue
+                elif code == '412':
+                    try:
+                        info = self.missing_information(
+                            info, dresponse.info
+                        )
+                    except NoData:
+                        res.add_error(MissingInformation(dresponse))
+                        continue
+                elif code == '405':
+                    try:
+                        methods = self.unknown_method(dresponse)
+                    except NoData:
+                        res.add_error(UnknownMethod(dresponse))
+                        continue
+
+                files = []
+                for dataitem in dresponse.getdataitem.dataitem:
+                    files.extend(dataitem.fileiditem.fileid)
+
+                request = self.create_getdatarequest(
+                    {dresponse.provider: files}, methods, info
+                )
+
+                self.download_all(
+                    self.api.service.GetData(request), methods, dw, path,
+                    qr, res, info
+                )
+            else:
+                res.add_error(UnknownStatus(dresponse))
+
+    def download(self, method, url, dw, callback, errback, *args):
+        """ Override to costumize download action. """
         if method.startswith('URL'):
             return dw.download(url, partial(self.mk_filename, *args),
                                callback, errback
                                )
-    raise NoData
+        raise NoData
 
-@staticmethod
+    @staticmethod
     def by_provider(response):
         """
-            Returns a dictionary of provider
-            corresponding to records in the response.
-            """
-        
+        Returns a dictionary of provider
+        corresponding to records in the response.
+        """
+
         map_ = defaultdict(list)
         for record in response:
             map_[record.provider].append(record)
         return map_
-    
+
     @staticmethod
     def by_fileid(response):
         """
-            Returns a dictionary of fileids
-            corresponding to records in the response.
-            """
-        
+        Returns a dictionary of fileids
+        corresponding to records in the response.
+        """
+
         return dict(
-                    (record.fileid, record) for record in response
-                    )
-    
+            (record.fileid, record) for record in response
+        )
+
     # pylint: disable=W0613
     def multiple_choices(self, choices, response):
         """ Override to pick between multiple download choices. """
@@ -874,17 +874,17 @@ def download(self, method, url, dw, callback, errback, *args):
             if elem in choices:
                 return [elem]
         raise NoData
-    
+
     # pylint: disable=W0613
     def missing_information(self, info, field):
         """ Override to provide missing information. """
         raise NoData
-    
+
     # pylint: disable=W0613
     def unknown_method(self, response):
         """ Override to pick a new method if the current one is unknown. """
         raise NoData
-    
+
     @classmethod
     def _can_handle_query(cls, *query):
         return all([x.__class__.__name__ in attrs.__all__ for x in query])
@@ -892,21 +892,21 @@ def download(self, method, url, dw, callback, errback, *args):
 
 @deprecated("0.8.0", alternative="Please use VSOClient")
 class InteractiveVSOClient(VSOClient):
-    
+
     """ Client for use in the REPL. Prompts user for data if required. """
-    
+
     def multiple_choices(self, choices, response):
         """
-            not documented yet
-            
-            Parameters
-            ----------
-            
+        not documented yet
+
+        Parameters
+        ----------
+
             choices : not documented yet
-            
+
             response : not documented yet
-            
-            """
+
+        """
         while True:
             for n, elem in enumerate(choices):
                 print("({num:d}) {choice!s}".format(num=n + 1, choice=elem))
@@ -928,51 +928,51 @@ class InteractiveVSOClient(VSOClient):
                 except IndexError:
                     continue
 
-def missing_information(self, info, field):
-    """
+    def missing_information(self, info, field):
+        """
         not documented yet
-        
+
         Parameters
         ----------
         info : not documented yet
-        not documented yet
+                not documented yet
         field : not documented yet
-        not documented yet
-        
+            not documented yet
+
         Returns
         -------
         choice : not documented yet
-        
-        .. todo::
-        improve documentation. what does this function do?
-        
-        """
-            choice = input(field + ': ')
-            if not choice:
-            raise NoData
-                return choice
 
-def search(self, *args, **kwargs):
-    """ When passed an Attr object, perform new-style query;
+        .. todo::
+            improve documentation. what does this function do?
+
+        """
+        choice = input(field + ': ')
+        if not choice:
+            raise NoData
+        return choice
+
+    def search(self, *args, **kwargs):
+        """ When passed an Attr object, perform new-style query;
         otherwise, perform legacy query.
         """
-            if isinstance(args[0], Attr):
-                return self.query(*args)
-                    else:
-                        return self.query_legacy(*args, **kwargs)
+        if isinstance(args[0], Attr):
+            return self.query(*args)
+        else:
+            return self.query_legacy(*args, **kwargs)
 
-def get(self, query_response, path=None, methods=('URL-FILE',), downloader=None):
-    """The path expands ``~`` to refer to the user's home directory.
+    def get(self, query_response, path=None, methods=('URL-FILE',), downloader=None):
+        """The path expands ``~`` to refer to the user's home directory.
         If the given path is an already existing directory, ``{file}`` is
         appended to this path. After that, all received parameters (including
         the updated path) are passed to :meth:`VSOClient.get`.
-        
+
         """
-            if path is not None:
+        if path is not None:
             path = os.path.abspath(os.path.expanduser(path))
             if os.path.exists(path) and os.path.isdir(path):
                 path = os.path.join(path, '{file}')
-                    return VSOClient.fetch(self, query_response, path, methods, downloader)
+        return VSOClient.fetch(self, query_response, path, methods, downloader)
 
 
 g_client = None
@@ -1000,4 +1000,3 @@ def get(query_response, path=None, methods=('URL-FILE',), downloader=None):
 
 
 get.__doc__ = VSOClient.search.__doc__
-

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -746,13 +746,6 @@ class VSOClient(object):
             request__datacontainer__datarequestitem=dris
         )
 
-    def _make_data_request_items(self, maps):
-        """
-        Construct a DataRequestItem per provider entry in maps.
-        """
-        return [self.make('DataRequestItem', provider=k, fileiditem__fileid=[v])
-                for k, v in iteritems(maps)]
-
     # pylint: disable=R0913,R0912
     def download_all(self, response, methods, dw, path, qr, res, info=None):
         GET_VERSION = [


### PR DESCRIPTION
I've not done extensive testing on this function, and it does reroute all queries to the JSOC (though if there isn't any HMI data it does nothing to the "maps" dictionary) so be a little wary when testing. Lines 713-715 reroute the normal soap message construction to _separate_hmi, which pulls all hmi fileids from the maps{'JSOC'} list and places them into data series-specific lists stored in listdict, which is merged with maps_dict (the original dict which would have been used to construct the message before).  The function then properly formats the soap query using a call to make that is very similar to the one that is used normally.

Jacob

fixes #2284 