### PR TITLE
New coordinate frames! (HEE, GSE, HCI, and GEI)

### DIFF
--- a/changelog/3212.feature.rst
+++ b/changelog/3212.feature.rst
@@ -1,0 +1,1 @@
+Added the coordinate frames `~sunpy.coordinates.frames.HeliocentricEarthEcliptic` (HEE), `~sunpy.coordinates.frames.GeocentricSolarEcliptic` (GSE), `~sunpy.coordinates.frames.HeliocentricInertial` (HCI), and `~sunpy.coordinates.frames.GeocentricEarthEquatorial` (GEI).

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -12,6 +12,7 @@ from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMap
 from astropy.coordinates.representation import (CartesianRepresentation, SphericalRepresentation,
                                                 CylindricalRepresentation,
                                                 UnitSphericalRepresentation)
+from astropy.time import Time
 
 from sunpy.sun.constants import radius as _RSUN
 from sunpy.util.decorators import add_common_docstring
@@ -21,6 +22,8 @@ from .frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribut
 
 from sunpy.util.decorators import add_common_docstring
 from sunpy.time.time import _variables_for_parse_time_docstring
+
+_J2000 = Time('J2000.0', scale='tt')
 
 __all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
            'Heliocentric', 'Helioprojective',
@@ -556,7 +559,7 @@ class GeocentricEarthEquatorial(SunPyBaseCoordinateFrame):
 
     - The origin is the center of the Earth
     - The z-axis is aligned with the Earth's rotation axis
-    - The x-axis is aligned with the vernal equinox (mean J2000.0)
+    - The x-axis is aligned with the mean (not true) vernal equinox
 
     Parameters
     ----------
@@ -571,6 +574,8 @@ class GeocentricEarthEquatorial(SunPyBaseCoordinateFrame):
         ``representation`` must be None).
     distance: `~astropy.units.Quantity` , optional, must be keyword
         The distance for this object from the Earth’s center. (``representation`` must be None).
+    equinox: {parse_time_types}
+        The date for the mean vernal equinox.  Defaults to the J2000.0 equinox.
     obstime: {parse_time_types}
         The date and time of the observation.
 
@@ -579,3 +584,5 @@ class GeocentricEarthEquatorial(SunPyBaseCoordinateFrame):
     Aberration due to Earth motion is not included.
     """
     default_representation = SphericalRepresentation
+
+    equinox = TimeFrameAttributeSunPy(default=_J2000)

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -472,8 +472,8 @@ class HeliocentricEarthEcliptic(SunPyBaseCoordinateFrame):
     A coordinate or frame in the Heliocentric Earth Ecliptic system.
 
     - The origin is the center of the Sun
-    - The z-axis is aligned with the mean ecliptic pole at the observation time
-    - The x-axis is aligned with the component of the Sun-Earth vector perpendicular to the z-axis
+    - The x-axis is aligned with the Sun-Earth vector
+    - The z-axis is aligned with the component of the mean ecliptic pole at the observation time
 
     Parameters
     ----------
@@ -498,8 +498,9 @@ class GeocentricSolarEcliptic(SunPyBaseCoordinateFrame):
     A coordinate or frame in the Geocentric Solar Ecliptic system.
 
     - The origin is the center of the Earth
-    - The z-axis is aligned with the mean ecliptic pole at the observation time
-    - The x-axis is aligned with the component of the Earth-Sun vector perpendicular to the z-axis
+    - The x-axis is aligned with the Earth-Sun vector
+    - The z-axis is aligned with the component of the mean ecliptic pole at the observation time
+      perpendicular to the x-axis
 
     Parameters
     ----------

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -65,6 +65,12 @@ def _frame_parameters():
     ret['radius'] = ("radius : `~astropy.units.Quantity`, optional\n"
                      "        The radial distance coordinate from Sun center for this object.\n"
                      "        Defaults to the radius of the Sun. Not needed if ``data`` is given.")
+    ret['distance_sun'] = ("distance : `~astropy.units.Quantity`, optional\n"
+                           "        The distance coordinate from Sun center for this object.\n"
+                           "        Not needed if ``data`` is given.")
+    ret['distance_earth'] = ("distance : `~astropy.units.Quantity`, optional\n"
+                             "        The distance coordinate from Earth center for this object.\n"
+                             "        Not needed if ``data`` is given.")
     ret['xyz'] = ("x : `~astropy.units.Quantity`, optional\n"
                   "        X-axis coordinate for this object. Not needed if ``data`` is given.\n"
                   "    y : `~astropy.units.Quantity`, optional\n"
@@ -76,6 +82,9 @@ def _frame_parameters():
                        "        it must be a solar system body that can be parsed by\n"
                        "        `~sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst`\n"
                        "        at the time ``obstime``. Defaults to Earth center.")
+    ret['equinox'] = (f"equinox : {_variables_for_parse_time_docstring()['parse_time_types']}\n"
+                      "        The date for the mean vernal equinox.\n"
+                      "        Defaults to the J2000.0 equinox.")
 
     return ret
 
@@ -469,55 +478,42 @@ class Helioprojective(SunPyBaseCoordinateFrame):
                                                           distance=d))
 
 
-@add_common_docstring(**_variables_for_parse_time_docstring())
+@add_common_docstring(**_frame_parameters())
 class HeliocentricEarthEcliptic(SunPyBaseCoordinateFrame):
     """
