### PR TITLE
Fix two bugs in scraper code.

### DIFF
--- a/changelog/3063.bugfix.1.rst
+++ b/changelog/3063.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fix `sunpy.util.scraper.Scraper` failing if a directory is not found on a remote server.

--- a/changelog/3063.bugfix.2.rst
+++ b/changelog/3063.bugfix.2.rst
@@ -1,0 +1,1 @@
+Correctly zero pad milliseconds in the `sunpy.util.scraper.Scraper` formatting to prevent errors when the millisecond value was less than 100.

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -166,8 +166,6 @@ def testFilesRange_sameDirectory_local():
     # tries to open a directory as a binary file.
     s = Scraper('/'.join(['file:/', rootdir,
                           'EIT', 'efz%Y%m%d.%H%M%S_s.fits']))
-    print(s.pattern)
-    print(s.now)
     startdate = parse_time((2004, 3, 1, 4, 0))
     enddate = parse_time((2004, 3, 1, 6, 30))
     assert len(s.filelist(TimeRange(startdate, enddate))) == 3

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -1,3 +1,6 @@
+import datetime
+from unittest.mock import patch, Mock
+
 import pytest
 
 import astropy.units as u
@@ -140,18 +143,27 @@ def testURL_pattern():
     assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
 
 
-@pytest.mark.xfail
-def testURL_patternMilliseconds():
+def testURL_patternMillisecondsGeneric():
     s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
-    # NOTE: Seems that if below fails randomly - not understood why
-    #       with `== True` fails a bit less...
     assert s._URL_followsPattern('fd_20130410_231211_119.fts')
     assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
     assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
 
 
+def testURL_patternMillisecondsZeroPadded():
+    # Asserts solution to ticket #1954.
+    # Milliseconds must be zero-padded in order to match URL lengths.
+    now_mock = Mock(return_value=datetime.datetime(2019, 4, 19, 0, 0, 0, 4009))
+    with patch('datetime.datetime', now=now_mock):
+        s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
+    now_mock.assert_called_once()
+    assert s.now == 'fd_20190419_000000_004.fts'
+
+
 @pytest.mark.xfail
 def testFilesRange_sameDirectory_local():
+    # Fails due to an IsADirectoryError, wrapped in a URLError, after `requests`
+    # tries to open a directory as a binary file.
     s = Scraper('/'.join(['file:/', rootdir,
                           'EIT', 'efz%Y%m%d.%H%M%S_s.fits']))
     print(s.pattern)
@@ -199,3 +211,13 @@ def test_ftp():
     s = Scraper(pattern)
     timerange = TimeRange('2016/5/18 15:28:00', '2016/5/20 16:30:50')
     assert len(s.filelist(timerange)) == 2
+
+
+@pytest.mark.remote_data
+def test_filelist_url_missing_directory():
+    # Asserts solution to ticket #2684.
+    # Attempting to access data for the year 1960 results in a 404, so no files are returned.
+    pattern = 'http://lasp.colorado.edu/eve/data_access/evewebdataproducts/level2/%Y/%j/'
+    s = Scraper(pattern)
+    timerange = TimeRange('1960/01/01 00:00:00', '1960/01/02 00:00:00')
+    assert len(s.filelist(timerange)) == 0


### PR DESCRIPTION
Fixed parser failing due to missing directory (#2684) and when milliseconds were less than 100 (#1954).

<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Addressed two issues:
* #2684 Fixed by catching the HTTP error and ignoring it if the error code was 404 (Not Found). Added a test asserting the fix.
* #1954 Fixed the randomly failing test by addressing the underlying bug -- milliseconds were not being zero-padded. The `_URL_followsPattern` logic relies on URL length, which changes if zero-padding isn't used. The randomness was due to the random chance of the current milliseconds time being less than 100 (_derived from microseconds_). Added a test asserting the fix by using a mocked datetime of the edge case. I was not able to get the two other tests mentioned in the ticket to fail.
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #2684 and fixes #1954 
