### PR TITLE
The new `sunpy.coordinates.sun`

### DIFF
--- a/changelog/3163.breaking.rst
+++ b/changelog/3163.breaking.rst
@@ -1,0 +1,1 @@
+All of the functions in `sunpy.sun.sun` and all of the Sun-specific functions in `sunpy.coordinates.ephemeris` have been moved to the new module `sunpy.coordinates.sun`.

--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -280,6 +280,9 @@ which is equivalent to::
 .. automodapi:: sunpy.coordinates.ephemeris
     :headings: ^#
 
+.. automodapi:: sunpy.coordinates.sun
+    :headings: ^#
+
 .. automodapi:: sunpy.coordinates.offset_frame
     :headings: ^#
 

--- a/docs/code_ref/sun.rst
+++ b/docs/code_ref/sun.rst
@@ -5,7 +5,7 @@ SunPy sun
 
 The sun submodule contains constants, parameters and models of the Sun.
 
-.. automodapi:: sunpy.sun
+.. automodapi:: sunpy.sun.sun
 
 .. automodapi:: sunpy.sun.constants
 

--- a/docs/dev_guide/sunpy_stability.yaml
+++ b/docs/dev_guide/sunpy_stability.yaml
@@ -32,8 +32,8 @@ roi:
   status: planned
   comments: There is very little functionality.
 sun:
-  status: stable
-  comments: Any future changes should largely maintain backwards compatibility.
+  status: dev
+  comments: Sub-module `constants` is stable.  Sub-module `models` will likely have major changes.  Sub-module `sun` is deprecated in 1.0 and will be removed in 2.0.
 time:
   status: stable
   comments: Any future changes should largely maintain backwards compatibility.

--- a/examples/units_and_coordinates/AltAz_Coordinate_transform.py
+++ b/examples/units_and_coordinates/AltAz_Coordinate_transform.py
@@ -10,7 +10,7 @@ elevation as a factor.
 """
 from astropy.coordinates import EarthLocation, AltAz, SkyCoord
 from astropy.time import Time
-from sunpy.coordinates import frames, get_sunearth_distance
+from sunpy.coordinates import frames, sun
 import astropy.units as u
 
 ######################################################################################
@@ -36,7 +36,7 @@ print('Altitude is {0} and Azimuth is {1}'.format(sun_altaz.T.alt, sun_altaz.T.a
 # We should get our original input which was the center of the Sun.
 # To go from Altitude/Azimuth to Helioprojective, you will need the distance to the Sun.
 # solar distance. Define distance with SunPy's almanac.
-distance = get_sunearth_distance(obstime)
+distance = sun.earth_distance(obstime)
 b = SkyCoord(az=sun_altaz.T.az, alt=sun_altaz.T.alt, distance=distance, frame=frame_altaz)
 sun_helio = b.transform_to(frames.Helioprojective)
 print('The helioprojective point is {0}, {1}'.format(sun_helio.T.Tx, sun_helio.T.Ty))

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -2,5 +2,6 @@ from .frames import *
 from .offset_frame import *
 from . import transformations
 from .ephemeris import *
+from . import sun
 
 from .wcs_utils import *

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -23,6 +23,7 @@ except ImportError:
 
 from sunpy.time import parse_time
 from sunpy import log
+from sunpy.util.decorators import deprecated
 
 from .frames import HeliographicStonyhurst as HGS
 from .transformations import _SUN_DETILT_MATRIX
@@ -107,184 +108,6 @@ def get_earth(time='now'):
     earth = SkyCoord(0*u.deg, earth.lat, earth.radius, frame=earth)
 
     return earth
-
-
-def get_sun_B0(time='now'):
-    """
-    Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
-    Sun-disk center as seen from Earth.  The range of B0 is +/-7.23 degrees.
-
-    Parameters
-    ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
-
-    Returns
-    -------
-    out : `~astropy.coordinates.Angle`
-        The position angle
-    """
-    return Angle(get_earth(time).lat)
-
-
-# Ignore warnings that result from going back in time to the first Carrington rotation
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", ErfaWarning)
-
-    # Carrington rotation 1 starts late in the day on 1853 Nov 9
-    # according to Astronomical Algorithms (Meeus 1998, p.191)
-    _time_first_rotation = Time('1853-11-09 21:36')
-
-    # Longitude of Earth at Carrington rotation 1 in de-tilted HCRS (so that solar north pole is Z)
-    _lon_first_rotation = \
-        get_earth(_time_first_rotation).hcrs.cartesian.transform(_SUN_DETILT_MATRIX) \
-        .represent_as(SphericalRepresentation).lon.to('deg')
-
-
-def get_sun_L0(time='now'):
-    """
-    Return the L0 angle for the Sun at a specified time, which is the Carrington longitude of the
-    Sun-disk center as seen from Earth.
-
-    .. warning::
-       Due to apparent disagreement between published references, the returned L0 may be inaccurate
-       by up to ~2 arcmin, which translates in the worst case to a shift of ~0.5 arcsec in
-       helioprojective coordinates for an observer at 1 AU.  Until this is resolved, be cautious
-       with analysis that depends critically on absolute (as opposed to relative) values of
-       Carrington longitude.
-
-    Parameters
-    ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
-
-    Returns
-    -------
-    out : `~astropy.coordinates.Longitude`
-        The Carrington longitude
-    """
-    obstime = parse_time(time)
-
-    # Calculate the longitude due to the Sun's rotation relative to the stars
-    # A sidereal rotation is defined to be exactly 25.38 days
-    sidereal_lon = Longitude((obstime.jd - _time_first_rotation.jd) / 25.38 * 360*u.deg)
-
-    # Calculate the longitude of the Earth in de-tilted HCRS
-    lon_obstime = get_earth(obstime).hcrs.cartesian.transform(_SUN_DETILT_MATRIX) \
-                  .represent_as(SphericalRepresentation).lon.to('deg')
-
-    return Longitude(lon_obstime - _lon_first_rotation - sidereal_lon)
-
-
-def get_sun_P(time='now'):
-    """
-    Return the position (P) angle for the Sun at a specified time, which is the angle between
-    geocentric north and solar north as seen from Earth, measured eastward from geocentric north.
-    The range of P is +/-26.3 degrees.
-
-    Parameters
-    ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
-
-    Returns
-    -------
-    out : `~astropy.coordinates.Angle`
-        The position angle
-    """
-    obstime = parse_time(time)
-
-    # Define the frame where its Z axis is aligned with geocentric north
-    geocentric = PrecessedGeocentric(equinox=obstime, obstime=obstime)
-
-    return _sun_north_angle_to_z(geocentric)
-
-
-def get_sunearth_distance(time='now'):
-    """
-    Return the distance between the Sun and the Earth at a specified time.
-
-    Parameters
-    ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
-
-    Returns
-    -------
-    out : `~astropy.coordinates.Distance`
-        The Sun-Earth distance
-    """
-    return get_earth(time).radius
-
-
-def get_sun_orientation(location, time='now'):
-    """
-    Return the orientation angle for the Sun from a specified Earth location and time.  The
-    orientation angle is the angle between local zenith and solar north, measured eastward from
-    local zenith.
-
-    Parameters
-    ----------
-    location : `~astropy.coordinates.EarthLocation`
-        Observer location on Earth
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
-
-    Returns
-    -------
-    out : `~astropy.coordinates.Angle`
-        The orientation of the Sun
-    """
-    obstime = parse_time(time)
-
-    # Define the frame where its Z axis is aligned with local zenith
-    local_frame = AltAz(obstime=obstime, location=location)
-
-    return _sun_north_angle_to_z(local_frame)
-
-
-def _sun_north_angle_to_z(frame):
-    """
-    Return the angle between solar north and the Z axis of the provided frame's coordinate system
-    and observation time.
-    """
-    # Find the Sun center in HGS at the frame's observation time(s)
-    sun_center_repr = SphericalRepresentation(0*u.deg, 0*u.deg, 0*u.km)
-    # The representation is repeated for as many times as are in obstime prior to transformation
-    sun_center = SkyCoord(sun_center_repr._apply('repeat', frame.obstime.size),
-                          frame=HGS, obstime=frame.obstime)
-
-    # Find the Sun north in HGS at the frame's observation time(s)
-    # Only a rough value of the solar radius is needed here because, after the cross product,
-    #   only the direction from the Sun center to the Sun north pole matters
-    sun_north_repr = SphericalRepresentation(0*u.deg, 90*u.deg, 690000*u.km)
-    # The representation is repeated for as many times as are in obstime prior to transformation
-    sun_north = SkyCoord(sun_north_repr._apply('repeat', frame.obstime.size),
-                         frame=HGS, obstime=frame.obstime)
-
-    # Find the Sun center and Sun north in the frame's coordinate system
-    sky_normal = sun_center.transform_to(frame).data.to_cartesian()
-    sun_north = sun_north.transform_to(frame).data.to_cartesian()
-
-    # Use cross products to obtain the sky projections of the two vectors (rotated by 90 deg)
-    sun_north_in_sky = sun_north.cross(sky_normal)
-    z_in_sky = CartesianRepresentation(0, 0, 1).cross(sky_normal)
-
-    # Normalize directional vectors
-    sky_normal /= sky_normal.norm()
-    sun_north_in_sky /= sun_north_in_sky.norm()
-    z_in_sky /= z_in_sky.norm()
-
-    # Calculate the signed angle between the two projected vectors
-    cos_theta = sun_north_in_sky.dot(z_in_sky)
-    sin_theta = sun_north_in_sky.cross(z_in_sky).dot(sky_normal)
-    angle = np.arctan2(sin_theta, cos_theta).to('deg')
-
-    # If there is only one time, this function's output should be scalar rather than array
-    if angle.size == 1:
-        angle = angle[0]
-
-    return Angle(angle)
 
 
 def get_horizons_coord(body, time='now', id_type='majorbody'):
@@ -373,3 +196,203 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     coord = SkyCoord(vector, frame=HeliocentricMeanEcliptic, obstime=obstime)
 
     return coord.transform_to(HGS)
+
+
+# The code beyond this point should be moved to sunpy.coordinates.sun after the deprecation period
+
+def _B0(time='now'):
+    """
+    Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
+    Sun-disk center as seen from Earth.  The range of B0 is +/-7.23 degrees.
+
+    Parameters
+    ----------
+    time : various
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+
+    Returns
+    -------
+    out : `~astropy.coordinates.Angle`
+        The position angle
+    """
+    return Angle(get_earth(time).lat)
+
+    
+# Ignore warnings that result from going back in time to the first Carrington rotation
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", ErfaWarning)
+
+    # Carrington rotation 1 starts late in the day on 1853 Nov 9
+    # according to Astronomical Algorithms (Meeus 1998, p.191)
+    _TIME_FIRST_ROTATION = Time('1853-11-09 21:36')
+
+    # Longitude of Earth at Carrington rotation 1 in de-tilted HCRS (so that solar north pole is Z)
+    _LON_FIRST_ROTATION = \
+        get_earth(_TIME_FIRST_ROTATION).hcrs.cartesian.transform(_SUN_DETILT_MATRIX) \
+        .represent_as(SphericalRepresentation).lon.to('deg')
+
+
+def _L0(time='now'):
+    """
+    Return the L0 angle for the Sun at a specified time, which is the Carrington longitude of the
+    Sun-disk center as seen from Earth.
+
+    .. warning::
+       Due to apparent disagreement between published references, the returned L0 may be inaccurate
+       by up to ~2 arcmin, which translates in the worst case to a shift of ~0.5 arcsec in
+       helioprojective coordinates for an observer at 1 AU.  Until this is resolved, be cautious
+       with analysis that depends critically on absolute (as opposed to relative) values of
+       Carrington longitude.
+
+    Parameters
+    ----------
+    time : various
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+
+    Returns
+    -------
+    out : `~astropy.coordinates.Longitude`
+        The Carrington longitude
+    """
+    obstime = parse_time(time)
+
+    # Calculate the longitude due to the Sun's rotation relative to the stars
+    # A sidereal rotation is defined to be exactly 25.38 days
+    sidereal_lon = Longitude((obstime.jd - _TIME_FIRST_ROTATION.jd) / 25.38 * 360*u.deg)
+
+    # Calculate the longitude of the Earth in de-tilted HCRS
+    lon_obstime = get_earth(obstime).hcrs.cartesian.transform(_SUN_DETILT_MATRIX) \
+                  .represent_as(SphericalRepresentation).lon.to('deg')
+
+    return Longitude(lon_obstime - _LON_FIRST_ROTATION - sidereal_lon)
+
+
+def _P(time='now'):
+    """
+    Return the position (P) angle for the Sun at a specified time, which is the angle between
+    geocentric north and solar north as seen from Earth, measured eastward from geocentric north.
+    The range of P is +/-26.3 degrees.
+
+    Parameters
+    ----------
+    time : various
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+
+    Returns
+    -------
+    out : `~astropy.coordinates.Angle`
+        The position angle
+    """
+    obstime = parse_time(time)
+
+    # Define the frame where its Z axis is aligned with geocentric north
+    geocentric = PrecessedGeocentric(equinox=obstime, obstime=obstime)
+
+    return _sun_north_angle_to_z(geocentric)
+
+
+def _earth_distance(time='now'):
+    """
+    Return the distance between the Sun and the Earth at a specified time.
+
+    Parameters
+    ----------
+    time : various
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+
+    Returns
+    -------
+    out : `~astropy.coordinates.Distance`
+        The Sun-Earth distance
+    """
+    return get_earth(time).radius
+
+
+def _orientation(location, time='now'):
+    """
+    Return the orientation angle for the Sun from a specified Earth location and time.  The
+    orientation angle is the angle between local zenith and solar north, measured eastward from
+    local zenith.
+
+    Parameters
+    ----------
+    location : `~astropy.coordinates.EarthLocation`
+        Observer location on Earth
+    time : various
+        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+
+    Returns
+    -------
+    out : `~astropy.coordinates.Angle`
+        The orientation of the Sun
+    """
+    obstime = parse_time(time)
+
+    # Define the frame where its Z axis is aligned with local zenith
+    local_frame = AltAz(obstime=obstime, location=location)
+
+    return _sun_north_angle_to_z(local_frame)
+
+
+def _sun_north_angle_to_z(frame):
+    """
+    Return the angle between solar north and the Z axis of the provided frame's coordinate system
+    and observation time.
+    """
+    # Find the Sun center in HGS at the frame's observation time(s)
+    sun_center_repr = SphericalRepresentation(0*u.deg, 0*u.deg, 0*u.km)
+    # The representation is repeated for as many times as are in obstime prior to transformation
+    sun_center = SkyCoord(sun_center_repr._apply('repeat', frame.obstime.size),
+                          frame=HGS, obstime=frame.obstime)
+
+    # Find the Sun north in HGS at the frame's observation time(s)
+    # Only a rough value of the solar radius is needed here because, after the cross product,
+    #   only the direction from the Sun center to the Sun north pole matters
+    sun_north_repr = SphericalRepresentation(0*u.deg, 90*u.deg, 690000*u.km)
+    # The representation is repeated for as many times as are in obstime prior to transformation
+    sun_north = SkyCoord(sun_north_repr._apply('repeat', frame.obstime.size),
+                         frame=HGS, obstime=frame.obstime)
+
+    # Find the Sun center and Sun north in the frame's coordinate system
+    sky_normal = sun_center.transform_to(frame).data.to_cartesian()
+    sun_north = sun_north.transform_to(frame).data.to_cartesian()
+
+    # Use cross products to obtain the sky projections of the two vectors (rotated by 90 deg)
+    sun_north_in_sky = sun_north.cross(sky_normal)
+    z_in_sky = CartesianRepresentation(0, 0, 1).cross(sky_normal)
+
+    # Normalize directional vectors
+    sky_normal /= sky_normal.norm()
+    sun_north_in_sky /= sun_north_in_sky.norm()
+    z_in_sky /= z_in_sky.norm()
+
+    # Calculate the signed angle between the two projected vectors
+    cos_theta = sun_north_in_sky.dot(z_in_sky)
+    sin_theta = sun_north_in_sky.cross(z_in_sky).dot(sky_normal)
+    angle = np.arctan2(sin_theta, cos_theta).to('deg')
+
+    # If there is only one time, this function's output should be scalar rather than array
+    if angle.size == 1:
+        angle = angle[0]
+
+    return Angle(angle)
+
+
+get_sun_B0 = deprecated('1.0', name='get_sun_B0',
+                        alternative='sunpy.coordinates.sun.B0')(_B0)
+
+
+get_sun_L0 = deprecated('1.0', name='get_sun_L0',
+                        alternative='sunpy.coordinates.sun.L0')(_L0)
+
+
+get_sun_P = deprecated('1.0', name='get_sun_P',
+                       alternative='sunpy.coordinates.sun.P')(_P)
+
+
+get_sunearth_distance = deprecated('1.0', name='get_sunearth_distance',
+                                   alternative='sunpy.coordinates.sun.earth_distance')(_earth_distance)
+
+
+get_sun_orientation = deprecated('1.0', name='get_sun_orientation',
+                                 alternative='sunpy.coordinates.sun.orientation')(_orientation)

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -381,22 +381,13 @@ def _sun_north_angle_to_z(frame):
     return Angle(angle)
 
 
-get_sun_B0 = deprecated('1.0', name='get_sun_B0',
-                        alternative='sunpy.coordinates.sun.B0')(_B0)
+# The following functions are moved in the API to sunpy.coordinates.sun and renamed
+_old_names = ['get_sun_B0', 'get_sun_L0', 'get_sun_P', 'get_sunearth_distance',
+              'get_sun_orientation']
+_new_module = 'sunpy.coordinates.sun.'
+_new_names = ['B0', 'L0', 'P', 'earth_distance', 'orientation']
 
-
-get_sun_L0 = deprecated('1.0', name='get_sun_L0',
-                        alternative='sunpy.coordinates.sun.L0')(_L0)
-
-
-get_sun_P = deprecated('1.0', name='get_sun_P',
-                       alternative='sunpy.coordinates.sun.P')(_P)
-
-
-get_sunearth_distance = deprecated('1.0', name='get_sunearth_distance',
-                                   alternative='sunpy.coordinates.sun.earth_distance'
-                                  )(_earth_distance)
-
-
-get_sun_orientation = deprecated('1.0', name='get_sun_orientation',
-                                 alternative='sunpy.coordinates.sun.orientation')(_orientation)
+# Create a deprecation hook for each of the functions
+# Note that the code for each of these functions is still in this module as a private function
+for old, new in zip(_old_names, _new_names):
+    vars()[old] = deprecated('1.0', name=old, alternative=_new_module + new)(vars()['_' + new])

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -29,6 +29,9 @@ from sunpy.time.time import _variables_for_parse_time_docstring
 from .frames import HeliographicStonyhurst as HGS
 from .transformations import _SUN_DETILT_MATRIX
 
+__author__ = "Albert Y. Shih"
+__email__ = "ayshih@gmail.com"
+
 __all__ = ['get_body_heliographic_stonyhurst', 'get_earth',
            'get_sun_B0', 'get_sun_L0', 'get_sun_P', 'get_sunearth_distance',
            'get_sun_orientation', 'get_horizons_coord']

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -23,7 +23,8 @@ except ImportError:
 
 from sunpy.time import parse_time
 from sunpy import log
-from sunpy.util.decorators import deprecated
+from sunpy.util.decorators import add_common_docstring, deprecated
+from sunpy.time.time import _variables_for_parse_time_docstring
 
 from .frames import HeliographicStonyhurst as HGS
 from .transformations import _SUN_DETILT_MATRIX
@@ -33,6 +34,7 @@ __all__ = ['get_body_heliographic_stonyhurst', 'get_earth',
            'get_sun_orientation', 'get_horizons_coord']
 
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 def get_body_heliographic_stonyhurst(body, time='now', observer=None):
     """
     Return a `~sunpy.coordinates.frames.HeliographicStonyhurst` frame for the location of a
