### PR TITLE
Fix the representation of observers in frame repr

### DIFF
--- a/changelog/2723.bugfix.rst
+++ b/changelog/2723.bugfix.rst
@@ -1,0 +1,1 @@
+Persist the string representation of an observer even though a concrete coordinate object has been calculated. Use this string representation to change the way the `~sunpy.frames.HeliographicStonyhurst` frame is printed so that when you print a `~astropy.coordinates.SkyCoord` object the string is shown and not the concrete coordinate object.

--- a/changelog/2723.bugfix.rst
+++ b/changelog/2723.bugfix.rst
@@ -1,1 +1,0 @@
-Persist the string representation of an observer even though a concrete coordinate object has been calculated. Use this string representation to change the way the `~sunpy.frames.HeliographicStonyhurst` frame is printed so that when you print a `~astropy.coordinates.SkyCoord` object the string is shown and not the concrete coordinate object.

--- a/changelog/2723.feature.rst
+++ b/changelog/2723.feature.rst
@@ -1,0 +1,5 @@
+Persist the name of a coordinate, i.e. "earth" even though a concrete
+coordinate object has been calculated and use this string representation to change
+the way the sunpy frames are printed. This is primarily to facilitate displaying
+the name of the body rather than the concrete coordinate when printing a
+`SkyCoord`.

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -143,7 +143,7 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
             if isinstance(observer, six.string_types):
                 if obstime is not None:
                     new_observer = self._convert_string_to_coord(observer.lower(), obstime)
-                    new_observer._observer_body = observer.lower()
+                    new_observer.object_name = observer
                     setattr(instance, '_' + self.name, new_observer)
                 else:
                     return observer

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -142,8 +142,9 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
             # the position of the observer.
             if isinstance(observer, six.string_types):
                 if obstime is not None:
-                    observer = self._convert_string_to_coord(observer.lower(), obstime)
-                    setattr(instance, '_' + self.name, observer)
+                    new_observer = self._convert_string_to_coord(observer.lower(), obstime)
+                    new_observer._observer_body = observer.lower()
+                    setattr(instance, '_' + self.name, new_observer)
                 else:
                     return observer
 

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -153,7 +153,7 @@ class HeliographicStonyhurst(BaseCoordinateFrame):
         if hasattr(self, "_observer_body"):
             return self._observer_body
         else:
-            return super().__repr__()
+            return super().__str__()
 
 
 class HeliographicCarrington(HeliographicStonyhurst):

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -276,15 +276,13 @@ class Heliocentric(BaseCoordinateFrame):
     >>> sc = SkyCoord(CartesianRepresentation(10*u.km, 1*u.km, 2*u.km),
     ...               obstime="2011/01/05T00:00:50", frame="heliocentric")
     >>> sc
-    <SkyCoord (Heliocentric: obstime=2011-01-05 00:00:50, observer=<HeliographicStonyhurst Coordinate (obstime=2011-01-05 00:00:50): (lon, lat, radius) in (deg, deg, AU)
-        (0., -3.43939103, 0.98334411)>): (x, y, z) in km
+    <SkyCoord (Heliocentric: obstime=2011-01-05 00:00:50, observer=earth): (x, y, z) in km
         (10., 1., 2.)>
 
     >>> sc = SkyCoord([1,2]*u.km, [3,4]*u.m, [5,6]*u.cm, frame="heliocentric", obstime="2011/01/01T00:00:54")
 
     >>> sc
