### PR TITLE
[zenodo] Removes the identifier to previous version so it creates the releases

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -126,12 +126,5 @@
             "name": "haathi"
         }
     ],
-    "access_right": "open",
-    "related_identifiers": [
-        {
-            "scheme": "doi",
-            "identifier": "10.5281/zenodo.591887",
-            "relation": "isVersionOf"
-        }
-    ]
+    "access_right": "open"
 }


### PR DESCRIPTION
Zenodo knows the relationship with the rest of the versions.

<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes Zenodo not building the releases on their website.
The relation with the parent version is not needed. Zenodo knows (probably as they come from the same repository).
