### PR TITLE
Remove test warnings from sunpy.coordinates

### DIFF
--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -58,7 +58,7 @@ class HeliographicStonyhurst(SunPyBaseCoordinateFrame):
 
         HeliographicStonyhurst(lon, lat, obstime)
         HeliographicStonyhurst(lon, lat, radius, obstime)
-        HeliographicStonyhurst(x, y, z, obstime, representation='cartesian')
+        HeliographicStonyhurst(x, y, z, obstime, representation_type='cartesian')
 
     Parameters
     ----------
@@ -133,7 +133,7 @@ class HeliographicStonyhurst(SunPyBaseCoordinateFrame):
     _default_wrap_angle = 180*u.deg
 
     def __init__(self, *args, **kwargs):
-        _rep_kwarg = kwargs.get('representation', None)
+        _rep_kwarg = kwargs.get('representation_type', None)
         wrap = kwargs.pop('wrap_longitude', True)
 
         if ('radius' in kwargs and kwargs['radius'].unit is u.one and

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -97,13 +97,13 @@ class NorthOffsetFrame(object):
             rotation = 180*u.deg
 
         if isinstance(origin_frame.data, UnitSphericalRepresentation):
-            new_rep = origin_frame.representation(lon=lon,
-                                                  lat=lat)
+            new_rep = origin_frame.representation_type(lon=lon,
+                                                       lat=lat)
 
         else:
-            new_rep = origin_frame.representation(lon=lon,
-                                                  lat=lat,
-                                                  distance=rep.distance)
+            new_rep = origin_frame.representation_type(lon=lon,
+                                                       lat=lat,
+                                                       distance=rep.distance)
 
         new_origin = origin_frame.realize_frame(new_rep)
         kwargs['origin'] = new_origin

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -40,7 +40,7 @@ These are common 2D params, kwargs are frame specific
 two_D_parameters = [
     ([0 * u.deg, 0 * u.arcsec], None),
     ([0 * u.deg, 0 * u.arcsec], {'obstime': '2011/01/01T00:00:00'}),
-    ([0 * u.deg, 0 * u.arcsec], {'representation': 'unitspherical'}),
+    ([0 * u.deg, 0 * u.arcsec], {'representation_type': 'unitspherical'}),
     ([UnitSphericalRepresentation(0 * u.deg, 0 * u.arcsec)], None),
     ([UnitSphericalRepresentation(0 * u.deg, 0 * u.arcsec)], None), (
         [UnitSphericalRepresentation(0 * u.deg, 0 * u.arcsec)],
@@ -52,7 +52,7 @@ These are common 3D params, kwargs are frame specific
 three_D_parameters = [
     ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], None),
     ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], {'obstime': '2011/01/01T00:00:00'}),
-    ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], {'representation': 'spherical'}),
+    ([0 * u.deg, 0 * u.arcsec, 1 * u.Mm], {'representation_type': 'spherical'}),
     ([SphericalRepresentation(0 * u.deg, 0 * u.arcsec, 1 * u.Mm)],
      None),
     ([SphericalRepresentation(0 * u.deg, 0 * u.arcsec, 1 * u.Mm)], None), (
@@ -73,7 +73,7 @@ def test_create_hpc_2d(args, kwargs):
 
     # Check we have the right class!
     assert isinstance(hpc1, Helioprojective)
-    rep_kwarg = kwargs.get('representation', None) if kwargs else None
+    rep_kwarg = kwargs.get('representation_type', None) if kwargs else None
 
     if rep_kwarg and rep_kwarg == 'unitspherical':
         # Check that we have a unitspherical representation
@@ -102,7 +102,7 @@ def test_create_3d(args, kwargs):
 
     # Check we have the right class!
     assert isinstance(hpc1, Helioprojective)
-    rep_kwarg = kwargs.get('representation', None) if kwargs else None
+    rep_kwarg = kwargs.get('representation_type', None) if kwargs else None
 
     if rep_kwarg and rep_kwarg == 'spherical':
         # Check that we have a unitspherical representation
@@ -215,7 +215,7 @@ def test_HEE_creation():
                                obstime=parse_time('2018-12-21'))
     _ = HeliographicStonyhurst(x=1*u.km, y=1*u.km, z=1*u.km,
                                obstime=parse_time('2018-12-21'),
-                               representation='cartesian')
+                               representation_type='cartesian')
 
 @pytest.mark.parametrize('frame',
                          [HeliographicStonyhurst, HeliographicCarrington])
