### PR TITLE
Fix date-obs handling in LASCOMap

### DIFF
--- a/changelog/2700.bugfix.rst
+++ b/changelog/2700.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the bug which crashes LASCOMap for when 'date-obs' is reformatted agian from a self applied function.

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -1,6 +1,7 @@
 """SOHO Map subclass definitions"""
 from __future__ import absolute_import, print_function, division
-#pylint: disable=W0221,W0222,E1101,E1121
+
+# pylint: disable=W0221,W0222,E1101,E1121
 
 __author__ = "Keith Hughitt"
 __email__ = "keith.hughitt@nasa.gov"
@@ -61,7 +62,6 @@ class EITMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
         GenericMap.__init__(self, data, header, **kwargs)
 
         # Fill in some missing info
@@ -114,14 +114,16 @@ class LASCOMap(GenericMap):
         self.meta['CUNIT2'] = self.meta['CUNIT2'].lower()
 
         # Fill in some missing or broken info
-        datestr = "{date}T{time}".format(date=self.meta.get('date-obs',
-                                                            self.meta.get('date_obs')
-                                                            ),
-                                         time=self.meta.get('time-obs',
-                                                            self.meta.get('time_obs')
-                                                            )
-                                         )
-        self.meta['date-obs'] = datestr
+        # Test if change has already been applied
+        if 'T' not in self.meta['date-obs']:
+            datestr = "{date}T{time}".format(date=self.meta.get('date-obs',
+                                                                self.meta.get('date_obs')
+                                                                ),
+                                             time=self.meta.get('time-obs',
+                                                                self.meta.get('time_obs')
+                                                                )
+                                             )
+            self.meta['date-obs'] = datestr
 
         # If non-standard Keyword is present, correct it too, for compatibility.
         if 'date_obs' in self.meta:


### PR DESCRIPTION
I changed the class LASCOMap within soho.py because if a LASCOMap has already been created and it is  called to .rotate() or .resample() on itself it will crash in the parse_time function under time.py because the LASCOMap change date-obs to (self.meta['date-obs'] + 'T' + self.meta['time-obs']) and the 'date-obs' change happens when a new LASCOMap is created but when .rotate() or .resample() are applied it returns a new instance of itself which in turn change the date-obs to the format but date-obs has already been formatted so when the program call self.date or any function requiring the date it will crash due to it being an invalid time string

Additions: 
I added an if statement to check if 'date-obs' has already been formatted.
If LASCOMap hasn't it formats 'date-obs' 
else it skips over the formatting of 'date-obs'.

Example of crash:
fits_image_url = "(insert url for LASCO image from soho)"
my_sunpy_map = sunpy.map.Map(fits_image_url)
rotated_map = my_sunpy_map.rotate()
print(rotated_map.date)