### PR TITLE
Handle saving out FITS from Astropy. 

### DIFF
--- a/changelog/2880.bugfix.rst
+++ b/changelog/2880.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `sunpy.io.fits.write` to handle the keyword ``COMMENT`` correctly.

--- a/sunpy/instr/aia.py
+++ b/sunpy/instr/aia.py
@@ -43,7 +43,7 @@ def aiaprep(aiamap):
     """
 
     if not isinstance(aiamap, (AIAMap, HMIMap)):
-        raise ValueError("Input must be an AIAMap")
+        raise ValueError("Input must be an AIAMap or HMIMap.")
 
     # Target scale is 0.6 arcsec/pixel, but this needs to be adjusted if the map
     # has already been rescaled.

--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -120,7 +120,7 @@ def get_header(afile):
         close = True
 
     try:
-        headers= []
+        headers = []
         for hdu in hdulist:
             try:
                 comment = "".join(hdu.header['COMMENT']).strip()
@@ -139,7 +139,7 @@ def get_header(afile):
             keydict = {}
             for card in hdu.header.cards:
                 if card.comment != '':
-                    keydict.update({card.keyword:card.comment})
+                    keydict.update({card.keyword: card.comment})
             header['KEYCOMMENTS'] = keydict
             header['WAVEUNIT'] = extract_waveunit(header)
 
@@ -204,11 +204,11 @@ def header_to_fits(header):
 
     for k, v in header.items():
         if isinstance(v, fits.header._HeaderCommentaryCards):
-            if k == 'comments':
+            if k.upper() == 'COMMENT':
                 comments = str(v).split('\n')
                 for com in comments:
-                    fits_header.add_comments(com)
-            elif k == 'history':
+                    fits_header.add_comment(com)
+            elif k.upper() == 'HISTORY':
                 hists = str(v).split('\n')
                 for hist in hists:
                     fits_header.add_history(hist)
@@ -306,5 +306,5 @@ def extract_waveunit(header):
                 waveunit = m.group(1)
                 break
     if waveunit == '':
-        return None # To fix problems associated with HMI FITS.
+        return None  # To fix problems associated with HMI FITS.
     return waveunit

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -1,11 +1,12 @@
-from astropy.io import fits
+import os
+from collections import OrderedDict
+
+import astropy.io.fits as fits
 
 import sunpy.io.fits
-from sunpy.io.fits import get_header, extract_waveunit
-
 import sunpy.data.test
-import os
-
+from sunpy.util import MetaDict
+from sunpy.io.fits import get_header, extract_waveunit
 from sunpy.data.test.waveunit import MEDN_IMAGE, MQ_IMAGE, NA_IMAGE, SVSM_IMAGE
 
 testpath = sunpy.data.test.rootdir
@@ -107,3 +108,11 @@ def test_simple_write_compressed(tmpdir):
     with fits.open(str(outfile)) as hdul:
         assert len(hdul) == 2
         assert isinstance(hdul[1], fits.CompImageHDU)
+
+def test_write_with_metadict_header_astropy(tmpdir):
+    fits_file = fits.open(AIA_171_IMAGE)
+    data, header = fits_file[0].data, fits_file[0].header
+    meta_header = MetaDict(OrderedDict(header))
+    temp_file = tmpdir / "temp.fits"
+    sunpy.io.fits.write(str(temp_file), data, meta_header)
+    assert temp_file.exists()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
If a Sunpy map has comments in it (which we can see by checking mapobject's meta attribute), and if we go ahead and save it, It will crash because the code is mistyped for checking 'comments' instead of 'comment' and it is calling wrong method of astropy i.e. 'add_comments' instead of 'add_comment'.

<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #2879
