### PR TITLE
Sort input file list

### DIFF
--- a/sunpy/io/setup_package.py
+++ b/sunpy/io/setup_package.py
@@ -30,5 +30,6 @@ def get_extensions():
         e = Extension('sunpy.io._pyana', **cfg)
         return [e]
 
+
 def requires_2to3():
     return False

--- a/sunpy/io/setup_package.py
+++ b/sunpy/io/setup_package.py
@@ -18,7 +18,8 @@ def get_extensions():
         # 'numpy' will be replaced with the proper path to the numpy includes
         cfg = setup_helpers.DistutilsExtensionArgs()
         cfg['include_dirs'].append('numpy')
-        cfg['sources'].extend(glob(os.path.join(os.path.dirname(__file__), 'src', 'ana', '*.c')))
+        cfg['sources'].extend(sorted(glob(
+            os.path.join(os.path.dirname(__file__), 'src', 'ana', '*.c'))))
         cfg['extra_compile_args'].extend(['-std=c99', '-O3'])
         # Squash some warnings
         cfg['extra_compile_args'].extend(['-Wno-unused-but-set-variable',


### PR DESCRIPTION
so that sunpy io modules build in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.