### PR TITLE
RTD back to conda due to openjpeg

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-CHANGELOG.md merge=union
-continuous-integration/python3.sh merge=union
 *fits binary
 *fit binary
 *fts binary

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,11 @@
 version: 2
 
+# We have to use conda since we need openjpeg support
+conda:
+  environment: .rtd-environment.yml
+
 python:
    version: 3.7
    install:
-      # Use this to override dep versions.
-      - requirements: docs/rtd_requirements.txt
       - method: pip
         path: .
-        extra_requirements:
-           - dev

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,0 +1,36 @@
+name: sunpy
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - pip
+  - openjpeg
+  - jsonschema=2.6.0
+  - numpy
+  - scipy
+  - matplotlib
+  - pandas
+  - astropy
+  - parfive
+  - sqlalchemy
+  - scikit-image
+  - glymur
+  - beautifulsoup4
+  - drms
+  - python-dateutil
+  - zeep
+  - tqdm
+  - asdf
+  - hypothesis
+  - pytest-astropy
+  - pytest-cov
+  - pytest-mock
+  - ruamel.yaml
+  - sphinx
+  - sphinx-astropy
+  - sphinx-gallery
+  - towncrier
+  - pip:
+    - sunpy-sphinx-theme
+    - jplephem
+    - astroquery

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,4 +1,0 @@
-# This file is used on ReadTheDocs to build the
-# documentation and is separate of tox.ini and setup.cfg
-jplephem
-astroquery


### PR DESCRIPTION
The build works in that it installs and builds the docs without the gallery but now I just get each job killed. 
I am hoping that once this is in master, it will at least build to a point where I can debug it. 