### PR TITLE
Tox our CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,25 +8,18 @@ apt-run: &apt-install
     apt update
     apt install -y graphviz build-essential
 
-docs-install: &docs-install
-  name: Install Python dependencies
+tox-install: &tox-install
+  name: Install Tox
   command: |
-    pip install -r requirements/docs.txt
-    pip install -U numpy==1.15.2
-
-image-conda-run: &image-conda-install
-  name: Install Python dependencies for figure tests
-  command: |
-    conda env create -f sunpy/tests/figure_tests_env_py36.yml
+    pip install git+https://github.com/drdavella/tox-conda.git
+    pip install tox
 
 image-run: &image-tests
   name: Run image tests
   environment:
     MPLBACKEND: Agg
   command: |
-    conda env list
-    source activate sunpy-figure-tests-3.6
-    python setup.py test --figure-only --coverage
+    tox -e figure
     pip install codecov
     codecov
 
@@ -53,14 +46,13 @@ jobs:
       - checkout
       - run: *skip-check
       - run: *apt-install
-      - run: *image-conda-install
+      - run: *tox-install
       - run: *image-tests
       - store_artifacts:
           path: figure_test_images
       - run:
           name: "Image comparison page is available at:"
           command: FIGS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/figure_test_images/fig_comparison.html"; echo $FIGS_URL
-
 
   html-docs:
     docker:
@@ -72,8 +64,8 @@ jobs:
       - checkout
       - run: *skip-check
       - run: *apt-install
-      - run: *docs-install
-      - run: python setup.py build_docs -w
+      - run: *tox-install
+      - run: tox -e py37-build_docs
       - store_artifacts:
           path: docs/_build/html
 
@@ -85,7 +77,6 @@ jobs:
           key: sample-data-v1
           paths:
             - ~/sunpy/data/sample_data
-
 
 workflows:
   version: 2
@@ -102,7 +93,6 @@ workflows:
   test-documentation:
     jobs:
       - html-docs
-
 
 notify:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
     - TOX_ARG=''
 
 stages:
-  # Do the offline tests, it will not proceed if any fail
+  # Do the offline jobs, it will not proceed if any fail
   - name: "Initial jobs"
   # Do the rest of the jobs
   - name: "Comprehensive jobs"
-  # Cron only tests
+  # Cron only jobs
   - name: "Cron jobs"
     if: type = cron
 
@@ -56,15 +56,16 @@ matrix:
 
 before_install:
   - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+  # We do not want to create the test env
   - echo "" > ci-helpers/travis/setup_dependencies_common.sh
   - source ci-helpers/travis/setup_conda.sh
   - pip install git+https://github.com/drdavella/tox-conda
 
 script:
-  - tox -e $TOX_ENV $TOX_ARG
+  - tox -vv -e $TOX_ENV $TOX_ARG
 
 after_success:
-    - if [[ $TOX_ARG = *"cov"* ]]; then codecov; fi
+  - codecov
 
 after_failure:
     # Send a nice matrix notification if the Astropy-dev job fails

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,130 +1,73 @@
 language: generic
-
-os:
-    - linux
-
-stage: Initial tests
-
-# Setting sudo to false opts in to Travis-CI container-based builds.
+os: linux
+# Run jobs on container-based infrastructure, can be overridden per job
 sudo: false
-
-branches:
-  except:
-    - /^auto-backport-of-pr-[0-9]+$/
-
-# The apt packages below are needed but can no longer be installed with
-# sudo apt-get.
-addons:
-    apt:
-        packages:
-            - libatlas-dev
-            - liblapack-dev
-            - gfortran
-            - graphviz
-            - texlive-latex-extra
-            - dvipng
-            - httpie
 
 # Configure the build environment. Global variables are defined for all configurations.
 env:
-    global:
-        - COLUMNS=180
-        - PYTHON_VERSION=3.6
-        - PREVIOUS_NUMPY=1.14.5
-        - NUMPY_VERSION='stable'
-        - ASTROPY_VERSION='stable'
-        - MAIN_CMD='python setup.py'
-        - SETUP_CMD='test --coverage'
-        - CONDA_CHANNELS='sunpy'
-        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib pytest mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock lxml pyyaml pandas pytest-astropy suds-jurko glymur pytest-xdist dask drms sphinx-astropy pytest-cov hypothesis'
-        - PIP_DEPENDENCIES='pytest-rerunfailures sunpy-sphinx-theme pytest-sugar'
-        - EVENT_TYPE='push pull_request cron'
-        - MPLBACKEND='agg'
-        - JOB='test'
+  global:
+    - EVENT_TYPE='push pull_request cron'
+    - TOX_ARG=''
 
 stages:
