### PR TITLE
Added mocking in fido_search for test_noaa

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,7 @@ Bug Fixes
 - Prevent a deprecation warning due to truth values of Quantity [#2358]
 - Print a warning when heliographic longitude is set to it's default value of 0 [#2480]
 - parse_time now parses numpy.datetime64 correctly. [#2572]
+- Added mocking to mock online tests for noaa.py. [#2900]
 
 0.8.5
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,7 +54,6 @@ Bug Fixes
 - Prevent a deprecation warning due to truth values of Quantity [#2358]
 - Print a warning when heliographic longitude is set to it's default value of 0 [#2480]
 - parse_time now parses numpy.datetime64 correctly. [#2572]
-- Added mocking to mock online tests for noaa.py. [#2900]
 
 0.8.5
 =====

--- a/changelog/2900.trivial.rst
+++ b/changelog/2900.trivial.rst
@@ -1,1 +1,1 @@
-Added mock tests for `sunpy.net.dataretriever.sources.noaa`, for mocking online requests.
+Used `unittest.mock` for creating offline tests for simulating online tests for `test_noaa.py`

--- a/changelog/2900.trivial.rst
+++ b/changelog/2900.trivial.rst
@@ -1,0 +1,1 @@
+Added mock tests for `sunpy.net.dataretriever.sources.noaa`, for mocking online requests.

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -14,7 +14,7 @@ from sunpy.net import attrs as a
 LCClient = noaa.NOAAIndicesClient()
 
 
-def create_mock_unified_object(start_date, end_date):
+def mock_query_object(start_date, end_date):
     '''
     Creation of a QueryResponse object, and prefill some
     downloaded data from noaa.NOAAIndicesClient().fetch(Time('20 ..)
@@ -41,8 +41,8 @@ def test_fetch_working():
     qr1 = LCClient.search(Time('2012/10/4', '2012/10/6'),
                           Instrument('noaa-indices'))
 
-    # Mock UnifiedResponse object
-    mock_qr = create_mock_unified_object('2012/10/4', '2012/10/6')
+    # Mock QueryResponse object
+    mock_qr = mock_query_object('2012/10/4', '2012/10/6')
     assert isinstance(mock_qr, qr1)
     assert mock_qr == qr1
 
@@ -83,7 +83,7 @@ def test_can_handle_query():
 
 
 @mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient.search',
-            return_value=create_mock_unified_object('2012/8/9', '2012/8/10'))
+            return_value=mock_query_object('2012/8/9', '2012/8/10'))
 def test_query(mock_search):
     qr1 = LCClient.search(
         Time('2012/8/9', '2012/8/10'), Instrument('noaa-indices'))
@@ -94,7 +94,7 @@ def test_query(mock_search):
 
 
 @mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient.search',
-            return_value=create_mock_unified_object('2012/10/4', '2012/10/6'))
+            return_value=mock_query_object('2012/10/4', '2012/10/6'))
 @mock.patch('sunpy.net.download.Results.wait',
             return_value=['some/path/extension/RecentIndices.txt'])
 def test_fetch(mock_wait, mock_search):
@@ -107,7 +107,7 @@ def test_fetch(mock_wait, mock_search):
 
 @mock.patch('sunpy.net.fido_factory.Fido.fetch',
             side_effect=(UnifiedResponse(
-                create_mock_unified_object("2012/10/4", "2012/10/6"))))
+                mock_query_object("2012/10/4", "2012/10/6"))))
 def test_fido(mock_fetch):
     qr = Fido.search(a.Time("2012/10/4", "2012/10/6"),
                      a.Instrument('noaa-indices'))

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -51,10 +51,15 @@ def test_fetch_working():
 
     # Compare if two objects have the same attribute
 
-    # Currently, QueryResponseBlock does not support
-    # comparison operation, so this is a ad-hoc
-    # hack for comparing the values
-    mock_qr[:][0]._map == qr1[:][0]._map
+    mock_qr = mock_qr[0]
+    qr = qr1[0]
+
+    assert mock_qr.source == qr.source
+    assert mock_qr.provider == qr.provider
+    assert mock_qr.physobs == qr.physobs
+    assert mock_qr.instrument == qr.instrument
+    assert mock_qr.url == qr.url
+    assert mock_qr.time == qr.time
 
     # Assert if the timerange is same
     assert qr1.time_range() == TimeRange('2012/10/4', '2012/10/6')

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -18,7 +18,7 @@ def create_mock_unified_object(start_date, end_date):
     Let us create a mock QueryResponse object
     using that, we will construct UnifiedResponse
     We will prefill some downloaded data from
-    running noaa.NOAAIndicesClient().search(Time('2012/8/9', '2012/8/10'),
+    running noaa.NOAAIndicesClient().fetch(Time('2012/8/9', '2012/8/10'),
                                                     Instrument('noaa-indices'))
     '''
     # Create a mock QueryResponse object

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -62,7 +62,8 @@ def test_fetch(time, instrument):
     assert len(download_list) == len(qr1)
 
 
-@mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient._get_default_uri', return_value='https://example.com' )
+@mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient._get_default_uri',\
+ return_value='https://example.com' )
 @mock.patch('sunpy.net.fido_factory.Fido.fetch', return_value=['*']*19)
 def test_fido(mock_search, mock_fetch):
     qr = Fido.search(a.Time("2012/10/4", "2012/10/6"), a.Instrument('noaa-indices'))

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -6,7 +6,6 @@ from sunpy.time import parse_time
 from sunpy.time.timerange import TimeRange
 from sunpy.net.vso.attrs import Time, Instrument
 from sunpy.net.dataretriever.client import QueryResponse
-from sunpy.net.dataretriever.client import QueryResponseBlock
 import sunpy.net.dataretriever.sources.noaa as noaa
 from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido
@@ -16,21 +15,14 @@ LCClient = noaa.NOAAIndicesClient()
 
 def create_mock_unified_object(start_date, end_date):
     '''
-    Let us create a mock QueryResponse object
-    using that, we will construct UnifiedResponse
-    We will prefill some downloaded data from
-    running noaa.NOAAIndicesClient().fetch(Time('2012/8/9', '2012/8/10'),
-                                                    Instrument('noaa-indices'))
+    Creation of a UnifiedResponse from QueryResponse object, and prefill some
+    downloaded data from noaa.NOAAIndicesClient().fetch(Time('20 ..)
     '''
     # Create a mock QueryResponse object
     map_ = {
         'Time_start': parse_time(start_date),
         'Time_end':  parse_time(end_date),
-        'source': 'sdic',
-        'instrument': 'noaa-indices',
-        'physobs': 'sunspot number',
-        'provider': 'swpc'
-
+        'source': 'sdic'
     }
 
     resp = QueryResponse.create(map_, LCClient._get_default_uri())
@@ -38,8 +30,7 @@ def create_mock_unified_object(start_date, end_date):
     resp.client = 'noaa-indices'
 
     # Create a UnifiedResponse object
-    uresp = UnifiedResponse(resp)
-    return (uresp)
+    return UnifiedResponse(resp)
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -1,11 +1,12 @@
-import pytest
-
 from unittest import mock
+
+import pytest
 
 from sunpy.time import parse_time
 from sunpy.time.timerange import TimeRange
 from sunpy.net.vso.attrs import Time, Instrument
-from sunpy.net.dataretriever.client import QueryResponse, QueryResponseBlock
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.dataretriever.client import QueryResponseBlock
 import sunpy.net.dataretriever.sources.noaa as noaa
 from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -31,13 +31,13 @@ def test_get_url_for_time_range(timerange, url_start, url_end):
 def test_can_handle_query():
     ans1 = noaa.NOAAIndicesClient._can_handle_query(
         Time('2012/8/9', '2012/8/10'), Instrument('noaa-indices'))
-    assert ans1 == True
+    assert ans1 is True
     ans2 = noaa.NOAAIndicesClient._can_handle_query(
         Time('2012/7/7', '2012/7/7'))
-    assert ans2 == False
+    assert ans2 is False
     ans3 = noaa.NOAAIndicesClient._can_handle_query(
         Time('2012/8/9', '2012/8/10'), Instrument('eve'))
-    assert ans3 == False
+    assert ans3 is False
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -43,7 +43,7 @@ def test_fetch_working():
 
     # Mock QueryResponse object
     mock_qr = mock_query_object('2012/10/4', '2012/10/6')
-    assert isinstance(mock_qr, qr1)
+
     assert mock_qr == qr1
 
     # Assert if the timerange is same

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -10,6 +10,7 @@ import sunpy.net.dataretriever.sources.noaa as noaa
 from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a
+
 LCClient = noaa.NOAAIndicesClient()
 
 
@@ -105,7 +106,8 @@ def test_fetch(mock_wait, mock_search):
 
 
 @mock.patch('sunpy.net.fido_factory.Fido.fetch',
-            side_effect=(UnifiedResponse(create_mock_unified_object("2012/10/4", "2012/10/6"))))
+            side_effect=(UnifiedResponse(
+                create_mock_unified_object("2012/10/4", "2012/10/6"))))
 def test_fido(mock_fetch):
     qr = Fido.search(a.Time("2012/10/4", "2012/10/6"),
                      a.Instrument('noaa-indices'))

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -44,7 +44,6 @@ def test_fetch_working():
 
     # Mock UnifiedResponse object
     mock_qr = create_mock_unified_object('2012/10/4', '2012/10/6')
-    assert isinstance(mock_qr, qr1)
     assert mock_qr == qr1
 
     # Assert if the timerange is same

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -15,10 +15,10 @@ LCClient = noaa.NOAAIndicesClient()
 
 
 def mock_query_object(start_date, end_date):
-    '''
+    """
     Creation of a QueryResponse object, and prefill some
     downloaded data from noaa.NOAAIndicesClient().fetch(Time('20 ..)
-    '''
+    """
     # Create a mock QueryResponse object
     map_ = {
         'Time_start': parse_time(start_date),
@@ -28,16 +28,16 @@ def mock_query_object(start_date, end_date):
 
     resp = QueryResponse.create(map_, LCClient._get_default_uri())
     # Attach the client with the QueryResponse
-    resp.client = 'noaa-indices'
+    resp.client = LCClient
     return resp
 
 
 @pytest.mark.remote_data
 def test_fetch_working():
-    '''
+    """
     Tests if the online server for noaa is working.
     Uses the url : ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt
-    '''
+    """
     qr1 = LCClient.search(Time('2012/10/4', '2012/10/6'),
                           Instrument('noaa-indices'))
 

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -22,13 +22,15 @@ def create_mock_unified_object(start_date, end_date):
                                                     Instrument('noaa-indices'))
     '''
     # Create a mock QueryResponse object
-    map_ = {}
-    map_['Time_start'] = parse_time(start_date)
-    map_['Time_end'] = parse_time(end_date)
-    map_['source'] = 'sdic'
-    map_['instrument'] = 'noaa-indices'
-    map_['physobs'] = 'sunspot number'
-    map_['provider'] = 'swpc'
+    map_ = {
+        'Time_start': parse_time(start_date),
+        'Time_end':  parse_time(end_date),
+        'source': 'sdic',
+        'instrument': 'noaa-indices',
+        'physobs': 'sunspot number',
+        'provider': 'swpc'
+
+    }
 
     resp = QueryResponse.create(map_, LCClient._get_default_uri())
     # Attach the client with the QueryResponse

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -36,8 +36,7 @@ def create_mock_unified_object(start_date, end_date):
 @pytest.mark.remote_data
 def test_fetch_working():
     '''
-    Tests if the online server for noaa
-    is working.
+    Tests if the online server for noaa is working.
     Uses the url : ftp://ftp.swpc.noaa.gov/pub/weekly/RecentIndices.txt
     '''
     qr1 = LCClient.search(Time('2012/10/4', '2012/10/6'),
@@ -90,7 +89,7 @@ def test_query(mock_search):
             side_effect=create_mock_unified_object('2012/10/4', '2012/10/6'))
 @mock.patch('sunpy.net.download.Results.wait',
             return_value=['some/path/extension/RecentIndices.txt'])
-def test_fetch1(mock_wait, mock_search):
+def test_fetch(mock_wait, mock_search):
     qr1 = LCClient.search(Time('2012/10/4', '2012/10/6'),
                           Instrument('noaa-indices'))
     res = LCClient.fetch(qr1)

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -15,7 +15,7 @@ LCClient = noaa.NOAAIndicesClient()
 
 def create_mock_unified_object(start_date, end_date):
     '''
-    Creation of a UnifiedResponse from QueryResponse object, and prefill some
+    Creation of a QueryResponse object, and prefill some
     downloaded data from noaa.NOAAIndicesClient().fetch(Time('20 ..)
     '''
     # Create a mock QueryResponse object
@@ -28,9 +28,7 @@ def create_mock_unified_object(start_date, end_date):
     resp = QueryResponse.create(map_, LCClient._get_default_uri())
     # Attach the client with the QueryResponse
     resp.client = 'noaa-indices'
-
-    # Create a UnifiedResponse object
-    return UnifiedResponse(resp)
+    return resp
 
 
 @pytest.mark.remote_data
@@ -44,6 +42,7 @@ def test_fetch_working():
 
     # Mock UnifiedResponse object
     mock_qr = create_mock_unified_object('2012/10/4', '2012/10/6')
+    assert isinstance(mock_qr, qr1)
     assert mock_qr == qr1
 
     # Assert if the timerange is same
@@ -83,7 +82,7 @@ def test_can_handle_query():
 
 
 @mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient.search',
-            side_effect=create_mock_unified_object('2012/8/9', '2012/8/10'))
+            return_value=create_mock_unified_object('2012/8/9', '2012/8/10'))
 def test_query(mock_search):
     qr1 = LCClient.search(
         Time('2012/8/9', '2012/8/10'), Instrument('noaa-indices'))
@@ -94,7 +93,7 @@ def test_query(mock_search):
 
 
 @mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient.search',
-            side_effect=create_mock_unified_object('2012/10/4', '2012/10/6'))
+            return_value=create_mock_unified_object('2012/10/4', '2012/10/6'))
 @mock.patch('sunpy.net.download.Results.wait',
             return_value=['some/path/extension/RecentIndices.txt'])
 def test_fetch(mock_wait, mock_search):
@@ -106,7 +105,7 @@ def test_fetch(mock_wait, mock_search):
 
 
 @mock.patch('sunpy.net.fido_factory.Fido.fetch',
-            side_effect=create_mock_unified_object("2012/10/4", "2012/10/6"))
+            side_effect=(UnifiedResponse(create_mock_unified_object("2012/10/4", "2012/10/6"))))
 def test_fido(mock_fetch):
     qr = Fido.search(a.Time("2012/10/4", "2012/10/6"),
                      a.Instrument('noaa-indices'))

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -45,6 +45,7 @@ def test_fetch_working():
     # Mock UnifiedResponse object
     mock_qr = create_mock_unified_object('2012/10/4', '2012/10/6')
     assert isinstance(mock_qr, qr1)
