### PR TITLE
[0.9] Helioviewer default file type change

### DIFF
--- a/changelog/2761.bugfix.rst
+++ b/changelog/2761.bugfix.rst
@@ -1,0 +1,1 @@
+Changed default file type for Helioviewer to prevent decode errors.

--- a/sunpy/net/helioviewer.py
+++ b/sunpy/net/helioviewer.py
@@ -208,6 +208,7 @@ class HelioviewerClient(object):
         >>> hv = HelioviewerClient()  # doctest: +REMOTE_DATA
         >>> file = hv.download_png('2012/07/16 10:08:00', 2.4, "[SDO,AIA,AIA,171,1,100]", x0=0, y0=0, width=1024, height=1024)   # doctest: +REMOTE_DATA
         >>> file = hv.download_png('2012/07/16 10:08:00', 4.8, "[SDO,AIA,AIA,171,1,100],[SOHO,LASCO,C2,white-light,1,100]", x1=-2800, x2=2800, y1=-2800, y2=2800)   # doctest: +REMOTE_DATA
+        >>> file = hv.download_jp2(datetime.datetime.now(), observatory='SDO', instrument='HMI', detector='HMI', measurement='continuum')   # doctest: +REMOTE_DATA
         """
         params = {
             "action": "takeScreenshot",

--- a/sunpy/util/net.py
+++ b/sunpy/util/net.py
@@ -78,7 +78,7 @@ def get_filename(sock, url):
     return six.text_type(name)
 
 
-def get_system_filename(sock, url, default=u"file"):
+def get_system_filename(sock, url, default=b"file"):
     """ Get filename from given urllib2.urlopen object and URL.
     First, attempts to extract Content-Disposition, second, extract
     from URL, eventually fall back to default. Returns bytestring
@@ -89,7 +89,7 @@ def get_system_filename(sock, url, default=u"file"):
     return name.encode(sys.getfilesystemencoding(), 'ignore')
 
 
-def get_system_filename_slugify(sock, url, default=u"file"):
+def get_system_filename_slugify(sock, url, default=b"file"):
     """ Get filename from given urllib2.urlopen object and URL.
     First, attempts to extract Content-Disposition, second, extract
     from URL, eventually fall back to default. Returns bytestring
@@ -98,7 +98,7 @@ def get_system_filename_slugify(sock, url, default=u"file"):
     return slugify(get_system_filename(sock, url, default))
 
 
-def download_file(url, directory, default=u'file', overwrite=False):
+def download_file(url, directory, default=b"file", overwrite=False):
     """ Download file from url into directory. Try to get filename from
     Content-Disposition header, otherwise get from path of url. Fall
     back to default if both fail. Only overwrite existing files when
@@ -111,7 +111,7 @@ def download_file(url, directory, default=u'file', overwrite=False):
     return path
 
 
-def download_fileobj(opn, directory, url='', default=u"file", overwrite=False):
+def download_fileobj(opn, directory, url='', default=b"file", overwrite=False):
     """ Download file from url into directory. Try to get filename from
     Content-Disposition header, otherwise get from path of url if given.
     Fall back to default if both fail. Only overwrite existing files when


### PR DESCRIPTION
To address #2760.

It seems that because `default=u'file'`, when name is not returned it tries to decode a `str` which is correct. 

Honestly, I am not sure if this is the best fix but it seems to not fail anymore for me. 
Because of this, I was not planning to submit this to master but just the 0.9 branch. 