### PR TITLE
pandas check for timeseries to_array()

### DIFF
--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -567,7 +567,10 @@ class GenericTimeSeries:
         `~numpy.ndarray`
             If the data is heterogeneous and contains booleans or objects, the result will be of ``dtype=object``.
         """
-        return self.data.to_numpy(**kwargs)
+        if hasattr(self.data, "to_numpy"):
+            return self.data.to_numpy(**kwargs)
+        else:
+            return self.data.values
 
     def __eq__(self, other):
         """


### PR DESCRIPTION
Fixes #3136

Already ported to the 1.0 branch. 