### PR TITLE
A dependency cleanup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ extra_requires = database, image, jpeg2000, net, tests, docs
 database_requires = sqlalchemy
 image_requires = scikit-image
 jpeg2000_requires = glymur
-net_requires = drms, suds-jurko, beautifulsoup4, requests, python-dateutil
+net_requires = drms, suds-jurko, beautifulsoup4, python-dateutil
 tests_requires = pytest, pytest-cov, pytest-mock, mock, hypothesis, pytest-astropy, pytest-rerunfailures
 docs_requires = ruamel.yaml, sphinx, sunpy-sphinx-theme, sphinx-gallery, sphinx-astropy, towncrier
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -13,7 +13,6 @@ import re
 import os
 import sys
 import logging
-import requests
 import warnings
 import socket
 import itertools
@@ -22,6 +21,8 @@ from datetime import datetime, timedelta
 from functools import partial
 from collections import defaultdict
 from suds import client, TypeNotFound
+from urllib.error import URLError, HTTPError
+from urllib.request import urlopen
 
 import astropy.units as u
 from astropy.table import QTable as Table
@@ -97,8 +98,8 @@ def iter_errors(response):
 
 def check_connection(url):
     try:
-        return requests.get(url).status_code == 200
-    except (socket.error, socket.timeout) as e:
+        return urlopen(url).getcode() == 200
+    except (socket.error, socket.timeout, HTTPError, URLError) as e:
         warnings.warn(
             "Connection failed with error {}. \n Retrying with different url and port.".format(e))
 

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -1,17 +1,15 @@
 import datetime
-from copy import deepcopy
 import warnings
+from copy import deepcopy
 from itertools import product
 
 import numpy as np
-from skimage import transform
+
 from astropy import units as u
 from astropy.coordinates import SkyCoord, Longitude
 
-import sunpy.map
 from sunpy.time import parse_time
-from sunpy.coordinates import frames, HeliographicStonyhurst
-from sunpy.image.util import to_norm, un_norm
+from sunpy.coordinates import HeliographicStonyhurst, frames
 
 __all__ = ['diff_rot', 'solar_rotate_coordinate', 'diffrot_map']
 
@@ -256,6 +254,12 @@ def diffrot_map(smap, time=None, dt=None, pad=False, **diffrot_kwargs):
         A map with the result of applying solar differential rotation to the
         input map.
     """
+    # Only this function needs scikit image
+    from skimage import transform
+    from sunpy.image.util import to_norm, un_norm
+    # Import map here for performance reasons.
+    import sunpy.map
+
     if (time is not None) and (dt is not None):
         raise ValueError('Only a time or an interval is accepted')
     elif not (time or dt):

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -138,22 +138,27 @@ def convert_time(time_string, **kwargs):
     raise ValueError("'{tstr!s}' is not a valid time string!".format(tstr=time_string))
 
 
-@convert_time.register(pandas.Timestamp)
-def convert_time_pandasTimestamp(time_string, **kwargs):
-    return time_string.to_pydatetime()
+# Only register pandas if we can import pandas
+try:
+    import pandas
 
+    @convert_time.register(pandas.Timestamp)
+    def convert_time_pandasTimestamp(time_string, **kwargs):
+        return time_string.to_pydatetime()
 
-@convert_time.register(pandas.Series)
-def convert_time_pandasSeries(time_string, **kwargs):
-    if 'datetime64' in str(time_string.dtype):
-        return np.array([dt.to_pydatetime() for dt in time_string])
-    else:
-        convert_time.dispatch(object)(time_string, **kwargs)
+    @convert_time.register(pandas.Series)
+    def convert_time_pandasSeries(time_string, **kwargs):
+        if 'datetime64' in str(time_string.dtype):
+            return np.array([dt.to_pydatetime() for dt in time_string])
+        else:
+            convert_time.dispatch(object)(time_string, **kwargs)
 
+    @convert_time.register(pandas.DatetimeIndex)
+    def convert_time_pandasDatetimeIndex(time_string, **kwargs):
+        return time_string._mpl_repr()
 
-@convert_time.register(pandas.DatetimeIndex)
-def convert_time_pandasDatetimeIndex(time_string, **kwargs):
-    return time_string._mpl_repr()
+except ImportError:
+    pass
 
 
 @convert_time.register(datetime)

--- a/sunpy/util/sysinfo.py
+++ b/sunpy/util/sysinfo.py
@@ -69,7 +69,7 @@ def get_sys_dict():
     except ImportError:
         sqlalchemy_version = "NOT INSTALLED"
 
-        sys_prop = {
+    sys_prop = {
             'Time': datetime.datetime.utcnow().strftime("%A, %d. %B %Y %I:%M%p UT"),
             'System': platform.system(),
             'Processor': platform.processor(),

--- a/sunpy/util/sysinfo.py
+++ b/sunpy/util/sysinfo.py
@@ -1,9 +1,7 @@
 import platform
 import datetime
 
-
 __all__ = ['get_sys_dict', 'system_info']
-
 
 
 def get_sys_dict():
@@ -71,24 +69,27 @@ def get_sys_dict():
     except ImportError:
         sqlalchemy_version = "NOT INSTALLED"
 
-    try:
-        from requests import __version__ as requests_version
-    except ImportError:
-        requests_version = "NOT INSTALLED"
+        sys_prop = {
+            'Time': datetime.datetime.utcnow().strftime("%A, %d. %B %Y %I:%M%p UT"),
+            'System': platform.system(),
+            'Processor': platform.processor(),
+            'SunPy': sunpy_version,
+            'SunPy_git': sunpy_git_description,
+            'Arch': platform.architecture()[0],
+            "Python": platform.python_version(),
+            'NumPy': numpy_version,
+            'SciPy': scipy_version,
+            'matplotlib': matplotlib_version,
+            'Astropy': astropy_version,
+            'Pandas': pandas_version,
+            'beautifulsoup': bs4_version,
+            'PyQt': pyqt_version,
+            'SUDS': suds_version,
+            'Sqlalchemy': sqlalchemy_version,
+        }
 
-
-
-    sys_prop = {'Time':datetime.datetime.utcnow().strftime("%A, %d. %B %Y %I:%M%p UT"),
-                'System':platform.system(), 'Processor':platform.processor(),
-                'SunPy':sunpy_version, 'SunPy_git':sunpy_git_description,
-                'Arch':platform.architecture()[0], "Python":platform.python_version(),
-                'NumPy':numpy_version,
-                'SciPy':scipy_version, 'matplotlib':matplotlib_version,
-                'Astropy':astropy_version, 'Pandas':pandas_version,
-                'beautifulsoup':bs4_version, 'PyQt':pyqt_version,
-                'SUDS':suds_version, 'Sqlalchemy':sqlalchemy_version, 'Requests':requests_version
-                }
     return sys_prop
+
 
 def system_info():
     """
