### PR TITLE
Bug in sunpy.time convert_time_str function

### DIFF
--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -224,6 +224,7 @@ def convert_time_str(time_string, **kwargs):
                 break
             if ts is None:
                 continue
+            #problem!!
             return Time.strptime(ts, time_format, **kwargs) + time_delta
         except ValueError:
             pass


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
In sunpy.time.time.py the astropy.time.Time.strptime is called but this does not exist, it comes from an older version of sunpy when the time types were datetimes
 

<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
