### PR TITLE
Modify `edges_to_centers_nd` calls in `base.py`

### DIFF
--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -526,7 +526,7 @@ class ArrayAnimator(BaseFuncAnimator, metaclass=abc.ABCMeta):
                     # and APIs using both [min, max] pair and manual definition of each pixel
                     # values can be unambiguously and simultanously supported.
                     extent += [axis_ranges[i][0], axis_ranges[i][-1]]
-                    axis_ranges[i] = edges_to_centers_nd(axis_ranges[i])
+                    axis_ranges[i] = edges_to_centers_nd(axis_ranges[i], 0)
                 elif axis_ranges[i].ndim == ndim and axis_ranges[i].shape[i] == data_shape[i]+1:
                     extent += [axis_ranges[i].min(), axis_ranges[i].max()]
                     axis_ranges[i] = edges_to_centers_nd(axis_ranges[i], i)


### PR DESCRIPTION
`edges_to_centers_nd` is dependent on `edge_axis` which apparently affects some calls. Probably there is more to fix.
