### PR TITLE
Refactor --coverage in the test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test --coverage'
         - CONDA_CHANNELS='sunpy'
-        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock lxml pyyaml pandas nomkl pytest-astropy suds-jurko glymur'
+        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock lxml pyyaml pandas nomkl pytest-astropy suds-jurko glymur pytest-xdist'
         - PIP_DEPENDENCIES='git+https://github.com/sphinx-gallery/sphinx-gallery sphinx-astropy pytest-sugar pytest-rerunfailures pytest-cov sunpy-sphinx-theme hypothesis drms'
         - EVENT_TYPE='push pull_request cron'
         - MPLBACKEND='agg'
@@ -59,7 +59,7 @@ matrix:
         # We run --online here because --online-only skips the doctests
          - python: 3.6
            stage: Comprehensive tests
-           env: SETUP_CMD="test --online --coverage"
+           env: SETUP_CMD="test --online --coverage --parallel 8"
 
         # Cron tests below this line
          - os: osx

--- a/changelog/2667.trivial.rst
+++ b/changelog/2667.trivial.rst
@@ -1,0 +1,1 @@
+Change to using pytest-cov for coverage report generation to enable support for parallel builds

--- a/sunpy/tests/coveragerc
+++ b/sunpy/tests/coveragerc
@@ -5,7 +5,7 @@ omit =
    sunpy/conftest*
    sunpy/cython_version*
    sunpy/*setup*
-   sunpy/*tests/*
+   sunpy/*/tests/*
    sunpy/version*
    sunpy/__init__*
 
@@ -15,7 +15,7 @@ omit =
    sunpy/conftest*
    sunpy/cython_version*
    sunpy/*setup*
-   sunpy/*tests/*
+   sunpy/*/tests/*
    sunpy/version*
    sunpy/__init__*
 

--- a/sunpy/tests/coveragerc
+++ b/sunpy/tests/coveragerc
@@ -1,23 +1,15 @@
 [run]
 source = sunpy
 omit =
-   sunpy/_astropy_init*
    sunpy/conftest*
    sunpy/cython_version*
    sunpy/*setup*
+   sunpy/extern/*
    sunpy/*/tests/*
    sunpy/version*
    sunpy/__init__*
 
 [report]
-omit =
-   sunpy/_astropy_init*
-   sunpy/conftest*
-   sunpy/cython_version*
-   sunpy/*setup*
-   sunpy/*/tests/*
-   sunpy/version*
-   sunpy/__init__*
 
 exclude_lines =
    # Have to re-enable the standard pragma

--- a/sunpy/tests/coveragerc
+++ b/sunpy/tests/coveragerc
@@ -10,6 +10,15 @@ omit =
    sunpy/__init__*
 
 [report]
+omit =
+   sunpy/_astropy_init*
+   sunpy/conftest*
+   sunpy/cython_version*
+   sunpy/*setup*
+   sunpy/*tests/*
+   sunpy/version*
+   sunpy/__init__*
+
 exclude_lines =
    # Have to re-enable the standard pragma
    pragma: no cover

--- a/sunpy/tests/helpers.py
+++ b/sunpy/tests/helpers.py
@@ -109,9 +109,11 @@ def figure_test(test_function):
 def _patch_coverage(testdir, sourcedir):
     import coverage
 
+    coveragerc = os.path.join(os.path.dirname(__file__), "coveragerc")
+
     # Load the .coverage file output by pytest-cov
     covfile = os.path.join(testdir, ".coverage")
-    cov = coverage.Coverage(covfile)
+    cov = coverage.Coverage(covfile, config_file=coveragerc)
     cov.load()
     cov.get_data()
 

--- a/sunpy/tests/helpers.py
+++ b/sunpy/tests/helpers.py
@@ -106,7 +106,8 @@ def figure_test(test_function):
     return wrapper
 
 
-def _patch_coverage(testdir, sourcedir):
+# Skip coverage on this because we test it every time the CI runs --coverage!
+def _patch_coverage(testdir, sourcedir):  # pragma: no cover
     import coverage
 
     coveragerc = os.path.join(os.path.dirname(__file__), "coveragerc")

--- a/sunpy/tests/helpers.py
+++ b/sunpy/tests/helpers.py
@@ -108,6 +108,11 @@ def figure_test(test_function):
 
 # Skip coverage on this because we test it every time the CI runs --coverage!
 def _patch_coverage(testdir, sourcedir):  # pragma: no cover
+    """
+    This function is used by the ``setup.py test`` command to change the
+    filepath of the source code from the temporary directory setup.py installs
+    the code into to the actual directory setup.py was executed in.
+    """
     import coverage
 
     coveragerc = os.path.join(os.path.dirname(__file__), "coveragerc")

--- a/sunpy/tests/runner.py
+++ b/sunpy/tests/runner.py
@@ -14,7 +14,7 @@ class SunPyTestRunner(TestRunner):
     # Disable certain astropy flags
     @keyword()
     def remote_data(self, remote_data, kwargs):
-        return NotImplemented
+        return NotImplemented  # pragma: no cover
 
     # Change the docsting on package
     @keyword(priority=10)

--- a/sunpy/tests/runner.py
+++ b/sunpy/tests/runner.py
@@ -94,3 +94,21 @@ class SunPyTestRunner(TestRunner):
         # Plugins are handled independently by `run_tests` so we define this
         # keyword just for the docstring
         return []
+
+    @keyword()
+    def coverage(self, coverage, kwargs):
+        if coverage:
+            ret = []
+            for path in self.package_path:
+                ret += ["--cov", path]
+            return ret
+
+        return []
+
+    @keyword()
+    def cov_report(self, cov_report, kwargs):
+        if kwargs['coverage'] and cov_report:
+            a = [cov_report] if isinstance(cov_report, str) else []
+            return ['--cov-report'] + a
+
+        return []

--- a/sunpy/tests/runner.py
+++ b/sunpy/tests/runner.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import os
+
 from astropy.tests.runner import TestRunner, keyword
 
 
@@ -98,9 +100,10 @@ class SunPyTestRunner(TestRunner):
     @keyword()
     def coverage(self, coverage, kwargs):
         if coverage:
+            coveragerc = os.path.join(self.base_path, "tests", "coveragerc")
             ret = []
             for path in self.package_path:
-                ret += ["--cov", path]
+                ret += ["--cov", path, "--cov-config", coveragerc]
             return ret
 
         return []

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -80,7 +80,7 @@ class SunPyTest(AstropyTest):
                'test_path={1.test_path!r}, '
                'args={1.args!r}, '
                'coverage={1.coverage!r}, '
-               'cov_report="{1.cov_report!r}", '
+               'cov_report={1.cov_report!r}, '
                'plugins={1.plugins!r}, '
                'verbose={1.verbose_results!r}, '
                'pastebin={1.pastebin!r}, '

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -51,7 +51,7 @@ class SunPyTest(AstropyTest):
 
         if self.coverage:
             # Copy the raw .coverage file back so it can be used for CI reports
-            cwd = os.path.join(os.path.abspath("."))
+            cwd = os.path.abspath(".")
             cmd_post = ('from sunpy.tests.helpers import _patch_coverage; '
                         'import os; '
                         'test_dir = os.path.abspath("."); '
@@ -59,7 +59,7 @@ class SunPyTest(AstropyTest):
 
             # Special case html as the default report
             if self.cov_report and (isinstance(self.cov_report, bool) or "html" in self.cov_report):
-                html_cov = os.path.join(os.path.abspath("."), "htmlcov")
+                html_cov = os.path.join(cwd, "htmlcov")
                 cov_report = f'html:{html_cov}'
             else:
                 cov_report = self.cov_report

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -22,6 +22,8 @@ class SunPyTest(AstropyTest):
                       'Also run tests that do require a internet connection.'),
                      ('online-only', None,
                       'Only run test that do require a internet connection.'),
+                     ('cov-report=', None,
+                      'How to display the coverage report, should be either "html" or "term"'),
                      ('figure', None,
                       'Run the figure tests.'),
                      # Run only tests that check figure generation
@@ -36,6 +38,7 @@ class SunPyTest(AstropyTest):
         self.online_only = False
         self.figure = False
         self.figure_only = False
+        self.cov_report = True
 
     def generate_testing_command(self):
         """
@@ -44,17 +47,30 @@ class SunPyTest(AstropyTest):
 
         cmd_pre = ''  # Commands to run before the test function
         cmd_post = ''  # Commands to run after the test function
+        cov_report = False
 
         if self.coverage:
-            pre, post = self._generate_coverage_commands()
-            cmd_pre += pre
-            cmd_post += post
+            # Copy the raw .coverage file back so it can be used for CI reports
+            cwd_covfile = os.path.join(os.path.abspath("."), ".coverage")
+            cmd_post = ('import shutil, os; '
+                        'covfile = os.path.join(os.path.abspath("."), ".coverage"); '
+                        f'shutil.copyfile(covfile, "{cwd_covfile}")'
+                        ' if os.path.isfile(covfile) else None; ')
+
+            # Special case html as the default report
+            if self.cov_report and (isinstance(self.cov_report, bool) or "html" in self.cov_report):
+                html_cov = os.path.join(os.path.abspath("."), "htmlcov")
+                cov_report = f'html:{html_cov}'
+            else:
+                cov_report = self.cov_report
 
         cmd = ('{cmd_pre}{0}; import {1.package_name}, sys; result = ('
                '{1.package_name}.self_test('
                'package={1.package!r}, '
                'test_path={1.test_path!r}, '
                'args={1.args!r}, '
+               'coverage={1.coverage!r}, '
+               'cov_report="{cov_report}", '
                'plugins={1.plugins!r}, '
                'verbose={1.verbose_results!r}, '
                'pastebin={1.pastebin!r}, '
@@ -74,6 +90,7 @@ class SunPyTest(AstropyTest):
                'sys.exit(result)')
         return cmd.format('pass',
                           self,
+                          cov_report=cov_report,
                           figure_dir=os.path.join(os.path.abspath('.'), "figure_test_images"),
                           cmd_pre=cmd_pre,
                           cmd_post=cmd_post)

--- a/sunpy/tests/setup_command.py
+++ b/sunpy/tests/setup_command.py
@@ -51,11 +51,11 @@ class SunPyTest(AstropyTest):
 
         if self.coverage:
             # Copy the raw .coverage file back so it can be used for CI reports
-            cwd_covfile = os.path.join(os.path.abspath("."), ".coverage")
-            cmd_post = ('import shutil, os; '
-                        'covfile = os.path.join(os.path.abspath("."), ".coverage"); '
-                        f'shutil.copyfile(covfile, "{cwd_covfile}")'
-                        ' if os.path.isfile(covfile) else None; ')
+            cwd = os.path.join(os.path.abspath("."))
+            cmd_post = ('from sunpy.tests.helpers import _patch_coverage; '
+                        'import os; '
+                        'test_dir = os.path.abspath("."); '
+                        f'_patch_coverage(test_dir, "{cwd}"); ')
 
             # Special case html as the default report
             if self.cov_report and (isinstance(self.cov_report, bool) or "html" in self.cov_report):


### PR DESCRIPTION
This moves us away from using astropy to calculate the code coverage and to using pytest-cov. This means that `--parallel` and `--coverage` from the test runner work, as well as enabling `--cov-report term` to work from `setup.py`