-    A coordinate or frame in the Heliocentric Earth Ecliptic system.
+    A coordinate or frame in the Heliocentric Earth Ecliptic (HEE) system.
 
-    - The origin is the center of the Sun
-    - The x-axis is aligned with the Sun-Earth vector
-    - The z-axis is aligned with the component of the mean ecliptic pole at the observation time
+    - The origin is the center of the Sun.
+    - The X-axis (0 degrees longitude and 0 degrees latitude) is aligned with the Sun-Earth line.
+    - The Z-axis (+90 degrees latitude) is aligned with the component perpendicular to the X-axis
+      of the mean ecliptic pole at the observation time.
 
     Parameters
     ----------
-    data: `~astropy.coordinates.BaseRepresentation` subclass instance
-        A representation object or ``None`` to have no data (or use the coordinate component
-        arguments, see below).
-    lon: `~astropy.coordinates.Angle`, optional
-        The longitude for this object (``lat`` must also be given and ``data`` must be None).
-    lat: `~astropy.coordinates.Angle`, optional
-        The latitude for this object (``lon`` must also be given and ``data`` must be None).
-    distance: `~astropy.units.Quantity` , optional
-        The distance for this object from the Sun’s center. (``data`` must be None).
-    obstime: {parse_time_types}
-        The date and time of the observation.
+    {data}
+    {lonlat}
+    {distance_sun}
+    {common}
     """
     default_representation = SphericalRepresentation
 
 
-@add_common_docstring(**_variables_for_parse_time_docstring())
+@add_common_docstring(**_frame_parameters())
 class GeocentricSolarEcliptic(SunPyBaseCoordinateFrame):
     """
-    A coordinate or frame in the Geocentric Solar Ecliptic system.
+    A coordinate or frame in the Geocentric Solar Ecliptic (GSE) system.
 
-    - The origin is the center of the Earth
-    - The x-axis is aligned with the Earth-Sun vector
-    - The z-axis is aligned with the component of the mean ecliptic pole at the observation time
-      perpendicular to the x-axis
+    - The origin is the center of the Earth.
+    - The X-axis (0 degrees longitude and 0 degrees latitude) is aligned with the Earth-Sun line.
+    - The Z-axis (+90 degrees latitude) is aligned with the component perpendicular to the X-axis
+      of the mean ecliptic pole at the observation time.
 
     Parameters
     ----------
-    data: `~astropy.coordinates.BaseRepresentation` subclass instance
-        A representation object or ``None`` to have no data (or use the coordinate component
-        arguments, see below).
-    lon: `~astropy.coordinates.Angle`, optional
-        The longitude for this object (``lat`` must also be given and ``data`` must be None).
-    lat: `~astropy.coordinates.Angle`, optional
-        The latitude for this object (``lon`` must also be given and ``data`` must be None).
-    distance: `~astropy.units.Quantity` , optional
-        The distance for this object from the Earth’s center. (``data`` must be None).
-    obstime: {parse_time_types}
-        The date and time of the observation.
+    {data}
+    {lonlat}
+    {distance_earth}
+    {common}
 
     Notes
     -----
