### PR TITLE
Adding rotation arguments to the header helper function

### DIFF
--- a/changelog/3139.bugfix.rst
+++ b/changelog/3139.bugfix.rst
@@ -1,1 +1,1 @@
-Add support for rotation parameters to `sunpy.map.make_fitswcs_header`
+Add support for rotation parameters to `sunpy.map.make_fitswcs_header`.

--- a/changelog/3139.bugfix.rst
+++ b/changelog/3139.bugfix.rst
@@ -1,0 +1,1 @@
+Add support for rotation parameters to `sunpy.map.make_fitswcs_header`

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -57,11 +57,12 @@ def make_fitswcs_header(data, coordinate, reference_pixel: u.pix = None,
         Defaults to ``([1., 1.] arcsec/pixel)``.
     rotation_angle : `~astropy.unit.Quantity`, optional
         Coordinate system rotation angle, will be converted to a rotation
-        matrix and stored in the `PCi_j` matrix. Can not be specified with
+        matrix and stored in the ``PCi_j`` matrix. Can not be specified with
         ``rotation_matrix``.
     rotation_matrix : `~numpy.ndarray` of dimensions 2x2, optional
         Matrix describing the rotation required to align solar North with
-        the top of the image in FITS PCi_j convention. Can not be specified with ``rotation_angle``.
+        the top of the image in FITS ``PCi_j`` convention. Can not be specified
+        with ``rotation_angle``.
     **kwargs:
         Additional arguments that will be put into the metadict header if they
         are in the list returned by `~sunpy.map.meta_keywords`. Additional

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -118,7 +118,7 @@ def make_fitswcs_header(data, coordinate, reference_pixel: u.pix = None,
     if reference_pixel is None:
         reference_pixel = u.Quantity([(data.shape[1] + 1)/2.*u.pixel, (data.shape[0] + 1)/2.*u.pixel])
     if scale is None:
-        scale = u.Quantity([1.0*u.arcsec, 1.0*u.arcsec])
+        scale = [1., 1.] * (u.arcsec/u.pixel)
 
     meta_wcs['crval1'], meta_wcs['crval2'] = (coordinate.spherical.lat.to_value(meta_wcs['cunit1']),
                                               coordinate.spherical.lon.to_value(meta_wcs['cunit2']))
@@ -126,14 +126,14 @@ def make_fitswcs_header(data, coordinate, reference_pixel: u.pix = None,
     meta_wcs['crpix1'], meta_wcs['crpix2'] = (reference_pixel[0].to_value(u.pixel),
                                               reference_pixel[1].to_value(u.pixel))
 
-    meta_wcs['cdelt1'], meta_wcs['cdelt2'] = (scale[0]*meta_wcs['cunit1']/u.pixel,
-                                              scale[1]*meta_wcs['cunit2']/u.pixel)
+    meta_wcs['cdelt1'], meta_wcs['cdelt2'] = (scale[0].to_value(meta_wcs['cunit1']/u.pixel),
+                                              scale[1].to_value(meta_wcs['cunit2']/u.pixel))
 
     if rotation_angle is not None and rotation_matrix is not None:
         raise ValueError("Can not specify both rotation angle and rotation matrix.")
 
     if rotation_angle is not None:
-        lam = scale[0] / scale[1]
+        lam = meta_wcs['cdelt1'] / meta_wcs['cdelt2']
         p = np.deg2rad(rotation_angle)
 
         rotation_matrix = np.array([[np.cos(p), -1 * lam * np.sin(p)],
@@ -177,7 +177,7 @@ def _get_wcs_meta(coordinate):
 
     cunit1, cunit2 = skycoord_wcs.wcs.cunit
     coord_meta = dict(skycoord_wcs.to_header())
-    coord_meta['cunit1'], coord_meta['cunit2'] = cunit1, cunit2
+    coord_meta['cunit1'], coord_meta['cunit2'] = cunit1.to_string("fits"), cunit2.to_string("fits")
 
     return coord_meta
 


### PR DESCRIPTION
### Description
This is a first pass to include the ability to add the rotation information into the map header helper function #3083 following #3126. 

At the moment it's just a patch job which now includes extra keyword arguments for `rotation_angle` (in u.deg) and then either a `rotation_matrix_pc` and `rotation_matrix_cd` for PCi_j and CDi_j rotation matrix. There's probably a nicer way to do this - any ideas?