@@ -43,8 +45,8 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None):
     ----------
     body : `str`
         The solar-system body for which to calculate positions
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format
     observer : `~astropy.coordinates.SkyCoord`
         If None, the returned coordinate is the instantaneous or "true" location.
         If not None, the returned coordinate is the astrometric location (i.e., accounts for light
@@ -87,6 +89,7 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None):
     return body_hgs
 
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 def get_earth(time='now'):
     """
     Return a `~astropy.coordinates.SkyCoord` for the location of the Earth at a specified time in
@@ -94,8 +97,8 @@ def get_earth(time='now'):
 
     Parameters
     ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format
 
     Returns
     -------
@@ -110,6 +113,7 @@ def get_earth(time='now'):
     return earth
 
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 def get_horizons_coord(body, time='now', id_type='majorbody'):
     """
     Queries JPL HORIZONS and returns a `~astropy.coordinates.SkyCoord` for the location of a
@@ -126,8 +130,8 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
         The solar-system body for which to calculate positions
     id_type : `str`
         If 'majorbody', search by name for planets or satellites.  If 'id', search by ID number.
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format
 
     Returns
     -------
@@ -203,6 +207,7 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
 
 # The code beyond this point should be moved to sunpy.coordinates.sun after the deprecation period
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 def _B0(time='now'):
     """
     Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
@@ -210,8 +215,8 @@ def _B0(time='now'):
 
     Parameters
     ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format
 
     Returns
     -------
@@ -235,6 +240,7 @@ with warnings.catch_warnings():
         .represent_as(SphericalRepresentation).lon.to('deg')
 
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 def _L0(time='now'):
     """
     Return the L0 angle for the Sun at a specified time, which is the Carrington longitude of the
@@ -249,8 +255,8 @@ def _L0(time='now'):
 
     Parameters
     ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format
 
     Returns
     -------
@@ -270,6 +276,7 @@ def _L0(time='now'):
     return Longitude(lon_obstime - _LON_FIRST_ROTATION - sidereal_lon)
 
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 def _P(time='now'):
     """
     Return the position (P) angle for the Sun at a specified time, which is the angle between
@@ -278,8 +285,8 @@ def _P(time='now'):
 
     Parameters
     ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format
 
     Returns
     -------
@@ -294,14 +301,15 @@ def _P(time='now'):
     return _sun_north_angle_to_z(geocentric)
 
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 def _earth_distance(time='now'):
     """
     Return the distance between the Sun and the Earth at a specified time.
 
     Parameters
     ----------
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format
 
     Returns
     -------
@@ -311,6 +319,7 @@ def _earth_distance(time='now'):
     return get_earth(time).radius
 
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 def _orientation(location, time='now'):
     """
     Return the orientation angle for the Sun from a specified Earth location and time.  The
@@ -321,8 +330,8 @@ def _orientation(location, time='now'):
     ----------
     location : `~astropy.coordinates.EarthLocation`
         Observer location on Earth
-    time : various
-        Time to use as `~astropy.time.Time` or in a parse_time-compatible format
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format
 
     Returns
     -------

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -114,8 +114,11 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     """
     Queries JPL HORIZONS and returns a `~astropy.coordinates.SkyCoord` for the location of a
     solar-system body at a specified time.  This location is the instantaneous or "true" location,
