### PR TITLE
Do not attempt to save comments to FITS if Card is missing

### DIFF
--- a/changelog/2748.bugfix.rst
+++ b/changelog/2748.bugfix.rst
@@ -1,0 +1,1 @@
+Do not attempt to save a FITS header comment for a keyword which is not in the header. This prevents an error on saving some maps after the metadata had been modified but not the comments.

--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -196,7 +196,9 @@ def write(fname, data, header, **kwargs):
 
     if isinstance(key_comments, dict):
         for k, v in key_comments.items():
-            fits_header.comments[k] = v
+            # Check that the Card for the comment exists before trying to write to it.
+            if k in fits_header:
+                fits_header.comments[k] = v
     elif key_comments:
         raise TypeError("KEYCOMMENTS must be a dictionary")
 

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -81,3 +81,18 @@ def test_extract_waveunit_wavelnthcomment_parentheses():
     # WAVELNTH comment is: "Observed wavelength (nm)"
     waveunit = extract_waveunit(get_header(SVSM_IMAGE)[0])
     assert waveunit == 'nm'
+
+
+def test_simple_write(tmpdir):
+    data, header = sunpy.io.fits.read(AIA_171_IMAGE)[0]
+    outfile = tmpdir / "test.fits"
+    sunpy.io.fits.write(str(outfile), data, header)
+    assert outfile.exists()
+
+
+def test_extra_comment_write(tmpdir):
+    data, header = sunpy.io.fits.read(AIA_171_IMAGE)[0]
+    header["KEYCOMMENTS"]["TEST"] = "Hello world"
+    outfile = tmpdir / "test.fits"
+    sunpy.io.fits.write(str(outfile), data, header)
+    assert outfile.exists()


### PR DESCRIPTION
This was happening when a keyword was deleted from the header without deleting the corresponding comment.

Fixes #2738 