### PR TITLE
Added the capability to query JPL HORIZONS

### DIFF
--- a/changelog/3113.feature.rst
+++ b/changelog/3113.feature.rst
@@ -1,1 +1,1 @@
-The new function `~sunpy.coordinates.get_horizons_coord()` enables querying JPL HORIZONS for the locations of a wide range of solar-system bodies, including spacecraft.
+The new function `~sunpy.coordinates.get_horizons_coord` enables querying JPL HORIZONS for the locations of a wide range of solar-system bodies, including spacecraft.

--- a/changelog/3113.feature.rst
+++ b/changelog/3113.feature.rst
@@ -1,0 +1,1 @@
+The new function `~sunpy.coordinates.get_horizons_coord()` enables querying JPL HORIZONS for the locations of a wide range of solar-system bodies, including spacecraft.

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -299,10 +299,41 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     out : `~astropy.coordinates.SkyCoord`
         Location of the solar-system body
 
+    Notes
+    -----
+    Be aware that there can be discrepancies between the coordinates returned by JPL HORIZONS,
+    the coordinates reported in mission data files, and the coordinates returned by
+    `~sunpy.coordinates.get_body_heliographic_stonyhurst()`.
+
     References
     ----------
     * `JPL HORIZONS <https://ssd.jpl.nasa.gov/?horizons>`_
     * `Astroquery <https://astroquery.readthedocs.io/en/latest/>`_