@@ -526,58 +522,49 @@ class GeocentricSolarEcliptic(SunPyBaseCoordinateFrame):
     default_representation = SphericalRepresentation
 
 
-@add_common_docstring(**_variables_for_parse_time_docstring())
+@add_common_docstring(**_frame_parameters())
 class HeliocentricInertial(SunPyBaseCoordinateFrame):
     """
-    A coordinate or frame in the Heliocentric Inertial system.
+    A coordinate or frame in the Heliocentric Inertial (HCI) system.
 
-    - The origin is the center of the Sun
-    - The z-axis is aligned with the solar rotation axis
-    - The x-axis is aligned with the solar ascending node on the ecliptic (mean J2000.0)
+    - The origin is the center of the Sun.
+    - The Z-axis (+90 degrees latitude) is aligned with the Sun's north pole.
+    - The X-axis (0 degrees longitude and 0 degrees latitude) is aligned with the solar ascending
+      node on the ecliptic (mean J2000.0).
 
     Parameters
     ----------
-    data: `~astropy.coordinates.BaseRepresentation` subclass instance
-        A representation object or ``None`` to have no data (or use the coordinate component
-        arguments, see below).
-    lon: `~astropy.coordinates.Angle`, optional
-        The longitude for this object (``lat`` must also be given and ``data`` must be None).
-    lat: `~astropy.coordinates.Angle`, optional
-        The latitude for this object (``lon`` must also be given and ``data`` must be None).
-    distance: `~astropy.units.Quantity` , optional
-        The distance for this object from the Sun’s center. (``data`` must be None).
-    obstime: {parse_time_types}
-        The date and time of the observation.
+    {data}
+    {lonlat}
+    {distance_sun}
+    {common}
+
+    Notes
+    -----
+    The solar ascending node on the ecliptic lies on the intersection of the solar equatorial
+    plane with the ecliptic plane, not on the intersection of the celestial equatorial plane with
+    the ecliptic plane.
     """
     default_representation = SphericalRepresentation
 
 
-@add_common_docstring(**_variables_for_parse_time_docstring())
+@add_common_docstring(**_frame_parameters())
 class GeocentricEarthEquatorial(SunPyBaseCoordinateFrame):
     """
     A coordinate or frame in the Geocentric Earth Equatorial (GEI) system.
 
-    - The origin is the center of the Earth
-    - The z-axis is aligned with the Earth's rotation axis
-    - The x-axis is aligned with the mean (not true) vernal equinox
+    - The origin is the center of the Earth.
+    - The Z-axis (+90 degrees latitude) is aligned with the Earth's north pole.
+    - The X-axis (0 degrees longitude and 0 degrees latitude) is aligned with the mean (not true)
+      vernal equinox.
 
     Parameters
     ----------
-    data: `~astropy.coordinates.BaseRepresentation` subclass instance
-        A representation object or ``None`` to have no data (or use the coordinate component
-        arguments, see below).
-    lon: `~astropy.coordinates.Angle`, optional, must be keyword
-        The longitude for this object (``lat`` must also be given and
-        ``representation`` must be None).
-    lat: `~astropy.coordinates.Angle`, optional, must be keyword
-        The latitude for this object (``lon`` must also be given and
-        ``representation`` must be None).
-    distance: `~astropy.units.Quantity` , optional, must be keyword
-        The distance for this object from the Earth’s center. (``representation`` must be None).
-    equinox: {parse_time_types}
-        The date for the mean vernal equinox.  Defaults to the J2000.0 equinox.
-    obstime: {parse_time_types}
-        The date and time of the observation.
+    {data}
+    {lonlat}
+    {distance_earth}
+    {equinox}
+    {common}
 
     Notes
     -----

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -24,7 +24,8 @@ from sunpy.time.time import _variables_for_parse_time_docstring
 
 __all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
            'Heliocentric', 'Helioprojective',
-           'HeliocentricEarthEcliptic', 'GeocentricSolarEcliptic']
+           'HeliocentricEarthEcliptic', 'GeocentricSolarEcliptic',
+           'HeliocentricInertial']
 
 
 def _frame_parameters():
@@ -517,5 +518,31 @@ class GeocentricSolarEcliptic(SunPyBaseCoordinateFrame):
     Notes
     -----
     Aberration due to Earth motion is not included.
+    """
+    default_representation = SphericalRepresentation
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+class HeliocentricInertial(SunPyBaseCoordinateFrame):
+    """
+    A coordinate or frame in the Heliocentric Inertial system.
+
+    - The origin is the center of the Sun
+    - The z-axis is aligned with the solar rotation axis
+    - The x-axis is aligned with the solar ascending node on the ecliptic (mean J2000.0)
+
+    Parameters
+    ----------
+    data: `~astropy.coordinates.BaseRepresentation` subclass instance
+        A representation object or ``None`` to have no data (or use the coordinate component
+        arguments, see below).
+    lon: `~astropy.coordinates.Angle`, optional
+        The longitude for this object (``lat`` must also be given and ``data`` must be None).
+    lat: `~astropy.coordinates.Angle`, optional
+        The latitude for this object (``lon`` must also be given and ``data`` must be None).
+    distance: `~astropy.units.Quantity` , optional
+        The distance for this object from the Sun’s center. (``data`` must be None).
+    obstime: {parse_time_types}
+        The date and time of the observation.
     """
     default_representation = SphericalRepresentation

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -25,7 +25,7 @@ from sunpy.time.time import _variables_for_parse_time_docstring
 __all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
            'Heliocentric', 'Helioprojective',
            'HeliocentricEarthEcliptic', 'GeocentricSolarEcliptic',
