### PR TITLE
Change the way observer location is calculated in Map

### DIFF
--- a/changelog/3115.breaking.1.rst
+++ b/changelog/3115.breaking.1.rst
@@ -1,0 +1,4 @@
+`sunpy.map.GenericMap` now checks for a complete observer location rather than
+individually defaulting coordinates (lat, lon, distance) to Earth position. If
+any one of the three coordinates is missing from the header the observer will
+be defaulted to Earth and a warning raised.

--- a/changelog/3115.breaking.rst
+++ b/changelog/3115.breaking.rst
@@ -1,0 +1,1 @@
+`sunpy.map.GenericMap` will no longer use the key `solar_b0` as a value for heliographic latitude.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -28,7 +28,7 @@ from sunpy.time import parse_time, is_time
 from sunpy.image.transform import affine_transform
 from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.image.resample import resample as sunpy_image_resample
-from sunpy.coordinates import get_sun_B0, get_sun_L0, get_sunearth_distance, get_earth
+from sunpy.coordinates import get_earth
 from sunpy.util.exceptions import SunpyUserWarning
 
 from astropy.nddata import NDData

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -29,6 +29,7 @@ from sunpy.image.transform import affine_transform
 from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.image.resample import resample as sunpy_image_resample
 from sunpy.coordinates import get_earth
+from sunpy.util import expand_list
 from sunpy.util.exceptions import SunpyUserWarning
 
 from astropy.nddata import NDData
@@ -567,6 +568,15 @@ class GenericMap(NDData):
                                                         'radius': self.meta.get('dsun_obs'),
                                                         'unit': (u.deg, u.deg, u.m),
                                                         'frame': "heliographic_carrington"}),]
+
+    def _remove_existing_observer_location(self):
+        """
+        Remove all keys that this map might use for observer location.
+        """
+        all_keys = expand_list([e[0] for e in self._supported_observer_coordinates])
+        for key in all_keys:
+            self.meta.pop(key)
+
     @property
     def observer_coordinate(self):
         """

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -28,7 +28,7 @@ from sunpy.time import parse_time, is_time
 from sunpy.image.transform import affine_transform
 from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.image.resample import resample as sunpy_image_resample
-from sunpy.coordinates import get_sun_B0, get_sun_L0, get_sunearth_distance
+from sunpy.coordinates import get_sun_B0, get_sun_L0, get_sunearth_distance, get_earth
 from sunpy.util.exceptions import SunpyUserWarning
 
 from astropy.nddata import NDData
@@ -422,20 +422,6 @@ class GenericMap(NDData):
         return self.meta.get('detector', "")
 
     @property
-    def dsun(self):
-        """The observer distance from the Sun."""
-        dsun = self.meta.get('dsun_obs', None)
-
-        if dsun is None:
-            if self._default_dsun is None:
-                warnings.warn("Missing metadata for Sun-spacecraft separation: assuming Sun-Earth distance.",
-                              SunpyUserWarning)
-                self._default_dsun = get_sunearth_distance(self.date).to(u.m)
-            return self._default_dsun
-
-        return u.Quantity(dsun, 'm')
-
-    @property
     def exposure_time(self):
         """Exposure time of the image in seconds."""
         return self.meta.get('exptime', 0.0) * u.s
@@ -562,71 +548,66 @@ class GenericMap(NDData):
                            self.meta.get('ctype2', 'HPLT-   '))
 
     @property
-    def carrington_longitude(self):
-        """Carrington longitude (crln_obs)."""
-        carrington_longitude = self.meta.get('crln_obs', None)
+    def _supported_observer_coordinates(self):
+        """
+        A list of supported coordinate systems.
 
