### PR TITLE
Updated the `sunpy.sun.sun` tests to be very stringent

### DIFF
--- a/sunpy/sun/tests/test_sun.py
+++ b/sunpy/sun/tests/test_sun.py
@@ -1,3 +1,5 @@
+import pytest
+
 from astropy.coordinates import Angle
 from astropy.time import Time
 import astropy.units as u
@@ -6,97 +8,129 @@ from astropy.tests.helper import assert_quantity_allclose
 from sunpy.sun import sun
 
 
-def test_true_longitude():
-    # Validate against a published value from the Astronomical Almanac (1992)
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.true_longitude(t), Angle('199d54m26.17s'), atol=0.1*u.arcsec)
+@pytest.fixture
+def t1():
+    return Time('1992-10-13', scale='tdb')
 
 
-def test_apparent_longitude():
-    # Validate against a published value from the Astronomical Almanac (1992)
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.apparent_longitude(t), Angle('199d54m21.56s'), atol=0.1*u.arcsec)
+@pytest.fixture
+def t2():
+    return Time('2013-06-17', scale='tt')
 
 
-def test_true_latitude():
-    # Validate against a published value from the Astronomical Almanac (1992)
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.true_latitude(t), Angle('0.72s'), atol=0.05*u.arcsec)
+def test_true_longitude(t1, t2):
+    # Validate against a published value from the Astronomical Almanac (1992, C16)
+    assert_quantity_allclose(sun.true_longitude(t1), Angle('199d54m26.17s'), atol=0.005*u.arcsec)
+
+    # Validate against a published value from the Astronomical Almanac (2013, C12)
+    assert_quantity_allclose(sun.true_longitude(t2), Angle('85d58m57.46s'), atol=0.005*u.arcsec)
 
 
-def test_apparent_latitude():
-    # Validate against a published value from the Astronomical Almanac (1992)
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.apparent_latitude(t), Angle('0.72s'), atol=0.05*u.arcsec)
+def test_apparent_longitude(t1, t2):
+    # Validate against a published value from the Astronomical Almanac (1992, C2+C16+B30)
+    assert_quantity_allclose(sun.apparent_longitude(t1), Angle('199d54m21.543s'), atol=0.005*u.arcsec)
+
+    # Validate against a published value from the Astronomical Almanac (2013, C2+C12+B61)
+    assert_quantity_allclose(sun.apparent_longitude(t2), Angle('85d58m49.334s'), atol=0.005*u.arcsec)
+
+
+def test_true_latitude(t1, t2):
+    # Validate against a published value from the Astronomical Almanac (1992, C16)
+    # Disagreement with published precision may be due to changes in definitions after 1992
+    assert_quantity_allclose(sun.true_latitude(t1), Angle('0.72s'), atol=0.05*u.arcsec)
+
+    # Validate against a published value from the Astronomical Almanac (2013, C12)
+    assert_quantity_allclose(sun.true_latitude(t2), Angle('-0.42s'), atol=0.005*u.arcsec)
+
+
+def test_apparent_latitude(t1, t2):
+    # Validate against a published value from the Astronomical Almanac (1992, C2+C16)
+    # Disagreement with published precision may be due to changes in definitions after 1992
+    assert_quantity_allclose(sun.apparent_latitude(t1), Angle('0.72s'), atol=0.05*u.arcsec)
+
+    # Validate against a published value from the Astronomical Almanac (2013, C2+C12)
+    assert_quantity_allclose(sun.apparent_latitude(t2), Angle('-0.42s'), atol=0.005*u.arcsec)
 
 
 def test_solar_semidiameter_angular_size():
+    # Regression-only test
     assert_quantity_allclose(sun.solar_semidiameter_angular_size("2012/11/11"), 968.871294 * u.arcsec, atol=1e-3 * u.arcsec)
     assert_quantity_allclose(sun.solar_semidiameter_angular_size("2043/03/01"), 968.326347 * u.arcsec, atol=1e-3 * u.arcsec)
     assert_quantity_allclose(sun.solar_semidiameter_angular_size("2001/07/21"), 944.039007 * u.arcsec, atol=1e-3 * u.arcsec)
 
 
-def test_mean_obliquity_of_ecliptic():
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.mean_obliquity_of_ecliptic(t), 84384.8*u.arcsec, atol=0.1*u.arcsec)
+def test_mean_obliquity_of_ecliptic(t1):
+    # Regression-only test
+    assert_quantity_allclose(sun.mean_obliquity_of_ecliptic(t1), 84384.8*u.arcsec,
+                             atol=0.1*u.arcsec)
 
 
 def test_true_rightascension():
+    # Regression-only test
     assert_quantity_allclose(sun.true_rightascension("2012/11/11"), 226.548*u.deg, atol=1e-3*u.deg)
     assert_quantity_allclose(sun.true_rightascension("2142/02/03"), 316.466*u.deg, atol=1e-3*u.deg)
     assert_quantity_allclose(sun.true_rightascension("2013/12/11"), 258.150*u.deg, atol=1e-3*u.deg)
 
 
