### PR TITLE
Fix Slicing a JSOC UnifiedResponse

### DIFF
--- a/changelog/2796.bugfix.rst
+++ b/changelog/2796.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the slicing a JSOC UnifiedResponse object. This bug was that when slice a Unifiedresponse this not saved the query_args attribute.

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -40,10 +40,24 @@ class JSOCResponse(Sequence):
         """
         table : `astropy.table.Table`
         """
-
-        self.table = table
-        self.query_args = None
-        self.requests = None
+        if isinstance(table, list):
+            # fido_factory._handle_record_slice
+            # will return a list containing the
+            # response that has been indexed,
+            # so we have to remove that.
+            new_table = table[0]
+            if isinstance(new_table, type(self)):
+                self.table = new_table.table
+                self.query_args = new_table.query_args
+                self.requests = new_table.requests
+            else:
+                self.table = table
+                self.query_args = None
+                self.requests = None
+        else:
+            self.table = table
+            self.query_args = None
+            self.requests = None
 
     def __str__(self):
         return str(self.table)
@@ -61,7 +75,10 @@ class JSOCResponse(Sequence):
             return len(self.table)
 
     def __getitem__(self, item):
-        return type(self)(self.table[item])
+        resp = type(self)(self.table[item])
+        resp.query_args = self.query_args
+        resp.requests = self.requests
+        return resp
 
     def __iter__(self):
         return (t for t in [self])

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -314,3 +314,15 @@ def test_repr(query):
         else:
             assert "Provider" not in rep_meth()
             assert "Providers" in rep_meth()
+
+
+@pytest.mark.remote_data
+def test_slicing_JSOC():
+    tstart = '2011/06/07 06:32:45'
+    tend = '2011/06/07 06:33:15'
+    res = Fido.search(a.Time(tstart, tend), a.jsoc.Series('hmi.M_45s'),
+                      a.jsoc.Notify('jsoc@cadair.com'))
+    result = Fido.fetch(res[0, 0])
+    assert isinstance(result, list)
+    assert result[0].endswith('hmi.m_45s.20110607_063300_TAI.2.magnetogram.fits')
+    assert result[1].endswith('hmi.m_45s.20110607_063345_TAI.2.magnetogram.fits')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
The problem reported on issue #2781  is because, when slice a JSOC UnifiedResponse:

`_handle_record_slice(...)`

the query_args is not set.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #2781 