-    and is not corrected for light travel time or observer motion.  This function requires the
-    Astroquery package to be installed and requires an Internet connection.
+    and is not corrected for light travel time or observer motion.
+
+    .. note::
+        This function requires the Astroquery package to be installed and
+        requires an Internet connection.
 
     Parameters
     ----------

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -217,7 +217,7 @@ def _B0(time='now'):
     """
     return Angle(get_earth(time).lat)
 
-    
+
 # Ignore warnings that result from going back in time to the first Carrington rotation
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", ErfaWarning)
@@ -391,7 +391,8 @@ get_sun_P = deprecated('1.0', name='get_sun_P',
 
 
 get_sunearth_distance = deprecated('1.0', name='get_sunearth_distance',
-                                   alternative='sunpy.coordinates.sun.earth_distance')(_earth_distance)
+                                   alternative='sunpy.coordinates.sun.earth_distance'
+                                  )(_earth_distance)
 
 
 get_sun_orientation = deprecated('1.0', name='get_sun_orientation',

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -127,9 +127,12 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     Parameters
     ----------
     body : `str`
-        The solar-system body for which to calculate positions
+        The solar-system body for which to calculate positions.  One can also use the search form
+        linked below to find valid names or ID numbers.
     id_type : `str`
-        If 'majorbody', search by name for planets or satellites.  If 'id', search by ID number.
+        If 'majorbody', search by name for planets, satellites, or other major bodies.
+        If 'smallbody', search by name for asteroids or comets.
+        If 'id', search by ID number.
     time : {parse_time_types}
         Time to use in a parse_time-compatible format
 
@@ -147,6 +150,7 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     References
     ----------
     * `JPL HORIZONS <https://ssd.jpl.nasa.gov/?horizons>`_
+    * `JPL HORIZONS form to search bodies <https://ssd.jpl.nasa.gov/horizons.cgi?s_target=1#top>`_
     * `Astroquery <https://astroquery.readthedocs.io/en/latest/>`_
 
     Examples

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -13,12 +13,12 @@ from astropy.coordinates.representation import (CartesianRepresentation, Spheric
                                                 CylindricalRepresentation,
                                                 UnitSphericalRepresentation)
 
-from sunpy import sun
+from sunpy.sun import constants
 
 from .frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribute
 
-RSUN_METERS = sun.constants.get('radius').si.to(u.m)
-DSUN_METERS = sun.constants.get('mean distance').si.to(u.m)
+RSUN_METERS = constants.get('radius').si.to(u.m)
+DSUN_METERS = constants.get('mean distance').si.to(u.m)
 
 __all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
            'Heliocentric', 'Helioprojective']

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -13,12 +13,9 @@ from astropy.coordinates.representation import (CartesianRepresentation, Spheric
                                                 CylindricalRepresentation,
                                                 UnitSphericalRepresentation)
 
-from sunpy.sun import constants
+from sunpy.sun.constants import radius as _RSUN
 
 from .frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribute
-
-RSUN_METERS = constants.get('radius').si.to(u.m)
-DSUN_METERS = constants.get('mean distance').si.to(u.m)
 
 __all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
            'Heliocentric', 'Helioprojective']
@@ -138,7 +135,7 @@ class HeliographicStonyhurst(SunPyBaseCoordinateFrame):
 
         if ('radius' in kwargs and kwargs['radius'].unit is u.one and
                 u.allclose(kwargs['radius'], 1*u.one)):
-            kwargs['radius'] = RSUN_METERS.to(u.km)
+            kwargs['radius'] = _RSUN.to(u.km)
 
         super(HeliographicStonyhurst, self).__init__(*args, **kwargs)
 
@@ -146,9 +143,9 @@ class HeliographicStonyhurst(SunPyBaseCoordinateFrame):
         # If representation was explicitly passed, do not change the rep.
         if not _rep_kwarg:
             # If we were passed a 3D rep extract the distance, otherwise
-            # calculate it from RSUN.
+            # calculate it from _RSUN.
             if isinstance(self._data, UnitSphericalRepresentation):
-                distance = RSUN_METERS.to(u.km)
+                distance = _RSUN.to(u.km)
                 self._data = SphericalRepresentation(lat=self._data.lat,
                                                      lon=self._data.lon,
                                                      distance=distance)
@@ -366,7 +363,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     }
 
     obstime = TimeFrameAttributeSunPy()
-    rsun = Attribute(default=RSUN_METERS.to(u.km))
+    rsun = Attribute(default=_RSUN.to(u.km))
     observer = ObserverCoordinateAttribute(HeliographicStonyhurst, default="earth")
     _default_wrap_angle = 180*u.deg
 

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -1,0 +1,399 @@
+"""
+This module provides Sun-related parameters.
+"""
+import numpy as np
+
+import astropy.units as u
+from astropy.coordinates import Angle, Latitude, Longitude, SkyCoord
+# Versions of Astropy that do not have *MeanEcliptic frames have the same frames
+# with the misleading names *TrueEcliptic
+try:
+    from astropy.coordinates import HeliocentricMeanEcliptic, GeocentricMeanEcliptic
+except ImportError:
+    from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
+    from astropy.coordinates import GeocentricTrueEcliptic as GeocentricMeanEcliptic
+from astropy import _erfa as erfa
+from astropy.coordinates.builtin_frames.utils import get_jd12
+
+from sunpy.sun import constants
+from sunpy.time import parse_time
+from sunpy.time.time import _variables_for_parse_time_docstring
+from sunpy.util.decorators import add_common_docstring
+
+__all__ = [
+    "solar_semidiameter_angular_size", "position", "carrington_rotation_number",
+    "true_longitude", "apparent_longitude", "true_latitude", "apparent_latitude",
+    "mean_obliquity_of_ecliptic", "true_rightascension", "true_declination",
+    "true_obliquity_of_ecliptic", "apparent_rightascension", "apparent_declination",
+    "print_params"
+]
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def solar_semidiameter_angular_size(t='now'):
+    """
+    Return the angular size of the semi-diameter of the Sun as viewed from Earth.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+    """
+    # Import here to avoid a circular import
+    from sunpy.coordinates import get_sunearth_distance
+    solar_semidiameter_rad = constants.radius / get_sunearth_distance(t)
+    return Angle(solar_semidiameter_rad.to(u.arcsec, equivalencies=u.dimensionless_angles()))
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def position(t='now', equinox_of_date=True):
+    """
+    Returns the apparent position of the Sun (right ascension and declination) on the
+    celestial sphere using the equatorial coordinate system, referred to the true equinox of date
+    (as default).  Corrections for nutation and aberration (for Earth motion) are included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+
+    equinox_of_date : `bool`
+        If True, output is referred to the true equinox of date.  Otherwise, output is referred to
+        the J2000.0 epoch.
+    """
+    ra = apparent_rightascension(t, equinox_of_date=equinox_of_date)
+    dec = apparent_declination(t, equinox_of_date=equinox_of_date)
+    return ra, dec
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def carrington_rotation_number(t='now'):
+    """
+    Return the Carrington Rotation number.
+
+    .. warning::
+        The accuracy of this function is under investigation.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+    """
+    jd = parse_time(t).jd
+    result = (1. / 27.2753) * (jd - 2398167.0) + 1.0
+    return result
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def true_longitude(t='now'):
+    """
+    Returns the Sun's true geometric longitude, referred to the mean equinox of date.  No
+    corrections for nutation or aberration are included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+    """
+    time = parse_time(t)
+
+    # Calculate Earth's true geometric longitude and add 180 degrees for the Sun's longitude.
+    # This approach is used because Astropy's GeocentricMeanEcliptic includes aberration.
+    earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='gcrs', obstime=time)
+    coord = earth.transform_to(HeliocentricMeanEcliptic(equinox=time))
+    lon = coord.lon + 180*u.deg
+
+    return Longitude(lon)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def apparent_longitude(t='now'):
+    """
+    Returns the Sun's apparent longitude, referred to the true equinox of date.  Corrections for
+    nutation and aberration (for Earth motion) are included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+
+    Notes
+    -----
+    The nutation model is IAU 2000A nutation with adjustments to match IAU 2006 precession.
+    """
+    time = parse_time(t)
+    sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
+    coord = sun.transform_to(GeocentricMeanEcliptic(equinox=time))
+
+    # Astropy's GeocentricMeanEcliptic already includes aberration, so only add nutation
+    jd1, jd2 = get_jd12(time, 'tt')
+    nut_lon, _ = erfa.nut06a(jd1, jd2)*u.radian
+    lon = coord.lon + nut_lon
+
+    return Longitude(lon)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def true_latitude(t='now'):
+    """
+    Returns the Sun's true geometric latitude, referred to the mean equinox of date.  No
+    corrections for nutation or aberration are included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+    """
+    time = parse_time(t)
+    sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
+    coord = sun.transform_to(GeocentricMeanEcliptic(equinox=time))
+
+    # Astropy's GeocentricMeanEcliptic includes aberration from Earth motion, but the contribution
+    # is negligible
+    lat = coord.lat
+
+    return Latitude(lat)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def apparent_latitude(t='now'):
+    """
+    Returns the Sun's apparent latitude, referred to the true equinox of date.  Corrections for
+    nutation and aberration (for Earth motion) are included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+    """
+    time = parse_time(t)
+    sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
+    coord = sun.transform_to(GeocentricMeanEcliptic(equinox=time))
+
+    # Astropy's GeocentricMeanEcliptic does not include nutation, but the contribution is negligible
+    lat = coord.lat
+
+    return Latitude(lat)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def mean_obliquity_of_ecliptic(t='now'):
+    """
+    Returns the mean obliquity of the ecliptic, using the IAU 2006 definition.  No correction for
+    nutation is included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+    """
+    time = parse_time(t)
+    jd1, jd2 = get_jd12(time, 'tt')
+    obl = erfa.obl06(jd1, jd2)*u.radian
+    return Angle(obl, u.arcsec)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def true_rightascension(t='now', equinox_of_date=True):
+    """
+    Returns the Sun's true geometric right ascension relative to Earth, referred to the mean equinox
+    of date (as default).  No corrections for nutation or aberration are included.  The correction
+    due to light travel time would be negligible, so the output is also the astrometric right
+    ascension.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+
+    equinox_of_date : `bool`
+        If True, output is referred to the mean equinox of date.  Otherwise, output is referred to
+        the J2000.0 epoch.
+    """
+    if equinox_of_date:
+        # Mean equinox of date
+        obl = mean_obliquity_of_ecliptic(t)  # excludes nutation
+        lon = true_longitude(t)
+        lat = true_latitude(t)
+
+        # See Astronomical Algorithms (Meeus 1998 p.93)
+        y = np.sin(lon) * np.cos(obl) - np.tan(lat) * np.sin(obl)
+        x = np.cos(lon)
+        result = np.arctan2(y, x)
+    else:
+        # J2000.0 epoch
+        # Calculate Earth's true geometric right ascension relative to the Sun and add 180 degrees.
+        # This approach is used because Astropy's GCRS includes aberration.
+        earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='gcrs', obstime=parse_time(t))
+        result = earth.hcrs.ra + 180*u.deg
+
+    return Longitude(result, u.hourangle)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def true_declination(t='now', equinox_of_date=True):
+    """
+    Returns the Sun's true geometric declination relative to Earth, referred to the mean equinox
+    of date (as default).  No corrections for nutation or aberration are included.  The correction
+    due to light travel time would be negligible, so the output is also the astrometric declination.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+
+    equinox_of_date : `bool`
+        If True, output is referred to the mean equinox of date.  Otherwise, output is referred to
+        the J2000.0 epoch.
+    """
+    if equinox_of_date:
+        # Mean equinox of date
+        obl = mean_obliquity_of_ecliptic(t)  # excludes nutation
+        lon = true_longitude(t)
+        lat = true_latitude(t)
+
+        # See Astronomical Algorithms (Meeus 1998 p.93)
+        result = np.arcsin(np.sin(lat) * np.cos(obl) + np.cos(lat) * np.sin(obl) * np.sin(lon))
+    else:
+        # J2000.0 epoch
+        # Calculate Earth's true geometric declination relative to the Sun and multipy by -1.
+        # This approach is used because Astropy's GCRS includes aberration.
+        earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='gcrs', obstime=parse_time(t))
+        result = -earth.hcrs.dec
+
+    return Latitude(result, u.deg)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def true_obliquity_of_ecliptic(t='now'):
+    """
+    Returns the true obliquity of the ecliptic, using the IAU 2006 definition.  Correction for
+    nutation is included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+
+    Notes
+    -----
+    The nutation model is IAU 2000A nutation with adjustments to match IAU 2006 precession.
+    """
+    time = parse_time(t)
+    jd1, jd2 = get_jd12(time, 'tt')
+    obl = erfa.obl06(jd1, jd2)*u.radian
+    _, nut_obl = erfa.nut06a(jd1, jd2)*u.radian
+    obl += nut_obl
+    return Angle(obl, u.arcsec)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def apparent_rightascension(t='now', equinox_of_date=True):
+    """
+    Returns the Sun's apparent right ascension relative to Earth, referred to the true equinox
+    of date (as default).  Corrections for nutation or aberration (for Earth motion) are included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+
+    equinox_of_date : `bool`
+        If True, output is referred to the true equinox of date.  Otherwise, output is referred to
+        the J2000.0 epoch.
+    """
+    if equinox_of_date:
+        # True equinox of date
+        obl = true_obliquity_of_ecliptic(t)  # includes nutation
+        lon = apparent_longitude(t)
+        lat = apparent_latitude(t)
+
+        # See Astronomical Algorithms (Meeus 1998 p.93)
+        y = np.sin(lon) * np.cos(obl) - np.tan(lat) * np.sin(obl)
+        x = np.cos(lon)
+        result = np.arctan2(y, x)
+    else:
+        # J2000.0 epoch
+        sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=parse_time(t))
+        result = sun.gcrs.ra
+
+    return Longitude(result, u.hourangle)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def apparent_declination(t='now', equinox_of_date=True):
+    """
+    Returns the Sun's apparent declination relative to Earth, referred to the true equinox
+    of date (as default).  Corrections for nutation or aberration (for Earth motion) are included.
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+
+    equinox_of_date : `bool`
+        If True, output is referred to the true equinox of date.  Otherwise, output is referred to
+        the J2000.0 epoch.
+    """
+    if equinox_of_date:
+        # True equinox of date
+        obl = true_obliquity_of_ecliptic(t)  # includes nutation
+        lon = apparent_longitude(t)
+        lat = apparent_latitude(t)
+
+        # See Astronomical Algorithms (Meeus 1998 p.93)
+        result = np.arcsin(np.sin(lat) * np.cos(obl) + np.cos(lat) * np.sin(obl) * np.sin(lon))
+    else:
+        # J2000.0 epoch
+        sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=parse_time(t))
+        result = sun.gcrs.dec
+
+    return Latitude(result, u.deg)
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def print_params(t='now'):
+    """
+    Print out a summary of solar ephemeris. 'True' values are true geometric values referred to the
+    mean equinox of date, with no corrections for nutation or aberration.  'Apparent' values are
+    referred to the true equinox of date, with corrections for nutation and aberration (for Earth
+    motion).
+
+    Parameters
+    ----------
+    t : {parse_time_types}
+        A time (usually the start time) specified as a parse_time-compatible
+        time string, number, or a datetime object.
+    """
+    # Import here to avoid circular import
+    from sunpy.coordinates.ephemeris import (get_sun_L0, get_sun_B0,
+                                             get_sun_P, get_sunearth_distance)
+
+    print('Solar Ephemeris for {} UTC\n'.format(parse_time(t).utc))
+    print('Distance = {}'.format(get_sunearth_distance(t)))
+    print('Semidiameter = {}'.format(solar_semidiameter_angular_size(t)))
+    print('True (long, lat) = ({}, {})'.format(true_longitude(t).to_string(),
+                                               true_latitude(t).to_string()))
+    print('Apparent (long, lat) = ({}, {})'.format(apparent_longitude(t).to_string(),
+                                                   apparent_latitude(t).to_string()))
+    print('True (RA, Dec) = ({}, {})'.format(true_rightascension(t).to_string(),
+                                             true_declination(t).to_string()))
+    print('Apparent (RA, Dec) = ({}, {})'.format(apparent_rightascension(t).to_string(),
+                                                 apparent_declination(t).to_string()))
+    print('Heliographic long. and lat of disk center = ({}, {})'.format(get_sun_L0(t).to_string(),
+                                                                        get_sun_B0(t).to_string()))
+    print('Position angle of north pole = {}'.format(get_sun_P(t)))
+    print('Carrington Rotation Number = {}'.format(carrington_rotation_number(t)))

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -1,5 +1,5 @@
 """