-   # Do the install jobs and one offline test, it will not proceed if any fail
-   - name: Initial tests
-   # Cron only tests
-   - name: Cron tests
-     if: type = cron
-   # Do the rest of the tests
-   - name: Comprehensive tests
+  # Do the offline tests, it will not proceed if any fail
+  - name: "Initial jobs"
+  # Do the rest of the jobs
+  - name: "Comprehensive jobs"
+  # Cron only tests
+  - name: "Cron jobs"
+    if: type = cron
 
 matrix:
+  include:
+    - os: osx
+      name: "macOS 3.7 (py37-offline)"
+      env: TOX_ENV='py37-offline'
+      stage: "Initial jobs"
 
-    # Don't wait for allowed failures
-    fast_finish: true
+    - name: "3.6 offline (py36-offline)"
+      env: TOX_ENV='py36-offline'
+      stage: "Initial jobs"
 
-    include:
-         # We order the jobs, in terms of the maintainers mood
-         # Order of tests run in build stages
-         - python: 3.6
-           stage: Initial tests
+    - name: "3.7 online (py37-online)"
+      env:
+        - TOX_ENV='py37-online'
+        - TOX_ARG='-- -n=8'
+      stage: "Comprehensive jobs"
 
-         # We order the jobs, in terms of the maintainers mood
-         # Order of tests run in build stages
-         - python: 3.7
-           stage: Initial tests
-           env: PYTHON_VERSION=3.7
+    - name: "AstroPy dev (py37-astropydev)"
+      env:
+        - TOX_ENV='py37-astropydev'
+      addons:
+        apt:
+          packages:
+            - httpie
+      stage: "Cron jobs"
 
-         # Comprehensive tests below this line
-         # We run --online here because --online-only skips the doctests
-         - python: 3.7
-           stage: Comprehensive tests
-           env: SETUP_CMD="test --online --coverage --parallel 8" PYTHON_VERSION=3.7
+    - name: "NumPy dev (py37-numpydev)"
+      addons:
+        apt:
+          packages:
+            - gfortran
+            - libatlas-dev
+            - libatlas-base-dev
+      env: TOX_ENV='py37-numpydev'
+      stage: "Cron jobs"
 
-        # Cron tests below this line
-         - os: osx
-           stage: Cron tests
-           language: generic
-           env: PYTHON_VERSION=3.6
-
-         - python: 3.6
-           stage: Cron tests
-           env: ASTROPY_VERSION='dev'
-
-         - python: 3.6
-           stage: Cron tests
-           env: NUMPY_VERSION='dev'
-
-         - python: 3.6
-           stage: Cron tests
-           env: SETUP_CMD='test --figure-only' ASTROPY_VERSION='dev'
-                CONDA_DEPENDENCIES='astropy'
-
-         - python: 3.6
-           stage: Cron tests
-           # Pip Upstream checks
-           env: SETUP_CMD='test' CONDA_DEPENDENCIES='' PIP_DEPENDENCIES='' JOB='pip'
-
-install:
-    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda.sh
-
-before_script:
-    # Download the sample data for the online builds only.
-    - if [[ $SETUP_CMD == *online-only* ]] || [[ $SETUP_CMD == *remote-data* ]]; then python -m "sunpy.data.sample"; fi
-    - if [[ $SETUP_CMD == *--figure* ]]; then conda env create --file sunpy/tests/figure_tests_env_py36.yml; source activate sunpy-figure-tests-3.6; python -m "sunpy.data.sample"; fi
-    - if [[ $JOB == *pip* ]]; then pip install .[all]; fi
+before_install:
+  - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+  - echo "" > ci-helpers/travis/setup_dependencies_common.sh
+  - source ci-helpers/travis/setup_conda.sh
+  - pip install git+https://github.com/drdavella/tox-conda
 
 script:
-    - $MAIN_CMD $SETUP_CMD
+  - tox -e $TOX_ENV $TOX_ARG
 
 after_success:
-    - if [[ $SETUP_CMD = *"cov"* ]]; then pip install codecov; codecov; fi
+    - if [[ $TOX_ARG = *"cov"* ]]; then codecov; fi
 
 after_failure:
     # Send a nice matrix notification if the Astropy-dev job fails
     - NOTIF_TEXT='Build '$TRAVIS_BUILD_NUMBER' (Astropy-dev) Failed:'$TRAVIS_BUILD_WEB_URL
     - AVATAR_URL='https://s3-eu-west-1.amazonaws.com/cadair.com/Tessa-pride.png'
