### PR TITLE
DOC: Add missing plot to end of units and coordinates guide

### DIFF
--- a/changelog/2813.doc.rst
+++ b/changelog/2813.doc.rst
@@ -1,0 +1,1 @@
+Add a missing plot to the end of the units and coordinates guide.

--- a/docs/guide/units-coordinates.rst
+++ b/docs/guide/units-coordinates.rst
@@ -199,34 +199,39 @@ one observer to a coordinate seen by another::
 Using Coordinates with SunPy Map
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-SunPy Map uses coordinates to specify locations on the image, and to plot
-overlays on plots of maps. When a Map is created, a coordinate frame is
-constructed from the header information. This can be accessed using
-``.coordinate_frame``::
+.. plot::
+   :include-source:
 
-  >>> import sunpy.map
-  >>> from sunpy.data.sample import AIA_171_IMAGE  # doctest: +REMOTE_DATA
-  >>> m = sunpy.map.Map(AIA_171_IMAGE) # doctest: +REMOTE_DATA
-  >>> m.coordinate_frame  # doctest: +REMOTE_DATA
-    <Helioprojective Frame (obstime=2011-06-07 06:33:02.770000, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07 06:33:02.770000): (lon, lat, radius) in (deg, deg, m)
-        (0., 0.048591, 1.51846026e+11)>)>
+   SunPy Map uses coordinates to specify locations on the image, and to plot
+   overlays on plots of maps. When a Map is created, a coordinate frame is
+   constructed from the header information. This can be accessed using
+   ``.coordinate_frame``:
 
-This can be used when creating a `~astropy.coordinates.SkyCoord` object to set
-the coordinate system to that image::
+   >>> import sunpy.map
+   >>> from sunpy.data.sample import AIA_171_IMAGE
+   >>> m = sunpy.map.Map(AIA_171_IMAGE)
+   >>> m.coordinate_frame
+     <Helioprojective Frame (obstime=2011-06-07 06:33:02.770000, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07 06:33:02.770000): (lon, lat, radius) in (deg, deg, m)
+         (0., 0.048591, 1.51846026e+11)>)>
 
-  >>> SkyCoord(100 * u.arcsec, 10*u.arcsec, frame=m.coordinate_frame) # doctest: +REMOTE_DATA
-  <SkyCoord (Helioprojective: obstime=2011-06-07 06:33:02.770000, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07 06:33:02.770000): (lon, lat, radius) in (deg, deg, m)
-      (0., 0.048591, 1.51846026e+11)>): (Tx, Ty) in arcsec
-      (100., 10.)>
+   This can be used when creating a `~astropy.coordinates.SkyCoord` object to set
+   the coordinate system to that image:
 
-This `~astropy.coordinates.SkyCoord` object could then be used to plot a point
-on top of the map::
+   >>> from astropy.coordinates import SkyCoord
+   >>> import astropy.units as u
+   >>> c = SkyCoord(100 * u.arcsec, 10*u.arcsec, frame=m.coordinate_frame)
+   >>> c
+   <SkyCoord (Helioprojective: obstime=2011-06-07 06:33:02.770000, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07 06:33:02.770000): (lon, lat, radius) in (deg, deg, m)
+       (0., 0.048591, 1.51846026e+11)>): (Tx, Ty) in arcsec
+       (100., 10.)>
 
-  >>> import matplotlib.pyplot as plt
+   This `~astropy.coordinates.SkyCoord` object could then be used to plot a point
+   on top of the map:
 
-  >>> ax = plt.subplot(projection=m)  # doctest: +REMOTE_DATA
-  >>> m.plot()  # doctest: +SKIP
-  >>> ax.plot_coord(c, 'o')  # doctest: +SKIP
+   >>> import matplotlib.pyplot as plt
+   >>> ax = plt.subplot(projection=m)
+   >>> m.plot()
+   >>> ax.plot_coord(c, 'o')
 
 For more information on coordinates see :ref:`sunpy-coordinates` section of
 the :ref:`reference`.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

Adds a missing plot to the end of the units and coordinates guide in the documentation. The section now renders like this:

<img width="390" alt="screen shot 2018-10-27 at 6 05 03 pm" src="https://user-images.githubusercontent.com/1847232/47610870-a0656200-da14-11e8-9969-f4d2bb5f70e8.png">

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #2756