### PR TITLE
remove mock dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           command: /opt/python/cp36-cp36m/bin/pip install --progress-bar off numpy==1.15.3 scipy astropy!=3.1.1 matplotlib==1.5.3
       - run:
           name: Install dependencies two
-          command: /opt/python/cp36-cp36m/bin/pip install --progress-bar off sqlalchemy scikit-image==0.13.1 glymur drms zeep beautifulsoup4 requests python-dateutil pytest pytest-cov pytest-mock pytest-xdist mock hypothesis pytest-astropy pytest-rerunfailures
+          command: /opt/python/cp36-cp36m/bin/pip install --progress-bar off sqlalchemy scikit-image==0.13.1 glymur drms zeep beautifulsoup4 requests python-dateutil pytest pytest-cov pytest-mock pytest-xdist hypothesis pytest-astropy pytest-rerunfailures
       - run:
           name: Run tests
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4

--- a/docs/guide/installation/advanced.rst
+++ b/docs/guide/installation/advanced.rst
@@ -96,8 +96,6 @@ To run the tests:
 
 - `hypothesis <https://github.com/HypothesisWorks/hypothesis-python>`_
 
-- `mock <https://github.com/testing-cabal/mock>`_
-
 - `pytest <https://docs.pytest.org/en/latest/>`_
 
 - `pytest-cov <https://github.com/pytest-dev/pytest-cov>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ image_requires = scikit-image
 jpeg2000_requires = glymur
 net_requires = drms, zeep, beautifulsoup4, python-dateutil
 asdf_requires = asdf
-tests_requires = pytest, pytest-cov, pytest-mock, pytest-xdist, mock, hypothesis, pytest-astropy, pytest-rerunfailures
+tests_requires = pytest, pytest-cov, pytest-mock, pytest-xdist, hypothesis, pytest-astropy, pytest-rerunfailures
 docs_requires = ruamel.yaml, sphinx, sunpy-sphinx-theme, sphinx-gallery, sphinx-astropy, towncrier
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 1.0.0.dev

--- a/sunpy/instr/tests/test_rhessi.py
+++ b/sunpy/instr/tests/test_rhessi.py
@@ -2,6 +2,7 @@
 """
 Unit tests for `sunpy.instr.rhessi`
 """
+import sys
 import textwrap
 
 from unittest import mock
@@ -125,7 +126,7 @@ def hessi_data():
                              Filename  Orb_st Orb_end         Start_time           End_time Status_flag    Npackets Drift_start   Drift_end Data source
          hsi_obssumm_19721101_139.fit       7       8 01-Nov-72 00:00:00 02-Nov-72 00:00:00           3           2       0.000       0.000
          hsi_obssumm_19721102_144.fit       9      10 02-Nov-72 00:00:00 03-Nov-72 00:00:00           4           1       0.000       0.000
-         """).splitlines()
+         """)
 
 
 def test_parse_observing_summary_dbase_file_mock():
@@ -133,8 +134,14 @@ def test_parse_observing_summary_dbase_file_mock():
     Ensure that all required data are extracted from the RHESSI
     observing summary database file mocked in `hessi_data()`
     """
-    mock_file = mock.mock_open()
-    mock_file.return_value.__iter__.return_value = hessi_data()
+
+    # We need to mock this test differently for 3.6 vs 3.7
+    # Hopefully they backport the fix to 3.6 in the future.
+    if sys.version_info[1] <= 6:
+        mock_file = mock.mock_open()
+        mock_file.return_value.__iter__.return_value = hessi_data().splitlines()
+    else:
+        mock_file = mock.mock_open(read_data=hessi_data())
 
     dbase_data = {}
     with mock.patch('sunpy.instr.rhessi.open', mock_file, create=True):

--- a/sunpy/instr/tests/test_rhessi.py
+++ b/sunpy/instr/tests/test_rhessi.py
@@ -4,7 +4,7 @@ Unit tests for `sunpy.instr.rhessi`
 """
 import textwrap
 
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 

--- a/sunpy/net/dataretriever/tests/test_rhessi.py
+++ b/sunpy/net/dataretriever/tests/test_rhessi.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from urllib.error import URLError
 from urllib.request import urlretrieve
 
-import mock
+from unittest import mock
 import pytest
 
 import sunpy.instr.rhessi

--- a/sunpy/net/tests/test_helio.py
+++ b/sunpy/net/tests/test_helio.py
@@ -1,6 +1,6 @@
 import urllib
 
-import mock
+from unittest import mock
 import pytest
 
 from sunpy.net.helio.parser import (link_test, taverna_parser, wsdl_retriever,

--- a/sunpy/tests/figure_tests_env_py36.yml
+++ b/sunpy/tests/figure_tests_env_py36.yml
@@ -18,7 +18,6 @@ dependencies:
   - requests=2.18.4
   - python-dateutil=2.6.1
   - hypothesis=3.44.24
-  - mock=2.0.0
   - pbr=3.1.1
   - pytest=3.4.0
   - pytest-mock=1.6.3

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     pytest-rerunfailures
     pytest-sugar
     offline,online,build_docs,astropydev: asdf
+    win32: pillow
 conda_deps =
     astropydev,numpydev: cython
     offline,online,build_docs: numpy<1.16

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ conda_deps =
     jinja2
     lxml
     matplotlib
-    mock
     openjpeg
     pandas
     pytest


### PR DESCRIPTION
From @yashrsharma44's pull request #2900 I've noticed we were using `mock` in other places, but mock is since 3.3 part of python's unittest. Since we are requiring python 3.6 this dependency can be removed.