### PR TITLE
Change the changelog: Towncrier

### DIFF
--- a/changelog/1983.feature.rst
+++ b/changelog/1983.feature.rst
@@ -1,0 +1,1 @@
+Change arguments to `sunpy.test` from ``offline=`` and ``online=`` to ``online`` and ``online_only``. This matches the behavior of the figure keyword arguments and comes as a part of a move to using a modified version of the Astropy test runner.

--- a/changelog/2408.trivial.rst
+++ b/changelog/2408.trivial.rst
@@ -1,0 +1,1 @@
+`~sunpy.time.parse_time` now uses `singledispatch` underneath.

--- a/changelog/2515.breaking.rst
+++ b/changelog/2515.breaking.rst
@@ -1,0 +1,2 @@
+Move the matplotlib animators from ``sunpy.visualisation.imageanimator`` and
+``sunpy.visualization.mapcubeanimator`` to `sunpy.visualization.animator`.

--- a/changelog/2598.trivial.rst
+++ b/changelog/2598.trivial.rst
@@ -1,0 +1,1 @@
+Revert the handling of ``quantity_allclose`` now that `astropy/astropy#7252 <https://github.com/astropy/astropy/pull/7252>`__ is merged. This also bumps the minimum astropy version to 3.0.2.

--- a/changelog/2613.trivial.rst
+++ b/changelog/2613.trivial.rst
@@ -1,0 +1,1 @@
+Replace the subclasses of matplotlib Slider and Button in `sunpy.visualization` with partial functions.

--- a/changelog/2621.bugfix.rst
+++ b/changelog/2621.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the bug that prevented VSO queries for HMI data from downloading file
+without speicifying `a.Physobs`.

--- a/changelog/2627.bugfix.rst
+++ b/changelog/2627.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `sunpy.map.mapcube.MapCube.plot`. The code had not been updated to support the changes to the wcsaxes helper functions.

--- a/changelog/2635.bugfix.rst
+++ b/changelog/2635.bugfix.rst
@@ -1,0 +1,1 @@
+Replace all use of the deprecated ``sunpy.cm.get_cmap`` with ``plt.get_cmap`` to prevent deprecation warnings being raised.

--- a/changelog/2636.bugfix.rst
+++ b/changelog/2636.bugfix.rst
@@ -1,0 +1,1 @@
+Fix generation of the coordinate transformation graph with Astropy 3.1.dev

--- a/changelog/2637.trivial.rst
+++ b/changelog/2637.trivial.rst
@@ -1,0 +1,1 @@
+Sort the ana C source files before building to enable reproducible builds.

--- a/changelog/2642.bugfix.rst
+++ b/changelog/2642.bugfix.rst
@@ -1,0 +1,2 @@
+Prevent helioviewer from erroring when downloading file to a directory that
+does not exist. It will now create the directory when required.

--- a/changelog/2644.trivial.rst
+++ b/changelog/2644.trivial.rst
@@ -1,0 +1,1 @@
+Migrate our changelog to using `towncrier <https://github.com/hawkowl/towncrier>`__.

--- a/changelog/2644.trivial.rst
+++ b/changelog/2644.trivial.rst
@@ -1,1 +1,2 @@
-Migrate our changelog to using `towncrier <https://github.com/hawkowl/towncrier>`__.
+We are now using `towncrier <https://github.com/hawkowl/towncrier>`__ to
+generate our changelogs.

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -18,7 +18,7 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 * ``bugfix``: fixes a reported bug.
 * ``doc``: documentation improvement, like rewording an entire session or adding missing docs.
 * ``removal``: feature deprecation or removal.
-* ``trivial``: A change which has no user facing effect or is so tiny the description will not be included in the changelog, only the PR number.
+* ``trivial``: A change which has no user facing effect or is tiny.
 
 So for example: ``123.feature.rst``, ``456.bugfix.rst``.
 

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -11,7 +11,7 @@ Make sure to use full sentences with correct case and punctuation, for example::
     Add support for Helioprojective coordinates in `sunpy.coordinates.frames`.
 
 Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
