### PR TITLE
Culled-down version of the transformation graph for our docs

### DIFF
--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -20,10 +20,9 @@ below.  See the documentation for `astropy.coordinates` for more information.
 from .frames import *
 from .offset_frame import *
 from . import transformations
-from .transformations import _make_sunpy_graph
 from .ephemeris import *
 from . import sun
 
 from .wcs_utils import *
 
-__doc__ += _make_sunpy_graph()
+__doc__ += transformations._make_sunpy_graph()

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -1,7 +1,29 @@
+"""
+This subpackage contains:
+
+* A robust framework for working with coordinate systems
+* Functions to obtain the locations of solar-system bodies
+* Functions to calculate Sun-specific coordinate information
+  (`sunpy.coordinates.sun`)
+
+The diagram below shows all of Sun-based and Earth-based coordinate systems
+available through `sunpy.coordinates`, as well as the transformations between
+them.  Each frame is labeled with the name of its class and its alias (useful
+for converting other coordinates to them using attribute-style access).
+
+The frames colored in cyan are implemented in `astropy.coordinates`, and there
+are other astronomical frames that can be transformed to that are not shown
+below.  See the documentation for `astropy.coordinates` for more information.
+
+"""
+
 from .frames import *
 from .offset_frame import *
 from . import transformations
+from .transformations import _make_sunpy_graph
 from .ephemeris import *
 from . import sun
 
 from .wcs_utils import *
+
+__doc__ += _make_sunpy_graph()

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -455,13 +455,8 @@ def _add_astropy_node(graph):
 
 
 def _tweak_graph(docstr):
-    # Edit the diagram description
-    output = docstr.replace('all of the coordinate systems built into the\n`~astropy.coordinates` '
-                            'package',
-                            'the most common coordinate systems available via `sunpy.coordinates`')
-    output = output.replace('transformations between them.',
-                            'transformations between them.  The other astronomical frames in '
-                            '`astropy.coordinates` are accessible as well, but are hidden here.')
+    # Remove Astropy's diagram description
+    output = docstr[docstr.find('.. Wrap the graph'):]
 
     # Change the Astropy node
     output = output.replace('Astropy [shape=oval label="Astropy\\n`REPLACE`"]',
@@ -484,6 +479,3 @@ def _tweak_graph(docstr):
         output = output.replace(frame + ' [style=filled fillcolor=lightcyan ', frame + ' [')
 
     return output
-
-
-__doc__ += _make_sunpy_graph()

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -432,6 +432,9 @@ def _make_sunpy_graph():
     # Restore the main transform graph
     frame_transform_graph = backup_graph
 
+    # Make adjustments to the graph
+    docstr = _tweak_graph(docstr)
+
     return docstr
 
 
@@ -449,6 +452,28 @@ def _add_astropy_node(graph):
     @graph.transform(FunctionTransform, ICRS, Astropy)
     def fake_transform2():
         pass
+
+
+def _tweak_graph(docstr):
+    # Edit the diagram description
+    output = docstr.replace('all of the coordinate systems built into the\n`~astropy.coordinates` '
+                            'package',
+                            'the most common coordinate systems available via `sunpy.coordinates`')
+    output = output.replace('transformations between them.',
+                            'transformations between them.  The other astronomical frames in '
+                            '`astropy.coordinates` are accessible as well, but are hidden here.')
+
+    # Change the Astropy node
+    output = output.replace('Astropy [shape=oval label="Astropy\\n`other frames`"]',
+                            'Astropy [shape=rectangle label="Astropy\'s\\nother frames"]')
+
+    # Change the Astropy<->ICRS links to black
+    output = output.replace('ICRS -> Astropy[  color = "#783001" ]',
+                            'ICRS -> Astropy[  color = "#000000" ]')
+    output = output.replace('Astropy -> ICRS[  color = "#783001" ]',
+                            'Astropy -> ICRS[  color = "#000000" ]')
+
+    return output
 
 
 __doc__ += _make_sunpy_graph()

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -480,4 +480,22 @@ def _tweak_graph(docstr):
     for frame in sunpy_frames:
         output = output.replace(frame + ' [', frame + ' [fillcolor=white ')
 
+    output = output.replace('<ul>\n\n',
+                            '<ul>\n\n' +
+                            _add_legend_row('SunPy frames', 'white') +
+                            _add_legend_row('Astropy frames', 'lightcyan'))
+
     return output
+
+
+def _add_legend_row(label, color):
+    row = '        <li style="list-style: none;">\n'\
+          '            <p style="font-size: 12px;line-height: 24px;font-weight: normal;'\
+          'color: #848484;padding: 0;margin: 0;">\n'\
+          '                <b>' + label + ':</b>\n'\
+          '                    <span class="dot" style="height: 20px;width: 40px;'\
+          'background-color: ' + color + ';border-radius: 50%;border: 1px solid black;'\
+          'display: inline-block;"></span>\n'\
+          '            </p>\n'\
+          '        </li>\n\n\n'
+    return row

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 import numpy as np
 
 import astropy.units as u
-from astropy.coordinates import HCRS, ConvertError, BaseCoordinateFrame, get_body_barycentric
+from astropy.coordinates import ICRS, HCRS, ConvertError, BaseCoordinateFrame, get_body_barycentric
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.representation import (CartesianRepresentation, SphericalRepresentation,
                                                 UnitSphericalRepresentation)
@@ -422,6 +422,8 @@ def _make_sunpy_graph():
     for name in cull_list:
         small_graph._cached_names.pop(name)
 
+    _add_astropy_node(small_graph)
+
     # Overwrite the main transform graph
     frame_transform_graph = small_graph
 
@@ -431,6 +433,22 @@ def _make_sunpy_graph():
     frame_transform_graph = backup_graph
 
     return docstr
+
+
+def _add_astropy_node(graph):
+    """
+    Add an 'Astropy' node that links to an ICRS node in the graph
+    """
+    class Astropy(BaseCoordinateFrame):
+        name = "other frames"
+
+    @graph.transform(FunctionTransform, Astropy, ICRS)
+    def fake_transform1():
+        pass
+
+    @graph.transform(FunctionTransform, ICRS, Astropy)
+    def fake_transform2():
+        pass
 
 
 __doc__ += _make_sunpy_graph()

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -469,13 +469,15 @@ def _tweak_graph(docstr):
     output = output.replace('Astropy -> ICRS[  color = "#783001" ]',
                             'Astropy -> ICRS[  color = "#000000" ]')
 
-    # Change all the ovals to be filled
-    output = output.replace('shape=oval', 'style=filled fillcolor=lightcyan shape=oval')
+    # Set the nodes to be filled and cyan by default
+    output = output.replace('AstropyCoordinateTransformGraph {',
+                            'AstropyCoordinateTransformGraph {\n'
+                            '        node [style=filled fillcolor=lightcyan]')
 
-    # Change SunPy frames back to not filled
+    # Set the nodes for SunPy frames to be white
     sunpy_frames = ['HeliographicStonyhurst', 'HeliographicCarrington',
                     'Heliocentric', 'Helioprojective']
     for frame in sunpy_frames:
-        output = output.replace(frame + ' [style=filled fillcolor=lightcyan ', frame + ' [')
+        output = output.replace(frame + ' [', frame + ' [fillcolor=white ')
 
     return output

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -399,7 +399,7 @@ def _make_sunpy_graph():
                  'heliographic_stonyhurst', 'heliographic_carrington',
                  'heliocentric', 'helioprojective',
                  'gcrs', 'precessedgeocentric', 'geocentrictrueecliptic', 'geocentricmeanecliptic',
-                 'cirs', 'altaz']
+                 'cirs', 'altaz', 'itrs']
 
     global frame_transform_graph
     backup_graph = deepcopy(frame_transform_graph)