-           'HeliocentricInertial']
+           'HeliocentricInertial', 'GeocentricEarthEquatorial']
 
 
 def _frame_parameters():
@@ -545,5 +545,37 @@ class HeliocentricInertial(SunPyBaseCoordinateFrame):
         The distance for this object from the Sun’s center. (``data`` must be None).
     obstime: {parse_time_types}
         The date and time of the observation.
+    """
+    default_representation = SphericalRepresentation
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+class GeocentricEarthEquatorial(SunPyBaseCoordinateFrame):
+    """
+    A coordinate or frame in the Geocentric Earth Equatorial (GEI) system.
+
+    - The origin is the center of the Earth
+    - The z-axis is aligned with the Earth's rotation axis
+    - The x-axis is aligned with the vernal equinox (mean J2000.0)
+
+    Parameters
+    ----------
+    data: `~astropy.coordinates.BaseRepresentation` subclass instance
+        A representation object or ``None`` to have no data (or use the coordinate component
+        arguments, see below).
+    lon: `~astropy.coordinates.Angle`, optional, must be keyword
+        The longitude for this object (``lat`` must also be given and
+        ``representation`` must be None).
+    lat: `~astropy.coordinates.Angle`, optional, must be keyword
+        The latitude for this object (``lon`` must also be given and
+        ``representation`` must be None).
+    distance: `~astropy.units.Quantity` , optional, must be keyword
+        The distance for this object from the Earth’s center. (``representation`` must be None).
+    obstime: {parse_time_types}
+        The date and time of the observation.
+
+    Notes
+    -----
+    Aberration due to Earth motion is not included.
     """
     default_representation = SphericalRepresentation

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -14,6 +14,8 @@ from astropy.coordinates.representation import (CartesianRepresentation, Spheric
                                                 UnitSphericalRepresentation)
 
 from sunpy.sun.constants import radius as _RSUN
+from sunpy.util.decorators import add_common_docstring
+from sunpy.time.time import _variables_for_parse_time_docstring
 
 from .frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribute
 
@@ -21,7 +23,8 @@ from sunpy.util.decorators import add_common_docstring
 from sunpy.time.time import _variables_for_parse_time_docstring
 
 __all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
-           'Heliocentric', 'Helioprojective']
+           'Heliocentric', 'Helioprojective',
+           'HeliocentricEarthEcliptic']
 
 
 def _frame_parameters():
@@ -460,3 +463,29 @@ class Helioprojective(SunPyBaseCoordinateFrame):
         return self.realize_frame(SphericalRepresentation(lon=lon,
                                                           lat=lat,
                                                           distance=d))
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+class HeliocentricEarthEcliptic(SunPyBaseCoordinateFrame):
+    """
+    A coordinate or frame in the Heliocentric Earth Ecliptic system.
+
+    - The origin is the center of the Sun
+    - The z-axis is aligned with the mean ecliptic pole at the observation time
+    - The x-axis is aligned with the component of the Sun-Earth vector perpendicular to the z-axis
+
+    Parameters
+    ----------
+    data: `~astropy.coordinates.BaseRepresentation` subclass instance
+        A representation object or ``None`` to have no data (or use the coordinate component
+        arguments, see below).
+    lon: `~astropy.coordinates.Angle`, optional
+        The longitude for this object (``lat`` must also be given and ``data`` must be None).
+    lat: `~astropy.coordinates.Angle`, optional
+        The latitude for this object (``lon`` must also be given and ``data`` must be None).
+    distance: `~astropy.units.Quantity` , optional
+        The distance for this object from the Sun’s center. (``data`` must be None).
+    obstime: {parse_time_types}
+        The date and time of the observation.
+    """
+    default_representation = SphericalRepresentation

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -24,7 +24,7 @@ from sunpy.time.time import _variables_for_parse_time_docstring
 
 __all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
            'Heliocentric', 'Helioprojective',
-           'HeliocentricEarthEcliptic']
+           'HeliocentricEarthEcliptic', 'GeocentricSolarEcliptic']
 
 
 def _frame_parameters():
@@ -487,5 +487,35 @@ class HeliocentricEarthEcliptic(SunPyBaseCoordinateFrame):
         The distance for this object from the Sun’s center. (``data`` must be None).
     obstime: {parse_time_types}
         The date and time of the observation.
+    """
+    default_representation = SphericalRepresentation
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+class GeocentricSolarEcliptic(SunPyBaseCoordinateFrame):
+    """
+    A coordinate or frame in the Geocentric Solar Ecliptic system.
+
+    - The origin is the center of the Earth
+    - The z-axis is aligned with the mean ecliptic pole at the observation time
+    - The x-axis is aligned with the component of the Earth-Sun vector perpendicular to the z-axis
+
+    Parameters
+    ----------
+    data: `~astropy.coordinates.BaseRepresentation` subclass instance
+        A representation object or ``None`` to have no data (or use the coordinate component
+        arguments, see below).
+    lon: `~astropy.coordinates.Angle`, optional
+        The longitude for this object (``lat`` must also be given and ``data`` must be None).
+    lat: `~astropy.coordinates.Angle`, optional
+        The latitude for this object (``lon`` must also be given and ``data`` must be None).
+    distance: `~astropy.units.Quantity` , optional
+        The distance for this object from the Earth’s center. (``data`` must be None).
+    obstime: {parse_time_types}
+        The date and time of the observation.
+
+    Notes
+    -----
+    Aberration due to Earth motion is not included.
     """
     default_representation = SphericalRepresentation

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -525,8 +525,8 @@ def test_hme_hee_sunspice():
     old = SkyCoord(0*u.deg, 10*u.deg, 1*u.AU, frame=HeliocentricMeanEcliptic(obstime='2019-06-01'))
     new = old.transform_to(HeliocentricEarthEcliptic)
 
