### PR TITLE
pin numpy for doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ docs-install: &docs-install
   name: Install Python dependencies
   command: |
     pip install -r requirements/docs.txt
+    pip install -U numpy==1.15.2
 
 image-conda-run: &image-conda-install
   name: Install Python dependencies for figure tests


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Numpy currently breaks EVERYTHING. The version is pinned in ci-helpers but not for docs. 
