### PR TITLE
Revert disallowing a no-op HPC<>HPC transformation without obstime

### DIFF
--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -74,9 +74,8 @@ def test_hpc_hpc_sc():
 
 
 def test_hpc_hpc_null():
-    obstime = "2011-01-01"
-    hpc_in = Helioprojective(0*u.arcsec, 0*u.arcsec, obstime=obstime)
-    hpc_out = Helioprojective(obstime=obstime)
+    hpc_in = Helioprojective(0*u.arcsec, 0*u.arcsec)
+    hpc_out = Helioprojective()
 
     hpc_new = hpc_in.transform_to(hpc_out)
 

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -57,7 +57,10 @@ def _carrington_offset(obstime):
     return get_sun_L0(obstime)
 
 
-def _observers_are_equal(obs_1, obs_2):
+def _observers_are_equal(obs_1, obs_2, string_ok=False):
+    if string_ok:
+        if obs_1 == obs_2:
+            return True
     if not (isinstance(obs_1, BaseCoordinateFrame) and isinstance(obs_2, BaseCoordinateFrame)):
         raise ValueError("To compare two observers, both must be instances of BaseCoordinateFrame. "
                          "Cannot compare two observers {} and {}.".format(obs_1, obs_2))
@@ -257,7 +260,7 @@ def hpc_to_hpc(heliopcoord, heliopframe):
     This converts from HPC to HPC, with different observer location parameters.
     It does this by transforming through HGS.
     """
-    if _observers_are_equal(heliopcoord.observer, heliopframe.observer):
+    if _observers_are_equal(heliopcoord.observer, heliopframe.observer, string_ok=True):
         return heliopframe.realize_frame(heliopcoord._data)
 
     if not isinstance(heliopframe.observer, BaseCoordinateFrame):


### PR DESCRIPTION
On second thougts it dosen't actually make any sense to allow a noop transfrom with obstime if we are not allowing it without obstime. Appart from anything else, this breaks doing a `frame.transform_to` blindly to make sure your frame is what you expect it to be.