### PR TITLE
Remove warning from GenericMap.submap when using pixel Quantities

### DIFF
--- a/changelog/2833.trivial.rst
+++ b/changelog/2833.trivial.rst
@@ -1,0 +1,1 @@
+Remove warning from ``GenericMap.submap`` when using pixel ``Quantities`` as input.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1289,11 +1289,7 @@ class GenericMap(NDData):
             y_pixels[1] = np.floor(y_pixels[1] + 1)
 
         elif (isinstance(bottom_left, u.Quantity) and bottom_left.unit.is_equivalent(u.pix) and
-              isinstance(top_right, u.Quantity) and bottom_left.unit.is_equivalent(u.pix)):
-
-            warnings.warn("GenericMap.submap now takes pixel values as `bottom_left`"
-                          " and `top_right` not `range_a` and `range_b`", Warning)
-
+              isinstance(top_right, u.Quantity) and top_right.unit.is_equivalent(u.pix)):
             x_pixels = u.Quantity([bottom_left[0], top_right[0]]).value
             y_pixels = u.Quantity([top_right[1], bottom_left[1]]).value
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

Removes warning from `GenericMap.submap` when using pixel `Quantities` as input.

The warning was added in sunpy 0.8.0 to make users aware of the change from `range_a`/`range_b` to `bottom_left`/`top_right` when using pixel `Quantities` as input. `GenericMap.submap` has had this new API in place for awhile now, so it's probably safe to remove the "change in behavior" warning.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #2578