### PR TITLE
Trick GitHub into seeing we have a code of conduct for the repo

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+../CODE_OF_CONDUCT.rst

--- a/.mailmap
+++ b/.mailmap
@@ -78,7 +78,7 @@ Garrison Taylor <garrisontaylor@gmail.com> gbear605 <garrisontaylor@gmail.com>
 Ankit Baruah <ankit.baruah1@gmail.com> abit2 <ankit.baruah1@gmail.com>
 Ankit Kumar <ankitkmr@users.noreply.github.com> ankitkmr <technocrat.ankit@gmail.com>
 Fionnlagh Mackenzie Dover <fmackenziedover1@sheffield.ac.uk> FinMacDov <fmackenziedover1@sheffield.ac.uk>
-Michael Charlton<m.charlton@mac.com> Michael <m.charlton@mac.com>
+Michael Charlton <m.charlton@mac.com> Michael <m.charlton@mac.com>
 Duygu Keşkek <duygukeskek@hotmail.com> Duygu KEŞKEK <duygukeskek@hotmail.com>
 Kaustubh Hiware <hiwarekaustubh@googlemail.com> kaustubhhiware <hiwarekaustubh@googlemail.com>
 Yash Jain <yashjainjain1704@gmail.com> yash_jain <yashjainjain1704@gmail.com>


### PR DESCRIPTION
It appears that GitHub hasn't automatically detected our rst code of conduct file, so this is a hack.