### PR TITLE
Fixed uses of a deprecated keyword

### DIFF
--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -68,7 +68,7 @@ class AIAMap(GenericMap):
                                                         'y': self.meta.get('haey_obs'),
                                                         'z': self.meta.get('haez_obs'),
                                                         'unit': u.m,
-                                                        'representation': CartesianRepresentation,
+                                                        'representation_type': CartesianRepresentation,
                                                         'frame': HeliocentricMeanEcliptic})
         ] + super()._supported_observer_coordinates
 

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -75,7 +75,7 @@ class EITMap(GenericMap):
                                                'y': self.meta.get('hec_y'),
                                                'z': self.meta.get('hec_z'),
                                                'unit': u.km,
-                                               'representation': CartesianRepresentation,
+                                               'representation_type': CartesianRepresentation,
                                                'frame': HeliocentricMeanEcliptic})
         ] + super()._supported_observer_coordinates
 


### PR DESCRIPTION
#3115 and #3067 used the now-deprecated `representation` keyword for `SkyCoord` instead of `representation_type`