### PR TITLE
Fix the detection of distance in Helioprojective.calculate_distance

### DIFF
--- a/changelog/3219.bugfix.rst
+++ b/changelog/3219.bugfix.rst
@@ -1,0 +1,3 @@
+Fix the behaviour of
+`sunpy.coordinates.frames.Helioprojective.calculate_distance` if the
+representation isn't Spherical.

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -392,8 +392,8 @@ class Helioprojective(SunPyBaseCoordinateFrame):
             now with a third coordinate.
         """
         # Skip if we already are 3D
-        if (isinstance(self._data, SphericalRepresentation) and
-                not (self.distance.unit is u.one and u.allclose(self.distance, 1*u.one))):
+        distance = self.spherical
+        if not (distance.unit is u.one and u.allclose(distance, 1*u.one)):
             return self
 
         if not isinstance(self.observer, BaseCoordinateFrame):

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -392,7 +392,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
             now with a third coordinate.
         """
         # Skip if we already are 3D
-        distance = self.spherical
+        distance = self.spherical.distance
         if not (distance.unit is u.one and u.allclose(distance, 1*u.one)):
             return self
 

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -153,6 +153,16 @@ def test_hpc_distance():
     assert_quantity_allclose(hpc2.distance, DSUN_METERS - RSUN_METERS)
 
 
+def test_hpc_distance_cartesian():
+    # Test detection of distance in other representations
+    hpc1 = Helioprojective(CartesianRepresentation(0 * u.km, 0 * u.km, 1 * u.Mm))
+
+    assert isinstance(hpc1, Helioprojective)
+    assert isinstance(hpc1._data, CartesianRepresentation)
+
+    assert hpc1.calculate_distance() is hpc1
+
+
 def test_hpc_distance_off_limb():
     hpc1 = Helioprojective(1500 * u.arcsec, 0 * u.arcsec,
                            observer=HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU))


### PR DESCRIPTION
This is a fix to the behaviour of the HelioProjective frame if you are for some weird reason, trying to instantiate a frame with a non-spherical representation.