### PR TITLE
Remove header from licence

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2018 The SunPy developers
+Copyright (c) 2013-2019 The SunPy developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,5 +1,3 @@
-SunPy is released under a BSD-style open source licence:
-
 Copyright (c) 2013-2018 The SunPy developers
 All rights reserved.
 


### PR DESCRIPTION
I think this was causing GitHub to not correctly identify the licence type. Also it's not that informative (and kinda wrong)