### PR TITLE
Aiaprep fix

### DIFF
--- a/changelog/2749.bugfix.rst
+++ b/changelog/2749.bugfix.rst
@@ -1,0 +1,1 @@
+Add support for `HMIMap` objects as input to `sunpy.instr.aia.aiaprep()`.

--- a/sunpy/instr/aia.py
+++ b/sunpy/instr/aia.py
@@ -5,7 +5,7 @@ Provides processing routines for data captured with the AIA instrument on SDO.
 import numpy as np
 import astropy.units as u
 
-from sunpy.map.sources.sdo import AIAMap
+from sunpy.map.sources.sdo import AIAMap, HMIMap
 
 __all__ = ['aiaprep']
 
@@ -42,7 +42,7 @@ def aiaprep(aiamap):
     therefore differ from the original file.
     """
 
-    if not isinstance(aiamap, AIAMap):
+    if not isinstance(aiamap, (AIAMap, HMIMap)):
         raise ValueError("Input must be an AIAMap")
 
     # Target scale is 0.6 arcsec/pixel, but this needs to be adjusted if the map

--- a/sunpy/instr/tests/test_aia.py
+++ b/sunpy/instr/tests/test_aia.py
@@ -13,9 +13,11 @@ from sunpy.instr.aia import aiaprep
 # functions
 
 
-@pytest.fixture
-def original():
-    return sunpy.map.Map(test.get_test_filepath("aia_171_level1.fits"))
+@pytest.fixture(scope="module",
+                params=[test.get_test_filepath("aia_171_level1.fits"),
+                        test.get_test_filepath("resampled_hmi.fits")])
+def original(request):
+    return sunpy.map.Map(request.param)
 
 
 @pytest.fixture


### PR DESCRIPTION
Allow `aiaprep()` to take a HMI map as input, plus associated test. Wasn't sure what the 'correct' HMI file for this purpose would be so I used the only one I had locally in the test data folder with 'hmi' in the name. Happy to change it to a better file if there is one.

When I find some time (hopefully soon) I'll change the name of the function to reflect this change but I wanted to get this PR'd so people can start using it.

Closes #2747 