-    assert_quantity_allclose(new.lon, Longitude(110.01610*u.deg), atol=0.5*u.arcsec, rtol=0)
-    assert_quantity_allclose(new.lat, 10.000300*u.deg, atol=0.5*u.arcsec, rtol=0)
+    assert_quantity_allclose(new.lon, Longitude(110.01610*u.deg), atol=0.01*u.arcsec, rtol=0)
+    assert_quantity_allclose(new.lat, 10.000300*u.deg, atol=0.01*u.arcsec, rtol=0)
     assert_quantity_allclose(new.distance, old.distance)
 
     # Transform from HAE precessed to the mean ecliptic of date instead of J2000.0
@@ -539,8 +539,8 @@ def test_hme_hee_sunspice():
                                                                              equinox='2019-06-01'))
     new = old.transform_to(HeliocentricEarthEcliptic)
 
-    assert_quantity_allclose(new.lon, Longitude(109.74535*u.deg), atol=0.5*u.arcsec, rtol=0)
-    assert_quantity_allclose(new.lat, 10.000070*u.deg, atol=0.5*u.arcsec, rtol=0)
+    assert_quantity_allclose(new.lon, Longitude(109.74535*u.deg), atol=0.05*u.arcsec, rtol=0)
+    assert_quantity_allclose(new.lat, 10.000070*u.deg, atol=0.01*u.arcsec, rtol=0)
     assert_quantity_allclose(new.distance, old.distance)
 
 
