### PR TITLE
[0.9] Fix bug in calculating LYRA measurement times.

### DIFF
--- a/changelog/2651.bugfix.rst
+++ b/changelog/2651.bugfix.rst
@@ -1,0 +1,1 @@
+The incorrect DATE header value was being used as the reference time for Lyra.

--- a/sunpy/lightcurve/sources/lyra.py
+++ b/sunpy/lightcurve/sources/lyra.py
@@ -130,11 +130,7 @@ class LYRALightCurve(LightCurve):
 
         # Start and end dates.  Different LYRA FITS files have
         # different tags for the date obs.
-        if 'date-obs' in hdulist[0].header:
-            start_str = hdulist[0].header['date-obs']
-        elif 'date_obs' in hdulist[0].header:
-            start_str = hdulist[0].header['date_obs']
-        # end_str = hdulist[0].header['date-end']
+        start_str = hdulist[0].header['date']
 
         # start = datetime.datetime.strptime(start_str, '%Y-%m-%dT%H:%M:%S.%f')
         start = parse_time(start_str)

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -128,7 +128,7 @@ class LYRATimeSeries(GenericTimeSeries):
         # end_str = hdulist[0].header['date-end']
         """
         metadata = MetaDict(OrderedDict(hdulist[0].header))
-        start_str = metadata.get('date-obs', metadata.get('date_obs', ''))
+        start_str = metadata.get('date-obs', metadata.get('date', ''))
 
         # start = datetime.datetime.strptime(start_str, '%Y-%m-%dT%H:%M:%S.%f')
         start = parse_time(start_str)


### PR DESCRIPTION
This PR fixes a bug when LYRALightCurve parses a FITS file.  The incorrect DATE header value was being used as the reference time.  This is corrected here.