+
+    Examples
+    --------
+    >>> from sunpy.coordinates import get_horizons_coord
+
+    Query the location of Venus
+
+    >>> get_horizons_coord('Venus barycenter', '2001-02-03 04:05:06')  # doctest: +REMOTE_DATA
+    INFO: Obtained JPL HORIZONS location for Venus Barycenter (2) [sunpy.coordinates.ephemeris]
+    <SkyCoord (HeliographicStonyhurst: obstime=2001-02-03T04:05:06.000): (lon, lat, radius) in (deg, deg, AU)
+        (326.06844114, -1.64998481, 0.71915147)>
+
+    Query the location of the SDO spacecraft
+
+    >>> get_horizons_coord('SDO', '2011-11-11 11:11:11')  # doctest: +REMOTE_DATA
+    INFO: Obtained JPL HORIZONS location for Solar Dynamics Observatory (spac [sunpy.coordinates.ephemeris]
+    <SkyCoord (HeliographicStonyhurst: obstime=2011-11-11T11:11:11.000): (lon, lat, radius) in (deg, deg, AU)
+        (0.01018888, 3.29640407, 0.99011042)>
+
+    Query the location of the SOHO spacecraft via its ID number (-21)
+
+    >>> get_horizons_coord(-21, '2004-05-06 11:22:33', 'id')  # doctest: +REMOTE_DATA
+    INFO: Obtained JPL HORIZONS location for SOHO (spacecraft) (-21) [sunpy.coordinates.ephemeris]
+    <SkyCoord (HeliographicStonyhurst: obstime=2004-05-06T11:22:33.000): (lon, lat, radius) in (deg, deg, AU)
+        (0.2523461, -3.55863351, 0.99923086)>
     """
     obstime = parse_time(time)
 

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -312,6 +312,13 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
 
     Examples
     --------
+    .. Run these tests with a temp cache dir
+    .. testsetup::
+        >>> from astropy.config.paths import set_temp_cache
+        >>> import tempfile
+        >>> c = set_temp_cache(tempfile.mkdtemp())
+        >>> _ = c.__enter__()
+
     >>> from sunpy.coordinates import get_horizons_coord
 
     Query the location of Venus
@@ -334,6 +341,9 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     INFO: Obtained JPL HORIZONS location for SOHO (spacecraft) (-21) [sunpy.coordinates.ephemeris]
     <SkyCoord (HeliographicStonyhurst: obstime=2004-05-06T11:22:33.000): (lon, lat, radius) in (deg, deg, AU)
         (0.2523461, -3.55863351, 0.99923086)>
+
+    .. testcleanup::
+        >>> _ = c.__exit__()
     """
     obstime = parse_time(time)
 

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -20,11 +20,6 @@ try:
     from astropy.coordinates import HeliocentricMeanEcliptic
 except ImportError:
     from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
-try:
-    from astroquery.jplhorizons import Horizons
-    ASTROQUERY_PRESENT = True
-except ImportError:
-    ASTROQUERY_PRESENT = False
 
 from sunpy.time import parse_time
 from sunpy import log
@@ -311,9 +306,8 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     """
     obstime = parse_time(time)
 
-    if not ASTROQUERY_PRESENT:
-        raise ImportError("This function requires the Astroquery package to be installed.")
-
+    # Import here so that astroquery is not a module-level dependency
+    from astroquery.jplhorizons import Horizons
     query = Horizons(id=body, id_type=id_type,
                      location='500@10',      # Heliocentric (mean ecliptic)
                      epochs=obstime.tdb.jd)  # Time must be provided in JD TDB

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -296,14 +296,14 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
 
     Returns
     -------
-    out : `~astropy.coordinates.SkyCoord`
+    `~astropy.coordinates.SkyCoord`
         Location of the solar-system body
 
     Notes
     -----
     Be aware that there can be discrepancies between the coordinates returned by JPL HORIZONS,
     the coordinates reported in mission data files, and the coordinates returned by
-    `~sunpy.coordinates.get_body_heliographic_stonyhurst()`.
+    `~sunpy.coordinates.get_body_heliographic_stonyhurst`.
 
     References
     ----------

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -344,7 +344,7 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
                      epochs=obstime.tdb.jd)  # Time must be provided in JD TDB
     try:
         result = query.vectors()
-    except:  # Catch and re-raise all exceptions, and also provide query URL if generated
+    except Exception:  # Catch and re-raise all exceptions, and also provide query URL if generated
         if query.uri is not None:
             log.error(f"See the raw output from the JPL HORIZONS query at {query.uri}")
         raise

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
-from astropy.coordinates import SkyCoord, EarthLocation
-from astropy.time import Time
-from astropy.constants import c as speed_of_light
 import pytest
+
+import astropy.units as u
+from astropy.config.paths import set_temp_cache
+from astropy.constants import c as speed_of_light
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.time import Time
 
 from sunpy.coordinates.ephemeris import *
 
@@ -114,18 +116,21 @@ def test_get_sun_orientation():
     assert_quantity_allclose(angle, -110.8*u.deg, atol=0.1*u.deg)
 
 
+
 @pytest.mark.remote_data
-def test_get_horizons_coord():
+def test_get_horizons_coord(tmpdir):
     # get_horizons_coord() depends on astroquery
     astroquery = pytest.importorskip("astroquery")
 
-    # Validate against published values from the Astronomical Almanac (2013)
-    e1 = get_horizons_coord('Geocenter', '2013-Jan-01')
+    with set_temp_cache(tmpdir):
+        # Validate against published values from the Astronomical Almanac (2013)
+        e1 = get_horizons_coord('Geocenter', '2013-Jan-01')
     assert_quantity_allclose((e1.lon + 1*u.deg) % (360*u.deg), 1*u.deg, atol=5e-6*u.deg)
     assert_quantity_allclose(e1.lat, -3.03*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e1.radius, 0.9832947*u.AU, atol=5e-7*u.AU)
 
-    e2 = get_horizons_coord('Geocenter', '2013-Sep-01')
+    with set_temp_cache(tmpdir):
+        e2 = get_horizons_coord('Geocenter', '2013-Sep-01')
     assert_quantity_allclose((e2.lon + 1*u.deg) % (360*u.deg), 1*u.deg, atol=5e-6*u.deg)
     assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)
@@ -138,5 +143,6 @@ def test_consistency_with_horizons():
 
     # Check whether the location of Earth is the same between Astropy and JPL HORIZONS
     e1 = get_earth()
-    e2 = get_horizons_coord('Geocenter')
+    with set_temp_cache(tmpdir):
+        e2 = get_horizons_coord('Geocenter')
     assert_quantity_allclose(e1.separation_3d(e2), 0*u.km, atol=25*u.km)

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -137,7 +137,7 @@ def test_get_horizons_coord(tmpdir):
 
 
 @pytest.mark.remote_data
-def test_consistency_with_horizons():
+def test_consistency_with_horizons(tmpdir):
     # get_horizons_coord() depends on astroquery
     astroquery = pytest.importorskip("astroquery")
 

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -116,6 +116,9 @@ def test_get_sun_orientation():
 
 @pytest.mark.remote_data
 def test_get_horizons_coord():
+    # get_horizons_coord() depends on astroquery
+    astroquery = pytest.importorskip("astroquery")
+
     # Validate against published values from the Astronomical Almanac (2013)
     e1 = get_horizons_coord('Geocenter', '2013-Jan-01')
     assert_quantity_allclose((e1.lon + 1*u.deg) % (360*u.deg), 1*u.deg, atol=5e-6*u.deg)
@@ -126,3 +129,14 @@ def test_get_horizons_coord():
     assert_quantity_allclose((e2.lon + 1*u.deg) % (360*u.deg), 1*u.deg, atol=5e-6*u.deg)
     assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)
+
+
+@pytest.mark.remote_data
+def test_consistency_with_horizons():
+    # get_horizons_coord() depends on astroquery
+    astroquery = pytest.importorskip("astroquery")
+
+    # Check whether the location of Earth is the same between Astropy and JPL HORIZONS
+    e1 = get_earth()
+    e2 = get_horizons_coord('Geocenter')
+    assert_quantity_allclose(e1.separation_3d(e2), 0*u.km, atol=25*u.km)

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -5,6 +5,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import SkyCoord, EarthLocation
 from astropy.time import Time
 from astropy.constants import c as speed_of_light
+import pytest
 
 from sunpy.coordinates.ephemeris import *
 
@@ -111,3 +112,17 @@ def test_get_sun_orientation():
     # Check the Southern Hemisphere
     angle = get_sun_orientation(EarthLocation(lat=-40*u.deg, lon=-75*u.deg), '2017-02-18 13:00')
     assert_quantity_allclose(angle, -110.8*u.deg, atol=0.1*u.deg)
+
+
+@pytest.mark.remote_data
+def test_get_horizons_coord():
+    # Validate against published values from the Astronomical Almanac (2013)
+    e1 = get_horizons_coord('Geocenter', '2013-Jan-01')
+    assert_quantity_allclose((e1.lon + 1*u.deg) % (360*u.deg), 1*u.deg, atol=5e-6*u.deg)
+    assert_quantity_allclose(e1.lat, -3.03*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e1.radius, 0.9832947*u.AU, atol=5e-7*u.AU)
+
+    e2 = get_horizons_coord('Geocenter', '2013-Sep-01')
+    assert_quantity_allclose((e2.lon + 1*u.deg) % (360*u.deg), 1*u.deg, atol=5e-6*u.deg)
+    assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)

--- a/sunpy/util/tests/test_config.py
+++ b/sunpy/util/tests/test_config.py
@@ -55,7 +55,7 @@ def test_print_config_files(undo_download_dir_patch):
 def test_get_and_create_download_dir(undo_download_dir_patch):
     # test default config
     path = get_and_create_download_dir()
-    assert Path(path) == (Path(USER) / 'sunpy' / 'data').resolve()
+    assert Path(path) == Path(USER) / 'sunpy' / 'data'
     # test updated config
     new_path = os.path.join(USER, 'sunpy_data_here_please')
     config.set('downloads', 'download_dir', new_path)
@@ -69,7 +69,7 @@ def test_get_and_create_download_dir(undo_download_dir_patch):
 def test_get_and_create_sample_dir():
     # test default config
     path = get_and_create_sample_dir()
-    assert Path(path) == Path(dirs.user_data_dir).resolve()
+    assert Path(path) == Path(dirs.user_data_dir)
     # test updated config
     new_path = os.path.join(USER, 'sample_data_here_please')
     config.set('downloads', 'sample_dir', new_path)

--- a/sunpy/util/tests/test_config.py
+++ b/sunpy/util/tests/test_config.py
@@ -55,7 +55,7 @@ def test_print_config_files(undo_download_dir_patch):
 def test_get_and_create_download_dir(undo_download_dir_patch):
     # test default config
     path = get_and_create_download_dir()
-    assert Path(path) == Path(USER) / 'sunpy' / 'data'
+    assert Path(path) == (Path(USER) / 'sunpy' / 'data').resolve()
     # test updated config
     new_path = os.path.join(USER, 'sunpy_data_here_please')
     config.set('downloads', 'download_dir', new_path)
@@ -69,7 +69,7 @@ def test_get_and_create_download_dir(undo_download_dir_patch):
 def test_get_and_create_sample_dir():
     # test default config
     path = get_and_create_sample_dir()
-    assert Path(path) == Path(dirs.user_data_dir)
+    assert Path(path) == Path(dirs.user_data_dir).resolve()
     # test updated config
     new_path = os.path.join(USER, 'sample_data_here_please')
     config.set('downloads', 'sample_dir', new_path)

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     pytest-xdist
     online: pytest-rerunfailures
     online: pytest-timeout
+    online: astroquery
 commands =
     offline,astropydev,numpydev: {env:PYTEST_COMMAND} {posargs}
     online: {env:PYTEST_COMMAND} --reruns 2 --timeout=180 --remote-data=any {posargs} {toxinidir}/docs

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ changedir = tmp
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
+    HOME = {homedir}
     PYTEST_COMMAND = pytest --pyargs sunpy --cov=sunpy --cov-config={toxinidir}/setup.cfg --verbose -m "not figure" --durations=25
 extras = all,tests
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ changedir = tmp
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    HOME = {homedir}
     PYTEST_COMMAND = pytest --pyargs sunpy --cov=sunpy --cov-config={toxinidir}/setup.cfg --verbose -m "not figure" --durations=25
 extras = all,tests
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,12 @@ changedir = tmp
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    HOME = {toxinidir}/..
     PYTEST_COMMAND = pytest --pyargs sunpy --cov=sunpy --cov-config={toxinidir}/setup.cfg --verbose -m "not figure" --durations=25
 extras = all,tests
 deps =
     astropydev,numpydev: cython
-    numpydev: git+https://github.com/numpy/numpy
-    astropydev: git+https://github.com/astropy/astropy
+    numpydev: git+git://github.com/numpy/numpy
+    astropydev: git+git://github.com/astropy/astropy
     pytest-cov
     pytest-xdist
     online: pytest-rerunfailures

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,13 @@ changedir = tmp
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
+    HOME = {toxinidir}/..
     PYTEST_COMMAND = pytest --pyargs sunpy --cov=sunpy --cov-config={toxinidir}/setup.cfg --verbose -m "not figure" --durations=25
 extras = all,tests
 deps =
     astropydev,numpydev: cython
-    numpydev: git+git://github.com/numpy/numpy
-    astropydev: git+git://github.com/astropy/astropy
+    numpydev: git+https://github.com/numpy/numpy
+    astropydev: git+https://github.com/astropy/astropy
     pytest-cov
     pytest-xdist
     online: pytest-rerunfailures


### PR DESCRIPTION
Here's a function to easily query JPL HORIZONS (via HTTPS) for the location of a solar-system body.  This function requires the astroquery package to be installed.  Be aware that the output for spacecraft may not be accurate.

## Examples of querying by name
```python
>>> from sunpy.coordinates import get_horizons_coord
>>> get_horizons_coord('SOHO', '2011-06-01 11:22:33')
<SkyCoord (HeliographicStonyhurst: obstime=2011-06-01T11:22:33.000): (lon, lat, radius) in (deg, deg, AU)
    (359.74707192, -0.70191324, 1.00451497)>
>>> get_horizons_coord('SDO', '2011-06-01 11:22:33')
<SkyCoord (HeliographicStonyhurst: obstime=2011-06-01T11:22:33.000): (lon, lat, radius) in (deg, deg, AU)
    (0.01222499, -0.65400412, 1.01407332)>
>>> get_horizons_coord('Deimos', '2011-06-01 11:22:33')
<SkyCoord (HeliographicStonyhurst: obstime=2011-06-01T11:22:33.000): (lon, lat, radius) in (deg, deg, AU)
    (137.86655038, 4.67297496, 1.42850571)>
```

## Example of an ambiguous query and a query by ID
```python
>>> get_horizons_coord('STEREO', '2011-06-01 11:22:33')
ValueError: Ambiguous target name; provide unique id:
  ID#      Name                               Designation  IAU/aliases/other
  -------  ---------------------------------- -----------  -------------------
     -234  STEREO-A (spacecraft)                           AHEAD

     -235  STEREO-B (spacecraft)                           BEHIND

  -234900  STEREO Third Stage (spacecraft)
>>> get_horizons_coord(-234, '2011-06-01 11:22:33', id_type='id')
<SkyCoord (HeliographicStonyhurst: obstime=2011-06-01T11:22:33.000): (lon, lat, radius) in (deg, deg, AU)
    (94.27943046, 7.34584532, 0.95739986)>
```

Could help address #3110