### PR TITLE
Added a __getitem__ to the TimeSeries

### DIFF
--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -623,6 +623,9 @@ class GenericTimeSeries:
         """
         return not self == other
 
+    def __getitem__(self, colname):
+        return self.quantity(colname)
+
     @classmethod
     def _parse_file(cls, filepath):
         """Parses a file - to be implemented in any subclass that may use files"""


### PR DESCRIPTION
This PR is for the issue #2605. 

Added a simpler way to call the quantity function using the __getitem__ method. Kind of replacing the
timeseries_data.quantity('colname')[index] with timeseries_data['colname'][index]

It kind of makes it more sense if one could just get the data directly instead of using the quantity function. 