-``<PULL REQUEST>`` is an pull request number, and ``<TYPE>`` is one of:
+``<PULL REQUEST>`` is a pull request number, and ``<TYPE>`` is one of:
 
 * ``breaking``: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
 * ``feature``: new user facing features and new behavior.

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -1,0 +1,30 @@
+.. This README was adapted from the pytest changelog readme under the terms of the MIT licence.
+
+This directory contains "newsfragments" which are short files that contain a small **ReST**-formatted
+text that will be added to the next ``CHANGELOG``.
+
+The ``CHANGELOG`` will be read by users, so this description should be aimed to sunpy users
+instead of describing internal changes which are only relevant to the developers.
+
+Make sure to use full sentences with correct case and punctuation, for example::
+
+    Add support for Helioprojective coordinates in `sunpy.coordinates.frames`.
+
+Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
+``<PULL REQUEST>`` is an pull request number, and ``<TYPE>`` is one of:
+
+* ``breaking``: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
+* ``feature``: new user facing features and new behavior.
+* ``bugfix``: fixes a reported bug.
+* ``doc``: documentation improvement, like rewording an entire session or adding missing docs.
+* ``removal``: feature deprecation or removal.
+* ``trivial``: A change which has no user facing effect or is so tiny the description will not be included in the changelog, only the PR number.
+
+So for example: ``123.feature.rst``, ``456.bugfix.rst``.
+
+If you are not sure what pull request type to use, don't hesitate to ask in your PR.
+
+Note that the ``towncrier`` tool will automatically
+reflow your text, so it will work best if you stick to a single paragraph, but multiple sentences and links are OK
+and encouraged. You can install ``towncrier`` and then run ``towncrier --draft``
+if you want to get a preview of how your change will look in the final release notes.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,6 +202,9 @@ napoleon_google_docstring = False
 
 extensions += ['sphinx_astropy.ext.edit_on_github', 'sphinx.ext.doctest', 'sphinx.ext.githubpages']
 
+# Remove the changelog links because towncrier now does this for us
+extensions.remove('sphinx_astropy.ext.changelog_links')
+
 # -- Options for the edit_on_github extension ---------------------------------
 # Don't import the module as "version" or it will override the
 # "version" configuration parameter

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,9 +202,6 @@ napoleon_google_docstring = False
 
 extensions += ['sphinx_astropy.ext.edit_on_github', 'sphinx.ext.doctest', 'sphinx.ext.githubpages']
 
-# Remove the changelog links because towncrier now does this for us
-extensions.remove('sphinx_astropy.ext.changelog_links')
-
 # -- Options for the edit_on_github extension ---------------------------------
 # Don't import the module as "version" or it will override the
 # "version" configuration parameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
     package = "sunpy"
     filename = "CHANGELOG.rst"
     directory = "changelog/"
-    issue_format = "`#{issue} <https://github.com/sunpy/sunpy/issues/{issue}>`_"
+    issue_format = "`#{issue} <https://github.com/sunpy/sunpy/pull/{issue}>`_"
 
     [[tool.towncrier.type]]
         directory = "breaking"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@
     package = "sunpy"
     filename = "CHANGELOG.rst"
     directory = "changelog/"
-    issue_format = "`#{issue} <https://github.com/sunpy/sunpy/pull/{issue}>`_"
+    issue_format = "`#{issue} <https://github.com/sunpy/sunpy/pull/{issue}>`__"
 
     [[tool.towncrier.type]]
         directory = "breaking"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[tool.towncrier]
