### PR TITLE
Squash test warnings in sunpy.database

### DIFF
--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -13,6 +13,7 @@ import pytest
 import sqlalchemy
 
 from astropy import units
+from astropy.utils.exceptions import AstropyUserWarning
 
 import sunpy
 import sunpy.data.test
@@ -608,7 +609,8 @@ def test_add_entries_from_fido_search_result_ignore_duplicates(database, fido_se
 
 def test_add_fom_path(database):
     assert len(database) == 0
-    database.add_from_dir(waveunitdir)
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        database.add_from_dir(waveunitdir)
     assert len(database) == 4
     database.undo()
     assert len(database) == 0
@@ -617,16 +619,19 @@ def test_add_fom_path(database):
 
 
 def test_add_fom_path_duplicates(database):
-    database.add_from_dir(waveunitdir)
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        database.add_from_dir(waveunitdir)
     assert len(database) == 4
-    with pytest.raises(EntryAlreadyAddedError):
+    with pytest.raises(EntryAlreadyAddedError), pytest.warns(AstropyUserWarning, match='File may have been truncated'):
         database.add_from_dir(waveunitdir)
 
 
 def test_add_fom_path_ignore_duplicates(database):
-    database.add_from_dir(waveunitdir)
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        database.add_from_dir(waveunitdir)
     assert len(database) == 4
-    database.add_from_dir(waveunitdir, ignore_already_added=True)
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        database.add_from_dir(waveunitdir, ignore_already_added=True)
     assert len(database) == 8
 
 

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -11,6 +11,8 @@ import os
 
 import astropy.units as u
 from astropy import conf
+from astropy.utils.exceptions import AstropyUserWarning
+
 import numpy as np
 
 from sunpy.database import Database
@@ -257,7 +259,8 @@ def test_entry_from_qr_block_kev(qr_block_with_kev_unit):
 
 
 def test_entries_from_file():
-    entries = list(entries_from_file(MQ_IMAGE))
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        entries = list(entries_from_file(MQ_IMAGE))
     assert len(entries) == 1
     entry = entries[0]
     assert len(entry.fits_header_entries) == 31
@@ -332,8 +335,9 @@ def test_entries_from_file_time_string_parse_format():
 
 
 def test_entries_from_dir():
-    entries = list(entries_from_dir(
-        waveunitdir, time_string_parse_format='%d/%m/%Y'))
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        entries = list(entries_from_dir(
+            waveunitdir, time_string_parse_format='%d/%m/%Y'))
     assert len(entries) == 4
     for entry, filename in entries:
         if filename.endswith('na120701.091058.fits'):
@@ -404,16 +408,18 @@ def test_entries_from_dir():
 
 
 def test_entries_from_dir_recursively_true():
-    entries = list(entries_from_dir(testdir, True,
-                                    default_waveunit='angstrom',
-                                    time_string_parse_format='%d/%m/%Y'))
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        entries = list(entries_from_dir(testdir, True,
+                                        default_waveunit='angstrom',
+                                        time_string_parse_format='%d/%m/%Y'))
     assert len(entries) == 130
 
 
 def test_entries_from_dir_recursively_false():
-    entries = list(entries_from_dir(testdir, False,
-                                    default_waveunit='angstrom',
-                                    time_string_parse_format='%d/%m/%Y'))
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        entries = list(entries_from_dir(testdir, False,
+                                        default_waveunit='angstrom',
+                                        time_string_parse_format='%d/%m/%Y'))
     assert len(entries) == 109
 
 


### PR DESCRIPTION
All just files that are smaller than expected (I guess because they have been manually truncated to be small test files)