-def test_true_rightascension_J2000():
+def test_true_rightascension_J2000(t1, t2):
     # Validate against JPL HORIZONS output
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.true_rightascension(t, equinox_of_date=False),
-                             Angle('13h13m53.65s'), atol=0.01*u.arcsec)
+    # https://ssd.jpl.nasa.gov/horizons_batch.cgi?batch=1&TABLE_TYPE=OBSERVER&COMMAND=10&CENTER=500&QUANTITIES=1&ANG_FORMAT=HMS&EXTRA_PREC=YES&TIME_TYPE=TT&TLIST=2448908.5%0A2456460.5
+    assert_quantity_allclose(sun.true_rightascension(t1, equinox_of_date=False),
+                             Angle('13h13m53.65s'), atol=0.005*u.arcsec)
+    assert_quantity_allclose(sun.true_rightascension(t2, equinox_of_date=False),
+                             Angle('05h41m40.32s'), atol=0.005*u.arcsec)
 
 
 def test_true_declination():
+    # Regression-only test
     assert_quantity_allclose(sun.true_declination("2012/11/11"), -17.470*u.deg, atol=1e-3*u.deg)
     assert_quantity_allclose(sun.true_declination("2245/12/01"), -21.717*u.deg, atol=1e-3*u.deg)
     assert_quantity_allclose(sun.true_declination("2014/05/27"), 21.245*u.deg, atol=1e-3*u.deg)
 
 
-def test_true_declination_J2000():
+def test_true_declination_J2000(t1, t2):
     # Validate against JPL HORIZONS output
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.true_declination(t, equinox_of_date=False),
-                             Angle('-7d49m20.8s'), atol=0.05*u.arcsec)
+    # https://ssd.jpl.nasa.gov/horizons_batch.cgi?batch=1&TABLE_TYPE=OBSERVER&COMMAND=10&CENTER=500&QUANTITIES=1&ANG_FORMAT=HMS&EXTRA_PREC=YES&TIME_TYPE=TT&TLIST=2448908.5%0A2456460.5
+    assert_quantity_allclose(sun.true_declination(t1, equinox_of_date=False),
+                             Angle('-7d49m20.84s'), atol=0.005*u.arcsec)
+    assert_quantity_allclose(sun.true_declination(t2, equinox_of_date=False),
+                             Angle('23d22m13.97s'), atol=0.005*u.arcsec)
 
 
-def test_true_obliquity_of_ecliptic():
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.true_obliquity_of_ecliptic(t), 84384.5*u.arcsec, atol=0.1*u.arcsec)
-
-
-def test_apparent_rightascension():
-    # Validate against a published value from the Astronomical Almanac (1992)
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.apparent_rightascension(t), Angle('13h13m30.749s'),
-                             atol=0.01*u.arcsec)
-
-
-def test_apparent_rightascension_J2000():
+def test_true_obliquity_of_ecliptic(t1):
     # Regression-only test
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.apparent_rightascension(t, equinox_of_date=False),
-                             Angle('13h13m52.37s'), atol=0.01*u.arcsec)
+    assert_quantity_allclose(sun.true_obliquity_of_ecliptic(t1), 84384.5*u.arcsec,
+                             atol=0.1*u.arcsec)
 
 
-def test_apparent_declination():
-    # Validate against a published value from the Astronomical Almanac (1992)
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.apparent_declination(t), Angle('-7d47m01.74s'), atol=0.05*u.arcsec)
+def test_apparent_rightascension(t1, t2):
+    # Validate against a published value from the Astronomical Almanac (1992, C16)
+    assert_quantity_allclose(sun.apparent_rightascension(t1), Angle('13h13m30.75s'),
+                             atol=0.005*u.arcsec)
+
+    # Validate against a published value from the Astronomical Almanac (2013, C12)
+    assert_quantity_allclose(sun.apparent_rightascension(t2), Angle('5h42m28.88s'),
+                             atol=0.01*u.arcsec)  # slight disagreement with published precision
 
 
-def test_apparent_declination_J2000():
+def test_apparent_rightascension_J2000(t1):
     # Regression-only test
-    t = Time('1992-10-13', scale='tdb')
-    assert_quantity_allclose(sun.apparent_declination(t, equinox_of_date=False),
-                             Angle('-7d49m13.09s'), atol=0.05*u.arcsec)
+    assert_quantity_allclose(sun.apparent_rightascension(t1, equinox_of_date=False),
+                             Angle('13h13m52.37s'), atol=0.005*u.arcsec)
+
+
+def test_apparent_declination(t1, t2):
+    # Validate against a published value from the Astronomical Almanac (1992, C16)
+    assert_quantity_allclose(sun.apparent_declination(t1), Angle('-7d47m01.7s'), atol=0.05*u.arcsec)
+
+    # Validate against a published value from the Astronomical Almanac (2013, C12)
+    assert_quantity_allclose(sun.apparent_declination(t2), Angle('23d22m27.8s'), atol=0.05*u.arcsec)
+
+
+def test_apparent_declination_J2000(t1):
+    # Regression-only test
+    assert_quantity_allclose(sun.apparent_declination(t1, equinox_of_date=False),
+                             Angle('-7d49m13.1s'), atol=0.05*u.arcsec)
 
 
 def test_print_params():


### PR DESCRIPTION
Partially just because I can, I've made the `sunpy.sun.sun` tests be very stringent.  As a demonstration of how awesome #3137 was, many checks are now at the <0.01-arcsecond level against published values.