### PR TITLE
Fix for checking inputs to header_helper, removing ability to add all kwargs and only ones defined

### DIFF
--- a/changelog/3183.bugfix.rst
+++ b/changelog/3183.bugfix.rst
@@ -1,0 +1,1 @@
+Updated `sunpy.map.header_helper.make_fitswcs_header` to be more strict on the inputs it accepts.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -146,8 +146,8 @@ An example of creating a header with these additional keywords::
     >>> header = sunpy.map.header_helper.make_fitswcs_header(data, coord,
     ...                                                      reference_pixel = u.Quantity([5, 5]*u.pixel),
     ...                                                      scale = u.Quantity([2, 2] *u.arcsec/u.pixel),
-    ...                                                      instrument = 'Test case', detector = 'UV detector',
-    ...                                                      wavelength = 1000, waveunit = 'angstrom')
+    ...                                                      telescope = 'Test case', instrument = 'UV detector',
+    ...                                                      wavelength = 1000*u.angstrom)
     >>> header  # doctest: +SKIP
     MetaDict([('wcsaxes', 2),
           ('crpix1', 5.0),

--- a/examples/map/map_from_numpy_array.py
+++ b/examples/map/map_from_numpy_array.py
@@ -34,8 +34,8 @@ coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime='2013-10-28 08:24', observer='e
 header = sunpy.map.header_helper.make_fitswcs_header(data, coord,
                                                      reference_pixel=u.Quantity([0, 0]*u.pixel),
                                                      scale=u.Quantity([2, 2]*u.arcsec/u.pixel),
-                                                     instrument='Test case', detector='UV detector',
-                                                     wavelength=1000, waveunit='angstrom')
+                                                     telescope='Fake Telescope', instrument='UV detector',
+                                                     wavelength=1000*u.angstrom)
 
 ##############################################################################
 # Let's now create our map.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -30,14 +30,13 @@ def meta_keywords():
     return _map_meta_keywords
 
 
-@u.quantity_input(reference_pixel=u.pix, scale=u.arcsec/u.pix,
-                  rotation_angle=u.deg, wavelength=u.angstrom, equivalencies=u.spectral(),
-                  exposure=u.s)
-def make_fitswcs_header(data, coordinate, reference_pixel=None,
-                        scale=None, rotation_angle=None,
+@u.quantity_input(equivalencies=u.spectral())
+def make_fitswcs_header(data, coordinate, reference_pixel: u.pix = None,
+                        scale: u.arcsec/u.pix = None,
+                        rotation_angle: u.deg = None,
                         rotation_matrix=None, instrument=None,
                         telescope=None, observatory=None,
-                        wavelength=None, exposure=None):
+                        wavelength: u.angstrom=None, exposure: u.s=None):
     """
     Function to create a FITS-WCS header from a coordinate object
     (`~astropy.coordinates.SkyCoord`) that is required to
@@ -222,7 +221,7 @@ def _get_instrument_meta(instrument, telescope, observatory, wavelength, exposur
         coord['obsrvtry'] = str(observatory)
     if wavelength is not None:
         coord['wavelnth'] = wavelength.to_value()
-        coord['waveunit'] = wavelength.unit.name
+        coord['waveunit'] = wavelength.unit.to_string("fits")
     if exposure is not None:
         coord['exptime'] = exposure.to_value(u.s)
 

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -30,12 +30,14 @@ def meta_keywords():
     return _map_meta_keywords
 
 
-@u.quantity_input
-def make_fitswcs_header(data, coordinate, reference_pixel: u.pix = None,
-                        scale: u.arcsec/u.pix = None,
-                        rotation_angle: u.deg = None,
-                        rotation_matrix=None,
-                        **kwargs):
+@u.quantity_input(reference_pixel=u.pix, scale=u.arcsec/u.pix,
+                  rotation_angle=u.deg, wavelength=u.angstrom, equivalencies=u.spectral(),
+                  exposure=u.s)
+def make_fitswcs_header(data, coordinate, reference_pixel=None,
+                        scale=None, rotation_angle=None,
+                        rotation_matrix=None, instrument=None,
+                        telescope=None, observatory=None,
+                        wavelength=None, exposure=None):
     """
     Function to create a FITS-WCS header from a coordinate object
     (`~astropy.coordinates.SkyCoord`) that is required to
@@ -63,17 +65,17 @@ def make_fitswcs_header(data, coordinate, reference_pixel: u.pix = None,
         Matrix describing the rotation required to align solar North with
         the top of the image in FITS ``PCi_j`` convention. Can not be specified
         with ``rotation_angle``.
-    **kwargs:
-        Additional arguments that will be put into the metadict header if they
-        are in the list returned by `~sunpy.map.meta_keywords`. Additional
-        keyword arguments for the instrument meta can also be given in the
-        following forms which will be translated to fits standard:
-
-        | ``instrument``
-        | ``telescope``
-        | ``observatory``
-        | ``wavelength``
-        | ``exposure``
+    instrument : `~str`, optional
+        Name of the instrument of the observation.
+    telescope : `~str`, optional
+        Name of the telescope of the observation.
+    observatory : `~str`, optional
+        Name of the observatory of the observation.
+    wavelength : `~u.Quantity`, optional
+        Wavelength of the observation as an astropy quanitity, e.g. 171*u.angstrom.
+        From this keyword, the meta keywords ``wavelnth`` and ``waveunit`` will be populated.
+    exposure : `~u.Quantity`, optional
+        Exposure time of the observation
 
     Returns
     -------
@@ -113,7 +115,7 @@ def make_fitswcs_header(data, coordinate, reference_pixel: u.pix = None,
         meta_observer = _get_observer_meta(coordinate)
         meta_wcs.update(meta_observer)
 
-    meta_instrument = _get_instrument_meta(**kwargs)
+    meta_instrument = _get_instrument_meta(instrument, telescope, observatory, wavelength, exposure)
     meta_wcs.update(meta_instrument)
 
     if reference_pixel is None:
@@ -146,10 +148,6 @@ def make_fitswcs_header(data, coordinate, reference_pixel: u.pix = None,
                                                   rotation_matrix[1, 0], rotation_matrix[1, 1])
 
     meta_dict = MetaDict(meta_wcs)
-
-    for key in kwargs:
-        if key in _map_meta_keywords:
-            meta_dict[key] = kwargs[key]
 
     return meta_dict
 
@@ -210,19 +208,23 @@ def _get_observer_meta(coordinate):
     return coord_meta
 
 
-def _get_instrument_meta(**kwargs):
+def _get_instrument_meta(instrument, telescope, observatory, wavelength, exposure):
     """
-    Function to correctly name keywords from kwargs
+    Function to correctly name keywords from keyword arguments
     """
     coord = {}
 
-    conversion = {'instrument': 'instrume', 'telescope': 'telescop',
-                  'observatory': 'obsrvtry', 'wavelength': 'wavelnth', 'exposure': 'exptime'}
-
-    kwargs_temp = kwargs.copy()
-    for key in kwargs_temp:
-        if key in conversion:
-            coord[conversion[key]] = kwargs.pop(key)
+    if instrument is not None:
+        coord['instrume'] = str(instrument)
+    if telescope is not None:
+        coord['telescop'] = str(telescope)
+    if observatory is not None:
+        coord['obsrvtry'] = str(observatory)
+    if wavelength is not None:
+        coord['wavelnth'] = wavelength.to_value()
+        coord['waveunit'] = wavelength.unit.name
+    if exposure is not None:
+        coord['exptime'] = exposure.to_value(u.s)
 
     return coord
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ changedir = tmp
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest --pyargs sunpy --cov=sunpy --cov-config={toxinidir}/setup.cfg --verbose -m "not figure" --durations=25
+    PYTEST_COMMAND = pytest --pyargs sunpy --cov=sunpy --cov-config={toxinidir}/setup.cfg --verbose -m "not figure" --durations=25 {toxinidir}/docs
 extras = all,tests
 deps =
     astropydev,numpydev: cython
@@ -20,7 +20,7 @@ deps =
     online: astroquery
 commands =
     offline,astropydev,numpydev: {env:PYTEST_COMMAND} {posargs}
-    online: {env:PYTEST_COMMAND} --reruns 2 --timeout=180 --remote-data=any {posargs} {toxinidir}/docs
+    online: {env:PYTEST_COMMAND} --reruns 2 --timeout=180 --remote-data=any {posargs}
 
 [testenv:build_docs]
 basepython = python3.7


### PR DESCRIPTION
### Description
The `header_helper.make_fitswcs_header` function was able to take any kwarg that was in the list of accepted meta data and then populated the MetaDict at the end of the function with any of these keywords, and hence allowed the user to overwrite the meta pulled from the SkyCoord, and have conflicting meta keywords. it was as such 
```
    for key in kwargs:
        if key in _map_meta_keywords:
            meta_dict[key] = kwargs[key]
```
This is now removed in this PR. 

I've also added that the keywords it will take are listed in the function, with both `exposure` and `wavelength` being astropy quantities. 

Fixes #3168


