### PR TITLE
Output figure diff in test figure page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ image-run: &image-tests
   command: |
     conda env list
     source activate sunpy-figure-tests-3.6
-    python setup.py test --figure-only --coverage
+    python setup.py test --figure-only --coverage --remote-data
     pip install codecov
     codecov
 

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -67,6 +67,6 @@ def pytest_unconfigure(config):
         with open(hashfile, 'w') as outfile:
             json.dump(new_hash_library, outfile, sort_keys=True, indent=4, separators=(',', ': '))
 
-        generate_figure_webpage()
+        generate_figure_webpage(new_hash_library)
         print('All images from image tests can be found in {0}'.format(figure_base_dir))
         print("The corresponding hash library is {0}".format(hashfile))


### PR DESCRIPTION
Requires remote data to download the baseline images to generate a diff, but I'm not sure if there's a way to avoid that?