+    assert mock_qr == qr1
 
     # Assert if the timerange is same
     assert qr1.time_range() == TimeRange('2012/10/4', '2012/10/6')

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -62,8 +62,8 @@ def test_fetch(time, instrument):
     assert len(download_list) == len(qr1)
 
 
-@mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient._get_default_uri',\
- return_value='https://example.com' )
+@mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient._get_default_uri',
+            return_value='https://example.com')
 @mock.patch('sunpy.net.fido_factory.Fido.fetch', return_value=['*']*19)
 def test_fido(mock_search, mock_fetch):
     qr = Fido.search(a.Time("2012/10/4", "2012/10/6"), a.Instrument('noaa-indices'))

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -73,13 +73,13 @@ def test_get_url_for_time_range(timerange, url_start, url_end):
 def test_can_handle_query():
     ans1 = noaa.NOAAIndicesClient._can_handle_query(
         Time('2012/8/9', '2012/8/10'), Instrument('noaa-indices'))
-    assert ans1 is True
+    assert ans1
     ans2 = noaa.NOAAIndicesClient._can_handle_query(
         Time('2012/7/7', '2012/7/7'))
-    assert ans2 is False
+    assert not ans2
     ans3 = noaa.NOAAIndicesClient._can_handle_query(
         Time('2012/8/9', '2012/8/10'), Instrument('eve'))
