### PR TITLE
Fix deprecation warning for SafeConfigParser

### DIFF
--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -15,7 +15,7 @@ def load_config():
     Read the sunpyrc configuration file. If one does not exists in the user's
     home directory then read in the defaults from module
     """
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
 
     # Get locations of SunPy configuration files to be loaded
     config_files = _find_config_files()


### PR DESCRIPTION
Fixes the following warning:

```
/home/travis/miniconda/envs/testenv/lib/python3.6/site-packages/sunpy/util/config.py:18: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  config = configparser.SafeConfigParser()
```