-This module provides Sun-related parameters.
+Sun-specific coordinate calculations
 """
 import warnings
 
@@ -42,8 +42,7 @@ def angular_radius(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
     """
     solar_semidiameter_rad = constants.radius / earth_distance(t)
     return Angle(solar_semidiameter_rad.to(u.arcsec, equivalencies=u.dimensionless_angles()))
@@ -59,8 +58,7 @@ def sky_position(t='now', equinox_of_date=True):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
 
     equinox_of_date : `bool`
         If True, output is referred to the true equinox of date.  Otherwise, output is referred to
@@ -82,8 +80,7 @@ def carrington_rotation_number(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
     """
     jd = parse_time(t).jd
     result = (1. / 27.2753) * (jd - 2398167.0) + 1.0
@@ -99,8 +96,7 @@ def true_longitude(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
     """
     time = parse_time(t)
 
@@ -122,8 +118,7 @@ def apparent_longitude(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
 
     Notes
     -----
@@ -150,8 +145,7 @@ def true_latitude(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
     """
     time = parse_time(t)
     sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
@@ -173,8 +167,7 @@ def apparent_latitude(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
     """
     time = parse_time(t)
     sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
@@ -195,8 +188,7 @@ def mean_obliquity_of_ecliptic(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
     """
     time = parse_time(t)
     jd1, jd2 = get_jd12(time, 'tt')
@@ -215,8 +207,7 @@ def true_rightascension(t='now', equinox_of_date=True):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
 
     equinox_of_date : `bool`
         If True, output is referred to the mean equinox of date.  Otherwise, output is referred to
@@ -252,8 +243,7 @@ def true_declination(t='now', equinox_of_date=True):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
 
     equinox_of_date : `bool`
         If True, output is referred to the mean equinox of date.  Otherwise, output is referred to
@@ -286,8 +276,7 @@ def true_obliquity_of_ecliptic(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
 
     Notes
     -----
@@ -310,8 +299,7 @@ def apparent_rightascension(t='now', equinox_of_date=True):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
 
     equinox_of_date : `bool`
         If True, output is referred to the true equinox of date.  Otherwise, output is referred to
@@ -344,8 +332,7 @@ def apparent_declination(t='now', equinox_of_date=True):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
 
     equinox_of_date : `bool`
         If True, output is referred to the true equinox of date.  Otherwise, output is referred to
@@ -378,8 +365,7 @@ def print_params(t='now'):
     Parameters
     ----------
     t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
+        Time to use in a parse-time-compatible format
     """
     print('Solar Ephemeris for {} UTC\n'.format(parse_time(t).utc))
     print('Distance = {}'.format(earth_distance(t)))

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -402,7 +402,20 @@ def print_params(t='now'):
 # deprecation period
 
 B0 = _B0
+B0.__module__ = __name__  # to be picked up by docs
+
+
 L0 = _L0
+L0.__module__ = __name__  # to be picked up by docs
+
+
 P = _P
+P.__module__ = __name__  # to be picked up by docs
+
+
 earth_distance = _earth_distance
+earth_distance.__module__ = __name__  # to be picked up by docs
+
+
 orientation = _orientation
+orientation.__module__ = __name__  # to be picked up by docs

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -398,24 +398,11 @@ def print_params(t='now'):
     print('Carrington Rotation Number = {}'.format(carrington_rotation_number(t)))
 
 
-# The code for these functions should be moved in from sunpy.coordinates.ephemeris after the
-# deprecation period
+# The following functions belong to this module, but their code is still in the old location of
+# sunpy.coordinates.ephemeris.  That code should be moved here after the deprecation period.
 
-B0 = _B0
-B0.__module__ = __name__  # to be picked up by docs
-
-
-L0 = _L0
-L0.__module__ = __name__  # to be picked up by docs
-
-
-P = _P
-P.__module__ = __name__  # to be picked up by docs
-
-
-earth_distance = _earth_distance
-earth_distance.__module__ = __name__  # to be picked up by docs
-
-
-orientation = _orientation
-orientation.__module__ = __name__  # to be picked up by docs
+# Create functions that call the appropriate private functions in sunpy.coordinates.ephemeris
+_functions = ['B0', 'L0', 'P', 'earth_distance', 'orientation']
+for func in _functions:
+    vars()[func] = vars()['_' + func]
+    vars()[func].__module__ = __name__  # so that docs think that the function is local

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -24,6 +24,9 @@ from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
 from .ephemeris import get_earth, _B0, _L0, _P, _earth_distance, _orientation
 
+__author__ = "Albert Y. Shih"
+__email__ = "ayshih@gmail.com"
+
 __all__ = [
     "angular_radius", "sky_position", "carrington_rotation_number",
     "true_longitude", "apparent_longitude", "true_latitude", "apparent_latitude",

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -5,7 +5,7 @@ import pytest
 import astropy.units as u
 from astropy.config.paths import set_temp_cache
 from astropy.constants import c as speed_of_light
-from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 
@@ -54,67 +54,6 @@ def test_get_earth():
     assert e2.lon == 0*u.deg
     assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)
-
-
-def test_get_sun_B0():
-    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
-    assert_quantity_allclose(get_sun_B0('1992-Oct-13'), 5.99*u.deg, atol=5e-3*u.deg)
-
-
-def test_get_sun_B0_array_time():
-    # Validate against published values from the Astronomical Almanac (2013)
-    sun_B0 = get_sun_B0(Time(['2013-04-01', '2013-12-01']))
-    assert_quantity_allclose(sun_B0[0], -6.54*u.deg, atol=5e-3*u.deg)
-    assert_quantity_allclose(sun_B0[1], 0.88*u.deg, atol=5e-3*u.deg)
-
-
-def test_get_sun_L0():
-    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
-    assert_quantity_allclose(get_sun_L0('1992-Oct-13'), 238.6317*u.deg, atol=5e-5*u.deg)
-
-
-def test_get_sun_L0_array_time():
-    # Validate against published values from the Astronomical Almanac (2013)
-    sun_L0 = get_sun_L0(Time(['2013-04-01', '2013-12-01']))
-    assert_quantity_allclose(sun_L0[0], 221.44*u.deg, atol=3e-2*u.deg)
-    assert_quantity_allclose(sun_L0[1], 237.83*u.deg, atol=3e-2*u.deg)
-
-
-def test_get_sun_P():
-    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
-    assert_quantity_allclose(get_sun_P('1992-Oct-13'), 26.27*u.deg, atol=5e-3*u.deg)
-
-
-def test_get_sun_P_array_time():
-    # Validate against published values from the Astronomical Almanac (2013)
-    sun_P = get_sun_P(Time(['2013-04-01', '2013-12-01']))
-    assert_quantity_allclose(sun_P[0], -26.15*u.deg, atol=1e-2*u.deg)
-    assert_quantity_allclose(sun_P[1], 16.05*u.deg, atol=1e-2*u.deg)
-
-
-def test_get_sunearth_distance():
-    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
-    assert_quantity_allclose(get_sunearth_distance('1992-Oct-13'), 0.997608*u.AU, atol=5e-7*u.AU)
-
-
-def test_get_sunearth_distance_array_time():
-    # Validate against published values from the Astronomical Almanac (2013)
-    sunearth_distance = get_sunearth_distance(Time(['2013-04-01', '2013-12-01']))
-    assert_quantity_allclose(sunearth_distance[0], 0.9992311*u.AU, atol=5e-7*u.AU)
-    assert_quantity_allclose(sunearth_distance[1], 0.9861362*u.AU, atol=5e-7*u.AU)
-
-
-def test_get_sun_orientation():
-    # Not currently aware of a published value to check against, so just self-check for now
-
-    # Check the Northern Hemisphere
-    angle = get_sun_orientation(EarthLocation(lat=40*u.deg, lon=-75*u.deg), '2017-07-18 12:00')
-    assert_quantity_allclose(angle, -59.4*u.deg, atol=0.1*u.deg)
-
-    # Check the Southern Hemisphere
-    angle = get_sun_orientation(EarthLocation(lat=-40*u.deg, lon=-75*u.deg), '2017-02-18 13:00')
-    assert_quantity_allclose(angle, -110.8*u.deg, atol=0.1*u.deg)
-
 
 
 @pytest.mark.remote_data

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -5,7 +5,7 @@ from astropy.time import Time
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 
-from sunpy.sun import sun
+from sunpy.coordinates import sun
 
 
 @pytest.fixture

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -1,6 +1,6 @@
 import pytest
 
-from astropy.coordinates import Angle
+from astropy.coordinates import Angle, EarthLocation, SkyCoord
 from astropy.time import Time
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
@@ -57,11 +57,11 @@ def test_apparent_latitude(t1, t2):
     assert_quantity_allclose(sun.apparent_latitude(t2), Angle('-0.42s'), atol=0.005*u.arcsec)
 
 
-def test_solar_semidiameter_angular_size():
+def test_angular_radius():
     # Regression-only test
-    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2012/11/11"), 968.871294 * u.arcsec, atol=1e-3 * u.arcsec)
-    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2043/03/01"), 968.326347 * u.arcsec, atol=1e-3 * u.arcsec)
-    assert_quantity_allclose(sun.solar_semidiameter_angular_size("2001/07/21"), 944.039007 * u.arcsec, atol=1e-3 * u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2012/11/11"), 968.871*u.arcsec, atol=1e-3*u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2043/03/01"), 968.326*u.arcsec, atol=1e-3*u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2001/07/21"), 944.039*u.arcsec, atol=1e-3*u.arcsec)
 
 
 def test_mean_obliquity_of_ecliptic(t1, t2):
@@ -148,13 +148,13 @@ def test_apparent_declination_J2000(t1):
                              Angle('-7d49m13.1s'), atol=0.05*u.arcsec)
 
 
-def test_position(t1, t2):
-    pos1 = sun.position(t1)
+def test_sky_position(t1, t2):
+    pos1 = sun.sky_position(t1)
     ra1 = sun.apparent_rightascension(t1)
     dec1 = sun.apparent_declination(t1)
     assert_quantity_allclose(pos1, (ra1, dec1))
 
-    pos2 = sun.position(t2, equinox_of_date=False)
+    pos2 = sun.sky_position(t2, equinox_of_date=False)
     ra2 = sun.apparent_rightascension(t2, equinox_of_date=False)
     dec2 = sun.apparent_declination(t2, equinox_of_date=False)
     assert_quantity_allclose(pos2, (ra2, dec2))
@@ -163,3 +163,63 @@ def test_position(t1, t2):
 def test_print_params():
     # Test only for any issues with printing; accuracy is covered by other tests
     sun.print_params()
+
+
+def test_B0():
+    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
+    assert_quantity_allclose(sun.B0('1992-Oct-13'), 5.99*u.deg, atol=5e-3*u.deg)
+
+
+def test_B0_array_time():
+    # Validate against published values from the Astronomical Almanac (2013)
+    sun_B0 = sun.B0(Time(['2013-04-01', '2013-12-01']))
+    assert_quantity_allclose(sun_B0[0], -6.54*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(sun_B0[1], 0.88*u.deg, atol=5e-3*u.deg)
+
+
+def test_L0():
+    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
+    assert_quantity_allclose(sun.L0('1992-Oct-13'), 238.6317*u.deg, atol=5e-5*u.deg)
+
+
+def test_L0_array_time():
+    # Validate against published values from the Astronomical Almanac (2013)
+    sun_L0 = sun.L0(Time(['2013-04-01', '2013-12-01']))
+    assert_quantity_allclose(sun_L0[0], 221.44*u.deg, atol=3e-2*u.deg)
+    assert_quantity_allclose(sun_L0[1], 237.83*u.deg, atol=3e-2*u.deg)
+
+
+def test_P():
+    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
+    assert_quantity_allclose(sun.P('1992-Oct-13'), 26.27*u.deg, atol=5e-3*u.deg)
+
+
+def test_P_array_time():
+    # Validate against published values from the Astronomical Almanac (2013)
+    sun_P = sun.P(Time(['2013-04-01', '2013-12-01']))
+    assert_quantity_allclose(sun_P[0], -26.15*u.deg, atol=1e-2*u.deg)
+    assert_quantity_allclose(sun_P[1], 16.05*u.deg, atol=1e-2*u.deg)
+
+
+def test_earth_distance():
+    # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
+    assert_quantity_allclose(sun.earth_distance('1992-Oct-13'), 0.997608*u.AU, atol=5e-7*u.AU)
+
+
+def test_earth_distance_array_time():
+    # Validate against published values from the Astronomical Almanac (2013)
+    sunearth_distance = sun.earth_distance(Time(['2013-04-01', '2013-12-01']))
+    assert_quantity_allclose(sunearth_distance[0], 0.9992311*u.AU, atol=5e-7*u.AU)
+    assert_quantity_allclose(sunearth_distance[1], 0.9861362*u.AU, atol=5e-7*u.AU)
+
+
+def test_orientation():
+    # Not currently aware of a published value to check against, so just self-check for now
+
+    # Check the Northern Hemisphere
+    angle = sun.orientation(EarthLocation(lat=40*u.deg, lon=-75*u.deg), '2017-07-18 12:00')
+    assert_quantity_allclose(angle, -59.4*u.deg, atol=0.1*u.deg)
+
+    # Check the Southern Hemisphere
+    angle = sun.orientation(EarthLocation(lat=-40*u.deg, lon=-75*u.deg), '2017-02-18 13:00')
+    assert_quantity_allclose(angle, -110.8*u.deg, atol=0.1*u.deg)

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -14,7 +14,8 @@ from astropy.time import Time
 
 from sunpy.coordinates import (Helioprojective, HeliographicStonyhurst,
                                HeliographicCarrington, Heliocentric,
-                               get_sun_L0, get_earth)
+                               get_earth)
+from sunpy.coordinates import sun
 from sunpy.time import parse_time
 
 
@@ -157,7 +158,7 @@ def test_hgs_hgc_roundtrip():
     hgcout = hgsin.transform_to(HeliographicCarrington(obstime=obstime))
 
     assert_quantity_allclose(hgsin.lat, hgcout.lat)
-    assert_quantity_allclose(hgcout.lon, get_sun_L0(obstime))
+    assert_quantity_allclose(hgcout.lon, sun.L0(obstime))
 
     hgsout = hgcout.transform_to(HeliographicStonyhurst(obstime=obstime))
 

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 
-from sunpy.sun import sun
+from sunpy.coordinates import sun
 import sunpy.map
 import sunpy.data.test
 from sunpy.coordinates import frames

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -23,7 +23,7 @@ from astropy.coordinates.representation import (CartesianRepresentation, Spheric
 from astropy.coordinates.transformations import FunctionTransform, DynamicMatrixTransform
 from astropy.coordinates.matrix_utilities import matrix_product, rotation_matrix, matrix_transpose
 
-from sunpy.sun import sun
+from sunpy.sun import constants
 
 from .frames import Heliocentric, Helioprojective, HeliographicCarrington, HeliographicStonyhurst
 
@@ -34,7 +34,7 @@ except ImportError:
     make_transform_graph_docs = lambda: _make_transform_graph_docs(frame_transform_graph)
 
 
-RSUN_METERS = sun.constants.get('radius').si.to(u.m)
+RSUN_METERS = constants.get('radius').si.to(u.m)
 
 __all__ = ['hgs_to_hgc', 'hgc_to_hgs', 'hcc_to_hpc',
            'hpc_to_hcc', 'hcc_to_hgs', 'hgs_to_hcc',

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -51,8 +51,8 @@ def _carrington_offset(obstime):
                          " Frame needs a obstime Attribute")
 
     # Import here to avoid a circular import
-    from .ephemeris import get_sun_L0
-    return get_sun_L0(obstime)
+    from .sun import L0
+    return L0(obstime)
 
 
 def _observers_are_equal(obs_1, obs_2, string_ok=False):

--- a/sunpy/instr/fermi.py
+++ b/sunpy/instr/fermi.py
@@ -11,7 +11,7 @@ import astropy.units as u
 from astropy.time import TimeDelta
 from astropy.coordinates import Latitude, Longitude
 
-from sunpy import sun
+from sunpy.coordinates import sun
 from sunpy.time import TimeRange, parse_time
 from sunpy.io.fits import fits
 
@@ -103,8 +103,8 @@ def get_detector_sun_angles_for_time(time, file):
 
     # this gets the sun position with RA in hours in decimal format (e.g. 4.3).
     # DEC is already in degrees
-    sunpos_ra_not_in_deg = [sun.sun.apparent_rightascension(time),
-                            sun.sun.apparent_declination(time)]
+    sunpos_ra_not_in_deg = [sun.apparent_rightascension(time),
+                            sun.apparent_declination(time)]
     # now Sun position with RA in degrees
     sun_pos = [sunpos_ra_not_in_deg[0].to('deg'), sunpos_ra_not_in_deg[1]]
     # sun_pos = [(sunpos_ra_not_in_deg[0] / 24) * 360., sunpos_ra_not_in_deg[1]]
@@ -147,8 +147,8 @@ def get_detector_sun_angles_for_date(date, file):
 
         # this gets the sun position with RA in hours in decimal format
         # (e.g. 4.3). DEC is already in degrees
-        sunpos_ra_not_in_deg = [sun.sun.apparent_rightascension(times[i]),
-                                sun.sun.apparent_declination(times[i])]
+        sunpos_ra_not_in_deg = [sun.apparent_rightascension(times[i]),
+                                sun.apparent_declination(times[i])]
         # now Sun position with RA in degrees
         sun_pos = [sunpos_ra_not_in_deg[0].to('deg'), sunpos_ra_not_in_deg[1]]
         # now get the angle between each detector and the Sun

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -62,7 +62,7 @@ from sunpy.sun import constants
 from sunpy import timeseries
 from sunpy.time import parse_time
 from sunpy.util.net import check_download_file
-from sunpy.coordinates import get_sunearth_distance
+from sunpy.coordinates import sun
 from sunpy.util.config import get_and_create_download_dir
 
 GOES_CONVERSION_DICT = {'X': u.Quantity(1e-4, "W/m^2"),
@@ -1268,7 +1268,7 @@ def _calc_xraylum(flux: u.W/u.m/u.m, date=None):
     """
     if date is not None:
         date = parse_time(date)
-        xraylum = 4 * np.pi * get_sunearth_distance(date).to("m")**2 * flux
+        xraylum = 4 * np.pi * sun.earth_distance(date).to("m")**2 * flux
     else:
         xraylum = 4 * np.pi * constants.au.to("m")**2 * flux
     return xraylum

--- a/sunpy/instr/goes.py
+++ b/sunpy/instr/goes.py
@@ -58,7 +58,7 @@ from astropy.time import TimeDelta
 from scipy import interpolate
 from scipy.integrate import trapz, cumtrapz
 
-from sunpy import sun
+from sunpy.sun import constants
 from sunpy import timeseries
 from sunpy.time import parse_time
 from sunpy.util.net import check_download_file
@@ -1270,7 +1270,7 @@ def _calc_xraylum(flux: u.W/u.m/u.m, date=None):
         date = parse_time(date)
         xraylum = 4 * np.pi * get_sunearth_distance(date).to("m")**2 * flux
     else:
-        xraylum = 4 * np.pi * sun.constants.au.to("m")**2 * flux
+        xraylum = 4 * np.pi * constants.au.to("m")**2 * flux
     return xraylum
 
 

--- a/sunpy/instr/rhessi.py
+++ b/sunpy/instr/rhessi.py
@@ -18,8 +18,7 @@ from astropy.time import Time
 
 import sunpy.io
 from sunpy.time import TimeRange, parse_time
-from sunpy.coordinates.sun import solar_semidiameter_angular_size
-from sunpy.coordinates import get_sunearth_distance
+from sunpy.coordinates import sun
 
 
 __all__ = ['parse_observing_summary_hdulist', 'backprojection', 'parse_observing_summary_dbase_file']
@@ -323,9 +322,9 @@ def backprojection(calibrated_event_list, pixel_size: u.arcsec=(1., 1.) * u.arcs
         "CTYPE2": "HPLT-TAN",
         "HGLT_OBS": 0,
         "HGLN_OBS": 0,
-        "RSUN_OBS": solar_semidiameter_angular_size(time_range.center).value,
+        "RSUN_OBS": sun.angular_radius(time_range.center).value,
         "RSUN_REF": sunpy.sun.constants.radius.value,
-        "DSUN_OBS": get_sunearth_distance(time_range.center).value * sunpy.sun.constants.au.value
+        "DSUN_OBS": sun.earth_distance(time_range.center).value * sunpy.sun.constants.au.value
     }
 
     result_map = sunpy.map.Map(image, dict_header)

--- a/sunpy/instr/rhessi.py
+++ b/sunpy/instr/rhessi.py
@@ -18,7 +18,7 @@ from astropy.time import Time
 
 import sunpy.io
 from sunpy.time import TimeRange, parse_time
-from sunpy.sun.sun import solar_semidiameter_angular_size
+from sunpy.coordinates.sun import solar_semidiameter_angular_size
 from sunpy.coordinates import get_sunearth_distance
 
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -546,7 +546,7 @@ class GenericMap(NDData):
         if rsun_arcseconds is None:
             warnings.warn("Missing metadata for solar radius: assuming photospheric limb as seen from Earth.",
                           SunpyUserWarning)
-            rsun_arcseconds = sun.solar_semidiameter_angular_size(self.date).to('arcsec').value
+            rsun_arcseconds = sun.angular_radius(self.date).to('arcsec').value
 
         return u.Quantity(rsun_arcseconds, 'arcsec')
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -23,7 +23,7 @@ import sunpy.cm
 from sunpy import config
 from sunpy.visualization import wcsaxes_compat, axis_labels_from_ctype, peek_show
 from sunpy.sun import constants
-from sunpy.sun import sun
+from sunpy.coordinates import sun
 from sunpy.time import parse_time, is_time
 from sunpy.image.transform import affine_transform
 from sunpy.image.resample import reshape_image_to_4d_superpixel

--- a/sunpy/map/sources/mlso.py
+++ b/sunpy/map/sources/mlso.py
@@ -6,7 +6,7 @@ import astropy.units as u
 
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
-from sunpy.coordinates import get_sunearth_distance
+from sunpy.coordinates import sun
 
 __all__ = ['KCorMap']
 
@@ -39,7 +39,7 @@ class KCorMap(GenericMap):
         self.meta['detector'] = 'KCor'
         self.meta['waveunit'] = 'nanometer'
         # Since KCor is on Earth, no need to raise the warning in mapbase
-        self.meta['dsun_obs'] = (get_sunearth_distance(self.date)).to(u.m).value
+        self.meta['dsun_obs'] = (sun.earth_distance(self.date)).to(u.m).value
         self.meta['hgln_obs'] = 0.0
         self._nickname = self.detector
 

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -42,4 +42,4 @@ def test_rsun_missing():
     """Tests output if 'rsun' is missing"""
     euvi_no_rsun = Map(fitspath)
     euvi_no_rsun.meta['rsun'] = None
-    assert euvi_no_rsun.rsun_obs.value == sun.solar_semidiameter_angular_size(euvi.date).to('arcsec').value
+    assert euvi_no_rsun.rsun_obs.value == sun.angular_radius(euvi.date).to('arcsec').value

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -8,7 +8,7 @@ import glob
 
 from sunpy.map.sources.stereo import EUVIMap
 from sunpy.map import Map
-from sunpy.sun import sun
+from sunpy.coordinates import sun
 import sunpy.data.test
 
 path = sunpy.data.test.rootdir

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -209,7 +209,8 @@ def test_coordinate_frame(aia171_test_map):
 
 
 def test_heliographic_longitude_crln(hmi_test_map):
-    assert hmi_test_map.heliographic_longitude == hmi_test_map.carrington_longitude - sun.L0(hmi_test_map.date)
+    assert hmi_test_map.heliographic_longitude == hmi_test_map.carrington_longitude - \
+                                                  sun.L0(hmi_test_map.date)
 
 
 def test_remove_observers(aia171_test_map):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -23,6 +23,7 @@ import sunpy.map
 import sunpy.sun
 import sunpy.data.test
 import sunpy.coordinates
+from sunpy.coordinates import sun
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 
@@ -172,7 +173,7 @@ def test_rsun_meters(generic_map):
 
 def test_rsun_obs(generic_map):
     with pytest.warns(SunpyUserWarning, match='Missing metadata for solar radius'):
-        assert generic_map.rsun_obs == sunpy.sun.solar_semidiameter_angular_size(generic_map.date)
+        assert generic_map.rsun_obs == sun.solar_semidiameter_angular_size(generic_map.date)
 
 
 def test_coordinate_system(generic_map):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -164,7 +164,7 @@ def test_detector(generic_map):
 
 def test_dsun(generic_map):
     with pytest.warns(SunpyUserWarning, match='Missing metadata for observer: assuming Earth-based observer.*'):
-        assert generic_map.dsun == sunpy.coordinates.get_sunearth_distance(generic_map.date).to(u.m)
+        assert generic_map.dsun == sun.earth_distance(generic_map.date).to(u.m)
 
 
 def test_rsun_meters(generic_map):
@@ -173,7 +173,7 @@ def test_rsun_meters(generic_map):
 
 def test_rsun_obs(generic_map):
     with pytest.warns(SunpyUserWarning, match='Missing metadata for solar radius'):
-        assert generic_map.rsun_obs == sun.solar_semidiameter_angular_size(generic_map.date)
+        assert generic_map.rsun_obs == sun.angular_radius(generic_map.date)
 
 
 def test_coordinate_system(generic_map):
@@ -182,12 +182,12 @@ def test_coordinate_system(generic_map):
 
 def test_carrington_longitude(generic_map):
     with pytest.warns(SunpyUserWarning, match='Missing metadata for observer: assuming Earth-based observer.*'):
-        assert generic_map.carrington_longitude == sunpy.coordinates.get_sun_L0(generic_map.date)
+        assert generic_map.carrington_longitude == sun.L0(generic_map.date)
 
 
 def test_heliographic_latitude(generic_map):
     with pytest.warns(SunpyUserWarning, match='Missing metadata for observer: assuming Earth-based observer.*'):
-        assert generic_map.heliographic_latitude == sunpy.coordinates.get_sun_B0(generic_map.date)
+        assert generic_map.heliographic_latitude == sun.B0(generic_map.date)
 
 
 def test_heliographic_longitude(generic_map):
@@ -209,7 +209,7 @@ def test_coordinate_frame(aia171_test_map):
 
 
 def test_heliographic_longitude_crln(hmi_test_map):
-    assert hmi_test_map.heliographic_longitude == hmi_test_map.carrington_longitude - sunpy.coordinates.get_sun_L0(hmi_test_map.date)
+    assert hmi_test_map.heliographic_longitude == hmi_test_map.carrington_longitude - sun.L0(hmi_test_map.date)
 
 
 def test_remove_observers(aia171_test_map):

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -12,7 +12,6 @@ from astropy.coordinates import SkyCoord
 import matplotlib.pyplot as plt
 
 import sunpy
-import sunpy.sun
 import sunpy.map
 import sunpy.coordinates
 import sunpy.data.test

--- a/sunpy/sun/__init__.py
+++ b/sunpy/sun/__init__.py
@@ -1,2 +1,1 @@
 from sunpy.sun._constants import *
-from sunpy.sun.sun import *

--- a/sunpy/sun/sun.py
+++ b/sunpy/sun/sun.py
@@ -17,76 +17,90 @@ __all__ = [
 ]
 
 
+# Sets the function's module to this module to be picked up docs
+def _fix(func):
+    func.__module__ = __name__
+
+
 solar_semidiameter_angular_size = deprecated('1.0', name='solar_semidiameter_angular_size',
                                              alternative='sunpy.coordinates.sun.angular_radius'
                                             )(_sun.angular_radius)
+_fix(solar_semidiameter_angular_size)
 
 
 position = deprecated('1.0', name='position',
                       alternative='sunpy.coordinates.sun.sky_position'
                      )(_sun.sky_position)
+_fix(position)
 
 
 carrington_rotation_number = deprecated('1.0',
                                         alternative='sunpy.coordinates.sun.carrington_rotation_number'
                                        )(_sun.carrington_rotation_number)
+_fix(carrington_rotation_number)
 
 
 true_longitude = deprecated('1.0',
                             alternative='sunpy.coordinates.sun.true_longitude'
                            )(_sun.true_longitude)
+_fix(true_longitude)
 
 
 apparent_longitude = deprecated('1.0',
                                 alternative='sunpy.coordinates.sun.apparent_longitude'
                                )(_sun.apparent_longitude)
+_fix(apparent_longitude)
 
 
 true_latitude = deprecated('1.0',
                            alternative='sunpy.coordinates.sun.true_latitude'
                           )(_sun.true_latitude)
+_fix(true_latitude)
 
 
 apparent_latitude = deprecated('1.0',
                                alternative='sunpy.coordinates.sun.apparent_latitude'
                               )(_sun.apparent_latitude)
-
-
-apparent_latitude = deprecated('1.0',
-                               alternative='sunpy.coordinates.sun.apparent_latitude'
-                              )(_sun.apparent_latitude)
+_fix(apparent_latitude)
 
 
 mean_obliquity_of_ecliptic = deprecated('1.0',
                                         alternative='sunpy.coordinates.sun.mean_obliquity_of_ecliptic'
                                        )(_sun.mean_obliquity_of_ecliptic)
+_fix(mean_obliquity_of_ecliptic)
 
 
 true_rightascension = deprecated('1.0',
                                  alternative='sunpy.coordinates.sun.true_rightascension'
                                 )(_sun.true_rightascension)
+_fix(true_rightascension)
 
 
 true_declination = deprecated('1.0',
                               alternative='sunpy.coordinates.sun.true_declination'
                              )(_sun.true_declination)
+_fix(true_declination)
 
 
 true_obliquity_of_ecliptic = deprecated('1.0',
                                         alternative='sunpy.coordinates.sun.true_obliquity_of_ecliptic'
                                        )(_sun.true_obliquity_of_ecliptic)
+_fix(true_obliquity_of_ecliptic)
 
 
 apparent_rightascension = deprecated('1.0',
                                      alternative='sunpy.coordinates.sun.apparent_rightascension'
                                     )(_sun.apparent_rightascension)
+_fix(apparent_rightascension)
 
 
 apparent_declination = deprecated('1.0',
                                   alternative='sunpy.coordinates.sun.apparent_declination'
                                  )(_sun.apparent_declination)
+_fix(apparent_declination)
 
 
 print_params = deprecated('1.0',
                           alternative='sunpy.coordinates.sun.print_params'
                          )(_sun.print_params)
+_fix(print_params)

--- a/sunpy/sun/sun.py
+++ b/sunpy/sun/sun.py
@@ -1,24 +1,8 @@
 """
 This module provides Sun-related parameters.
 """
-import numpy as np
-
-import astropy.units as u
-from astropy.coordinates import Angle, Latitude, Longitude, SkyCoord
-# Versions of Astropy that do not have *MeanEcliptic frames have the same frames
-# with the misleading names *TrueEcliptic
-try:
-    from astropy.coordinates import HeliocentricMeanEcliptic, GeocentricMeanEcliptic
-except ImportError:
-    from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
-    from astropy.coordinates import GeocentricTrueEcliptic as GeocentricMeanEcliptic
-from astropy import _erfa as erfa
-from astropy.coordinates.builtin_frames.utils import get_jd12
-
-from sunpy.sun import constants
-from sunpy.time import parse_time
-from sunpy.time.time import _variables_for_parse_time_docstring
-from sunpy.util.decorators import add_common_docstring
+from sunpy.coordinates import sun as _sun
+from sunpy.util.decorators import deprecated
 
 __all__ = [
     "solar_semidiameter_angular_size", "position", "carrington_rotation_number",
@@ -29,371 +13,43 @@ __all__ = [
 ]
 
 
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def solar_semidiameter_angular_size(t='now'):
-    """
-    Return the angular size of the semi-diameter of the Sun as viewed from Earth.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-    """
-    # Import here to avoid a circular import
-    from sunpy.coordinates import get_sunearth_distance
-    solar_semidiameter_rad = constants.radius / get_sunearth_distance(t)
-    return Angle(solar_semidiameter_rad.to(u.arcsec, equivalencies=u.dimensionless_angles()))
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def position(t='now', equinox_of_date=True):
-    """
-    Returns the apparent position of the Sun (right ascension and declination) on the
-    celestial sphere using the equatorial coordinate system, referred to the true equinox of date
-    (as default).  Corrections for nutation and aberration (for Earth motion) are included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-
-    equinox_of_date : `bool`
-        If True, output is referred to the true equinox of date.  Otherwise, output is referred to
-        the J2000.0 epoch.
-    """
-    ra = apparent_rightascension(t, equinox_of_date=equinox_of_date)
-    dec = apparent_declination(t, equinox_of_date=equinox_of_date)
-    return ra, dec
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def carrington_rotation_number(t='now'):
-    """
-    Return the Carrington Rotation number.
-
-    .. warning::
-        The accuracy of this function is under investigation.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-    """
-    jd = parse_time(t).jd
-    result = (1. / 27.2753) * (jd - 2398167.0) + 1.0
-    return result
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def true_longitude(t='now'):
-    """
-    Returns the Sun's true geometric longitude, referred to the mean equinox of date.  No
-    corrections for nutation or aberration are included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-    """
-    time = parse_time(t)
-
-    # Calculate Earth's true geometric longitude and add 180 degrees for the Sun's longitude.
-    # This approach is used because Astropy's GeocentricMeanEcliptic includes aberration.
-    earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='gcrs', obstime=time)
-    coord = earth.transform_to(HeliocentricMeanEcliptic(equinox=time))
-    lon = coord.lon + 180*u.deg
-
-    return Longitude(lon)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def apparent_longitude(t='now'):
-    """
-    Returns the Sun's apparent longitude, referred to the true equinox of date.  Corrections for
-    nutation and aberration (for Earth motion) are included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-
-    Notes
-    -----
-    The nutation model is IAU 2000A nutation with adjustments to match IAU 2006 precession.
-    """
-    time = parse_time(t)
-    sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
-    coord = sun.transform_to(GeocentricMeanEcliptic(equinox=time))
-
-    # Astropy's GeocentricMeanEcliptic already includes aberration, so only add nutation
-    jd1, jd2 = get_jd12(time, 'tt')
-    nut_lon, _ = erfa.nut06a(jd1, jd2)*u.radian
-    lon = coord.lon + nut_lon
-
-    return Longitude(lon)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def true_latitude(t='now'):
-    """
-    Returns the Sun's true geometric latitude, referred to the mean equinox of date.  No
-    corrections for nutation or aberration are included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-    """
-    time = parse_time(t)
-    sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
-    coord = sun.transform_to(GeocentricMeanEcliptic(equinox=time))
-
-    # Astropy's GeocentricMeanEcliptic includes aberration from Earth motion, but the contribution
-    # is negligible
-    lat = coord.lat
-
-    return Latitude(lat)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def apparent_latitude(t='now'):
-    """
-    Returns the Sun's apparent latitude, referred to the true equinox of date.  Corrections for
-    nutation and aberration (for Earth motion) are included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-    """
-    time = parse_time(t)
-    sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
-    coord = sun.transform_to(GeocentricMeanEcliptic(equinox=time))
-
-    # Astropy's GeocentricMeanEcliptic does not include nutation, but the contribution is negligible
-    lat = coord.lat
-
-    return Latitude(lat)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def mean_obliquity_of_ecliptic(t='now'):
-    """
-    Returns the mean obliquity of the ecliptic, using the IAU 2006 definition.  No correction for
-    nutation is included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-    """
-    time = parse_time(t)
-    jd1, jd2 = get_jd12(time, 'tt')
-    obl = erfa.obl06(jd1, jd2)*u.radian
-    return Angle(obl, u.arcsec)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def true_rightascension(t='now', equinox_of_date=True):
-    """
-    Returns the Sun's true geometric right ascension relative to Earth, referred to the mean equinox
-    of date (as default).  No corrections for nutation or aberration are included.  The correction
-    due to light travel time would be negligible, so the output is also the astrometric right
-    ascension.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-
-    equinox_of_date : `bool`
-        If True, output is referred to the mean equinox of date.  Otherwise, output is referred to
-        the J2000.0 epoch.
-    """
-    if equinox_of_date:
-        # Mean equinox of date
-        obl = mean_obliquity_of_ecliptic(t)  # excludes nutation
-        lon = true_longitude(t)
-        lat = true_latitude(t)
-
-        # See Astronomical Algorithms (Meeus 1998 p.93)
-        y = np.sin(lon) * np.cos(obl) - np.tan(lat) * np.sin(obl)
-        x = np.cos(lon)
-        result = np.arctan2(y, x)
-    else:
-        # J2000.0 epoch
-        # Calculate Earth's true geometric right ascension relative to the Sun and add 180 degrees.
-        # This approach is used because Astropy's GCRS includes aberration.
-        earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='gcrs', obstime=parse_time(t))
-        result = earth.hcrs.ra + 180*u.deg
-
-    return Longitude(result, u.hourangle)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def true_declination(t='now', equinox_of_date=True):
-    """
-    Returns the Sun's true geometric declination relative to Earth, referred to the mean equinox
-    of date (as default).  No corrections for nutation or aberration are included.  The correction
-    due to light travel time would be negligible, so the output is also the astrometric declination.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-
-    equinox_of_date : `bool`
-        If True, output is referred to the mean equinox of date.  Otherwise, output is referred to
-        the J2000.0 epoch.
-    """
-    if equinox_of_date:
-        # Mean equinox of date
-        obl = mean_obliquity_of_ecliptic(t)  # excludes nutation
-        lon = true_longitude(t)
-        lat = true_latitude(t)
-
-        # See Astronomical Algorithms (Meeus 1998 p.93)
-        result = np.arcsin(np.sin(lat) * np.cos(obl) + np.cos(lat) * np.sin(obl) * np.sin(lon))
-    else:
-        # J2000.0 epoch
-        # Calculate Earth's true geometric declination relative to the Sun and multipy by -1.
-        # This approach is used because Astropy's GCRS includes aberration.
-        earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='gcrs', obstime=parse_time(t))
-        result = -earth.hcrs.dec
-
-    return Latitude(result, u.deg)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def true_obliquity_of_ecliptic(t='now'):
-    """
-    Returns the true obliquity of the ecliptic, using the IAU 2006 definition.  Correction for
-    nutation is included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-
-    Notes
-    -----
-    The nutation model is IAU 2000A nutation with adjustments to match IAU 2006 precession.
-    """
-    time = parse_time(t)
-    jd1, jd2 = get_jd12(time, 'tt')
-    obl = erfa.obl06(jd1, jd2)*u.radian
-    _, nut_obl = erfa.nut06a(jd1, jd2)*u.radian
-    obl += nut_obl
-    return Angle(obl, u.arcsec)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def apparent_rightascension(t='now', equinox_of_date=True):
-    """
-    Returns the Sun's apparent right ascension relative to Earth, referred to the true equinox
-    of date (as default).  Corrections for nutation or aberration (for Earth motion) are included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-
-    equinox_of_date : `bool`
-        If True, output is referred to the true equinox of date.  Otherwise, output is referred to
-        the J2000.0 epoch.
-    """
-    if equinox_of_date:
-        # True equinox of date
-        obl = true_obliquity_of_ecliptic(t)  # includes nutation
-        lon = apparent_longitude(t)
-        lat = apparent_latitude(t)
-
-        # See Astronomical Algorithms (Meeus 1998 p.93)
-        y = np.sin(lon) * np.cos(obl) - np.tan(lat) * np.sin(obl)
-        x = np.cos(lon)
-        result = np.arctan2(y, x)
-    else:
-        # J2000.0 epoch
-        sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=parse_time(t))
-        result = sun.gcrs.ra
-
-    return Longitude(result, u.hourangle)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def apparent_declination(t='now', equinox_of_date=True):
-    """
-    Returns the Sun's apparent declination relative to Earth, referred to the true equinox
-    of date (as default).  Corrections for nutation or aberration (for Earth motion) are included.
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-
-    equinox_of_date : `bool`
-        If True, output is referred to the true equinox of date.  Otherwise, output is referred to
-        the J2000.0 epoch.
-    """
-    if equinox_of_date:
-        # True equinox of date
-        obl = true_obliquity_of_ecliptic(t)  # includes nutation
-        lon = apparent_longitude(t)
-        lat = apparent_latitude(t)
-
-        # See Astronomical Algorithms (Meeus 1998 p.93)
-        result = np.arcsin(np.sin(lat) * np.cos(obl) + np.cos(lat) * np.sin(obl) * np.sin(lon))
-    else:
-        # J2000.0 epoch
-        sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=parse_time(t))
-        result = sun.gcrs.dec
-
-    return Latitude(result, u.deg)
-
-
-@add_common_docstring(**_variables_for_parse_time_docstring())
-def print_params(t='now'):
-    """
-    Print out a summary of solar ephemeris. 'True' values are true geometric values referred to the
-    mean equinox of date, with no corrections for nutation or aberration.  'Apparent' values are
-    referred to the true equinox of date, with corrections for nutation and aberration (for Earth
-    motion).
-
-    Parameters
-    ----------
-    t : {parse_time_types}
-        A time (usually the start time) specified as a parse_time-compatible
-        time string, number, or a datetime object.
-    """
-    # Import here to avoid circular import
-    from sunpy.coordinates.ephemeris import (get_sun_L0, get_sun_B0,
-                                             get_sun_P, get_sunearth_distance)
-
-    print('Solar Ephemeris for {} UTC\n'.format(parse_time(t).utc))
-    print('Distance = {}'.format(get_sunearth_distance(t)))
-    print('Semidiameter = {}'.format(solar_semidiameter_angular_size(t)))
-    print('True (long, lat) = ({}, {})'.format(true_longitude(t).to_string(),
-                                               true_latitude(t).to_string()))
-    print('Apparent (long, lat) = ({}, {})'.format(apparent_longitude(t).to_string(),
-                                                   apparent_latitude(t).to_string()))
-    print('True (RA, Dec) = ({}, {})'.format(true_rightascension(t).to_string(),
-                                             true_declination(t).to_string()))
-    print('Apparent (RA, Dec) = ({}, {})'.format(apparent_rightascension(t).to_string(),
-                                                 apparent_declination(t).to_string()))
-    print('Heliographic long. and lat of disk center = ({}, {})'.format(get_sun_L0(t).to_string(),
-                                                                        get_sun_B0(t).to_string()))
-    print('Position angle of north pole = {}'.format(get_sun_P(t)))
-    print('Carrington Rotation Number = {}'.format(carrington_rotation_number(t)))
+solar_semidiameter_angular_size = deprecated('1.0')(_sun.solar_semidiameter_angular_size)
+
+
+position = deprecated('1.0')(_sun.position)
+
+
+carrington_rotation_number = deprecated('1.0')(_sun.carrington_rotation_number)
+
+
+true_longitude = deprecated('1.0')(_sun.true_longitude)
+
+
+apparent_longitude = deprecated('1.0')(_sun.apparent_longitude)
+
+
+true_latitude = deprecated('1.0')(_sun.true_latitude)
+
+
+apparent_latitude = deprecated('1.0')(_sun.apparent_latitude)
+
+
+mean_obliquity_of_ecliptic = deprecated('1.0')(_sun.mean_obliquity_of_ecliptic)
+
+
+true_rightascension = deprecated('1.0')(_sun.true_rightascension)
+
+
+true_declination = deprecated('1.0')(_sun.true_declination)
+
+
+true_obliquity_of_ecliptic = deprecated('1.0')(_sun.true_obliquity_of_ecliptic)
+
+
+apparent_rightascension = deprecated('1.0')(_sun.apparent_rightascension)
+
+
+apparent_declination = deprecated('1.0')(_sun.apparent_declination)
+
+
+print_params = deprecated('1.0')(_sun.print_params)

--- a/sunpy/sun/sun.py
+++ b/sunpy/sun/sun.py
@@ -17,90 +17,17 @@ __all__ = [
 ]
 
 
-# Sets the function's module to this module to be picked up docs
-def _fix(func):
-    func.__module__ = __name__
+# The names for the functions in sunpy.coordinates.sun
+_new_module = 'sunpy.coordinates.sun.'
+_new_names = [
+    "angular_radius", "sky_position", "carrington_rotation_number",
+    "true_longitude", "apparent_longitude", "true_latitude", "apparent_latitude",
+    "mean_obliquity_of_ecliptic", "true_rightascension", "true_declination",
+    "true_obliquity_of_ecliptic", "apparent_rightascension", "apparent_declination",
+    "print_params"
+]
 
-
-solar_semidiameter_angular_size = deprecated('1.0', name='solar_semidiameter_angular_size',
-                                             alternative='sunpy.coordinates.sun.angular_radius'
-                                            )(_sun.angular_radius)
-_fix(solar_semidiameter_angular_size)
-
-
-position = deprecated('1.0', name='position',
-                      alternative='sunpy.coordinates.sun.sky_position'
-                     )(_sun.sky_position)
-_fix(position)
-
-
-carrington_rotation_number = deprecated('1.0',
-                                        alternative='sunpy.coordinates.sun.carrington_rotation_number'
-                                       )(_sun.carrington_rotation_number)
-_fix(carrington_rotation_number)
-
-
-true_longitude = deprecated('1.0',
-                            alternative='sunpy.coordinates.sun.true_longitude'
-                           )(_sun.true_longitude)
-_fix(true_longitude)
-
-
-apparent_longitude = deprecated('1.0',
-                                alternative='sunpy.coordinates.sun.apparent_longitude'
-                               )(_sun.apparent_longitude)
-_fix(apparent_longitude)
-
-
-true_latitude = deprecated('1.0',
-                           alternative='sunpy.coordinates.sun.true_latitude'
-                          )(_sun.true_latitude)
-_fix(true_latitude)
-
-
-apparent_latitude = deprecated('1.0',
-                               alternative='sunpy.coordinates.sun.apparent_latitude'
-                              )(_sun.apparent_latitude)
-_fix(apparent_latitude)
-
-
-mean_obliquity_of_ecliptic = deprecated('1.0',
-                                        alternative='sunpy.coordinates.sun.mean_obliquity_of_ecliptic'
-                                       )(_sun.mean_obliquity_of_ecliptic)
-_fix(mean_obliquity_of_ecliptic)
-
-
-true_rightascension = deprecated('1.0',
-                                 alternative='sunpy.coordinates.sun.true_rightascension'
-                                )(_sun.true_rightascension)
-_fix(true_rightascension)
-
-
-true_declination = deprecated('1.0',
-                              alternative='sunpy.coordinates.sun.true_declination'
-                             )(_sun.true_declination)
-_fix(true_declination)
-
-
-true_obliquity_of_ecliptic = deprecated('1.0',
-                                        alternative='sunpy.coordinates.sun.true_obliquity_of_ecliptic'
-                                       )(_sun.true_obliquity_of_ecliptic)
-_fix(true_obliquity_of_ecliptic)
-
-
-apparent_rightascension = deprecated('1.0',
-                                     alternative='sunpy.coordinates.sun.apparent_rightascension'
-                                    )(_sun.apparent_rightascension)
-_fix(apparent_rightascension)
-
-
-apparent_declination = deprecated('1.0',
-                                  alternative='sunpy.coordinates.sun.apparent_declination'
-                                 )(_sun.apparent_declination)
-_fix(apparent_declination)
-
-
-print_params = deprecated('1.0',
-                          alternative='sunpy.coordinates.sun.print_params'
-                         )(_sun.print_params)
-_fix(print_params)
+# Create a deprecation hook for each of the functions
+for old, new in zip(__all__, _new_names):
+    vars()[old] = deprecated('1.0', name=old, alternative=_new_module + new)(getattr(_sun, new))
+    vars()[old].__module__ = __name__  # so that docs think that the function is local

--- a/sunpy/sun/sun.py
+++ b/sunpy/sun/sun.py
@@ -13,43 +13,76 @@ __all__ = [
 ]
 
 
-solar_semidiameter_angular_size = deprecated('1.0')(_sun.solar_semidiameter_angular_size)
+solar_semidiameter_angular_size = deprecated('1.0', name='solar_semidiameter_angular_size',
+                                             alternative='sunpy.coordinates.sun.angular_radius'
+                                            )(_sun.angular_radius)
 
 
-position = deprecated('1.0')(_sun.position)
+position = deprecated('1.0', name='position',
+                      alternative='sunpy.coordinates.sun.sky_position'
+                     )(_sun.sky_position)
 
 
-carrington_rotation_number = deprecated('1.0')(_sun.carrington_rotation_number)
+carrington_rotation_number = deprecated('1.0',
+                                        alternative='sunpy.coordinates.sun.carrington_rotation_number'
+                                       )(_sun.carrington_rotation_number)
 
 
-true_longitude = deprecated('1.0')(_sun.true_longitude)
+true_longitude = deprecated('1.0',
+                            alternative='sunpy.coordinates.sun.true_longitude'
+                           )(_sun.true_longitude)
 
 
-apparent_longitude = deprecated('1.0')(_sun.apparent_longitude)
+apparent_longitude = deprecated('1.0',
+                                alternative='sunpy.coordinates.sun.apparent_longitude'
+                               )(_sun.apparent_longitude)
 
 
-true_latitude = deprecated('1.0')(_sun.true_latitude)
+true_latitude = deprecated('1.0',
+                           alternative='sunpy.coordinates.sun.true_latitude'
+                          )(_sun.true_latitude)
 
 
-apparent_latitude = deprecated('1.0')(_sun.apparent_latitude)
+apparent_latitude = deprecated('1.0',
+                               alternative='sunpy.coordinates.sun.apparent_latitude'
+                              )(_sun.apparent_latitude)
 
 
-mean_obliquity_of_ecliptic = deprecated('1.0')(_sun.mean_obliquity_of_ecliptic)
+apparent_latitude = deprecated('1.0',
+                               alternative='sunpy.coordinates.sun.apparent_latitude'
+                              )(_sun.apparent_latitude)
 
 
-true_rightascension = deprecated('1.0')(_sun.true_rightascension)
+mean_obliquity_of_ecliptic = deprecated('1.0',
+                                        alternative='sunpy.coordinates.sun.mean_obliquity_of_ecliptic'
+                                       )(_sun.mean_obliquity_of_ecliptic)
 
 
-true_declination = deprecated('1.0')(_sun.true_declination)
+true_rightascension = deprecated('1.0',
+                                 alternative='sunpy.coordinates.sun.true_rightascension'
+                                )(_sun.true_rightascension)
 
 
-true_obliquity_of_ecliptic = deprecated('1.0')(_sun.true_obliquity_of_ecliptic)
+true_declination = deprecated('1.0',
+                              alternative='sunpy.coordinates.sun.true_declination'
+                             )(_sun.true_declination)
 
 
-apparent_rightascension = deprecated('1.0')(_sun.apparent_rightascension)
+true_obliquity_of_ecliptic = deprecated('1.0',
+                                        alternative='sunpy.coordinates.sun.true_obliquity_of_ecliptic'
+                                       )(_sun.true_obliquity_of_ecliptic)
 
 
-apparent_declination = deprecated('1.0')(_sun.apparent_declination)
+apparent_rightascension = deprecated('1.0',
+                                     alternative='sunpy.coordinates.sun.apparent_rightascension'
+                                    )(_sun.apparent_rightascension)
 
 
-print_params = deprecated('1.0')(_sun.print_params)
+apparent_declination = deprecated('1.0',
+                                  alternative='sunpy.coordinates.sun.apparent_declination'
+                                 )(_sun.apparent_declination)
+
+
+print_params = deprecated('1.0',
+                          alternative='sunpy.coordinates.sun.print_params'
+                         )(_sun.print_params)

--- a/sunpy/sun/sun.py
+++ b/sunpy/sun/sun.py
@@ -1,4 +1,8 @@
 """
+.. deprecated:: 1.0
+    This module is deprecated and may be removed in a future version.
+        Use sunpy.coordinates.sun instead.
+
 This module provides Sun-related parameters.
 """
 from sunpy.coordinates import sun as _sun

--- a/sunpy/util/exceptions.py
+++ b/sunpy/util/exceptions.py
@@ -30,11 +30,7 @@ class SunpyUserWarning(UserWarning, SunpyWarning):
     """
 
 
-# For PEP 565 (https://www.python.org/dev/peps/pep-0565/) compliance.
-DeprecationClass = DeprecationWarning if sys.version_info >= (3, 7) else FutureWarning
-
-
-class SunpyDeprecationWarning(DeprecationClass, SunpyWarning):
+class SunpyDeprecationWarning(FutureWarning, SunpyWarning):
     """
     A warning class to indicate a deprecated feature.
     """


### PR DESCRIPTION
As proposed in #3158, this PR gathers all functions from `sunpy.sun.sun` and some functions from `sunpy.coordinates.ephemeris` into a new `sunpy.coordinates.sun`.  Of note:

- Deprecation warnings abound.  ~However, do our deprecation warnings not show by default?  I have to turn them on (via `warnings.simplefilter`)~  Fixed by @Cadair 
- To avoid circular imports, I had to leave the `sunpy.coordinates.ephemeris` functions' code where it was.  I renamed the functions to be private functions, and call them in place with deprecated hooks and call them from their future locations with their future names.  It's weird, I know, but it can all be cleaned up once we're past the deprecation period.
- ~I don't understand why the docs are failing (but maybe it's because of my contortions above?)~  Ah, the automatic docs ignore functions that have `__module__` different from the current module because they look to be non-local.

Closes #3158