-    - if [[ -n "$NOTIFURL" && $ASTROPY_VERSION == *dev* ]]; then http --verify=no POST $NOTIFURL displayName="Travis Bot" avatarUrl="$AVATAR_URL" text="$NOTIF_TEXT"; fi
-
-# Notify the IRC channel of build status
-notifications:
-  webhooks:
-    urls:
-      - "https://scalar.vector.im/api/neb/services/hooks/dHJhdmlzLWNpLyU0MENhZGFpciUzQW1hdHJpeC5vcmcvJTIxTWVSZEZwRW9uTG9Dd2hvSGVUJTNBbWF0cml4Lm9yZw"
-    on_success: change  # always|never|change
-    on_failure: always
-    on_start: never
+    - if [[ -n "$NOTIFURL" && $TOX_ENV == *astropydev* ]]; then http --verify=no POST $NOTIFURL displayName="Travis Bot" avatarUrl="$AVATAR_URL" text="$NOTIF_TEXT"; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,42 +3,29 @@
 
 environment:
 
-    global:
-        PYTHON: "C:\\conda"
-        MINICONDA_VERSION: "latest"
-        CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-        PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
-                          # of 32 bit and 64 bit builds are needed, move this
-                          # to the matrix section.
-        CONDA_CHANNELS: "conda-forge"
-        CONDA_DEPENDENCIES: "scipy matplotlib pytest mock pandas requests beautifulsoup4 sqlalchemy scikit-image pytest-mock suds-jurko glymur drms"
-        PIP_DEPENDENCIES: "hypothesis sunpy-sphinx-theme pytest-astropy"
-        NUMPY_VERSION: "stable"
-        ASTROPY_VERSION: "stable"
+  global:
+      PYTHON: "C:\\conda"
+      PYTHON_VERSION: "3.7"
+      MINICONDA_VERSION: "latest"
+      CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+      PIP_DEPENDENCIES: "tox git+git://github.com/drdavella/tox-conda"
+      PYTHON_ARCH: "64"
 
-    matrix:
-        - PYTHON_VERSION: "3.6"
-        - PYTHON_VERSION: "3.7"
-
-matrix:
-    fast_finish: true
-
-
-platform:
-    - x64
-
-os: Visual Studio 2017
+  matrix:
+      # Make sure that installation does not fail
+      - TOXENV: "py37-offline"
+        TOX_CMD: "tox"
+        TOX_ARGS: ""
 
 install:
+    - "git submodule update --init"
     - "git clone git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
-    - "conda remove --force pillow"
-    - "pip install pillow"
 
-# Not a .NET project, we build SunPy in the install step instead
+# Not a .NET project
 build: false
 
 test_script:
-    - "%CMD_IN_ENV% python setup.py test"
+  - "%CMD_IN_ENV% %TOX_CMD% %TOX_ARGS%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,20 +5,25 @@ environment:
 
   global:
       PYTHON: "C:\\conda"
-      PYTHON_VERSION: "3.7"
       MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-      PIP_DEPENDENCIES: "tox git+git://github.com/drdavella/tox-conda"
       PYTHON_ARCH: "64"
+      CONDA_CHANNELS: "sunpy"
+      PIP_DEPENDENCIES: "tox git+git://github.com/drdavella/tox-conda"
+      PYTHON_VERSION: "3.6"
 
   matrix:
-      # Make sure that installation does not fail
-      - TOXENV: "py37-offline"
-        TOX_CMD: "tox"
+      # Py37 NumPy seems to be broken.
+      # So we still use py36 here.
+      - TOXENV: "py36-offline"
+        TOX_CMD: "tox -vv"
         TOX_ARGS: ""
 
+platform: x64
+
+os: Visual Studio 2017
+
 install:
-    - "git submodule update --init"
     - "git clone git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/changelog/2839.feature.rst
+++ b/changelog/2839.feature.rst
@@ -1,0 +1,1 @@
+Added full Tox support for SunPy tests, documentation build and figure tests.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,8 +26,9 @@
 # be accessible, and the documentation will not build correctly.
 
 import os
-import datetime
 import sys
+import pathlib
+import datetime
 from distutils.version import LooseVersion
 
 from sphinx import __version__
@@ -241,21 +242,21 @@ github_issues_url = 'https://github.com/sunpy/sunpy/issues/'
 # -- Options for the Sphinx gallery -------------------------------------------
 if has_sphinx_gallery:
     extensions += ["sphinx_gallery.gen_gallery"]
