### PR TITLE
Allow coordinate frames to have no observer set

### DIFF
--- a/changelog/3118.feature.rst
+++ b/changelog/3118.feature.rst
@@ -1,0 +1,2 @@
+Enable explicitly setting the observer of a coordinate frame to `'none'` if it
+is incorrect to default to Earth.

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -136,7 +136,9 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
             # If the observer is a string and we have obstime then calculate
             # the position of the observer.
             if isinstance(observer, str):
-                if obstime is not None:
+                if observer == 'none':
+                    return None
+                elif obstime is not None:
                     new_observer = self._convert_string_to_coord(observer.lower(), obstime)
                     new_observer.object_name = observer
                     setattr(instance, '_' + self.name, new_observer)

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -92,6 +92,16 @@ def test_string_coord():
     assert coord.obstime == parse_time(obstime)
 
 
+def test_none_observer_coord():
+    obstime = "2011-01-01"
+
+    obs = Helioprojective(observer="none", obstime=obstime).observer
+    assert obs is None
+
+    obs = Helioprojective(observer="none", obstime=None).observer
+    assert obs is None
+
+
 def test_coord_get():
 
     # Test default (instance=None)


### PR DESCRIPTION
~(This is post-1.0: While I think this is a bit of an edge case I was thinking about this the other day and wanted to get something together so I didn't forget.)~

It is currently impossible to not have an observer set on a HPC / HCC coordinate frame (which is very possible as @ehsteve @hayesla and I were discussing in context of #3083 ). If you don't explicitly set one (or set it to `None`) it will default to Earth. This PR adds the ability to set the observer to `'none'` which will result in no observer being set on the frame.

While I think this is useful  I am a little concerned by the usability of this feature. We can not have `None` be the "no observer" option without changing the default to be "no observer" however `'none'` feels weird as well.

Finally, I need to work out how the transformations should handle this case. I think what we want is if the observer attribute (different from kwarg) on either side of the transform is `None` then it should raise an error about not being able to do the transform without an observer set.

---

This does form part of the larger discussion that's going on about how and what we should default the observer to. Currently both coordinates and map default to Earth, but is this actually want we want to do? Do we instead want to default to no observer and not let any transformations happen?