### PR TITLE
Add sections to citation page

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -9,15 +9,12 @@ Publications
 
 Please add the following line to the conclusion or acknowledgements:
 
-   *This research has made use of SunPy, an open-source and free
+   *This research has made use of SunPy vX.Y, an open-source and free
    community-developed solar data analysis package written in Python
    (citation).*
 
-The citation should be to the `SunPy v0.5 paper`_/`arXiv(open access)`_.
-
-If you have the time, please also email us to let us know about your paper, as we
-maintain a `public list`_ of papers on `Zotero`_. A BibTeX entry for
-LaTeX users is:
+The citation should be to the `SunPy paper`_/`arXiv(open access)`_ and the
+version number should cite the `Zenodo DOI`_ for the version used in your work.
 
 .. code:: bibtex
 
@@ -52,10 +49,9 @@ Please include the `Sunpy logo`_ on the title, conclusion slide, or
 bout page. For websites please link the image to `sunpy.org`_.
 Other versions of the logo are available in the `sunpy-logo repository`_.
 
-.. _SunPy v0.5 paper: https://iopscience.iop.org/article/10.1088/1749-4699/8/1/014009
+.. _SunPy paper: https://iopscience.iop.org/article/10.1088/1749-4699/8/1/014009
 .. _arXiv(open access): https://arxiv.org/abs/1505.02563
-.. _public list: https://www.zotero.org/groups/sunpy_-_python_for_solar_physicists
-.. _Zotero: https://www.zotero.org/
-.. _Sunpy logo: http://sunpy.org/about/#acknowledging
-.. _sunpy.org: http://sunpy.org/
+.. _Sunpy logo: https://sunpy.org/about/#acknowledging
+.. _sunpy.org: https://sunpy.org/
 .. _sunpy-logo repository: https://github.com/sunpy/sunpy-logo/
+.. _Zenodo DOI: https://doi.org/10.5281/zenodo.591887

--- a/CITATION.rst
+++ b/CITATION.rst
@@ -3,20 +3,21 @@ Acknowledging or Citing SunPy
 
 If you have used SunPy in your scientific work we would appreciate it if you would acknowledge it.
 The continued growth and development of SunPy is dependent on the community being aware of the use SunPy.
-If you use SunPy, we therefore ask that you acknowledge SunPy appropriately in a publication, presentation, poster, or talk.
 
--  **For a publication**, we recommend the following line be added to
-   the conclusion or acknowledgements:
+Publications
+------------
+
+Please add the following line to the conclusion or acknowledgements:
 
    *This research has made use of SunPy, an open-source and free
    community-developed solar data analysis package written in Python
    (citation).*
 
-   The citation is to the `SunPy v0.5 paper`_/`arXiv(open access)`_. If
-   the journal allows please also include a link to sunpy.org. If you
-   have the time, please email us to let us know about your paper, as we
-   maintain a `public list`_ of papers on `Zotero`_. A BibTeX entry for
-   LaTeX users is:
+The citation should be to the `SunPy v0.5 paper`_/`arXiv(open access)`_.
+
+If you have the time, please also email us to let us know about your paper, as we
+maintain a `public list`_ of papers on `Zotero`_. A BibTeX entry for
+LaTeX users is:
 
 .. code:: bibtex
 
@@ -44,12 +45,12 @@ If you use SunPy, we therefore ask that you acknowledge SunPy appropriately in a
           adsnote = {Provided by the SAO/NASA Astrophysics Data System}
         }
 
--  **For a poster, talks, or project websites**, please include the
-   `Sunpy logo`_ on the title, conclusion slide, or about page. For
-   websites please link the image to `sunpy.org`_. Other versions of the
-   logo are available in the `sunpy-logo repository`_.
+Posters and talks
+-----------------
 
-Thank you, in advance, for your support.
+Please include the `Sunpy logo`_ on the title, conclusion slide, or
+bout page. For websites please link the image to `sunpy.org`_.
+Other versions of the logo are available in the `sunpy-logo repository`_.
 
 .. _SunPy v0.5 paper: https://iopscience.iop.org/article/10.1088/1749-4699/8/1/014009
 .. _arXiv(open access): https://arxiv.org/abs/1505.02563

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,0 +1,1 @@
+.. include:: ../CITATION.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,3 +15,4 @@ We have a documentation :any:`index <genindex>` and a :any:`module <modindex>` l
   dev_guide/index
   whatsnew/index
   coc
+  about


### PR DESCRIPTION
xref the chat earlier. This adds some sections to the citing page which I think makes it more immediately readable.

I also added `docs/about.rst`, so people building the docs actually get a `about.html` page (one wasn't generated before).