### PR TITLE
missing pytest dep for RTD

### DIFF
--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -10,6 +10,7 @@ scikit-image
 glymur
 drms
 zeep
+pytest
 asdf
 beautifulsoup4
 requests


### PR DESCRIPTION
Should fix the RTD build. 

Should have skipped the CI. 