### PR TITLE
Don't assume arcseconds when CUNIT metadata isn't present

### DIFF
--- a/changelog/2847.breaking.rst
+++ b/changelog/2847.breaking.rst
@@ -1,0 +1,2 @@
+Maps no longer assume that the pixel units are arcseconds if the units aren't
+explicitly set.

--- a/changelog/2847.breaking.rst
+++ b/changelog/2847.breaking.rst
@@ -1,2 +1,3 @@
 Maps no longer assume that the pixel units are arcseconds if the units aren't
-explicitly set.
+explicitly set. In addition to this if critical metadata is missing from when
+creating a map, the map will fail to initialize and will raise an error.

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -45,6 +45,17 @@ e.g. `~sunpy.map.sources.sdo.AIAMap` or `~sunpy.map.sources.soho.LASCOMap`
 (see :ref:`map-classes` to see a list of all of them), or if no
 instrument matches, a 2D map `~sunpy.map.mapbase.GenericMap`.
 
+Fixing map metadata
+^^^^^^^^^^^^^^^^^^^
+
+If you need to fix the metadata of a fits file before it is handed to `Map`, this can be done as
+follows:
+
+    >>> [data, header] = sunpy.io.fits.read(filepath) # doctest: +SKIP
+    >>> header['cunit1'] = 'arcsec' # doctest: +SKIP
+    >>> header['cunit2'] = 'arcsec' # doctest: +SKIP
+    >>> map = sunpy.map.Map(data, header) # doctest: +SKIP
+
 
 .. autoclass:: sunpy.map.map_factory.MapFactory
 

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -45,7 +45,7 @@ given then some default values are assumed. Here is a simple example::
     >>> import numpy as np
 
     >>> data = np.arange(0,100).reshape(10,10)
