### PR TITLE
Make sure we are only slicing with ints and not numpy.int64s

### DIFF
--- a/changelog/2856.bugfix.rst
+++ b/changelog/2856.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure imageanimators only slice arrays with integers

--- a/sunpy/visualization/animator/image.py
+++ b/sunpy/visualization/animator/image.py
@@ -126,7 +126,7 @@ class ImageAnimator(ArrayAnimator):
         """Updates plot based on slider/array dimension being iterated."""
         val = int(val)
         ax_ind = self.slider_axes[slider.slider_ind]
-        ind = np.argmin(np.abs(self.axis_ranges[ax_ind] - val))
+        ind = int(np.argmin(np.abs(self.axis_ranges[ax_ind] - val)))
         self.frame_slice[ax_ind] = ind
         if val != slider.cval:
             if self._non_regular_plot_axis:
@@ -246,7 +246,7 @@ class ImageAnimatorWCS(ImageAnimator):
         """Updates plot based on slider/array dimension being iterated."""
         val = int(val)
         ax_ind = self.slider_axes[slider.slider_ind]
-        ind = np.argmin(np.abs(self.axis_ranges[ax_ind] - val))
+        ind = int(np.argmin(np.abs(self.axis_ranges[ax_ind] - val)))
         self.frame_slice[ax_ind] = ind
         list_slices_wcsaxes = list(self.slices_wcsaxes)
         list_slices_wcsaxes[self.wcs.naxis-ax_ind-1] = val


### PR DESCRIPTION
I discovered this while working on some dkist stuff, it's a pretty subtle distinction but it's just better practice to cast back to `int`.