### PR TITLE
Clipping Map plots to a percentile interval

### DIFF
--- a/changelog/3100.feature.rst
+++ b/changelog/3100.feature.rst
@@ -1,0 +1,1 @@
+Map plotting now accepts the optional keyword `clip_interval` for specifying a percentile interval for clipping.  For example, if the interval (5%, 99%) is specified, the bounds of the z axis are chosen such that the lowest 5% of pixels and the highest 1% of pixels are excluded.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1655,29 +1655,30 @@ class GenericMap(NDData):
         figure.show()
 
     @toggle_pylab
-    def plot(self, annotate=True, axes=None, title=True, clip_percentile=None, **imshow_kwargs):
+    @u.quantity_input(clip_interval=u.percent)
+    def plot(self, annotate=True, axes=None, title=True, clip_interval=None, **imshow_kwargs):
         """
         Plots the map object using matplotlib, in a method equivalent
         to plt.imshow() using nearest neighbour interpolation.
 
         Parameters
         ----------
-        annotate : bool
-            If True, the data is plotted at it's natural scale; with
+        annotate : `bool`, optional
+            If `True`, the data is plotted at its natural scale; with
             title and axis labels.
 
         axes: `~matplotlib.axes` or None
             If provided the image will be plotted on the given axes. Else the
             current matplotlib axes will be used.
 
-        title : bool
-            If True, include the title
+        title : `bool`, optional
+            If `True`, include the title.
 
-        clip_percentile : tuple of 2 numbers
+        clip_interval : two-element `~astropy.units.Quantity`, optional
             If provided, the data will be clipped to the percentile interval bounded by the two
-            numbers
+            numbers.
 
-        **imshow_kwargs  : dict
+        **imshow_kwargs  : `dict`
             Any additional imshow arguments that should be used
             when plotting.
 
@@ -1740,11 +1741,12 @@ class GenericMap(NDData):
             imshow_args.update({'extent': x_range + y_range})
         imshow_args.update(imshow_kwargs)
 
-        if clip_percentile is not None:
-            if len(clip_percentile) == 2:
-                vmin, vmax = AsymmetricPercentileInterval(*clip_percentile).get_limits(self.data)
+        if clip_interval is not None:
+            if len(clip_interval) == 2:
+                clip_percentages = clip_interval.to('%').value
+                vmin, vmax = AsymmetricPercentileInterval(*clip_percentages).get_limits(self.data)
             else:
-                raise ValueError("Clip percentile interval must be a tuple of 2 numbers")
+                raise ValueError("Clip percentile interval must be specified as two numbers.")
 
             imshow_args['vmin'] = vmin
             imshow_args['vmax'] = vmax

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -47,6 +47,11 @@ def test_plot_aia171(aia171_test_map):
 
 
 @figure_test
+def test_plot_aia171_clip(aia171_test_map):
+    aia171_test_map.plot(clip_interval=(5., 99.)*u.percent)
+
+
+@figure_test
 def test_peek_aia171(aia171_test_map):
     aia171_test_map.peek()
 

--- a/sunpy/tests/figure_hashes_py36.json
+++ b/sunpy/tests/figure_hashes_py36.json
@@ -10,6 +10,7 @@
     "sunpy.map.tests.test_plotting.test_peek_grid_spacing_aia171": "9ddc7026bc6ba47bc79c039e255ed4b1b9e6fdedfbd6c73279390bcd427dab4a",
     "sunpy.map.tests.test_plotting.test_peek_limb_aia171": "dbee8e3f01517a79b6305e03e52b3b6cdcfb4deb46f6d3d92efdcf6700e73742",
     "sunpy.map.tests.test_plotting.test_plot_aia171": "eb9784d991df9291be773eaafcdb979bccc3d9d628a88c30369c5bc8c922e2bf",
+    "sunpy.map.tests.test_plotting.test_plot_aia171_clip": "d16762707b2df85108b43763ad4ee617e4267876e87782cc8b0fa11d45f7ddd0",
     "sunpy.map.tests.test_plotting.test_plot_aia171_nowcsaxes": "bb26ffc0b687ec737a65ccfc97b77ec1948db4782dc906b60df80f1bc45750e3",
     "sunpy.map.tests.test_plotting.test_plot_aia171_superpixel": "7bd6e4676e97df576d28fcc5405f727175ce4317cf61d6f86662700a6c49312c",
     "sunpy.map.tests.test_plotting.test_plot_aia171_superpixel_nowcsaxes": "cc63ec9ac905682e379519468d5ccdd379d6079fa856f6581d8ae283b4132be3",


### PR DESCRIPTION
This PR adds the capability to easily clip Map plots to a percentile interval.  Facilitates fixing of #2590.  Discuss.

## No clipping (the default)
```python
>>> import sunpy.data.sample
>>> from sunpy.map import Map
>>> m = Map(sunpy.data.sample.AIA_171_IMAGE)
>>> m.peek()
```
![a](https://user-images.githubusercontent.com/991759/57486942-4116c300-727d-11e9-9ae7-fe7e2070eb7a.png)

## With clipping
Here, the clipping percentile interval is (1%, 99.95%).  That is, the lowest 1% and the highest 0.05% of pixels are being clipped out.
```python
>>> import astropy.units as u
>>> import sunpy.data.sample
>>> from sunpy.map import Map
>>> m = Map(sunpy.data.sample.AIA_171_IMAGE)
>>> m.peek(clip_interval=(1., 99.95)*u.percent)
```
![b](https://user-images.githubusercontent.com/991759/57486951-46740d80-727d-11e9-91d8-577ac46322bf.png)