### PR TITLE
Create Map using a Dask array

### DIFF
--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -28,6 +28,13 @@ from sunpy.extern import six
 
 from sunpy.extern.six.moves.urllib.request import urlopen
 
+SUPPORTED_ARRAY_TYPES = (np.ndarray,)
+try:
+    import dask.array
+    SUPPORTED_ARRAY_TYPES += (dask.array.Array,)
+except ImportError:
+    pass
+
 __authors__ = ["Russell Hewett, Stuart Mumford"]
 __email__ = "stuart@mumford.me.uk"
 
@@ -173,7 +180,7 @@ class MapFactory(BasicRegistrationFactory):
                 data_header_pairs.append(arg)
 
             # Data-header pair not in a tuple
-            elif (isinstance(arg, np.ndarray) and
+            elif (isinstance(arg, SUPPORTED_ARRAY_TYPES) and
                   self._validate_meta(args[i+1])):
 
                 pair = (args[i], OrderedDict(args[i+1]))

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -23,6 +23,12 @@ try:
 except ImportError:
     HAS_SQLALCHEMY = False
 
+try:
+    import dask.array
+    HAS_DASK = True
+except ImportError:
+    HAS_DASK = False
+
 filepath = sunpy.data.test.rootdir
 a_list_of_many = glob.glob(os.path.join(filepath, "EIT", "*"))
 a_fname = a_list_of_many[0]
@@ -83,6 +89,14 @@ class TestMap(object):
         data = np.arange(0,100).reshape(10,10)
         header = {'cdelt1': 10, 'cdelt2': 10, 'telescop':'sunpy'}
         pair_map = sunpy.map.Map(data, header)
+        assert isinstance(pair_map, sunpy.map.GenericMap)
+
+    # requires dask array to run properly
+    @pytest.mark.skipif('not HAS_DASK')
+    def test_dask_array(self):
+        amap = sunpy.map.Map(AIA_171_IMAGE)
+        da = dask.array.from_array(amap.data, chunks=(1, 1))
+        pair_map = sunpy.map.Map(da, amap.meta)
         assert isinstance(pair_map, sunpy.map.GenericMap)
 
     # requires sqlalchemy to run properly


### PR DESCRIPTION
See issue #2687. This PR makes a change to the map factory such that, instead of checking that the input data array is a numpy array, it checks a whitelist of allowed data array types. Currently, these include

* `np.ndarray`
* `dask.array.Array`

The dependency on dask is still optional. However, it should be noted that scikit image, which is already a sunpy dependency, depends on dask-core so we really get this dependency for free.

I've also included a map factory test.