### PR TITLE
Made HEC treat start_time and end_time as astropy.time.Time objects

### DIFF
--- a/changelog/2969.bugfix.rst
+++ b/changelog/2969.bugfix.rst
@@ -1,1 +1,1 @@
-Changed HEC to recognize `parse_time()` output as `astropy.time.Time` object.
+`sunpy.net.helio.hec.HECClient.time_query` now resolves the correct input time format.

--- a/changelog/2969.bugfix.rst
+++ b/changelog/2969.bugfix.rst
@@ -1,0 +1,1 @@
+Changed HEC to recognize `parse_time()` output as `astropy.time.Time` object.

--- a/sunpy/net/helio/hec.py
+++ b/sunpy/net/helio/hec.py
@@ -110,8 +110,8 @@ class HECClient(object):
             table = self.make_table_list()
         start_time = parse_time(start_time)
         end_time = parse_time(end_time)
-        results = self.hec_client.service.TimeQuery(STARTTIME=start_time.isoformat(),
-                                                    ENDTIME=end_time.isoformat(),
+        results = self.hec_client.service.TimeQuery(STARTTIME=start_time.isot,
+                                                    ENDTIME=end_time.isot,
                                                     FROM=table,
                                                     MAXRECORDS=max_records)
         results = votable_handler(etree.tostring(results))

--- a/sunpy/net/tests/test_helio.py
+++ b/sunpy/net/tests/test_helio.py
@@ -5,6 +5,7 @@ import pytest
 
 from sunpy.net.helio.parser import (link_test, taverna_parser, wsdl_retriever,
                                     endpoint_parser, webservice_parser)
+from sunpy.net.helio import hec
 
 
 def wsdl_endpoints():
@@ -251,3 +252,13 @@ def test_link_test_on_urlerror(mock_link_test):
     returns `None`
     """
     link_test('') is None
+
+    
+@pytest.mark.remote_data
+def test_time_query():
+    hc = hec.HECClient()
+    start = '2005/01/03'
+    end = '2005/12/03'
+    table_name = 'rhessi_hxr_flare'
+    res = hc.time_query(start, end, table=table_name, max_records=10)
+    assert len(res.array) == 10

--- a/sunpy/net/tests/test_helio.py
+++ b/sunpy/net/tests/test_helio.py
@@ -253,7 +253,7 @@ def test_link_test_on_urlerror(mock_link_test):
     """
     link_test('') is None
 
-    
+
 @pytest.mark.remote_data
 def test_time_query():
     hc = hec.HECClient()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Changed the way time is accessed to pass into TimeQuery() from `.isoformat()` to `.isot`.
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #2964 
