### PR TITLE
Added support for mocking online tests in test_lyra_ud.py

### DIFF
--- a/changelog/2958.trivial.rst
+++ b/changelog/2958.trivial.rst
@@ -1,0 +1,1 @@
+Used `unittest.mock` for creating offline tests for simulating online tests for `test_lyra_ud.py`

--- a/sunpy/net/dataretriever/tests/test_lyra_ud.py
+++ b/sunpy/net/dataretriever/tests/test_lyra_ud.py
@@ -1,5 +1,8 @@
 import pytest
+from unittest import mock
+from datetime import datetime, timedelta
 
+import astropy.units as u
 from sunpy.time.timerange import TimeRange
 from sunpy.time import parse_time
 from sunpy.net.vso.attrs import Time, Instrument
@@ -13,6 +16,97 @@ from hypothesis import given, settings
 from sunpy.net.tests.strategies import time_attr
 
 LCClient = lyra.LYRAClient()
+
+
+def mock_query_object(start_date, end_date):
+    """
+    Creation of a QueryResponse object, and prefill some
+    downloaded data from lyra.LYRAClient().fetch(Time('20 ..)
+    """
+    # Create a mock QueryResponse object
+    map_ = {
+        'TimeRange': TimeRange(parse_time(start_date), parse_time(end_date)),
+        'Time_start': parse_time(start_date),
+        'Time_end':  parse_time(end_date),
+        'source': 'Proba2',
+        'instrument': 'lyra',
+        'physobs': 'irradiance',
+        'provider': 'esa'
+    }
+
+    resp = QueryResponse.create(map_,
+    LCClient._get_url_for_timerange(TimeRange(parse_time(start_date), parse_time(end_date))))
+    # Attach the client with the QueryResponse
+    resp.client = LCClient
+    return resp
+
+
+@pytest.mark.remote_data
+def test_fetch_working():
+    """
+    Tests if the mock fetch contains the correct data.
+    """
+
+    qr1 = LCClient.search(a.Time('2012/10/4', '2012/10/6'),
+                          a.Instrument('lyra'))
+
+    # Create a mock query object
+    mock_qr = mock_query_object('2012/10/4', '2012/10/6')
+
+    mock_qr = mock_qr[0]
+    qr = qr1[0]
+    # Assert the values
+    assert mock_qr.source == qr.source
+    assert mock_qr.instrument == qr.instrument
+    assert mock_qr.physobs == qr.physobs
+    assert mock_qr.provider == qr.provider
+    assert mock_qr.url == qr.url
+    assert mock_qr.time == qr.time
+
+    # Assert if the time range is same
+    assert qr1.time_range() == TimeRange('2012/10/4', '2012/10/6')
+
+    # Assert the fetch object, and whether it returns the correct set of files
+    res = LCClient.fetch(qr1)
+    download_list = res.wait(progress=False)
+    assert len(download_list) == len(qr1)
+
+
+def daterange(start_date, end_date):
+    """
+    Helper function to create an iterable of datetime
+    containing each days as its entries from start to end
+    date
+    """
+
+    start_date = datetime.strptime(start_date, '%Y/%m/%d')
+    end_date = datetime.strptime(end_date, '%Y/%m/%d')
+    range_of_date = int((end_date - start_date).days)
+
+    if range_of_date is not 0:
+        for n in range(range_of_date+1):
+            yield start_date + timedelta(n)
+    else:
+        yield start_date
+
+
+# Create mocker fixtures for using parametrized tests
+@pytest.fixture
+def create_mock_fetch(mocker, sdate, edate, instrument):
+    mocker.patch('sunpy.net.fido_factory.Fido.fetch',
+        side_effect=(UnifiedResponse(mock_query_object(sdate, edate))))
+
+
+@pytest.fixture
+def create_mock_search(mocker, sdate, edate, instrument):
+    mocker.patch('sunpy.net.dataretriever.sources.lyra.LYRAClient.search',
+        return_value=mock_query_object(sdate, edate))
+
+
+@pytest.fixture
+def create_mock_result(mocker, sdate, edate, instrument):
+    mocker.patch('sunpy.net.download.Results.wait',
+    return_value=[LCClient._get_url_for_date(parse_time(date)) for date in daterange(sdate, edate)])
 
 
 @pytest.mark.parametrize("timerange,url_start,url_end", [
@@ -59,25 +153,27 @@ def test_query(time):
     assert qr1.time_range().end == time.end
 
 
-@pytest.mark.remote_data
-@pytest.mark.parametrize("time,instrument", [
-    (Time('2013/8/27', '2013/8/27'), Instrument('lyra')),
-    (Time('2013/2/4', '2013/2/6'), Instrument('lyra')),
+@pytest.mark.usefixtures('create_mock_search')
+@pytest.mark.usefixtures('create_mock_result')
+@pytest.mark.parametrize("sdate, edate ,instrument", [
+    ('2013/8/27', '2013/8/27', Instrument('lyra')),
+    ('2013/2/4', '2013/2/6', Instrument('lyra')),
 ])
-def test_get(time, instrument):
-    qr1 = LCClient.search(time, instrument)
+def test_get(sdate, edate, instrument):
+    qr1 = LCClient.search(TimeRange(sdate, edate), instrument)
     res = LCClient.fetch(qr1)
     download_list = res.wait(progress=False)
     assert len(download_list) == len(qr1)
 
 
-@pytest.mark.remote_data
+@pytest.mark.usefixtures('create_mock_fetch')
 @pytest.mark.parametrize(
-    "time, instrument",
-    [(a.Time('2012/10/4', '2012/10/6'), a.Instrument('lyra')),
-     (a.Time('2013/10/5', '2013/10/7'), a.Instrument('lyra'))])
-def test_fido(time, instrument):
-    qr = Fido.search(time, instrument)
+    "sdate, edate, instrument",
+    [('2012/10/4', '2012/10/6', a.Instrument('lyra')),
+     ('2013/10/5', '2013/10/7', a.Instrument('lyra'))]
+     )
+def test_fido(sdate, edate, instrument):
+    qr = Fido.search(a.Time(sdate, edate), a.Instrument('lyra'))
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile

--- a/sunpy/net/dataretriever/tests/test_lyra_ud.py
+++ b/sunpy/net/dataretriever/tests/test_lyra_ud.py
@@ -1,13 +1,16 @@
 import pytest
+
 from unittest import mock
 from datetime import datetime, timedelta
 
 import astropy.units as u
+import sunpy.net.dataretriever.sources.lyra as lyra
+
 from sunpy.time.timerange import TimeRange
 from sunpy.time import parse_time
 from sunpy.net.vso.attrs import Time, Instrument
 from sunpy.net.dataretriever.client import QueryResponse
-import sunpy.net.dataretriever.sources.lyra as lyra
+
 from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a

--- a/sunpy/net/dataretriever/tests/test_lyra_ud.py
+++ b/sunpy/net/dataretriever/tests/test_lyra_ud.py
@@ -28,7 +28,7 @@ def mock_query_object(start_date, end_date):
     """
     # Create a mock QueryResponse object
     map_ = {
-        'TimeRange': TimeRange(parse_time(start_date), parse_time(end_date)),
+        'TimeRange': TimeRange(start_date, end_date),
         'Time_start': parse_time(start_date),
         'Time_end':  parse_time(end_date),
         'source': 'Proba2',
@@ -37,8 +37,7 @@ def mock_query_object(start_date, end_date):
         'provider': 'esa'
     }
 
-    resp = QueryResponse.create(map_,
-    LCClient._get_url_for_timerange(TimeRange(parse_time(start_date), parse_time(end_date))))
+    resp = QueryResponse.create(map_,LCClient._get_url_for_timerange(TimeRange(start_date, end_date)))
     # Attach the client with the QueryResponse
     resp.client = LCClient
     return resp


### PR DESCRIPTION
1. Used mocking to mock online tests
2. Use mocker to parametrize different values of the test
3. Created a function to cross-check the return values of the mocked function

Partial fix #2874 
