### PR TITLE
Generate ASDF schema docs automatically using sphinx-asdf

### DIFF
--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -268,6 +268,23 @@ which is equivalent to::
         (0., 0.048591, 1.51846026e+11)>)>
 
 
+ASDF Schemas
+------------
+
+Sunpy defines `ASDF <http://asdf-standard.readthedocs.io>`__ schemas that are
+used for validating the representation of Sunpy-specific coordinates in the
+ASDF format. These schemas contain useful documentation about the associated
+types, and can also be used by other implementations that wish to interoperate
+with these transform definitions.
+
+.. asdf-autoschemas::
+
+   coordinates/frames/heliocentric-1.0.0
+   coordinates/frames/heliographic_carrington-1.0.0
+   coordinates/frames/heliographic_stonyhurst-1.0.0
+   coordinates/frames/helioprojective-1.0.0
+
+
 .. automodapi:: sunpy.coordinates
     :headings: ^#
 

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -142,3 +142,17 @@ manually register your class and matching method using the following method
     import sunpy.map
 
     sunpy.map.Map.register(FutureMap, FutureMap.some_matching_method)
+
+
+ASDF Schemas
+------------
+
+Sunpy defines an `ASDF <http://asdf-standard.readthedocs.io>`__ schema that is
+used for validating the representation of the `~sunpy.map.GenericMap` type in
+the ASDF format. This schema contains useful documentation about the associated
+types, and can also be used by other implementations that wish to interoperate
+with these transform definitions.
+
+.. asdf-autoschemas::
+
+   map/generic_map-1.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -231,7 +231,8 @@ napoleon_use_rtype = False
 # Disable google style docstrings
 napoleon_google_docstring = False
 
-extensions += ['sphinx_astropy.ext.edit_on_github', 'sphinx.ext.doctest', 'sphinx.ext.githubpages']
+extensions += ['sphinx_astropy.ext.edit_on_github', 'sphinx.ext.doctest',
+               'sphinx.ext.githubpages', 'sphinx_asdf']
 
 # -- Options for the edit_on_github extension ---------------------------------
 # Don't import the module as "version" or it will override the
@@ -274,6 +275,19 @@ if has_sphinx_gallery:
         'abort_on_example_error': True,
         'plot_gallery': True
     }
+
+
+# -- Options for ASDF schema docs -------------------------------------------
+# Top-level directory containing ASDF schemas (relative to current directory)
+asdf_schema_path = '../sunpy/io/special/asdf/schemas'
+# This is the prefix common to all schema IDs in this repository
+asdf_schema_standard_prefix = 'sunpy.org/sunpy'
+asdf_schema_reference_mappings = [
+    ('tag:stsci.edu:asdf',
+     'http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/'),
+    ('tag:astropy.org:astropy',
+     'http://astropy.readthedocs.io/en/latest/generated/astropy.org/astropy/'),
+]
 
 
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ tests =
 docs =
   ruamel.yaml
   sphinx
+  sphinx-asdf
   sphinx-astropy
   sphinx-gallery
   sunpy-sphinx-theme


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR adds automatically generated ASDF schema documentation to the sphinx docs. It uses the [sphinx-asdf](https://github.com/spacetelescope/sphinx-asdf) plugin.