@@ -253,7 +253,7 @@ def test_create_hgs_force_2d(frame, args, kwargs):
     # Check we have the right class!
     assert isinstance(hgs1, frame)
 
-    rep_kwarg = kwargs.get('representation', None) if kwargs else None
+    rep_kwarg = kwargs.get('representation_type', None) if kwargs else None
 
     if rep_kwarg == 'unitspherical':
         assert isinstance(hgs1._data, UnitSphericalRepresentation)
@@ -281,7 +281,7 @@ def test_create_hgs_3d(frame, args, kwargs):
     # Check we have the right class!
     assert isinstance(hgs1, frame)
 
-    rep_kwarg = kwargs.get('representation', None) if kwargs else None
+    rep_kwarg = kwargs.get('representation_type', None) if kwargs else None
 
     if rep_kwarg == 'spherical':
         assert isinstance(hgs1._data, SphericalRepresentation)
@@ -373,7 +373,7 @@ two_D_parameters = [
 
 @pytest.mark.parametrize("args, kwargs",
                          two_D_parameters + [([0 * u.deg, 0 * u.arcsec],
-                                              {'representation': 'unitspherical'})])
+                                              {'representation_type': 'unitspherical'})])
 def test_skycoord_hpc(args, kwargs):
     """
     Test that when instantiating a HPC frame with SkyCoord calculate distance

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -169,7 +169,7 @@ def test_hgs_cartesian_rep_to_hpc():
                              frame=HeliographicStonyhurst(obstime=obstime),
                              representation_type='cartesian')
     hgscoord_sph = hgscoord_cart.copy()
-    hgscoord_sph.representation = 'spherical'
+    hgscoord_sph.representation_type = 'spherical'
     hpccoord_cart = hgscoord_cart.transform_to(Helioprojective(obstime=obstime))
     hpccoord_sph = hgscoord_sph.transform_to(Helioprojective(obstime=obstime))
     assert_quantity_allclose(hpccoord_cart.Tx, hpccoord_sph.Tx)
@@ -187,7 +187,7 @@ def test_hgs_cartesian_rep_to_hcc():
                              frame=HeliographicStonyhurst(obstime=obstime),
                              representation_type='cartesian')
     hgscoord_sph = hgscoord_cart.copy()
-    hgscoord_sph.representation = 'spherical'
+    hgscoord_sph.representation_type = 'spherical'
     hcccoord_cart = hgscoord_cart.transform_to(Heliocentric(obstime=obstime))
     hcccoord_sph = hgscoord_sph.transform_to(Heliocentric(obstime=obstime))
     assert_quantity_allclose(hcccoord_cart.x, hcccoord_sph.x)
@@ -205,7 +205,7 @@ def test_hgs_cartesian_rep_to_hgc():
                              frame=HeliographicStonyhurst(obstime=obstime),
                              representation_type='cartesian')
     hgscoord_sph = hgscoord_cart.copy()
-    hgscoord_sph.representation = 'spherical'
+    hgscoord_sph.representation_type = 'spherical'
     # HGC
     hgccoord_cart = hgscoord_cart.transform_to(HeliographicCarrington(obstime=obstime))
     hgccoord_sph = hgscoord_sph.transform_to(HeliographicCarrington(obstime=obstime))


### PR DESCRIPTION
xref #2886; mainly using `representation_type` instead of `representation`.