### PR TITLE
Replace np.matrix() with np.array()

### DIFF
--- a/changelog/2719.breaking.rst
+++ b/changelog/2719.breaking.rst
@@ -1,0 +1,3 @@
+Rotation matrices inside map objects were previously stored as numpy matrices, but are now
+stored as numpy arrays, as numpy will eventually remove their matrix datatype. See
+https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html for more information.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1155,7 +1155,7 @@ class GenericMap(NDData):
         # "subtracting" the rotation matrix used in the rotate from the old one
         # That being calculate the dot product of the old header data with the
         # inverse of the rotation matrix.
-        pc_C = np.dot(self.rotation_matrix, rmatrix.I)
+        pc_C = np.dot(self.rotation_matrix, np.linalg.inv(rmatrix))
         new_meta['PC1_1'] = pc_C[0, 0]
         new_meta['PC1_2'] = pc_C[0, 1]
         new_meta['PC2_1'] = pc_C[1, 0]

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1086,8 +1086,8 @@ class GenericMap(NDData):
                                 [s, c]])
 
         # Calculate the shape in pixels to contain all of the image data
-        extent = np.max(np.abs(np.vstack((self.data.shape * rmatrix,
-                                          self.data.shape * rmatrix.T))), axis=0)
+        extent = np.max(np.abs(np.vstack((self.data.shape @ rmatrix,
+                                          self.data.shape @ rmatrix.T))), axis=0)
 
         # Calculate the needed padding or unpadding
         diff = np.asarray(np.ceil((extent - self.data.shape) / 2), dtype=int).ravel()