@@ -443,7 +443,7 @@ def _add_astropy_node(graph):
     Add an 'Astropy' node that links to an ICRS node in the graph
     """
     class Astropy(BaseCoordinateFrame):
-        name = "other frames"
+        name = "REPLACE"
 
     @graph.transform(FunctionTransform, Astropy, ICRS)
     def fake_transform1():
@@ -464,14 +464,24 @@ def _tweak_graph(docstr):
                             '`astropy.coordinates` are accessible as well, but are hidden here.')
 
     # Change the Astropy node
-    output = output.replace('Astropy [shape=oval label="Astropy\\n`other frames`"]',
-                            'Astropy [shape=rectangle label="Astropy\'s\\nother frames"]')
+    output = output.replace('Astropy [shape=oval label="Astropy\\n`REPLACE`"]',
+                            'Astropy [shape=box3d style=filled fillcolor=lightcyan '
+                            'label="Other frames\\nin Astropy"]')
 
     # Change the Astropy<->ICRS links to black
     output = output.replace('ICRS -> Astropy[  color = "#783001" ]',
                             'ICRS -> Astropy[  color = "#000000" ]')
     output = output.replace('Astropy -> ICRS[  color = "#783001" ]',
                             'Astropy -> ICRS[  color = "#000000" ]')
+
+    # Change all the ovals to be filled
+    output = output.replace('shape=oval', 'style=filled fillcolor=lightcyan shape=oval')
+
+    # Change SunPy frames back to not filled
+    sunpy_frames = ['HeliographicStonyhurst', 'HeliographicCarrington',
+                    'Heliocentric', 'Helioprojective']
+    for frame in sunpy_frames:
+        output = output.replace(frame + ' [style=filled fillcolor=lightcyan ', frame + ' [')
 
     return output
 


### PR DESCRIPTION
- Removes most of the astronomical frames from the diagram in the docs
- Adds a box for "Other frames in Astropy"
- Edits the description text before the diagram because the default talks only about Astropy
- Moves the description and graph from `sunpy.coordinates.transform` to `sunpy.coordinates`

Here's what the graph looks like:

![graph](https://user-images.githubusercontent.com/991759/59043980-3b47d980-884b-11e9-8e53-cafc59ba4415.png)

Closes #2846 