### PR TITLE
Tidy docstring for solar_rotate_coordinate

### DIFF
--- a/changelog/2708.docfix.rst
+++ b/changelog/2708.docfix.rst
@@ -1,0 +1,1 @@
+Clean up the docstring for `sunpy.physics.differential_rotation.solar_rotate_coordinate` to make the example clearer.

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -125,9 +125,10 @@ def solar_rotate_coordinate(coordinate,
 
     **diff_rot_kwargs : keyword arguments
         Keyword arguments are passed on as keyword arguments to `~sunpy.physics.differential_rotation.diff_rot`.
+
     Returns
     -------
-    coordinate : `~astropy.coordinates.SkyCoord``
+    coordinate : `~astropy.coordinates.SkyCoord`
         The locations of the input coordinates after the application of
         solar rotation in the input coordinate frame.
 
@@ -137,9 +138,11 @@ def solar_rotate_coordinate(coordinate,
     >>> from astropy.coordinates import SkyCoord
     >>> from sunpy.coordinates import frames
     >>> from sunpy.physics.differential_rotation import solar_rotate_coordinate
-    >>> obstime = '2010-09-10 12:34:56'
-    >>> c = SkyCoord(-570*u.arcsec, 120*u.arcsec, obstime=obstime, observer="earth", frame=frames.Helioprojective)
-    >>> solar_rotate_coordinate(c, '2010-09-10 13:34:56')
+
+    >>> start_time = '2010-09-10 12:34:56'
+    >>> end_time = '2010-09-10 13:34:56'
+    >>> c = SkyCoord(-570*u.arcsec, 120*u.arcsec, obstime=start_time, frame=frames.Helioprojective)
+    >>> solar_rotate_coordinate(c, end_time)
     <SkyCoord (Helioprojective: obstime=2010-09-10 13:34:56, rsun=695508.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
         (-562.37689548, 119.26840368, 1.50083152e+08)>
 


### PR DESCRIPTION
I noticed this example wasn't as clear as it could have been when I was looking at it because of #2706 