@@ -1111,7 +1111,7 @@ class GenericMap(NDData):
 
         # Convert the axis of rotation from data coordinates to pixel coordinates
         pixel_rotation_center = u.Quantity(temp_map.world_to_pixel(self.reference_coordinate,
-                                                                  origin=0)).value
+                                                                   origin=0)).value
         del temp_map
 
         if recenter:

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -700,12 +700,12 @@ class GenericMap(NDData):
         the top of the image.
         """
         if 'PC1_1' in self.meta:
-            return np.matrix([[self.meta['PC1_1'], self.meta['PC1_2']],
-                              [self.meta['PC2_1'], self.meta['PC2_2']]])
+            return np.array([[self.meta['PC1_1'], self.meta['PC1_2']],
+                             [self.meta['PC2_1'], self.meta['PC2_2']]])
 
         elif 'CD1_1' in self.meta:
-            cd = np.matrix([[self.meta['CD1_1'], self.meta['CD1_2']],
-                            [self.meta['CD2_1'], self.meta['CD2_2']]])
+            cd = np.array([[self.meta['CD1_1'], self.meta['CD1_2']],
+                           [self.meta['CD2_1'], self.meta['CD2_2']]])
 
             cdelt = u.Quantity(self.scale).value
 
@@ -724,8 +724,8 @@ class GenericMap(NDData):
         lam = self.scale[0] / self.scale[1]
         p = np.deg2rad(self.meta.get('CROTA2', 0))
 
-        return np.matrix([[np.cos(p), -1 * lam * np.sin(p)],
-                          [1/lam * np.sin(p), np.cos(p)]])
+        return np.array([[np.cos(p), -1 * lam * np.sin(p)],
+                         [1/lam * np.sin(p), np.cos(p)]])
 
 # #### Miscellaneous #### #
 
@@ -1082,7 +1082,8 @@ class GenericMap(NDData):
             # Calculate the parameters for the affine_transform
             c = np.cos(np.deg2rad(angle))
             s = np.sin(np.deg2rad(angle))
-            rmatrix = np.matrix([[c, -s], [s, c]])
+            rmatrix = np.array([[c, -s],
+                                [s, c]])
 
         # Calculate the shape in pixels to contain all of the image data
         extent = np.max(np.abs(np.vstack((self.data.shape * rmatrix,
@@ -1706,7 +1707,7 @@ class GenericMap(NDData):
         if not _basic_plot:
             # Check that the image is properly oriented
             if (not wcsaxes_compat.is_wcsaxes(axes) and
-                not np.array_equal(self.rotation_matrix, np.matrix(np.identity(2)))):
+                    not np.array_equal(self.rotation_matrix, np.identity(2))):
                 warnings.warn("This map is not properly oriented. Plot axes may be incorrect",
                               Warning)
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -204,13 +204,13 @@ def test_coordinate_frame(aia171_test_map):
 # Test Rotation WCS conversion
 # ==============================================================================
 def test_rotation_matrix_pci_j(generic_map):
-    np.testing.assert_allclose(generic_map.rotation_matrix, np.matrix([[0., -1.], [1., 0.]]))
+    np.testing.assert_allclose(generic_map.rotation_matrix, np.array([[0., -1.], [1., 0.]]))
 
 
 def test_rotation_matrix_crota(aia171_test_map):
     np.testing.assert_allclose(aia171_test_map.rotation_matrix,
-                               np.matrix([[9.99999943e-01, -3.38820761e-04],
-                                          [3.38820761e-04, 9.99999943e-01]]))
+                               np.array([[9.99999943e-01, -3.38820761e-04],
+                                         [3.38820761e-04, 9.99999943e-01]]))
 
 
 def test_rotation_matrix_cd_cdelt():
@@ -230,7 +230,7 @@ def test_rotation_matrix_cd_cdelt():
         'NAXIS2': 6
     }
     cd_map = sunpy.map.Map((data, header))
-    np.testing.assert_allclose(cd_map.rotation_matrix, np.matrix([[0., -1.], [1., 0]]))
+    np.testing.assert_allclose(cd_map.rotation_matrix, np.array([[0., -1.], [1., 0]]))
 
 
 def test_rotation_matrix_cd_cdelt_square():
@@ -250,12 +250,12 @@ def test_rotation_matrix_cd_cdelt_square():
         'NAXIS2': 6
     }
     cd_map = sunpy.map.Map((data, header))
-    np.testing.assert_allclose(cd_map.rotation_matrix, np.matrix([[0., -1], [1., 0]]))
+    np.testing.assert_allclose(cd_map.rotation_matrix, np.array([[0., -1], [1., 0]]))
 
 
 def test_swap_cd():
     amap = sunpy.map.Map(os.path.join(testpath, 'swap_lv1_20140606_000113.fits'))
-    np.testing.assert_allclose(amap.rotation_matrix, np.matrix([[1., 0], [0, 1.]]))
+    np.testing.assert_allclose(amap.rotation_matrix, np.array([[1., 0], [0, 1.]]))
 
 
 def test_data_range(generic_map):
@@ -461,7 +461,7 @@ def test_superpixel(aia171_test_map, aia171_test_map_with_mask):
 def calc_new_matrix(angle):
     c = np.cos(np.deg2rad(angle))
     s = np.sin(np.deg2rad(angle))
-    return np.matrix([[c, -s], [s, c]])
+    return np.array([[c, -s], [s, c]])
 
 
 def test_rotate(aia171_test_map):
@@ -541,13 +541,13 @@ def test_rotate_scale_cdelt(generic_map):
 
 def test_rotate_new_matrix(generic_map):
     # Rotate by CW90 to go from CCW 90 in generic map to CCW 180
-    rot_map = generic_map.rotate(rmatrix=np.matrix([[0, 1], [-1, 0]]))
-    np.testing.assert_allclose(rot_map.rotation_matrix, np.matrix([[-1, 0], [0, -1]]))
+    rot_map = generic_map.rotate(rmatrix=np.array([[0, 1], [-1, 0]]))
+    np.testing.assert_allclose(rot_map.rotation_matrix, np.array([[-1, 0], [0, -1]]))
 
 
 def test_rotate_rmatrix_angle(generic_map):
     with pytest.raises(ValueError):
-        generic_map.rotate(angle=5, rmatrix=np.matrix([[1, 0], [0, 1]]))
+        generic_map.rotate(angle=5, rmatrix=np.array([[1, 0], [0, 1]]))
 
 
 def test_rotate_invalid_order(generic_map):


### PR DESCRIPTION
Currently running the doc build results in a lot of the following warning:
```
/root/project/build/lib.linux-x86_64-3.6/sunpy/map/mapbase.py:704: PendingDeprecationWarning:
the matrix subclass is not the recommended way to represent matrices or deal with linear algebra
(see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html).
Please adjust your code to use regular ndarray.
```


This PR swaps out `np.matrix()` for `np.array()`.