@@ -548,6 +548,13 @@ def test_hee_hee():
     # Test HEE loopback transformation
     obstime = Time('2001-01-01')
     old = SkyCoord(90*u.deg, 10*u.deg, 1*u.AU, frame=HeliocentricEarthEcliptic(obstime=obstime))
+
+    new = old.transform_to(HeliocentricEarthEcliptic)
+
+    assert_quantity_allclose(new.lon, old.lon)
+    assert_quantity_allclose(new.lat, old.lat)
+    assert_quantity_allclose(new.distance, old.distance)
+
     new = old.transform_to(HeliocentricEarthEcliptic(obstime=obstime + 1*u.day))
 
     assert_quantity_allclose(new.lon, old.lon - 1*u.deg, atol=0.1*u.deg)  # due to Earth motion
@@ -557,8 +564,6 @@ def test_hee_hee():
 
 def test_hee_gse_sunspice():
     # Compare our HEE->GSE transformation against SunSPICE
-    # Be aware that the GSE origin in SunSPICE is not quite at Earth center: the ecliptic longitude
-    #   is Earth's, but the ecliptic latitude is zero.  This is the reason for the discrepancies.
     #
     # IDL> coord = [0.7d, -20.d, 10.d]
     # IDL> convert_sunspice_coord, '2019-06-01', coord, 'HEE', 'GSE', /au, /degrees
@@ -570,8 +575,8 @@ def test_hee_gse_sunspice():
     new = old.geocentricsolarecliptic
 
     assert_quantity_allclose(new.lon, 32.777377*u.deg, atol=0.01*u.arcsec, rtol=0)
-    assert_quantity_allclose(new.lat, 15.594639*u.deg, atol=2*u.arcsec, rtol=0)
-    assert_quantity_allclose(new.distance, 0.45215884*u.AU, rtol=1e-5)
+    assert_quantity_allclose(new.lat, 15.594639*u.deg, atol=0.01*u.arcsec, rtol=0)
+    assert_quantity_allclose(new.distance, 0.45215884*u.AU)
 
 
 def test_gse_gse():
@@ -620,7 +625,7 @@ def test_hme_hci_sunspice():
 def test_hci_hci():
     # Test HCI loopback transformation
     old = SkyCoord(90*u.deg, 10*u.deg, 0.7*u.AU, frame=HeliocentricInertial(obstime='2001-01-01'))
-    new = old.transform_to(HeliocentricInertial)
+    new = old.transform_to(HeliocentricMeanEcliptic).transform_to(HeliocentricInertial)
 
     assert_quantity_allclose(new.lon, old.lon)
     assert_quantity_allclose(new.lat, old.lat)


### PR DESCRIPTION
I've added four coordinate frames:

- Heliocentric Earth Ecliptic (HEE)
- Geocentric Solar Ecliptic (GSE)
- Heliocentric Inertial (HCI)
- Geocentric Earth Equatorial (GEI)

All transformations are implemented and are tested against SunSPICE (see #3203).  Here's the transformation graph (with the frame names of Astropy 3.2.x):

![graph](https://user-images.githubusercontent.com/991759/62385510-49506880-b523-11e9-95a8-2ff4f419cd20.png)

Miscellaneous notes:

- `GeocentricSolarEcliptic` and `GeocentricEarthEquatorial` are transformed through heliocentric frames because of how Astropy handles aberration due to Earth motion.
- ~SunSPICE doesn't appear to be accounting for Earth's ecliptic latitude (very small but non-zero) when transforming from HEE to GSE.  I need to chat with Bill Thompson.~  I hadn't implemented HEE and GSE quite correctly, but that is now fixed.
- ~The implementation for longitude wrap angles has been tweaked for the better.~  Moved to separate PR (#3223)
- `GeocentricEarthEquatorial` defaults to J2000.0 (which is what SunSPICE assumes), but one can also use it with the mean equinox of date (i.e., GEI_D) by specifying `equinox` with the same time as `obstime`.