-    >>> header = {'cdelt1': 10, 'cdelt2': 10, 'telescop':'sunpy'}
+    >>> header = {'cdelt1': 10, 'cdelt2': 10, 'telescop':'sunpy', 'cunit1': 'arcsec', 'cunit2': 'arcsec'}
     >>> my_map = sunpy.map.Map(data, header)
 
 The keys in the header follows the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`_.

--- a/examples/map/map_from_numpy_array.py
+++ b/examples/map/map_from_numpy_array.py
@@ -19,7 +19,7 @@ import sunpy.data.sample
 # SunPy Maps store 2D data in a numpy array and additional data in a metadata
 # dictionary giving information relating to the data and instrument.
 data = np.random.rand(20,15)
-header = {}
+header = {'cunit1': 'arcsec', 'cunit2': 'arcsec'}
 manual_map = sunpy.map.Map((data, header))
 
 ##############################################################################

--- a/examples/map/maps_example.py
+++ b/examples/map/maps_example.py
@@ -27,7 +27,7 @@ import sunpy.data.sample
 # Or using creating manually by using tuple with the data/header within:
 
 data = np.random.rand(20, 15)
-header = {}
+header = {'cunit1': 'arcsec', 'cunit2': 'arcsec'}
 manual_map = sunpy.map.Map((data, header))
 
 ##############################################################################

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -8,7 +8,7 @@ import astropy.io.fits
 from astropy.wcs import WCS
 
 import sunpy
-from sunpy.map.mapbase import GenericMap
+from sunpy.map.mapbase import GenericMap, MapMetaValidationError
 from sunpy.map.compositemap import CompositeMap
 from sunpy.map.mapsequence import MapSequence
 
@@ -78,15 +78,15 @@ class MapFactory(BasicRegistrationFactory):
     * data, wcs object, in tuple
 
     >>> from astropy.wcs import WCS
-    >>> wcs = WCS(sunpy.data.sample.AIA_171_IMAGE)     # doctest: +REMOTE_DATA
-    >>> data = fits.getdata(sunpy.data.sample.AIA_171_IMAGE)    # doctest: +REMOTE_DATA
+    >>> wcs = WCS(sunpy.data.sample.AIA_171_ROLL_IMAGE)     # doctest: +REMOTE_DATA
+    >>> data = fits.getdata(sunpy.data.sample.AIA_171_ROLL_IMAGE)    # doctest: +REMOTE_DATA
     >>> mymap = sunpy.map.Map((data, wcs))    # doctest: +REMOTE_DATA
 
     * data, wcs object, not in tuple
 
     >>> from astropy.wcs import WCS
-    >>> wcs = WCS(sunpy.data.sample.AIA_171_IMAGE)     # doctest: +REMOTE_DATA
-    >>> data = fits.getdata(sunpy.data.sample.AIA_171_IMAGE)    # doctest: +REMOTE_DATA
+    >>> wcs = WCS(sunpy.data.sample.AIA_171_ROLL_IMAGE)     # doctest: +REMOTE_DATA
+    >>> data = fits.getdata(sunpy.data.sample.AIA_171_ROLL_IMAGE)    # doctest: +REMOTE_DATA
     >>> mymap = sunpy.map.Map(data, wcs)   # doctest: +REMOTE_DATA
 
     * File names
@@ -288,15 +288,19 @@ class MapFactory(BasicRegistrationFactory):
 
             try:
                 new_map = self._check_registered_widgets(data, meta, **kwargs)
+                new_maps.append(new_map)
             except (NoMatchError, MultipleMatchError, ValidationFunctionError):
                 if not silence_errors:
                     raise
+            except MapMetaValidationError as e:
+                warnings.warn(f"One of the data, header pairs failed to validate with: {e}")
             except Exception:
                 raise
 
-            new_maps.append(new_map)
-
         new_maps += already_maps
+
+        if not len(new_maps):
+            raise RuntimeError('No maps loaded')
 
         # If the list is meant to be a sequence, instantiate a map sequence
         if sequence:

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -37,6 +37,9 @@ class SJIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        # Assume pixel units are arcesc if not given
+        header['cunit1'] = header.get('cunit1', 'arcsec')
+        header['cunit2'] = header.get('cunit2', 'arcsec')
         GenericMap.__init__(self, data, header, **kwargs)
 
         self.meta['detector'] = "SJI"

--- a/sunpy/map/sources/rhessi.py
+++ b/sunpy/map/sources/rhessi.py
@@ -38,6 +38,9 @@ class RHESSIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        # Assume pixel units are arcesc if not given
+        header['cunit1'] = header.get('cunit1', 'arcsec')
+        header['cunit2'] = header.get('cunit2', 'arcsec')
 
         GenericMap.__init__(self, data, header, **kwargs)
 

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -39,7 +39,6 @@ class AIAMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
         GenericMap.__init__(self, data, header, **kwargs)
 
         # Fill in some missing info

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -60,11 +60,15 @@ class EITMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-        GenericMap.__init__(self, data, header, **kwargs)
+        # Assume pixel units are arcesc if not given
+        header['cunit1'] = header.get('cunit1', 'arcsec')
+        header['cunit2'] = header.get('cunit2', 'arcsec')
 
+        GenericMap.__init__(self, data, header, **kwargs)
         # Fill in some missing info
         self.meta['detector'] = "EIT"
         self.meta['waveunit'] = "Angstrom"
+
         self._fix_dsun()
         self._nickname = self.detector
         self.plot_settings['cmap'] = plt.get_cmap(self._get_cmap_name())
@@ -172,7 +176,9 @@ class MDIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
+        # Assume pixel units are arcesc if not given
+        header['cunit1'] = header.get('cunit1', 'arcsec')
+        header['cunit2'] = header.get('cunit2', 'arcsec')
         GenericMap.__init__(self, data, header, **kwargs)
 
         # Fill in some missing or broken info

--- a/sunpy/map/sources/tests/test_iris_source.py
+++ b/sunpy/map/sources/tests/test_iris_source.py
@@ -13,24 +13,22 @@ import sunpy.data.test
 
 path = sunpy.data.test.rootdir
 fitspath = glob.glob(os.path.join(path, "iris_l2_20130801_074720_4040000014_SJI_1400_t000.fits"))
-irislist = Map(fitspath)
+irismap = Map(fitspath)
+
 
 # IRIS Tests
 def test_fitstoIRIS():
     """Tests the creation of SJIMap using FITS."""
-    for amap in irislist:
-        assert (isinstance(amap, (SJIMap, GenericMap)))
+    assert (isinstance(irismap, SJIMap))
+
 
 def test_is_datasource_for():
     """Test the is_datasource_for method of SJIMap.
     Note that header data to be provided as an argument
     can be a MetaDict object."""
-    for amap in irislist:
-        if isinstance(amap, SJIMap):
-            assert amap.is_datasource_for(amap.data, amap.meta)
+    assert irismap.is_datasource_for(irismap.data, irismap.meta)
+
 
 def test_observatory():
     """Tests the observatory property of SJIMap."""
-    for amap in irislist:
-        if isinstance(amap, SJIMap):
-            assert amap.observatory == "IRIS"
+    assert irismap.observatory == "IRIS"

--- a/sunpy/map/sources/tests/test_mdi_source.py
+++ b/sunpy/map/sources/tests/test_mdi_source.py
@@ -14,10 +14,12 @@ path = sunpy.data.test.rootdir
 fitspath = glob.glob(os.path.join(path, "mdi_fd_Ic_6h_01d.5871.0000_s.fits"))
 mdi = Map(fitspath)
 
+
 # MDI Tests
 def test_fitstoMDI():
     """Tests the creation of MDIMap using FITS."""
     assert isinstance(mdi, MDIMap)
+
 
 def test_is_datasource_for():
     """Test the is_datasource_for method of MDIMap.
@@ -25,9 +27,11 @@ def test_is_datasource_for():
     can be a MetaDict object."""
     assert mdi.is_datasource_for(mdi.data, mdi.meta)
 
+
 def test_observatory():
     """Tests the observatory property of the MDIMap object."""
     assert mdi.observatory == "SOHO"
+
 
 def test_measurement():
     """Tests the measurement property of the MDIMap object."""

--- a/sunpy/map/sources/tests/test_trace_source.py
+++ b/sunpy/map/sources/tests/test_trace_source.py
@@ -9,15 +9,18 @@ import sunpy.data.test
 path = sunpy.data.test.rootdir
 fitspath = os.path.join(path, "tsi20010130_025823_a2.fits")
 
+
 @pytest.fixture(scope="module")
 def createTRACE():
     """Creates a TRACEMap from a FITS file."""
     return Map(fitspath)
 
+
 # TRACE Tests
 def test_fitstoTRACE(createTRACE):
     """Tests the creation of TRACEMap using FITS."""
     assert isinstance(createTRACE, TRACEMap)
+
 
 def test_is_datasource_for(createTRACE):
     """Test the is_datasource_for method of TRACEMap.
@@ -25,9 +28,11 @@ def test_is_datasource_for(createTRACE):
     can be a MetaDict object."""
     assert createTRACE.is_datasource_for(createTRACE.data, createTRACE.meta)
 
+
 def test_measurement(createTRACE):
     """Tests the measurement property of the TRACEMap object."""
     assert int(createTRACE.measurement) == 171
+
 
 def test_observatory(createTRACE):
     """Tests the observatory property of the TRACEMap object."""

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -48,6 +48,9 @@ class TRACEMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        # Assume pixel units are arcesc if not given
+        header['cunit1'] = header.get('cunit1', 'arcsec')
+        header['cunit2'] = header.get('cunit2', 'arcsec')
 
         GenericMap.__init__(self, data, header, **kwargs)
 

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -25,6 +25,7 @@ a_fname = a_list_of_many[0]
 AIA_171_IMAGE = os.path.join(filepath, 'aia_171_level1.fits')
 RHESSI_IMAGE = os.path.join(filepath, 'hsi_image_20101016_191218.fits')
 
+
 #==============================================================================
 # Map Factory Tests
 #==============================================================================
@@ -41,37 +42,47 @@ class TestMap(object):
         assert isinstance(comp, sunpy.map.CompositeMap)
 
     def test_patterns(self):
-        ## Test different Map pattern matching ##
+        # Test different Map pattern matching
+
         # File name
         eitmap = sunpy.map.Map(a_fname)
         assert isinstance(eitmap, sunpy.map.GenericMap)
+
         # Directory
         maps = sunpy.map.Map(os.path.join(filepath, "EIT"))
         assert isinstance(maps, list)
         assert ([isinstance(amap,sunpy.map.GenericMap) for amap in maps])
+
         # Glob
         maps = sunpy.map.Map(os.path.join(filepath, "EIT", "*"))
         assert isinstance(maps, list)
         assert ([isinstance(amap,sunpy.map.GenericMap) for amap in maps])
+
         # Already a Map
         amap = sunpy.map.Map(maps[0])
         assert isinstance(amap, sunpy.map.GenericMap)
+
         # A list of filenames
         maps = sunpy.map.Map(a_list_of_many)
         assert isinstance(maps, list)
         assert ([isinstance(amap,sunpy.map.GenericMap) for amap in maps])
+
         # Data-header pair in a tuple
         pair_map = sunpy.map.Map((amap.data, amap.meta))
         assert isinstance(pair_map, sunpy.map.GenericMap)
+
         # Data-header pair not in a tuple
         pair_map = sunpy.map.Map(amap.data, amap.meta)
         assert isinstance(pair_map, sunpy.map.GenericMap)
+
         # Data-wcs object pair in tuple
         pair_map = sunpy.map.Map((amap.data, WCS(AIA_171_IMAGE)))
         assert isinstance(pair_map, sunpy.map.GenericMap)
+
         # Data-wcs object pair not in a tuple
         pair_map = sunpy.map.Map(amap.data, WCS(AIA_171_IMAGE))
         assert isinstance(pair_map, sunpy.map.GenericMap)
+
         # Data-header from FITS
         with fits.open(a_fname) as hdul:
             data = hdul[0].data
@@ -82,9 +93,12 @@ class TestMap(object):
         assert isinstance(pair_map, sunpy.map.GenericMap)
         pair_map = sunpy.map.Map(data, header)
         assert isinstance(pair_map, sunpy.map.GenericMap)
-        #Custom Map
-        data = np.arange(0,100).reshape(10,10)
-        header = {'cdelt1': 10, 'cdelt2': 10, 'telescop':'sunpy'}
+
+        # Custom Map
+        data = np.arange(0, 100).reshape(10, 10)
+        header = {'cdelt1': 10, 'cdelt2': 10,
+                  'telescop': 'sunpy',
+                  'cunit1': 'arcsec', 'cunit2': 'arcsec'}
         pair_map = sunpy.map.Map(data, header)
         assert isinstance(pair_map, sunpy.map.GenericMap)
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -228,7 +228,9 @@ def test_rotation_matrix_cd_cdelt():
         'CD2_1': 10,
         'CD2_2': 0,
         'NAXIS1': 6,
-        'NAXIS2': 6
+        'NAXIS2': 6,
+        'CUNIT1': 'arcsec',
+        'CUNIT2': 'arcsec'
     }
     cd_map = sunpy.map.Map((data, header))
     np.testing.assert_allclose(cd_map.rotation_matrix, np.array([[0., -1.], [1., 0]]))
@@ -248,7 +250,9 @@ def test_rotation_matrix_cd_cdelt_square():
         'CD2_1': 10,
         'CD2_2': 0,
         'NAXIS1': 6,
-        'NAXIS2': 6
+        'NAXIS2': 6,
+        'CUNIT1': 'arcsec',
+        'CUNIT2': 'arcsec'
     }
     cd_map = sunpy.map.Map((data, header))
     np.testing.assert_allclose(cd_map.rotation_matrix, np.array([[0., -1], [1., 0]]))
@@ -304,7 +308,9 @@ def test_default_shift():
         'CD2_1': 10,
         'CD2_2': 0,
         'NAXIS1': 6,
-        'NAXIS2': 6
+        'NAXIS2': 6,
+        'CUNIT1': 'arcsec',
+        'CUNIT2': 'arcsec',
     }
     cd_map = sunpy.map.Map((data, header))
     assert cd_map.shifted_value[0].value == 0
@@ -592,8 +598,8 @@ def test_validate_meta(generic_map):
             'waveunit': 'ANGSTROM'
         }
         bad_map = sunpy.map.Map((generic_map.data, bad_header))
-        for count, meta_property in enumerate(('cunit1', 'cunit2', 'waveunit')):
-            assert meta_property.upper() in str(w[count].message)
+
+    assert 'waveunit'.upper() in str(w[0].message)
 
 
 # Heliographic Map Tests
@@ -664,6 +670,8 @@ def test_more_than_two_dimensions():
     bad_data = np.random.rand(4, 4, 3, 5)
     hdr = fits.Header()
     hdr['TELESCOP'] = 'XXX'
+    hdr['cunit1'] = 'arcsec'
+    hdr['cunit2'] = 'arcsec'
     bad_map = sunpy.map.Map(bad_data, hdr)
     # Test fails if map.ndim > 2 and if the dimensions of the array are wrong.
     assert bad_map.ndim is 2
@@ -673,7 +681,10 @@ def test_more_than_two_dimensions():
 def test_missing_metadata_warnings():
     # Checks that warnings for missing metadata are only raised once
     with pytest.warns(Warning) as record:
-        array_map = sunpy.map.Map(np.random.rand(20, 15), {})
+        header = {}
+        header['cunit1'] = 'arcsec'
+        header['cunit2'] = 'arcsec'
+        array_map = sunpy.map.Map(np.random.rand(20, 15), header)
         array_map.peek()
     # There should be 4 warnings for missing metadata
     assert len([w for w in record if 'Missing metadata' in str(w)]) == 4


### PR DESCRIPTION
Blindly assuming that data is in units of arcseconds seems like a Bad Idea. A concrete example is LASCO C3 data that doesn't have any metadata (see https://github.com/sunpy/sunpy/pull/2775#issuecomment-428933507 and comments below). Currently LASCO C3 data with missing metadata is assumed to be in arcseconds, which is completely wrong and results in e.g. the draw-solar-limb function putting the solar limb in completely the wrong place without even a warning.

At the very least I think assuming arcseconds when metadata is missing should be done on an instrument-by-instrument level, and not in `mapbase`. This PR removes the arcsecod assumption in mapbase.