### PR TITLE
Modified /sunpy/instr/goes.py so that 'hek' is imported only in the f…

### DIFF
--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -105,8 +105,7 @@ def get_goes_event_list(timerange, goes_class_filter=None):
         e.g. 'M1', 'X2'.
 
     """
-
-    # import hek here so that other functions don't import hek as they don't need it
+    # Importing hek here to avoid calling code that relies on optional dependencies.
     from sunpy.net import hek
 
     # use HEK module to search for GOES events

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -59,7 +59,6 @@ from scipy import interpolate
 from scipy.integrate import trapz, cumtrapz
 
 from sunpy import sun
-from sunpy.net import hek
 from sunpy import timeseries
 from sunpy.time import parse_time
 from sunpy.util.net import check_download_file
@@ -106,6 +105,10 @@ def get_goes_event_list(timerange, goes_class_filter=None):
         e.g. 'M1', 'X2'.
 
     """
+
+    # import hek here so that other functions don't import hek as they don't need it
+    from sunpy.net import hek
+
     # use HEK module to search for GOES events
     client = hek.HEKClient()
     event_type = 'FL'


### PR DESCRIPTION
…unction that uses it.

<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
Solves the unexpected error as described in #2821 by moving `import hek` into `get_goes_event_list`.
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #2821 