+    path = pathlib.Path.cwd()
+    example_dir = path.parent.joinpath('examples')
     sphinx_gallery_conf = {
         'backreferences_dir':
-        'generated{}modules'.format(os.sep),  # path to store the module using example template
-        'filename_pattern':
-        '^((?!skip_).)*$',  # execute all examples except those that start with "skip_"
-        'examples_dirs': os.path.join('..', 'examples'),  # path to the examples scripts
+        path.joinpath('generated', 'modules'),  # path to store the module using example template
+        'filename_pattern': '^((?!skip_).)*$',  # execute all examples except those that start with "skip_"
+        'examples_dirs': example_dir,  # path to the examples scripts
         'subsection_order': ExplicitOrder([(os.path.join('..', 'examples/acquiring_data')),
                                            (os.path.join('..', 'examples/maps')),
                                            (os.path.join('..', 'examples/time_series')),
                                            (os.path.join('..', 'examples/units_and_coordinates')),
                                            (os.path.join('..', 'examples/plotting')),
                                            (os.path.join('..', 'examples/computer_vision_techniques'))]),
-        'gallery_dirs': os.path.join('generated',
-                                     'gallery'),  # path to save gallery generated examples
-        'default_thumb_file': os.path.join('docs', 'logo', 'sunpy_icon_128x128.png'),
+        'gallery_dirs': path.joinpath('generated', 'gallery'),  # path to save gallery generated examples
+        'default_thumb_file': path.joinpath('logo', 'sunpy_icon_128x128.png'),
         'reference_url': {
             'sunpy': None,
             'astropy': 'http://docs.astropy.org/en/stable/',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,8 +254,8 @@ if has_sphinx_gallery:
                                            (os.path.join('..', 'examples/plotting')),
                                            (os.path.join('..', 'examples/computer_vision_techniques'))]),
         'gallery_dirs': os.path.join('generated',
-                                    'gallery'),  # path to save gallery generated examples
-        'default_thumb_file': os.path.join('.', 'logo', 'sunpy_icon_128x128.png'),
+                                     'gallery'),  # path to save gallery generated examples
+        'default_thumb_file': os.path.join('docs', 'logo', 'sunpy_icon_128x128.png'),
         'reference_url': {
             'sunpy': None,
             'astropy': 'http://docs.astropy.org/en/stable/',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,24 +1,3 @@
-[build_docs]
-source-dir = docs
-build-dir = docs/_build
-all_files = 1
-
-[tool:pytest]
-minversion = 3.0
-testpaths = "sunpy" "docs"
-norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "astropy_helpers" "examples"
-doctest_plus = enabled
-doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
-addopts = -p no:warnings --doctest-rst
-markers =
-    online: marks this test function as needing online connectivity.
-    figure: marks this test function as using hash-based Matplotlib figure verification. This mark is not meant to be directly applied, but is instead automatically applied when a test function uses the @sunpy.tests.helpers.figure_test decorator.
-# Disable internet access for tests not marked remote_data
-remote_data_strict = True
-
-[ah_bootstrap]
-auto_use = True
-
 [metadata]
 package_name = sunpy
 description = SunPy: Python for Solar Physics
@@ -42,6 +21,27 @@ version = 1.0.0.dev
 # Note: you will also need to change this in your package's __init__.py
 minimum_python_version = 3.6
 
+[ah_bootstrap]
+auto_use = True
+
+[build_docs]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
+[tool:pytest]
+minversion = 3.0
+testpaths = "sunpy" "docs"
+norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "astropy_helpers" "examples"
+doctest_plus = enabled
+doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
+addopts = -p no:warnings --doctest-rst
+markers =
+    online: marks this test function as needing online connectivity.
+    figure: marks this test function as using hash-based Matplotlib figure verification. This mark is not meant to be directly applied, but is instead automatically applied when a test function uses the @sunpy.tests.helpers.figure_test decorator.
+# Disable internet access for tests not marked remote_data
+remote_data_strict = True
+
 [pycodestyle]
 max_line_length = 100
 # E101 - mix of tabs and spaces
@@ -61,11 +61,8 @@ exclude = extern,sphinx,*parsetab.py
 [flake8]
 max-line-length = 100
 
-[yapf]
-column_limit = 100
-
 [isort]
-line_length = 99
+line_length = 100
 not_skip = __init__.py
 sections = FUTURE, STDLIB, THIRDPARTY, ASTROPY, FIRSTPARTY, LOCALFOLDER
 default_section = THIRDPARTY

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,7 @@
-[build_sphinx]
-source-dir = docs
-build-dir = docs/_build
-all_files = 1
-
 [build_docs]
 source-dir = docs
 build-dir = docs/_build
 all_files = 1
-
-[upload_docs]
-upload-dir = docs/_build/html
-show-response = 1
 
 [tool:pytest]
 minversion = 3.0
@@ -76,11 +67,37 @@ column_limit = 100
 [isort]
 line_length = 99
 not_skip = __init__.py
-sections=FUTURE,STDLIB,THIRDPARTY,ASTROPY,FIRSTPARTY,LOCALFOLDER
-default_section=THIRDPARTY
+sections = FUTURE, STDLIB, THIRDPARTY, ASTROPY, FIRSTPARTY, LOCALFOLDER
+default_section = THIRDPARTY
 known_first_party = sunpy
-known_astropy=astropy
-multi_line_output=0
-balanced_wrapping=True
-include_trailing_comma=false
-length_sort=True
+known_astropy = astropy
+multi_line_output = 0
+balanced_wrapping = True
+include_trailing_comma = false
+length_sort = True
+
+[coverage:run]
+source = sunpy
+omit =
+   sunpy/conftest*
+   sunpy/cython_version*
+   sunpy/*setup*
+   sunpy/extern/*
+   sunpy/*/tests/*
+   sunpy/version*
+   sunpy/__init__*
+
+[coverage:report]
+exclude_lines =
+   # Have to re-enable the standard pragma
+   pragma: no cover
+   # Don't complain about packages we have installed
+   except ImportError
+   # Don't complain if tests don't hit assertions
+   raise AssertionError
+   raise NotImplementedError
+   # Don't complain about script hooks
+   def main\(.*\):
+   # Ignore branches that don't pertain to this version of Python
+   pragma: py{ignore_python_version}
+   six.PY{ignore_python_version}

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py{37,36}-offline,py{37,36}-{online,astropydev,numpydev,build_docs},fi
 
 [testenv]
 setenv =
-    MPLBACKEND=agg
-    COLUMNS=180
+    MPLBACKEND = agg
+    COLUMNS = 180
 deps =
     astropydev: git+git://github.com/astropy/astropy
     numpydev: git+git://github.com/numpy/numpy

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,62 @@
+[tox]
+envlist = py{37,36}-offline,py{37,36}-{online,astropydev,numpydev,build_docs},figure
+
+[testenv]
+setenv =
+    MPLBACKEND=agg
+    COLUMNS=180
+deps =
+    astropydev: git+git://github.com/astropy/astropy
+    numpydev: git+git://github.com/numpy/numpy
+    build_docs: sunpy-sphinx-theme
+    codecov
+    pytest-rerunfailures
+    pytest-sugar
+conda_deps =
+    astropydev,numpydev: cython
+    offline,online,build_docs: numpy
+    offline,online,build_docs: astropy
+    # bug with doc folder path
+    build_docs: sphinx<1.8
+    build_docs: sphinx-astropy
+    build_docs: ruamel.yaml
+    beautifulsoup4
+    dask
+    drms
+    glymur
+    hypothesis
+    jinja2
+    lxml
+    matplotlib
+    mock
+    openjpeg
+    pandas
+    # breaks too much
+    pytest<3.10
+    pytest-astropy
+    pytest-cov
+    pytest-mock
+    pytest-xdist
+    requests
+    scikit-image
+    scipy
+    sqlalchemy
+    suds-jurko
+conda_channels = sunpy
+commands =
+    offline,astropydev,numpydev: pytest -m "not figure" --cov=./sunpy {posargs}
+    online: pytest -m "not figure" --remote-data=any --cov=./sunpy {posargs}
+    build_docs: sphinx-build docs docs/_build/html -W -b html
+
+[testenv:figure]
+basepython = python3.6
+conda_deps =
+    python = 3.6.5
+    astropy = 3.0.3
+    numpy = 1.14.2
+    freetype = 2.8.1
+    matplotlib = 2.1.2
+    scipy = 1.0.1
+    {[testenv]conda_deps}
+conda_channels = conda-forge
+commands = pytest -m "figure" --cov=./sunpy


### PR DESCRIPTION
We now use Tox for run all our CI.

It also allow us to pre-define and generate the same conda environment as the CI locally so we can debug issues this way now. 

```bash
$ tox -al
py37-offline
py36-offline
py37-online
py37-astropydev
py37-numpydev
py37-build_docs
py36-online
py36-astropydev
py36-numpydev
py36-build_docs
figure
```

The old ways are still supported. **FOR NOW**