### PR TITLE
Changed "online" mark to "remote_data" and updated formatting

### DIFF
--- a/docs/dev_guide/tests.rst
+++ b/docs/dev_guide/tests.rst
@@ -40,7 +40,7 @@ have corresponding test modules `test_xml.py` and `test_multimethod.py` in
 
 There are some tests for functions and methods in SunPy that require a
 working connection to the internet. pytest is configured in a way that it
-iterates over all tests that have been marked as *online* and checks if
+iterates over all tests that have been marked as `pytest.mark.remote_data` and checks if
 there is an established connection to the internet. If there is none, the
 test is skipped, otherwise it is run. Marking tests is pretty
 straightforward in pytest: use the decorator ``@pytest.mark.remote_data`` to
@@ -92,7 +92,7 @@ the module on the command line, e.g.::
 for the tests for `sunpy.util.xml`.
 
 To run only tests that been marked with a specific pytest mark using the
-decorator ``@pytest.mark`` (see the section *Writing a unit test*), use the
+decorator ``@pytest.mark.MARK`` (see the section *Writing a unit test*), use the
 following command (where ``MARK`` is the name of the mark)::
 
   py.test -k MARK
@@ -102,9 +102,9 @@ code (where ``MARK`` is the name of the mark)::
 
   py.test -k-MARK
 
-Note that pytest is configured to skip all tests with the mark *online* if
+Note that pytest is configured to skip all tests with the mark `pytest.mark.remote_data` if
 there is no connection to the internet. This cannot be circumvented, i.e.
-it cannot be forced to run a test with the mark *online* if there is no
+pytest cannot be forced to run a test with the mark `pytest.mark.remote_data` if there is no
 working internet connection (rename the mark to something else to call the test
 function anyway).
 


### PR DESCRIPTION
As requested by @dpshelio in sunpy/sunpy#2620

Format update makes remote_data mark consistent with figure mark

<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
