### PR TITLE
Make sure package does not import itself during setup

### DIFF
--- a/sunpy/__init__.py
+++ b/sunpy/__init__.py
@@ -21,14 +21,21 @@ try:
 except ImportError:
     __githash__ = ''
 
-import os
-from sunpy.util.config import load_config, print_config
-from sunpy.util import system_info
-from sunpy.tests.runner import SunPyTestRunner
+try:
+    _ASTROPY_SETUP_
+except NameError:
+    _ASTROPY_SETUP_ = False
 
-self_test = SunPyTestRunner.make_test_runner_in(os.path.dirname(__file__))
 
-# Load user configuration
-config = load_config()
+if not _ASTROPY_SETUP_:
+    import os
+    from sunpy.util.config import load_config, print_config
+    from sunpy.util import system_info
+    from sunpy.tests.runner import SunPyTestRunner
 
-__all__ = ['config', 'self_test', 'system_info']
+    self_test = SunPyTestRunner.make_test_runner_in(os.path.dirname(__file__))
+
+    # Load user configuration
+    config = load_config()
+
+    __all__ = ['config', 'self_test', 'system_info']


### PR DESCRIPTION
This bug came up during a discussion with @Cadair while we were trying to test `egg_info` in a completely clean environment. More on that later.

This is only a problem when running `setup.py` for the very first time in a completely clean environment, which is why most users/developers never notice it. It also has the curious property of not affecting release builds (where `.dev` is not in the version string), which is why it doesn't affect users who install the package using `pip` or `conda`.