### PR TITLE
Added rsun_obs property to return a quantity

### DIFF
--- a/changelog/3099.bugfix.rst
+++ b/changelog/3099.bugfix.rst
@@ -1,0 +1,1 @@
+Added rsun_obs property to STEREO map sources. It returns a quantity in arcsec consistent with other Maps and overwrites mapbase's assumption of a photospheric limb as seen Added rsun_obs property to stereo map sources.

--- a/changelog/3099.bugfix.rst
+++ b/changelog/3099.bugfix.rst
@@ -1,1 +1,1 @@
-Added rsun_obs property to STEREO map sources. It returns a quantity in arcsec consistent with other Maps and overwrites mapbase's assumption of a photospheric limb as seen Added rsun_obs property to stereo map sources.
+Added `~sunpy.map.EUVIMap.rsun_obs`. It returns a quantity in arcsec consistent with other `sunpy.map.GenericMap` and overwrites mapbase's assumption of a photospheric limb as seen from Earth.

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -68,9 +68,7 @@ class EUVIMap(GenericMap):
         rsun_arcseconds = self.meta.get('rsun', None)
 
         if rsun_arcseconds is None:
-            warnings.warn("Missing metadata for solar radius: assuming photospheric limb as seen from Earth.",
-                          SunpyUserWarning)
-            rsun_arcseconds = sun.solar_semidiameter_angular_size(self.date).to('arcsec').value
+            rsun_arcseconds = super().rsun_obs
 
         return u.Quantity(rsun_arcseconds, 'arcsec')
 

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 
 from astropy.visualization import PowerStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
+import astropy.units as u
 
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
@@ -54,6 +55,24 @@ class EUVIMap(GenericMap):
         https://sohowww.nascom.nasa.gov/solarsoft/stereo/secchi/doc/FITS_keywords.pdf
         """
         return self.meta.get('rsun', None)
+
+    @property
+    def rsun_obs(self):
+        """
+        Radius of the sun in arcseconds as a quantity.
+
+        References
+        ----------
+        https://sohowww.nascom.nasa.gov/solarsoft/stereo/secchi/doc/FITS_keywords.pdf
+        """
+        rsun_arcseconds = self.meta.get('rsun', None)
+
+        if rsun_arcseconds is None:
+            warnings.warn("Missing metadata for solar radius: assuming photospheric limb as seen from Earth.",
+                          SunpyUserWarning)
+            rsun_arcseconds = sun.solar_semidiameter_angular_size(self.date).to('arcsec').value
+
+        return u.Quantity(rsun_arcseconds, 'arcsec')
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -8,6 +8,7 @@ import glob
 
 from sunpy.map.sources.stereo import EUVIMap
 from sunpy.map import Map
+from sunpy.sun import sun
 import sunpy.data.test
 
 path = sunpy.data.test.rootdir
@@ -37,3 +38,8 @@ def test_rsun_obs():
     """Tests the rsun_obs property"""
     assert euvi.rsun_obs.value == euvi.meta['rsun']
 
+def test_rsun_missing():
+    """Tests output if 'rsun' is missing"""
+    euvi_no_rsun = Map(fitspath)
+    euvi_no_rsun.meta['rsun'] = None
+    assert euvi_no_rsun.rsun_obs.value == sun.solar_semidiameter_angular_size(euvi.date).to('arcsec').value

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -32,3 +32,8 @@ def test_measurement():
 def test_observatory():
     """Tests the observatory property of the EUVIMap object."""
     assert euvi.observatory == "STEREO A"
+
+def test_rsun_obs():
+    """Tests the rsun_obs property"""
+    assert euvi.rsun_obs.value == euvi.meta['rsun']
+


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Added rsun_obs property to stereo map sources. It returns a quantity in arcsec consistent with other Maps and overwrites mapbase's assumption of a photospheric limb as seen from Earth. 