@@ -97,13 +98,12 @@ def system_info():
     """
     sys_prop = get_sys_dict()
 
-# title
+    # title
     print("==========================================================")
     print(" SunPy Installation Information\n")
     print("==========================================================\n")
 
-
-# general properties
+    # general properties
     print("###########")
     print(" General")
     print("###########")
@@ -118,28 +118,26 @@ def system_info():
     elif sys_prop['System'] == "Darwin":
         print("OS: Mac OS X {0} ({1})".format(platform.mac_ver()[0], sys_prop['Processor']))
     elif sys_prop['System'] == "Windows":
-        print("OS: Windows {0} {1} ({2})".format(platform.release(),
-                                                 platform.version(), sys_prop['Processor']))
+        print("OS: Windows {0} {1} ({2})".format(platform.release(), platform.version(),
+                                                 sys_prop['Processor']))
     else:
         print("Unknown OS ({0})".format(sys_prop['Processor']))
 
     print("\n")
-# required libraries
+    # required libraries
     print("###########")
     print(" Required Libraries ")
     print("###########")
 
-    for sys_info in ['Python', 'NumPy', 'SciPy',
-              'matplotlib', 'Astropy', 'Pandas']:
+    for sys_info in ['Python', 'NumPy', 'SciPy', 'matplotlib', 'Astropy', 'Pandas']:
         print('{0}: {1}'.format(sys_info, sys_prop[sys_info]))
 
     print("\n")
 
-# recommended
+    # recommended
     print("###########")
     print(" Recommended Libraries ")
     print("###########")
 
-    for sys_info in ['beautifulsoup', 'PyQt', 'SUDS',
-                     'Sqlalchemy', 'Requests']:
+    for sys_info in ['beautifulsoup', 'PyQt', 'SUDS', 'Sqlalchemy']:
         print('{0}: {1}'.format(sys_info, sys_prop[sys_info]))


### PR DESCRIPTION
@dstansby @nabobalis and I have been having some conversations about the number of dependencies SunPy has and how as we get more packages relying on SunPy not all users might want all dependencies all the time.

I noticed that since #2188 was merged the only point we were using `requests` was for one very simple check in `vso.py` so I replaced that with a standard library version, which means we can drop requests completely as a sunpy dep.

Finally, I have taken the executive decision that we are going to start putting imports in functions! We shouldn't do this when we don't have to, but things that are optional dependancies should probably be imported inside functions if they are in files which have a lot of functionality which do not use the optional dep and only one that does. I have also done the same thing with `sunpy.map` in a few places, because `sunpy.map` takes a *long* time to import, so it makes sense to delay pulling in all that until it's actually needed.

I am very open to discussion and debate on any of this, and in fact am fully expecting it :stuck_out_tongue: 

**Update: I decided to move the Rhessi stuff into it's own PR. #2808**