### PR TITLE
Fix some inconsistent online tests

### DIFF
--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -230,7 +230,7 @@ def _remove_lytaf_events(time, channels=None, artifacts=None,
     Remove LARs (Large Angle Rotations) from time series.
 
         >>> time_clean, channels_clean = _remove_lytaf_events(
-        ...   time, channels=[channel_1, channel_2], artifacts=['LAR'])  # doctest: +REMOTE_DATA
+        ...   time, channels=[channel_1, channel_2], artifacts=['LAR'])  # doctest: +SKIP
 
     """
     # Check inputs

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -62,8 +62,8 @@ class RHESSIClient(GenericClient):
         --------
         >>> from sunpy.net.dataretriever.sources.rhessi import RHESSIClient
         >>> RHESSIClient().get_observing_summary_filename(('2011/04/04', '2011/04/05'))   # doctest: +REMOTE_DATA
-        ['https://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20110404_042.fits',
-        'https://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20110405_031.fits']
+        ['https://.../hessidata/metadata/catalog/hsi_obssumm_20110404_042.fits',
+        'https://.../hessidata/metadata/catalog/hsi_obssumm_20110405_031.fits']
         """
         dt = TimeRange(time_range)
         # remove time from dates

--- a/sunpy/net/helio/parser.py
+++ b/sunpy/net/helio/parser.py
@@ -230,4 +230,6 @@ def wsdl_retriever(service='HEC'):
         if end_point is not None and link_test(end_point) is not None:
             wsdl = end_point
             break
+    if wsdl is None:
+        raise ValueError("No online HELIO servers can be found.")
     return wsdl

--- a/sunpy/net/helio/parser.py
+++ b/sunpy/net/helio/parser.py
@@ -217,19 +217,20 @@ def wsdl_retriever(service='HEC'):
         this function to take a while to return. Timeout duration can be
         controlled through the LINK_TIMEOUT value
     """
+    def fail(): raise ValueError("No online HELIO servers can be found.")
     service_links = webservice_parser(service=service)
     wsdl = None
     wsdl_links = None
     if service_links is None:
-        return None
+        fail()
     for link in service_links:
         wsdl_links = taverna_parser(link)
     if wsdl_links is None:
-        return None
+        fail()
     for end_point in wsdl_links:
         if end_point is not None and link_test(end_point) is not None:
             wsdl = end_point
             break
     if wsdl is None:
-        raise ValueError("No online HELIO servers can be found.")
+        fail()
     return wsdl

--- a/sunpy/net/tests/test_helio.py
+++ b/sunpy/net/tests/test_helio.py
@@ -169,10 +169,10 @@ def test_taverna_parser_get_taverna_links(mock_endpoint_parser):
 @mock.patch('sunpy.net.helio.parser.webservice_parser', return_value=None)
 def test_wsdl_retriever_no_content(mock_endpoint_parser):
     """
-    No links found? Return None
+    No links found? Raise ValueError
     """
     with pytest.raises(ValueError):
-        assert wsdl_retriever() is None
+        wsdl_retriever()
 
 
 @mock.patch('sunpy.net.helio.parser.webservice_parser', return_value=wsdl_urls())
@@ -189,10 +189,10 @@ def test_wsdl_retriever_get_link(mock_link_test, mock_taverna_parser, mock_webse
 @mock.patch('sunpy.net.helio.parser.taverna_parser', return_value=None)
 def test_wsdl_retriever_no_taverna_urls(mock_taverna_parser, mock_webservice_parser):
     """
-    Unable to find any valid Taverna URLs? Return None
+    Unable to find any valid Taverna URLs? Raise ValueError
     """
     with pytest.raises(ValueError):
-        assert wsdl_retriever() is None
+        wsdl_retriever()
 
 
 @mock.patch('sunpy.net.helio.parser.link_test', return_value=None)
@@ -200,10 +200,10 @@ def test_wsdl_retriever_no_taverna_urls(mock_taverna_parser, mock_webservice_par
 @mock.patch('sunpy.net.helio.parser.taverna_parser', return_value=some_taverna_urls())
 def test_wsdl_retriever_wsdl(mock_taverna_parser, mock_webservice_parser, mock_link_test):
     """
-    Unable to find any valid Taverna URLs? Return None
+    Unable to find any valid Taverna URLs? Raise ValueError
     """
     with pytest.raises(ValueError):
-        assert wsdl_retriever() is None
+        wsdl_retriever()
 
 
 @mock.patch('sunpy.net.helio.parser.urllib.request.urlopen')

--- a/sunpy/net/tests/test_helio.py
+++ b/sunpy/net/tests/test_helio.py
@@ -3,7 +3,6 @@ import urllib
 import mock
 import pytest
 
-from sunpy.net.helio import hec
 from sunpy.net.helio.parser import (link_test, taverna_parser, wsdl_retriever,
                                     endpoint_parser, webservice_parser)
 
@@ -172,7 +171,8 @@ def test_wsdl_retriever_no_content(mock_endpoint_parser):
     """
     No links found? Return None
     """
-    assert wsdl_retriever() is None
+    with pytest.raises(ValueError):
+        assert wsdl_retriever() is None
 
 
 @mock.patch('sunpy.net.helio.parser.webservice_parser', return_value=wsdl_urls())
@@ -191,7 +191,19 @@ def test_wsdl_retriever_no_taverna_urls(mock_taverna_parser, mock_webservice_par
     """
     Unable to find any valid Taverna URLs? Return None
     """
-    assert wsdl_retriever() is None
+    with pytest.raises(ValueError):
+        assert wsdl_retriever() is None
+
+
+@mock.patch('sunpy.net.helio.parser.link_test', return_value=None)
+@mock.patch('sunpy.net.helio.parser.webservice_parser', return_value=wsdl_urls())
+@mock.patch('sunpy.net.helio.parser.taverna_parser', return_value=some_taverna_urls())
+def test_wsdl_retriever_wsdl(mock_taverna_parser, mock_webservice_parser, mock_link_test):
+    """
+    Unable to find any valid Taverna URLs? Return None
+    """
+    with pytest.raises(ValueError):
+        assert wsdl_retriever() is None
 
 
 @mock.patch('sunpy.net.helio.parser.urllib.request.urlopen')


### PR DESCRIPTION
This also adds a much better error message when we can't connect to any HELIO servers.

TODO:

- [x] A test for the helio error