-        if carrington_longitude is None:
-            if self._default_carrington_longitude is None:
-                warnings.warn("Missing metadata for Carrington longitude: assuming Earth-based observer.",
-                              SunpyUserWarning)
-                self._default_carrington_longitude = get_sun_L0(self.date)
-            carrington_longitude = self._default_carrington_longitude
-
-        if isinstance(carrington_longitude, str):
-            carrington_longitude = float(carrington_longitude)
-
-        return u.Quantity(carrington_longitude, 'deg')
-
-    @property
-    def heliographic_latitude(self):
-        """Heliographic latitude."""
-        heliographic_latitude = self.meta.get('hglt_obs',
-                                              self.meta.get('crlt_obs',
-                                                            self.meta.get('solar_b0', None)))
-
-        if heliographic_latitude is None:
-            if self._default_heliographic_latitude is None:
-                warnings.warn("Missing metadata for heliographic latitude: assuming Earth-based observer.",
-                              SunpyUserWarning)
-                self._default_heliographic_latitude = get_sun_B0(self.date)
-            heliographic_latitude = self._default_heliographic_latitude
-
-        if isinstance(heliographic_latitude, str):
-            heliographic_latitude = float(heliographic_latitude)
-
-        return u.Quantity(heliographic_latitude, 'deg')
-
-    @property
-    def heliographic_longitude(self):
-        """Heliographic longitude."""
-        heliographic_longitude = self.meta.get('hgln_obs', None)
-
-        if heliographic_longitude is None:
-            if self.meta.get('crln_obs', None) is not None:
-                heliographic_longitude = self.meta['crln_obs'] * u.deg - get_sun_L0(self.date)
-            else:
-                if self._default_heliographic_longitude is None:
-                    warnings.warn("Missing metadata for heliographic longitude: assuming longitude of 0 degrees.",
-                                  SunpyUserWarning)
-                    self._default_heliographic_longitude = 0
-                heliographic_longitude = self._default_heliographic_longitude
-
-        if isinstance(heliographic_longitude, str):
-            heliographic_longitude = float(heliographic_longitude)
-
-        return u.Quantity(heliographic_longitude, 'deg')
-
+        This is a list so it can easily maintain a strict order. The list of
+        two element tuples, the first item in the tuple is the keys that need
+        to be in the header to use this coordinate system and the second is the
+        kwargs to SkyCoord.
+        """
+        return [(('hgln_obs', 'hglt_obs', 'dsun_obs'), {'lon': self.meta.get('hgln_obs'),
+                                                        'lat': self.meta.get('hglt_obs'),
+                                                        'radius': self.meta.get('dsun_obs'),
+                                                        'unit': (u.deg, u.deg, u.m),
+                                                        'frame': "heliographic_stonyhurst"}),
+                (('crln_obs', 'crlt_obs', 'dsun_obs'), {'lon': self.meta.get('crln_obs'),
+                                                        'lat': self.meta.get('crlt_obs'),
+                                                        'radius': self.meta.get('dsun_obs'),
+                                                        'unit': (u.deg, u.deg, u.m),
+                                                        'frame': "heliographic_carrington"}),]
     @property
     def observer_coordinate(self):
         """
         The Heliographic Stonyhurst Coordinate of the observer.
         """
-        return SkyCoord(lat=self.heliographic_latitude,
-                        lon=self.heliographic_longitude,
-                        radius=self.dsun,
-                        obstime=self.date,
-                        frame='heliographic_stonyhurst')
+        for keys, kwargs in self._supported_observer_coordinates:
+            if all([k in self.meta for k in keys]):
+                return SkyCoord(obstime=self.date, **kwargs).heliographic_stonyhurst
+
+        all_keys = [str(e[0]) for e in self._supported_observer_coordinates]
+        all_keys = '\n'.join(all_keys)
+        warning_message = ("Missing metadata for observer: assuming Earth-based observer."
+                           "The following sets of keys were checked:\n" + all_keys)
+        warnings.warn(warning_message, SunpyUserWarning)
+
+        return get_earth(self.date)
+
+    @property
+    def heliographic_latitude(self):
+        """Heliographic latitude."""
+        return self.observer_coordinate.lat
+
+    @property
+    def heliographic_longitude(self):
+        """Heliographic longitude."""
+        return self.observer_coordinate.lon
+
+    @property
+    def carrington_latitude(self):
+        """Carrington latitude."""
+        return self.observer_coordinate.heliographic_carrington.lat
+
+    @property
+    def carrington_longitude(self):
+        """Carrington longitude."""
+        return self.observer_coordinate.heliographic_carrington.lon
+
+    @property
+    def dsun(self):
+        """The observer distance from the Sun."""
+        return self.observer_coordinate.radius.to('m')
 
     @property
     def _reference_longitude(self):

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -63,43 +63,14 @@ class AIAMap(GenericMap):
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, AsinhStretch(0.01)))
 
     @property
-    def observer_coordinate(self):
-        """
-        The Heliographic Stonyhurst Coordinate of the observer.
-
-        This coordinate is determined using the Heliocentric Aries Ecliptic (HAE) coordinates
-        in the header.
-        """
-        vector = CartesianRepresentation(self.meta['haex_obs'],
-                                         self.meta['haey_obs'],
-                                         self.meta['haez_obs'])
-        coord = SkyCoord(vector * u.m, frame=HeliocentricMeanEcliptic, obstime=self.date)
-        return coord.heliographic_stonyhurst
-
-    @property
-    def heliographic_latitude(self):
-        """Heliographic latitude."""
-        return self.observer_coordinate.lat
-
-    @property
-    def heliographic_longitude(self):
-        """Heliographic longitude."""
-        return self.observer_coordinate.lon
-
-    @property
-    def carrington_latitude(self):
-        """Carrington latitude."""
-        return self.observer_coordinate.heliographic_carrington.lat
-
-    @property
-    def carrington_longitude(self):
-        """Carrington longitude."""
-        return self.observer_coordinate.heliographic_carrington.lon
-
-    @property
-    def dsun(self):
-        """The observer distance from the Sun."""
-        return self.observer_coordinate.radius.to('m')
+    def _supported_observer_coordinates(self):
+        return [(('haex_obs', 'haey_obs', 'haez_obs'), {'x': self.meta.get('haex_obs'),
+                                                        'y': self.meta.get('haey_obs'),
+                                                        'z': self.meta.get('haez_obs'),
+                                                        'unit': u.m,
+                                                        'representation': CartesianRepresentation,
+                                                        'frame': HeliocentricMeanEcliptic})
+        ] + super()._supported_observer_coordinates
 
     @property
     def observatory(self):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -211,6 +211,13 @@ def test_heliographic_longitude_crln(hmi_test_map):
     assert hmi_test_map.heliographic_longitude == hmi_test_map.carrington_longitude - sunpy.coordinates.get_sun_L0(hmi_test_map.date)
 
 
+def test_remove_observers(aia171_test_map):
+    aia171_test_map._remove_existing_observer_location()
+    with pytest.warns(SunpyUserWarning,
+                      match='Missing metadata for observer: assuming Earth-based observer.*'):
+        aia171_test_map.observer_coordinate
+
+
 # ==============================================================================
 # Test Rotation WCS conversion
 # ==============================================================================

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -162,7 +162,7 @@ def test_detector(generic_map):
 
 
 def test_dsun(generic_map):
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for Sun-spacecraft separation'):
+    with pytest.warns(SunpyUserWarning, match='Missing metadata for observer: assuming Earth-based observer.*'):
         assert generic_map.dsun == sunpy.coordinates.get_sunearth_distance(generic_map.date).to(u.m)
 
 
@@ -180,17 +180,17 @@ def test_coordinate_system(generic_map):
 
 
 def test_carrington_longitude(generic_map):
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for Carrington longitude'):
+    with pytest.warns(SunpyUserWarning, match='Missing metadata for observer: assuming Earth-based observer.*'):
         assert generic_map.carrington_longitude == sunpy.coordinates.get_sun_L0(generic_map.date)
 
 
 def test_heliographic_latitude(generic_map):
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for heliographic latitude'):
+    with pytest.warns(SunpyUserWarning, match='Missing metadata for observer: assuming Earth-based observer.*'):
         assert generic_map.heliographic_latitude == sunpy.coordinates.get_sun_B0(generic_map.date)
 
 
 def test_heliographic_longitude(generic_map):
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for heliographic longitude'):
+    with pytest.warns(SunpyUserWarning, match='Missing metadata for observer: assuming Earth-based observer.*'):
         assert generic_map.heliographic_longitude == 0.
 
 
@@ -697,8 +697,8 @@ def test_missing_metadata_warnings():
         header['cunit2'] = 'arcsec'
         array_map = sunpy.map.Map(np.random.rand(20, 15), header)
         array_map.peek()
-    # There should be 4 warnings for missing metadata
-    assert len([w for w in record if 'Missing metadata' in str(w)]) == 4
+    # There should be 2 warnings for missing metadata (obstime and observer location)
+    assert len([w for w in record if w.category is SunpyUserWarning]) == 2
 
 
 def test_fits_header(aia171_test_map):


### PR DESCRIPTION
This is essentially a re-do and generalisation of #3056 because of the error @wafels has encountered in #2972 

In #2972 @wafels changes the observer location in the header (to HGS) which dosen't work with an `AIAMap` because we now extract a different set of kwargs from the header and therefore to overwrite the location successfully we would have to write HEA coordinates to the header.

This PR changes AIAMap to default to extracting HEA but to fall back to HGS or HGC if those keys are present but not the previous ones.


This however, causes a change in behaviour of Map because it now checks for all three of the observer location keys *in one go* rather than checking them individually and then defaulting them individually to Earth if they can't be found. This means that if some of the header information is there and some of it isn't before this PR we could end up with an inconsistent observer location, which now wouldn't happen.

fixes #3068 