### PR TITLE
Fix #3045 return an empty HEK table

### DIFF
--- a/changelog/3046.bugfix.rst
+++ b/changelog/3046.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in `sunpy.net.hek` which raised and error if a search returned zero results, now returns an empty `sunpy.net.hek.HEKTable`.

--- a/sunpy/net/hek/hek.py
+++ b/sunpy/net/hek/hek.py
@@ -16,6 +16,7 @@ from itertools import chain
 from astropy.table import Table, Row, Column
 from astropy.time import Time
 
+from sunpy import log
 from sunpy.net import attr
 from sunpy.util import unique
 from sunpy.net.hek import attrs
@@ -73,7 +74,12 @@ class HEKClient(object):
             results.extend(result['result'])
 
             if not result['overmax']:
-                return HEKTable(results)
+                if len(results) > 0:
+                    return HEKTable(results)
+                else:
+                    log.info('Search returned no results')
+                    return HEKTable()
+
             page += 1
 
     def search(self, *query):

--- a/sunpy/net/hek/hek.py
+++ b/sunpy/net/hek/hek.py
@@ -16,7 +16,6 @@ from itertools import chain
 from astropy.table import Table, Row, Column
 from astropy.time import Time
 
-from sunpy import log
 from sunpy.net import attr
 from sunpy.util import unique
 from sunpy.net.hek import attrs
@@ -77,7 +76,6 @@ class HEKClient(object):
                 if len(results) > 0:
                     return HEKTable(results)
                 else:
-                    log.info('Search returned no results')
                     return HEKTable()
 
             page += 1

--- a/sunpy/net/tests/test_hek.py
+++ b/sunpy/net/tests/test_hek.py
@@ -117,6 +117,21 @@ def test_hek_client():
 
 
 @pytest.mark.remote_data
+def test_hek_empty_search_result():
+    startTime = '1985-05-04 00:00:00'
+    endTime = '1985-05-04 00:00:00'
+    eventType = 'FL'
+
+    hekTime = hek.attrs.Time(startTime, endTime)
+    hekEvent = hek.attrs.EventType(eventType)
+
+    h = hek.HEKClient()
+    hek_query = h.search(hekTime, hekEvent)
+    assert type(hek_query) == sunpy.net.hek.hek.HEKTable
+    assert len(hek_query) == 0
+
+
+@pytest.mark.remote_data
 def test_getitem(hek_client_creator):
     hc = hek_client_creator
     assert hc.__getitem__(0) == hc[0]


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Check for an empty query result and if found return empty HEKTable instance and test to cover this case.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3045 