### PR TITLE
Removed `sunpy.sun.sun.solar_cycle_number`

### DIFF
--- a/changelog/3150.removal.rst
+++ b/changelog/3150.removal.rst
@@ -1,0 +1,1 @@
+Removed `~sunpy.sun.sun.solar_cycle_number` because it was fundamentally flawed

--- a/sunpy/sun/sun.py
+++ b/sunpy/sun/sun.py
@@ -21,29 +21,12 @@ from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
 
 __all__ = [
-    "solar_cycle_number", "solar_semidiameter_angular_size", "carrington_rotation_number",
-    "position",
+    "solar_semidiameter_angular_size", "position", "carrington_rotation_number",
     "true_longitude", "apparent_longitude", "true_latitude", "apparent_latitude",
     "mean_obliquity_of_ecliptic", "true_rightascension", "true_declination",
     "true_obliquity_of_ecliptic", "apparent_rightascension", "apparent_declination",
     "print_params"
 ]
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def solar_cycle_number(t='now'):
-    """
-    Return the solar cycle number.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-    """
-    time = parse_time(t)
-    result = (int(time.strftime('%Y')) + 8) % 28 + 1
-    return result
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())

--- a/sunpy/sun/tests/test_sun.py
+++ b/sunpy/sun/tests/test_sun.py
@@ -30,12 +30,6 @@ def test_apparent_latitude():
     assert_quantity_allclose(sun.apparent_latitude(t), Angle('0.72s'), atol=0.05*u.arcsec)
 
 
-def test_solar_cycle_number():
-    assert_quantity_allclose(sun.solar_cycle_number("2012/11/11"), 5, atol=1e-1)
-    assert_quantity_allclose(sun.solar_cycle_number("2011/2/22"), 4, atol=1e-1)
-    assert_quantity_allclose(sun.solar_cycle_number("2034/1/15"), 27, atol=1e-1)
-
-
 def test_solar_semidiameter_angular_size():
     assert_quantity_allclose(sun.solar_semidiameter_angular_size("2012/11/11"), 968.871294 * u.arcsec, atol=1e-3 * u.arcsec)
     assert_quantity_allclose(sun.solar_semidiameter_angular_size("2043/03/01"), 968.326347 * u.arcsec, atol=1e-3 * u.arcsec)


### PR DESCRIPTION
This function has been broken since its [inception in 2011](https://github.com/sunpy/sunpy/commit/64d9f78aa4d568ded6dbae36d8e6c8863f62057d#diff-5074c05f93f63925e350880e4ca213f9R39).  This was [noted as broken in 2013](https://github.com/sunpy/sunpy/issues/472#issuecomment-20257906) and [re-noted as broken in 2014](https://github.com/sunpy/sunpy/pull/1030#discussion_r13520694), but no one ever did anything about it.  Now I am.  Bye bye!

To be explicit, it's fundamentally broken because:
- The solar-cycle numbers that it returns are nonsensical; they increase by 1 every year and wrap every 28 years.
- Even if the function were fixed to give something close to reasonable (by changing the modulo to a division by a nominal solar-cycle period), we can't possibly return something that's uncontroversial, so why even try?