-    <SkyCoord (Heliocentric: obstime=2011-01-01 00:00:54, observer=<HeliographicStonyhurst Coordinate (obstime=2011-01-01 00:00:54): (lon, lat, radius) in (deg, deg, AU)
-        (0., -2.97725356, 0.98335586)>): (x, y, z) in (km, m, cm)
+    <SkyCoord (Heliocentric: obstime=2011-01-01 00:00:54, observer=earth): (x, y, z) in (km, m, cm)
         [(1., 3., 5.), (2., 4., 6.)]>
     """
 
@@ -335,13 +333,11 @@ class Helioprojective(BaseCoordinateFrame):
     >>> sc = SkyCoord(0*u.deg, 0*u.deg, 5*u.km, obstime="2010/01/01T00:00:00",
     ...               frame="helioprojective")
     >>> sc
-    <SkyCoord (Helioprojective: obstime=2010-01-01 00:00:00, rsun=695508.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2010-01-01 00:00:00): (lon, lat, radius) in (deg, deg, AU)
-        (0., -3.00724817, 0.98330294)>): (Tx, Ty, distance) in (arcsec, arcsec, km)
+    <SkyCoord (Helioprojective: obstime=2010-01-01 00:00:00, rsun=695508.0 km, observer=earth): (Tx, Ty, distance) in (arcsec, arcsec, km)
         (0., 0., 5.)>
     >>> sc = SkyCoord(0*u.deg, 0*u.deg, obstime="2010/01/01T00:00:00", frame="helioprojective")
     >>> sc
-    <SkyCoord (Helioprojective: obstime=2010-01-01 00:00:00, rsun=695508.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2010-01-01 00:00:00): (lon, lat, radius) in (deg, deg, AU)
-        (0., -3.00724817, 0.98330294)>): (Tx, Ty) in arcsec
+    <SkyCoord (Helioprojective: obstime=2010-01-01 00:00:00, rsun=695508.0 km, observer=earth): (Tx, Ty) in arcsec
         (0., 0.)>
     """
 

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -145,6 +145,16 @@ class HeliographicStonyhurst(BaseCoordinateFrame):
         if wrap and isinstance(self._data, (UnitSphericalRepresentation, SphericalRepresentation)):
             self._data.lon.wrap_angle = self._default_wrap_angle
 
+    def __str__(self):
+        """
+        We override this here so that when you print a SkyCoord it shows the
+        observer as the string and not the whole massive coordinate.
+        """
+        if hasattr(self, "_observer_body"):
+            return self._observer_body
+        else:
+            return super().__repr__()
+
 
 class HeliographicCarrington(HeliographicStonyhurst):
     """

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -47,10 +47,11 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
         We override this here so that when you print a SkyCoord it shows the
         observer as the string and not the whole massive coordinate.
         """
-        if self.object_name:
+        if getattr(self, "object_name", None):
             return f"<{self.__class__.__name__} Coordinate for '{self.object_name}'>"
         else:
             return super().__str__()
+
 
 class HeliographicStonyhurst(SunPyBaseCoordinateFrame):
     """

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -285,13 +285,13 @@ class Heliocentric(SunPyBaseCoordinateFrame):
     >>> sc = SkyCoord(CartesianRepresentation(10*u.km, 1*u.km, 2*u.km),
     ...               obstime="2011/01/05T00:00:50", frame="heliocentric")
     >>> sc
-    <SkyCoord (Heliocentric: obstime=2011-01-05 00:00:50, observer=earth): (x, y, z) in km
+    <SkyCoord (Heliocentric: obstime=2011-01-05 00:00:50, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (x, y, z) in km
         (10., 1., 2.)>
 
     >>> sc = SkyCoord([1,2]*u.km, [3,4]*u.m, [5,6]*u.cm, frame="heliocentric", obstime="2011/01/01T00:00:54")
 
     >>> sc
-    <SkyCoord (Heliocentric: obstime=2011-01-01 00:00:54, observer=earth): (x, y, z) in (km, m, cm)
+    <SkyCoord (Heliocentric: obstime=2011-01-01 00:00:54, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (x, y, z) in (km, m, cm)
         [(1., 3., 5.), (2., 4., 6.)]>
     """
 
@@ -342,11 +342,11 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     >>> sc = SkyCoord(0*u.deg, 0*u.deg, 5*u.km, obstime="2010/01/01T00:00:00",
     ...               frame="helioprojective")
     >>> sc