-    assert ans3 is False
+    assert not ans3
 
 
 @mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient.search',

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -1,5 +1,7 @@
 import pytest
 
+from unittest import mock
+
 from sunpy.time import parse_time
 from sunpy.time.timerange import TimeRange
 from sunpy.net.vso.attrs import Time, Instrument
@@ -60,13 +62,10 @@ def test_fetch(time, instrument):
     assert len(download_list) == len(qr1)
 
 
-@pytest.mark.remote_data
-@pytest.mark.parametrize(
-    "time, instrument",
-    [(a.Time("2012/10/4", "2012/10/6"), a.Instrument('noaa-indices')),
-     (a.Time('2013/10/5', '2013/10/7'), a.Instrument('noaa-indices'))])
-def test_fido(time, instrument):
-    qr = Fido.search(time, instrument)
+@mock.patch('sunpy.net.dataretriever.sources.noaa.NOAAIndicesClient._get_default_uri', return_value='https://example.com' )
+@mock.patch('sunpy.net.fido_factory.Fido.fetch', return_value=['*']*19)
+def test_fido(mock_search, mock_fetch):
+    qr = Fido.search(a.Time("2012/10/4", "2012/10/6"), a.Instrument('noaa-indices'))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -14,6 +14,7 @@ from sunpy.net import attrs as a
 LCClient = noaa.NOAAIndicesClient()
 
 
