### PR TITLE
Fix output of figure tests being put in temp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,4 @@ $RECYCLE.BIN/
 sunpydata.sqlite
 
 v/
-result_images*
+figure_test_images*

--- a/changelog/2658.bugfix.rst
+++ b/changelog/2658.bugfix.rst
@@ -1,0 +1,1 @@
+Running the figure tests with ``setup.py test`` now saves the figures and the hashes to the same directory as setup.py.

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -13,8 +13,9 @@ except ImportError:
 else:
     matplotlib.use('Agg')
 
+import sunpy.tests.helpers
 from sunpy.tests.hash import HASH_LIBRARY_NAME
-from sunpy.tests.helpers import new_hash_library, test_fig_dir
+from sunpy.tests.helpers import new_hash_library
 from sunpy.extern import six
 
 import pytest
@@ -35,6 +36,15 @@ else:
     HAVE_REMOTEDATA = remotedata_spec is not None
 
 
+def pytest_addoption(parser):
+    parser.addoption("--figure_dir", action="store", default="./figure_test_images")
+
+
+@pytest.fixture(scope='session', autouse=True)
+def figure_base_dir(request):
+    sunpy.tests.helpers.figure_base_dir = request.config.getoption("--figure_dir")
+
+
 def pytest_runtest_setup(item):
     """
     pytest hook to skip all tests that have the mark 'online' if the
@@ -49,9 +59,10 @@ def pytest_runtest_setup(item):
 def pytest_unconfigure(config):
     if len(new_hash_library) > 0:
         # Write the new hash library in JSON
-        hashfile = os.path.join(test_fig_dir, HASH_LIBRARY_NAME)
+        figure_base_dir = os.path.abspath(config.getoption("--figure_dir"))
+        hashfile = os.path.join(figure_base_dir, HASH_LIBRARY_NAME)
         with open(hashfile, 'w') as outfile:
             json.dump(new_hash_library, outfile, sort_keys=True, indent=4, separators=(',', ': '))
 
-        print('All images from image tests can be found in {0}'.format(test_fig_dir))
+        print('All images from image tests can be found in {0}'.format(figure_base_dir))
         print("The corresponding hash library is {0}".format(hashfile))

--- a/sunpy/tests/runner.py
+++ b/sunpy/tests/runner.py
@@ -72,6 +72,17 @@ class SunPyTestRunner(TestRunner):
 
         return []
 
+    @keyword()
+    def figure_dir(self, figure_dir, kwargs):
+        """
+        figure_tests : str, optional
+            Set the output directory for figure test images and hashes.
+        """
+        if figure_dir:
+            return ['--figure_dir', figure_dir]
+
+        return []
+
     # Define this to change the default value to None
     @keyword()
     def plugins(self, plugins, kwargs):

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -7,8 +7,7 @@ Created on Sat Jun  7 19:36:08 2014
 This file is designed to be imported and ran only via setup.py, hence it's
 dependency on astropy_helpers which will be available in that context.
 """
-from __future__ import absolute_import, division, print_function
-
+import os
 import copy
 
 from astropy_helpers.commands.test import AstropyTest
@@ -69,6 +68,7 @@ class SunPyTest(AstropyTest):
                'online_only={1.online_only!r}, '
                'figure={1.figure!r}, '
                'figure_only={1.figure_only!r}, '
+               'figure_dir="{figure_dir}", '
                'pep8={1.pep8!r}, '
                'pdb={1.pdb!r}, '
                'open_files={1.open_files!r}, '
@@ -80,5 +80,6 @@ class SunPyTest(AstropyTest):
                'sys.exit(result)')
         return cmd.format('pass',
                           self,
+                          figure_dir=os.path.join(os.path.abspath('.'), "figure_test_images"),
                           cmd_pre=cmd_pre,
                           cmd_post=cmd_post)


### PR DESCRIPTION
When running the tests with setup.py test the figure images would be put in the temp dir with the install of SunPy and then immediately deleted.
This adds the configuration at the various layers needed to pass through the directory in which setup.py was run.

closes #2653 