-    <SkyCoord (Helioprojective: obstime=2010-01-01 00:00:00, rsun=695508.0 km, observer=earth): (Tx, Ty, distance) in (arcsec, arcsec, km)
+    <SkyCoord (Helioprojective: obstime=2010-01-01 00:00:00, rsun=695508.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
         (0., 0., 5.)>
     >>> sc = SkyCoord(0*u.deg, 0*u.deg, obstime="2010/01/01T00:00:00", frame="helioprojective")
     >>> sc
-    <SkyCoord (Helioprojective: obstime=2010-01-01 00:00:00, rsun=695508.0 km, observer=earth): (Tx, Ty) in arcsec
+    <SkyCoord (Helioprojective: obstime=2010-01-01 00:00:00, rsun=695508.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty) in arcsec
         (0., 0.)>
     """
 

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -29,11 +29,30 @@ from .frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribut
 RSUN_METERS = sun.constants.get('radius').si.to(u.m)
 DSUN_METERS = sun.constants.get('mean distance').si.to(u.m)
 
-__all__ = ['HeliographicStonyhurst', 'HeliographicCarrington', 'Heliocentric',
-           'Helioprojective']
+__all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
+           'Heliocentric', 'Helioprojective']
 
 
-class HeliographicStonyhurst(BaseCoordinateFrame):
+class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
+    """
+    Inject a nice way of representing the object which the coordinate represents.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.object_name = None
+        return super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        """
+        We override this here so that when you print a SkyCoord it shows the
+        observer as the string and not the whole massive coordinate.
+        """
+        if self.object_name:
+            return f"<{self.__class__.__name__} Coordinate for '{self.object_name}'>"
+        else:
+            return super().__str__()
+
+class HeliographicStonyhurst(SunPyBaseCoordinateFrame):
     """
     A coordinate or frame in the Stonyhurst Heliographic system.
 
@@ -145,16 +164,6 @@ class HeliographicStonyhurst(BaseCoordinateFrame):
         if wrap and isinstance(self._data, (UnitSphericalRepresentation, SphericalRepresentation)):
             self._data.lon.wrap_angle = self._default_wrap_angle
 
-    def __str__(self):
-        """
-        We override this here so that when you print a SkyCoord it shows the
-        observer as the string and not the whole massive coordinate.
-        """
-        if hasattr(self, "_observer_body"):
-            return self._observer_body
-        else:
-            return super().__str__()
-
 
 class HeliographicCarrington(HeliographicStonyhurst):
     """
@@ -233,7 +242,7 @@ class HeliographicCarrington(HeliographicStonyhurst):
     obstime = TimeFrameAttributeSunPy()
 
 
-class Heliocentric(BaseCoordinateFrame):
+class Heliocentric(SunPyBaseCoordinateFrame):
     """
     A coordinate or frame in the Heliocentric system.
 
@@ -296,7 +305,7 @@ class Heliocentric(BaseCoordinateFrame):
     observer = ObserverCoordinateAttribute(HeliographicStonyhurst, default="earth")
 
 
-class Helioprojective(BaseCoordinateFrame):
+class Helioprojective(SunPyBaseCoordinateFrame):
     """
     A coordinate or frame in the Helioprojective (Cartesian) system.
 

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -109,6 +109,10 @@ def test_coord_get():
     assert_quantity_allclose(obs.lat, earth.lat)
     assert_quantity_allclose(obs.radius, earth.radius)
 
+    assert hasattr(obs, "_observer_body")
+    assert obs._observer_body == "earth"
+    assert str(obs) == "earth"
+
     # Test get
     obstime = "2013-04-01"
     obs = Helioprojective(obstime=obstime).observer
@@ -128,6 +132,10 @@ def test_coord_get():
     assert_quantity_allclose(obs.lon, mars.lon)
     assert_quantity_allclose(obs.lat, mars.lat)
     assert_quantity_allclose(obs.radius, mars.radius)
+
+    assert hasattr(obs, "_observer_body")
+    assert obs._observer_body == "mars"
+    assert str(obs) == "mars"
 
 
 def test_default_hcc_observer():

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -109,9 +109,9 @@ def test_coord_get():
     assert_quantity_allclose(obs.lat, earth.lat)
     assert_quantity_allclose(obs.radius, earth.radius)
 
-    assert hasattr(obs, "_observer_body")
-    assert obs._observer_body == "earth"
-    assert str(obs) == "earth"
+    assert hasattr(obs, "object_name")
+    assert obs.object_name == "earth"
+    assert str(obs) == "<HeliographicStonyhurst Coordinate for 'earth'>"
 
     # Test get
     obstime = "2013-04-01"
@@ -135,7 +135,7 @@ def test_coord_get():
 
     assert hasattr(obs, "_observer_body")
     assert obs._observer_body == "mars"
-    assert str(obs) == "mars"
+    assert str(obs) == "<HeliographicStonyhurst Coordinate for 'mars'>"
 
 
 def test_default_hcc_observer():

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -133,8 +133,8 @@ def test_coord_get():
     assert_quantity_allclose(obs.lat, mars.lat)
     assert_quantity_allclose(obs.radius, mars.radius)
 
-    assert hasattr(obs, "_observer_body")
-    assert obs._observer_body == "mars"
+    assert hasattr(obs, "object_name")
+    assert obs.object_name == "mars"
     assert str(obs) == "<HeliographicStonyhurst Coordinate for 'mars'>"
 
 

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -141,8 +141,7 @@ def solar_rotate_coordinate(coordinate,
     >>> obstime = '2010-09-10 12:34:56'
     >>> c = SkyCoord(-570*u.arcsec, 120*u.arcsec, obstime=obstime, observer=get_earth(obstime), frame=frames.Helioprojective)
     >>> solar_rotate_coordinate(c, '2010-09-10 13:34:56')
-    <SkyCoord (Helioprojective: obstime=2010-09-10 13:34:56, rsun=695508.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2010-09-10 13:34:56): (lon, lat, radius) in (deg, deg, AU)
-        (0., 7.24822784, 1.00695436)>): (Tx, Ty, distance) in (arcsec, arcsec, km)
+    <SkyCoord (Helioprojective: obstime=2010-09-10 13:34:56, rsun=695508.0 km, observer=earth): (Tx, Ty, distance) in (arcsec, arcsec, km)
         (-562.37689548, 119.26840368, 1.50083152e+08)>
 
     """

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -137,11 +137,10 @@ def solar_rotate_coordinate(coordinate,
     >>> from astropy.coordinates import SkyCoord
     >>> from sunpy.coordinates import frames
     >>> from sunpy.physics.differential_rotation import solar_rotate_coordinate
-    >>> from sunpy.coordinates.ephemeris import get_earth
     >>> obstime = '2010-09-10 12:34:56'
-    >>> c = SkyCoord(-570*u.arcsec, 120*u.arcsec, obstime=obstime, observer=get_earth(obstime), frame=frames.Helioprojective)
+    >>> c = SkyCoord(-570*u.arcsec, 120*u.arcsec, obstime=obstime, observer="earth", frame=frames.Helioprojective)
     >>> solar_rotate_coordinate(c, '2010-09-10 13:34:56')
-    <SkyCoord (Helioprojective: obstime=2010-09-10 13:34:56, rsun=695508.0 km, observer=earth): (Tx, Ty, distance) in (arcsec, arcsec, km)
+    <SkyCoord (Helioprojective: obstime=2010-09-10 13:34:56, rsun=695508.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
         (-562.37689548, 119.26840368, 1.50083152e+08)>
 
     """


### PR DESCRIPTION
This fixes the issue raised by @tiagopereira in #2706 that the observer representation is very verbose when a more useful representation is "earth". This fixes that.