+
 def mock_query_object(start_date, end_date):
     """
     Creation of a QueryResponse object, and prefill some
@@ -21,9 +22,13 @@ def mock_query_object(start_date, end_date):
     """
     # Create a mock QueryResponse object
     map_ = {
+        'TimeRange' : TimeRange(parse_time(start_date), parse_time(end_date)),
         'Time_start': parse_time(start_date),
         'Time_end':  parse_time(end_date),
-        'source': 'sdic'
+        'source': 'sdic',
+        'instrument': 'noaa-indices',
+        'physobs':'sunspot number',
+        'provider':'swpc'
     }
 
     resp = QueryResponse.create(map_, LCClient._get_default_uri())
@@ -44,7 +49,12 @@ def test_fetch_working():
     # Mock QueryResponse object
     mock_qr = mock_query_object('2012/10/4', '2012/10/6')
 
-    assert mock_qr == qr1
+    # Compare if two objects have the same attribute
+
+    # Currently, QueryResponseBlock does not support
+    # comparison operation, so this is a ad-hoc
+    # hack for comparing the values
+    mock_qr[:][0]._map == qr1[:][0]._map
 
     # Assert if the timerange is same
     assert qr1.time_range() == TimeRange('2012/10/4', '2012/10/6')

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -41,6 +41,14 @@ def test_fetch_working():
     '''
     qr1 = LCClient.search(Time('2012/10/4', '2012/10/6'),
                           Instrument('noaa-indices'))
+
+    # Mock UnifiedResponse object
+    mock_qr = create_mock_unified_object('2012/10/4', '2012/10/6')
+    assert isinstance(mock_qr, qr1)
+
+    # Assert if the timerange is same
+    assert qr1.time_range() == TimeRange('2012/10/4', '2012/10/6')
+
     res = LCClient.fetch(qr1)
     download_list = res.wait(progress=False)
     assert len(download_list) == len(qr1)


### PR DESCRIPTION
1. Note that this is test commit, demonstrating the mocking of `Fido.search` and `Fido.fetch`
2. Further tests using mock would be written after this pattern of mocking is useful

<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Partial work for #2874