+    package = "sunpy"
+    filename = "CHANGELOG.rst"
+    directory = "changelog/"
+    issue_format = "`#{issue} <https://github.com/sunpy/sunpy/issues/{issue}>`_"
+
+    [[tool.towncrier.type]]
+        directory = "breaking"
+        name = "Backwards Incompatible Changes"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "api"
+        name = "API Changes"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "removal"
+      name = "Deprecations and Removals"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "feature"
+      name = "Features"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "bugfix"
+      name = "Bug Fixes"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "doc"
+      name = "Improved Documentation"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "trivial"
+      name = "Trivial/Internal Changes"
+      showcontent = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,48 @@
+[ tool.sunpy-bot ]
+  # disable astropy checks
+  changelog_check = false
+  autoclose_stale_pull_request = false
+
+  # SunPy Checks
+  check_towncrier_changelog = true
+  check_milestone = true
+  post_pr_comment = true
+
+  all_passed_message = """
+
+  Thanks for the pull request @{pr_handler.user}! Everything looks great!
+"""
+
+  [ tool.sunpy-bot.towncrier_changelog ]
+    changelog_skip_label = "No Changelog Entry Needed"
+    help_url = "https://github.com/Cadair/sunpy/blob/towncrier/changelog/README.rst"
+
+    missing_file_message = """
+
+
+* I didn't detect a changelog file in this pull request, and it is not labelled 'No Changelog Entry Needed'.
+  Please add a changelog file to the `changelog/` directory following the instructions in the changelog [README](https://github.com/Cadair/sunpy/blob/towncrier/changelog/README.rst).
+"""
+    wrong_type_message = """
+
+
+* The changelog file you added is not one of the allowed types. Please use one of the types described in the changelog [README](https://github.com/Cadair/sunpy/blob/towncrier/changelog/README.rst)
+"""
+
+    wrong_number_message = """
+
+
+* The number in the changelog file you added does not match the number of this pull request. Please rename the file.
+"""
+
+  [ tool.sunpy-bot.milestone_checker ]
+
+    missing_message = """
+
+
+* This pull request does not have a milestone assigned to it. Only maintainers can change this, so you don't need to worry about it. :smile:
+"""
+
 [tool.towncrier]
     package = "sunpy"
     filename = "CHANGELOG.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@
 """
 
   [ tool.sunpy-bot.towncrier_changelog ]
+    verify_pr_number = true
     changelog_skip_label = "No Changelog Entry Needed"
     help_url = "https://github.com/Cadair/sunpy/blob/towncrier/changelog/README.rst"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,4 @@
     [[tool.towncrier.type]]
       directory = "trivial"
       name = "Trivial/Internal Changes"
-      showcontent = false
+      showcontent = true


### PR DESCRIPTION
This Pull Request migrates our changelog to [towncrier](https://github.com/hawkowl/towncrier).

This PR adds some instructions for how to use the changelog in `changelog/README.rst` it's pretty easy, rather than adding a line to `CHANGELOG.rst` add a file named `<pr number>.<type>.rst` to the new `changelog/` directory, for a list of types and their descriptions see the `changelog/README.rst` file.

The main advantage I see with using this approach is backporting, each changelog entry can be independently backported to the branch(es) that it needs to be on and then towncrier will automatically incorporate it into that releases changelog, this means that contributors do not need to worry about the section in which to write the changelog entry, it will be added to the correct section based on release. It also means it will continue our long tradition of duplicating our changelog entries across releases (i.e. all the bug fix entries for 0.9.1 will also be in the 1.0.0 changelog).

The result of running `towncrier` on this branch is the following, which gets preprended to the changelog file, and staged for commit as part of the release process.

```
Sunpy 1.0.dev9637 (2018-05-28)
==============================


Features
--------

- Change arguments to `sunpy.test` from ``offline=`` and ``online=`` to
  ``online`` and ``online_only``. This matches the behavior of the figure
  keyword arguments and comes as a part of a move to using a modified version
  of the Astropy test runner. (`#1983
  <https://github.com/sunpy/sunpy/issues/1983>`_)


Bug Fixes
---------

- Fix `sunpy.map.mapcube.MapCube.plot`. The code had not been updated to
  support the changes to the wcsaxes helper functions. (`#2627
  <https://github.com/sunpy/sunpy/issues/2627>`_)
- Replace all use of the deprecated ``sunpy.cm.get_cmap`` with ``plt.get_cmap``
  to prevent deprecation warnings being raised. (`#2635
  <https://github.com/sunpy/sunpy/issues/2635>`_)
- Fix generation of the coordinate transformation graph with Astropy 3.1.dev
  (`#2636 <https://github.com/sunpy/sunpy/issues/2636>`_)


Trivial/Internal Changes
------------------------

- `~sunpy.time.parse_time` now uses `singledispatch` underneath. (`#2408
  <https://github.com/sunpy/sunpy/issues/2408>`_)
- Revert the handling of ``quantity_allclose`` now that `astropy/astropy#7252
  <https://github.com/astropy/astropy/pull/7252>`__ is merged. This also bumps
  the minimum astropy version to 3.0.2. (`#2598
  <https://github.com/sunpy/sunpy/issues/2598>`_)
- Sort the ana C source files before building to enable reproducible builds.
  (`#2637 <https://github.com/sunpy/sunpy/issues/2637>`_)
```