### PR TITLE
Raise error in hpc<->hcc when observer is not the same

### DIFF
--- a/changelog/2725.bugfix.rst
+++ b/changelog/2725.bugfix.rst
@@ -1,0 +1,1 @@
+Raise an error when transforming between HPC and HCC frames if the observer is not the same.

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -235,7 +235,6 @@ def test_hpc_to_hcc_different_observer():
     # defined by different observers.
     # NOTE: This test is currently expected to fail because the HCC<->HPC transformation does
     # not account for observer location. It will be updated once this is fixed.
-    rsun = 1*u.m
     D0 = 1*u.km
     L0 = 1*u.deg
     observer_1 = HeliographicStonyhurst(lat=0*u.deg, lon=0*u.deg, radius=D0)

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -3,7 +3,8 @@ import pytest
 
 import astropy.units as u
 from astropy.tests.helper import quantity_allclose, assert_quantity_allclose
-from astropy.coordinates import SkyCoord, get_body_barycentric, HeliocentricTrueEcliptic, Angle
+from astropy.coordinates import (SkyCoord, get_body_barycentric, HeliocentricTrueEcliptic, Angle,
+                                 ConvertError)
 from astropy.time import Time
 
 from sunpy.coordinates import (Helioprojective, HeliographicStonyhurst,
@@ -210,4 +211,37 @@ def test_hgs_cartesian_rep_to_hgc():
     assert_quantity_allclose(hgccoord_cart.lat, hgccoord_sph.lat)
     assert_quantity_allclose(hgccoord_cart.lon, hgccoord_sph.lon)
     assert_quantity_allclose(hgccoord_cart.radius, hgccoord_sph.radius)
-    
+
+
+def test_hcc_to_hpc_different_observer():
+    # This test checks transformation HCC->HPC in the case where the HCC and HPC frames are
+    # defined by different observers.
+    # NOTE: This test is currently expected tovfail because the HCC<->HPC transformation does 
+    # not account for observer location. It will be updated once this is fixed.
+    rsun = 1*u.m
+    D0 = 1*u.km
+    L0 = 1*u.deg
+    observer_1 = HeliographicStonyhurst(lat=0*u.deg, lon=0*u.deg, radius=D0)
+    observer_2 = HeliographicStonyhurst(lat=0*u.deg, lon=L0, radius=D0)
+    hcc_frame = Heliocentric(observer=observer_1)
+    hpc_frame = Helioprojective(observer=observer_2)
+    hcccoord = SkyCoord(x=rsun, y=rsun, z=rsun, frame=hcc_frame)
+    with pytest.raises(ConvertError):
+        hcccoord.transform_to(hpc_frame)
+
+
+def test_hpc_to_hcc_different_observer():
+    # This test checks transformation HPC->HCC in the case where the HCC and HPC frames are
+    # defined by different observers.
+    # NOTE: This test is currently expected to fail because the HCC<->HPC transformation does 
+    # not account for observer location. It will be updated once this is fixed.
+    rsun = 1*u.m
+    D0 = 1*u.km
+    L0 = 1*u.deg
+    observer_1 = HeliographicStonyhurst(lat=0*u.deg, lon=0*u.deg, radius=D0)
+    observer_2 = HeliographicStonyhurst(lat=0*u.deg, lon=L0, radius=D0)
+    hcc_frame = Heliocentric(observer=observer_1)
+    hpc_frame = Helioprojective(observer=observer_2)
+    hpccoord = SkyCoord(Tx=0*u.arcsec, Ty=0*u.arcsec, frame=hpc_frame)
+    with pytest.raises(ConvertError):
+        hpccoord.transform_to(hcc_frame)

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -74,9 +74,9 @@ def test_hpc_hpc_sc():
 
 
 def test_hpc_hpc_null():
-
-    hpc_in = Helioprojective(0*u.arcsec, 0*u.arcsec)
-    hpc_out = Helioprojective()
+    obstime = "2011-01-01"
+    hpc_in = Helioprojective(0*u.arcsec, 0*u.arcsec, obstime=obstime)
+    hpc_out = Helioprojective(obstime=obstime)
 
     hpc_new = hpc_in.transform_to(hpc_out)
 

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -216,7 +216,7 @@ def test_hgs_cartesian_rep_to_hgc():
 def test_hcc_to_hpc_different_observer():
     # This test checks transformation HCC->HPC in the case where the HCC and HPC frames are
     # defined by different observers.
-    # NOTE: This test is currently expected tovfail because the HCC<->HPC transformation does 
+    # NOTE: This test is currently expected to fail because the HCC<->HPC transformation does
     # not account for observer location. It will be updated once this is fixed.
     rsun = 1*u.m
     D0 = 1*u.km
@@ -233,7 +233,7 @@ def test_hcc_to_hpc_different_observer():
 def test_hpc_to_hcc_different_observer():
     # This test checks transformation HPC->HCC in the case where the HCC and HPC frames are
     # defined by different observers.
-    # NOTE: This test is currently expected to fail because the HCC<->HPC transformation does 
+    # NOTE: This test is currently expected to fail because the HCC<->HPC transformation does
     # not account for observer location. It will be updated once this is fixed.
     rsun = 1*u.m
     D0 = 1*u.km

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -56,6 +56,16 @@ def _carrington_offset(obstime):
     from .ephemeris import get_sun_L0
     return get_sun_L0(obstime)
 
+
+def _observers_are_equal(obs_1, obs_2):
+    if obs_1 == obs_2:
+        return True
+    else:
+        return (quantity_allclose(obs_1.lat, obs_2.lat) and
+                quantity_allclose(obs_1.lon, obs_2.lon) and
+                quantity_allclose(obs_1.radius, obs_2.radius))
+
+
 # =============================================================================
 # ------------------------- Transformation Framework --------------------------
 # =============================================================================
@@ -103,7 +113,7 @@ def hcc_to_hpc(helioccoord, heliopframe):
     """
     Convert from Heliocentic Cartesian to Helioprojective Cartesian.
     """
-    if helioccoord.observer != heliopframe.observer:
+    if not _observers_are_equal(helioccoord.observer, heliopframe.observer):
         raise ConvertError("Cannot directly transform heliocentric coordinates to "
                            "helioprojective coordinates for different "
                            "observers {} and {}. See discussion in this GH issue: "
@@ -134,7 +144,7 @@ def hpc_to_hcc(heliopcoord, heliocframe):
     """
     Convert from Helioprojective Cartesian to Heliocentric Cartesian.
     """
-    if heliopcoord.observer != heliocframe.observer:
+    if not _observers_are_equal(heliopcoord.observer, heliocframe.observer):
         raise ConvertError("Cannot directly transform helioprojective coordinates to "
                            "heliocentric coordinates for different "
                            "observers {} and {}. See discussion in this GH issue: "
@@ -240,7 +250,6 @@ def hgs_to_hcc(heliogcoord, heliocframe):
     return heliocframe.realize_frame(representation)
 
 
-
 @frame_transform_graph.transform(FunctionTransform, Helioprojective,
                                  Helioprojective)
 def hpc_to_hpc(heliopcoord, heliopframe):
@@ -248,10 +257,7 @@ def hpc_to_hpc(heliopcoord, heliopframe):
     This converts from HPC to HPC, with different observer location parameters.
     It does this by transforming through HGS.
     """
-    if (heliopcoord.observer == heliopframe.observer or
-        (quantity_allclose(heliopcoord.observer.lat, heliopframe.observer.lat) and
-         quantity_allclose(heliopcoord.observer.lon, heliopframe.observer.lon) and
-         quantity_allclose(heliopcoord.observer.radius, heliopframe.observer.radius))):
+    if _observers_are_equal(heliopcoord.observer, heliopframe.observer):
         return heliopframe.realize_frame(heliopcoord._data)
 
     if not isinstance(heliopframe.observer, BaseCoordinateFrame):

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -106,7 +106,8 @@ def hcc_to_hpc(helioccoord, heliopframe):
     if helioccoord.observer != heliopframe.observer:
         raise ConvertError("Cannot transform heliocentric coordinates to "
                            "helioprojective coordinates for different "
-                           "observers {} and {}".format(helioccoord.observer, heliopframe.observer))
+                           "observers {} and {}.".format(helioccoord.observer, heliopframe.observer)
+                           "Try converting to an intermediate heliographic stonyhurst frame.")
 
     x = helioccoord.x.to(u.m)
     y = helioccoord.y.to(u.m)
@@ -134,7 +135,8 @@ def hpc_to_hcc(heliopcoord, heliocframe):
     if heliopcoord.observer != heliocframe.observer:
         raise ConvertError("Cannot transform helioprojective coordinates to "
                            "heliocentric coordinates for different "
-                           "observers {} and {}".format(heliopcoord.observer, heliocframe.observer))
+                           "observers {} and {}".format(heliopcoord.observer, heliocframe.observer)
+                           "Try converting to an intermediate heliographic stonyhurst frame.")
 
     if not isinstance(heliopcoord.observer, BaseCoordinateFrame):
         raise ConvertError("Cannot transform helioprojective coordinates to "

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -104,10 +104,12 @@ def hcc_to_hpc(helioccoord, heliopframe):
     Convert from Heliocentic Cartesian to Helioprojective Cartesian.
     """
     if helioccoord.observer != heliopframe.observer:
-        raise ConvertError("Cannot transform heliocentric coordinates to "
+        raise ConvertError("Cannot directly transform heliocentric coordinates to "
                            "helioprojective coordinates for different "
-                           "observers {} and {}.".format(helioccoord.observer, heliopframe.observer)
-                           "Try converting to an intermediate heliographic stonyhurst frame.")
+                           "observers {} and {}. See discussion in this GH issue: "
+                           "https://github.com/sunpy/sunpy/issues/2712. Try converting to "
+                           "an intermediate heliographic Stonyhurst frame.".format(
+                               helioccoord.observer, heliopframe.observer))
 
     x = helioccoord.x.to(u.m)
     y = helioccoord.y.to(u.m)
@@ -133,10 +135,12 @@ def hpc_to_hcc(heliopcoord, heliocframe):
     Convert from Helioprojective Cartesian to Heliocentric Cartesian.
     """
     if heliopcoord.observer != heliocframe.observer:
-        raise ConvertError("Cannot transform helioprojective coordinates to "
+        raise ConvertError("Cannot directly transform helioprojective coordinates to "
                            "heliocentric coordinates for different "
-                           "observers {} and {}".format(heliopcoord.observer, heliocframe.observer)
-                           "Try converting to an intermediate heliographic stonyhurst frame.")
+                           "observers {} and {}. See discussion in this GH issue: "
+                           "https://github.com/sunpy/sunpy/issues/2712. Try converting to "
+                           "an intermediate heliographic Stonyhurst frame.".format(
+                               heliopcoord.observer, heliocframe.observer))
 
     if not isinstance(heliopcoord.observer, BaseCoordinateFrame):
         raise ConvertError("Cannot transform helioprojective coordinates to "

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -103,6 +103,10 @@ def hcc_to_hpc(helioccoord, heliopframe):
     """
     Convert from Heliocentic Cartesian to Helioprojective Cartesian.
     """
+    if helioccoord.observer != heliopframe.observer:
+        raise ConvertError("Cannot transform heliocentric coordinates to "
+                           "helioprojective coordinates for different "
+                           "observers {} and {}".format(helioccoord.observer, heliopframe.observer))
 
     x = helioccoord.x.to(u.m)
     y = helioccoord.y.to(u.m)
@@ -127,6 +131,11 @@ def hpc_to_hcc(heliopcoord, heliocframe):
     """
     Convert from Helioprojective Cartesian to Heliocentric Cartesian.
     """
+    if heliopcoord.observer != heliocframe.observer:
+        raise ConvertError("Cannot transform helioprojective coordinates to "
+                           "heliocentric coordinates for different "
+                           "observers {} and {}".format(heliopcoord.observer, heliocframe.observer))
+
     if not isinstance(heliopcoord.observer, BaseCoordinateFrame):
         raise ConvertError("Cannot transform helioprojective coordinates to "
                            "heliocentric coordinates for observer '{}' "

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -58,12 +58,12 @@ def _carrington_offset(obstime):
 
 
 def _observers_are_equal(obs_1, obs_2):
-    if obs_1 == obs_2:
-        return True
-    else:
-        return (quantity_allclose(obs_1.lat, obs_2.lat) and
-                quantity_allclose(obs_1.lon, obs_2.lon) and
-                quantity_allclose(obs_1.radius, obs_2.radius))
+    if not (isinstance(obs_1, BaseCoordinateFrame) and isinstance(obs_2, BaseCoordinateFrame)):
+        raise ValueError("To compare two observers, both must be instances of BaseCoordinateFrame. "
+                         "Cannot compare two observers {} and {}.".format(obs_1, obs_2))
+    return (quantity_allclose(obs_1.lat, obs_2.lat) and
+            quantity_allclose(obs_1.lon, obs_2.lon) and
+            quantity_allclose(obs_1.radius, obs_2.radius))
 
 
 # =============================================================================


### PR DESCRIPTION
Temporary fix for #2712 until a proper solution is implemented. Raise error so that we aren't just failing silently.