### PR TITLE
Fixed Carrington longitude and Carrington rotation number

### DIFF
--- a/changelog/3178.bugfix.rst
+++ b/changelog/3178.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed accuracy issues with the calculations of Carrington longitude (`~sunpy.coordinates.sun.L0`) and Carrington rotation number (`~sunpy.coordinates.sun.carrington_rotation_number`).

--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -131,7 +131,7 @@ coordinates is::
        (0., 0.)>
    >>> c.transform_to(frames.HeliographicCarrington)
    <SkyCoord (HeliographicCarrington: obstime=2017-07-26T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
-      (283.99298362, 5.31701821, 695700.00000125)>
+      (283.95274241, 5.31701821, 695700.00000125)>
 
 It is also possible to transform to any coordinate system implemented in Astropy. This can be used to find the position of the solar limb in AltAz equatorial coordinates::
 

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -269,7 +269,7 @@ def _L0(time='now'):
 
     Returns
     -------
-    ~astropy.coordinates.Longitude`
+    `~astropy.coordinates.Longitude`
         The Carrington longitude
 
     Notes
@@ -280,7 +280,7 @@ def _L0(time='now'):
     References
     ----------
     * Siedelmann et al. (2007), "Report of the IAU/IAG Working Group on cartographic coordinates
-    and rotational elements: 2006" `(link) <http://dx.doi.org/10.1007/s10569-007-9072-y>`_
+      and rotational elements: 2006" `(link) <http://dx.doi.org/10.1007/s10569-007-9072-y>`_
     """
     obstime = parse_time(time)
 

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -239,13 +239,16 @@ def _detilt_lon(coord):
     coord_detilt = coord.hcrs.cartesian.transform(_SUN_DETILT_MATRIX)
     return coord_detilt.represent_as(SphericalRepresentation).lon.to('deg')
 
+
 # J2000.0 epoch
 _J2000 = Time('J2000.0', scale='tt')
+
 
 # One of the two nodes of intersection between the ICRF equator and Sun's equator in HCRS
 _NODE = SkyCoord(_SOLAR_NORTH_POLE_HCRS.lon + 90*u.deg, 0*u.deg, frame='hcrs')
 
-# The longitude in the de-tilted frame of the Sun's prime meridian
+
+# The longitude in the de-tilted frame of the Sun's prime meridian.
 # Siedelmann et al. (2007) and earlier define the apparent longitude of the meridian as seen from
 # Earth as 84.10 degrees eastward from the above-defined node of intersection.
 # Siedelmann et al. (2007) and later also define the true longitude of the meridian (i.e., without

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -18,6 +18,7 @@ except ImportError:
 from astropy import _erfa as erfa
 from astropy.coordinates.builtin_frames.utils import get_jd12
 
+from sunpy import log
 from sunpy.sun import constants
 from sunpy.time import parse_time
 from sunpy.time.time import _variables_for_parse_time_docstring
@@ -75,7 +76,9 @@ def sky_position(t='now', equinox_of_date=True):
 @add_common_docstring(**_variables_for_parse_time_docstring())
 def carrington_rotation_number(t='now'):
     """
-    Return the Carrington rotation number.
+    Return the Carrington rotation number.  Each whole rotation number marks when the Sun's prime
+    meridian coincides with the central meridian as seen from Earth, with the first rotation
+    starting on 1853 November 9.
 
     Parameters
     ----------
@@ -90,13 +93,18 @@ def carrington_rotation_number(t='now'):
     estimate = (time.tt.jd - 2398167.4) / 27.2753 + 1
     estimate_int, estimate_frac = divmod(estimate, 1)
 
-    # Calculate the actual fractional rotation number
+    # The fractional rotation number from the above estimate is inaccurate, so calculate the actual
+    # fractional rotation number from the longitude of the central meridian (L0)
     actual_frac = 1 - L0(time).to('deg').value / 360
 
     # Calculate any adjustment to the integer rotation number due to wrapping
     wrap_adjustment = np.around(estimate_frac - actual_frac)
 
-    return estimate_int + actual_frac + wrap_adjustment
+    actual = estimate_int + actual_frac + wrap_adjustment
+
+    log.debug(f"Carrington rotation number: estimate is {estimate}, actual is {actual}")
+
+    return actual
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -172,21 +172,21 @@ def test_B0():
 
 def test_B0_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
-    sun_B0 = sun.B0(Time(['2013-04-01', '2013-12-01']))
+    sun_B0 = sun.B0(Time(['2013-04-01', '2013-12-01'], scale='tt'))
     assert_quantity_allclose(sun_B0[0], -6.54*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(sun_B0[1], 0.88*u.deg, atol=5e-3*u.deg)
 
 
 def test_L0():
     # Validate against a published value from Astronomical Algorithms (Meeus 1998, p.191)
-    assert_quantity_allclose(sun.L0('1992-Oct-13'), 238.6317*u.deg, atol=5e-5*u.deg)
+    assert_quantity_allclose(sun.L0('1992-Oct-13'), 238.63*u.deg, atol=2e-2*u.deg)
 
 
 def test_L0_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
-    sun_L0 = sun.L0(Time(['2013-04-01', '2013-12-01']))
-    assert_quantity_allclose(sun_L0[0], 221.44*u.deg, atol=3e-2*u.deg)
-    assert_quantity_allclose(sun_L0[1], 237.83*u.deg, atol=3e-2*u.deg)
+    sun_L0 = sun.L0(Time(['2013-04-01', '2013-12-01'], scale='tt'))
+    assert_quantity_allclose(sun_L0[0], 221.44*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(sun_L0[1], 237.83*u.deg, atol=5e-3*u.deg)
 
 
 def test_P():
@@ -196,7 +196,7 @@ def test_P():
 
 def test_P_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
-    sun_P = sun.P(Time(['2013-04-01', '2013-12-01']))
+    sun_P = sun.P(Time(['2013-04-01', '2013-12-01'], scale='tt'))
     assert_quantity_allclose(sun_P[0], -26.15*u.deg, atol=1e-2*u.deg)
     assert_quantity_allclose(sun_P[1], 16.05*u.deg, atol=1e-2*u.deg)
 
@@ -208,9 +208,9 @@ def test_earth_distance():
 
 def test_earth_distance_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
-    sunearth_distance = sun.earth_distance(Time(['2013-04-01', '2013-12-01']))
-    assert_quantity_allclose(sunearth_distance[0], 0.9992311*u.AU, atol=5e-7*u.AU)
-    assert_quantity_allclose(sunearth_distance[1], 0.9861362*u.AU, atol=5e-7*u.AU)
+    sunearth_distance = sun.earth_distance(Time(['2013-04-01', '2013-12-01'], scale='tt'))
+    assert_quantity_allclose(sunearth_distance[0], 0.9992311*u.AU, atol=5e-8*u.AU)
+    assert_quantity_allclose(sunearth_distance[1], 0.9861362*u.AU, atol=5e-8*u.AU)
 
 
 def test_orientation():

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -1,5 +1,7 @@
 import pytest
 
+from numpy.testing import assert_allclose
+
 from astropy.coordinates import Angle, EarthLocation, SkyCoord
 from astropy.time import Time
 import astropy.units as u
@@ -209,8 +211,8 @@ def test_earth_distance():
 def test_earth_distance_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
     sunearth_distance = sun.earth_distance(Time(['2013-04-01', '2013-12-01'], scale='tt'))
-    assert_quantity_allclose(sunearth_distance[0], 0.9992311*u.AU, atol=5e-8*u.AU)
-    assert_quantity_allclose(sunearth_distance[1], 0.9861362*u.AU, atol=5e-8*u.AU)
+    assert_quantity_allclose(sunearth_distance[0], 0.9992311*u.AU, rtol=0, atol=5e-8*u.AU)
+    assert_quantity_allclose(sunearth_distance[1], 0.9861362*u.AU, rtol=0, atol=5e-8*u.AU)
 
 
 def test_orientation():
@@ -223,3 +225,26 @@ def test_orientation():
     # Check the Southern Hemisphere
     angle = sun.orientation(EarthLocation(lat=-40*u.deg, lon=-75*u.deg), '2017-02-18 13:00')
     assert_quantity_allclose(angle, -110.8*u.deg, atol=0.1*u.deg)
+
+
+# Validate against published values from the Astronomical Almanac (2013, C4)
+@pytest.mark.parametrize("date, day_fraction, rotation_number",
+                         [('2012-12-29', 0.49, 2132),
+                          ('2013-01-25', 0.83, 2133),
+                          ('2013-02-22', 0.17, 2134),
+                          ('2013-03-21', 0.49, 2135),
+                          ('2013-04-17', 0.78, 2136),
+                          ('2013-05-15', 0.02, 2137),
+                          ('2013-06-11', 0.22, 2138),
+                          ('2013-07-08', 0.42, 2139),
+                          ('2013-08-04', 0.63, 2140),
+                          ('2013-08-31', 0.87, 2141),
+                          ('2013-09-28', 0.14, 2142),
+                          ('2013-10-25', 0.43, 2143),
+                          ('2013-11-21', 0.73, 2144),
+                          ('2013-12-19', 0.05, 2145),
+                          ('2014-01-15', 0.38, 2146),
+                          ('2014-02-11', 0.73, 2147)])
+def test_carrington_rotation_number(date, day_fraction, rotation_number):
+    assert_allclose(sun.carrington_rotation_number(Time(date, scale='tt') + day_fraction*u.day),
+                    rotation_number, rtol=0, atol=2e-4)

--- a/sunpy/map/sources/tests/test_mdi_source.py
+++ b/sunpy/map/sources/tests/test_mdi_source.py
@@ -53,5 +53,5 @@ def test_waveunit(mdi):
 def test_observer(mdi):
     assert isinstance(mdi.observer_coordinate.frame, frames.HeliographicStonyhurst)
     assert u.allclose(mdi.observer_coordinate.lat, -5.774028172878*u.deg)
-    assert u.allclose(mdi.observer_coordinate.lon, -0.1327673730752963*u.deg)
+    assert u.allclose(mdi.observer_coordinate.lon, -0.10181577*u.deg)
     assert u.allclose(mdi.observer_coordinate.radius, 0.9739569156244*u.AU)


### PR DESCRIPTION
Welp, I didn't quite manage to get this fix into 1.0, but now it's done!  The calculations of Carrington longitude and Carrington rotation number have been fixed to use modern definitions, and the outputs match the *Astronomical Almanac*.  If there are discrepancies with other sources (e.g., SSW), it's likely those other sources are doing it wrong.

Closes #2224 and closes #1646

