### PR TITLE
Improved handling of longitude wrap angles in frames

### DIFF
--- a/changelog/3223.bugfix.rst
+++ b/changelog/3223.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where the longitude of a coordinate would not wrap at the expected angle following a frame transformation.

--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -258,14 +258,14 @@ If you want to obtain a un-realized coordinate frame corresponding to a
   >>> amap = sunpy.map.Map(AIA_171_IMAGE)  # doctest: +REMOTE_DATA
   >>> amap.observer_coordinate  # doctest: +REMOTE_DATA
     <SkyCoord (HeliographicStonyhurst: obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
-        (359.99593689, 0.04787238, 1.51846026e+11)>
+        (-0.00406308, 0.04787238, 1.51846026e+11)>
 
 which is equivalent to::
 
   >>> from astropy.wcs.utils import wcs_to_celestial_frame # doctest: +REMOTE_DATA
   >>> wcs_to_celestial_frame(amap.wcs)  # doctest: +REMOTE_DATA
     <Helioprojective Frame (obstime=2011-06-07T06:33:02.770, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
-        (359.99593689, 0.04787238, 1.51846026e+11)>)>
+        (-0.00406308, 0.04787238, 1.51846026e+11)>)>
 
 
 .. automodapi:: sunpy.coordinates

--- a/docs/guide/units-coordinates.rst
+++ b/docs/guide/units-coordinates.rst
@@ -209,7 +209,7 @@ Using Coordinates with SunPy Map
    >>> m = sunpy.map.Map(AIA_171_IMAGE)  # doctest: +REMOTE_DATA
    >>> m.coordinate_frame  # doctest: +REMOTE_DATA
    <Helioprojective Frame (obstime=2011-06-07T06:33:02.770, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
-       (359.99593689, 0.04787238, 1.51846026e+11)>)>
+       (-0.00406308, 0.04787238, 1.51846026e+11)>)>
 
    This can be used when creating a `~astropy.coordinates.SkyCoord` object to set
    the coordinate system to that image:
@@ -219,7 +219,7 @@ Using Coordinates with SunPy Map
    >>> c = SkyCoord(100 * u.arcsec, 10*u.arcsec, frame=m.coordinate_frame)  # doctest: +REMOTE_DATA
    >>> c  # doctest: +REMOTE_DATA
    <SkyCoord (Helioprojective: obstime=2011-06-07T06:33:02.770, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
-       (359.99593689, 0.04787238, 1.51846026e+11)>): (Tx, Ty) in arcsec
+       (-0.00406308, 0.04787238, 1.51846026e+11)>): (Tx, Ty) in arcsec
        (100., 10.)>
 
    This `~astropy.coordinates.SkyCoord` object could then be used to plot a point

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -172,7 +172,7 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     >>> get_horizons_coord('Venus barycenter', '2001-02-03 04:05:06')  # doctest: +REMOTE_DATA
     INFO: Obtained JPL HORIZONS location for Venus Barycenter (2) [sunpy.coordinates.ephemeris]
     <SkyCoord (HeliographicStonyhurst: obstime=2001-02-03T04:05:06.000): (lon, lat, radius) in (deg, deg, AU)
-        (326.06844114, -1.64998481, 0.71915147)>
+        (-33.93155883, -1.64998481, 0.71915147)>
 
     Query the location of the SDO spacecraft
 

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -23,12 +23,30 @@ __all__ = ['HeliographicStonyhurst', 'HeliographicCarrington',
 
 class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
     """
-    Inject a nice way of representing the object which the coordinate represents.
+    * Defines a default longitude wrap angle of 180 degrees, which can be overridden by the class
+      variable `_wrap_angle`.
+    * Inject a nice way of representing the object which the coordinate represents.
     """
+    _wrap_angle = 180*u.deg
 
     def __init__(self, *args, **kwargs):
         self.object_name = None
+
+        # If wrap_longitude=False is passed in, do not impose a specific wrap angle for the frame
+        if not kwargs.pop('wrap_longitude', True):
+            self._wrap_angle = None
+
         return super().__init__(*args, **kwargs)
+
+    def represent_as(self, base, s='base', in_frame_units=False):
+        """
+        If a frame wrap angle is set, use that wrap angle for any spherical representations.
+        """
+        data = super().represent_as(base, s, in_frame_units=in_frame_units)
+        if self._wrap_angle is not None and \
+           isinstance(data, (UnitSphericalRepresentation, SphericalRepresentation)):
+            data.lon.wrap_angle = self._wrap_angle
+        return data
 
     def __str__(self):
         """
@@ -127,17 +145,14 @@ class HeliographicStonyhurst(SunPyBaseCoordinateFrame):
 
     obstime = TimeFrameAttributeSunPy()
 
-    _default_wrap_angle = 180*u.deg
-
     def __init__(self, *args, **kwargs):
         _rep_kwarg = kwargs.get('representation_type', None)
-        wrap = kwargs.pop('wrap_longitude', True)
 
         if ('radius' in kwargs and kwargs['radius'].unit is u.one and
                 u.allclose(kwargs['radius'], 1*u.one)):
             kwargs['radius'] = _RSUN.to(u.km)
 
-        super(HeliographicStonyhurst, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Make 3D if specified as 2D
         # If representation was explicitly passed, do not change the rep.
@@ -149,9 +164,6 @@ class HeliographicStonyhurst(SunPyBaseCoordinateFrame):
                 self._data = SphericalRepresentation(lat=self._data.lat,
                                                      lon=self._data.lon,
                                                      distance=distance)
-
-        if wrap and isinstance(self._data, (UnitSphericalRepresentation, SphericalRepresentation)):
-            self._data.lon.wrap_angle = self._default_wrap_angle
 
 
 class HeliographicCarrington(HeliographicStonyhurst):
@@ -207,7 +219,6 @@ class HeliographicCarrington(HeliographicStonyhurst):
     name = "heliographic_carrington"
     default_representation = SphericalRepresentation
 
-
     frame_specific_representation_info = {
         SphericalRepresentation: [RepresentationMapping(reprname='lon',
                                                         framename='lon',
@@ -227,11 +238,11 @@ class HeliographicCarrington(HeliographicStonyhurst):
                                                             defaultunit=u.deg)],
     }
 
-    _default_wrap_angle = 360*u.deg
+    _wrap_angle = 360*u.deg
     obstime = TimeFrameAttributeSunPy()
 
 
-class Heliocentric(BaseCoordinateFrame):
+class Heliocentric(SunPyBaseCoordinateFrame):
     """
     A coordinate or frame in the Heliocentric system.
 
@@ -365,15 +376,6 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     obstime = TimeFrameAttributeSunPy()
     rsun = Attribute(default=_RSUN.to(u.km))
     observer = ObserverCoordinateAttribute(HeliographicStonyhurst, default="earth")
-    _default_wrap_angle = 180*u.deg
-
-    def __init__(self, *args, **kwargs):
-        wrap = kwargs.pop('wrap_longitude', True)
-
-        BaseCoordinateFrame.__init__(self, *args, **kwargs)
-
-        if wrap and isinstance(self._data, (UnitSphericalRepresentation, SphericalRepresentation)):
-            self._data.lon.wrap_angle = self._default_wrap_angle
 
     def calculate_distance(self):
         """


### PR DESCRIPTION
(This was originally part of #3212, but I feel that it qualifies as a bug fix to get into 1.0.2 rather than wait until 1.1.)

We intend to have all of our frames wrap longitudes at 180 degrees (i.e., the range is -180 deg to +180 deg, rather than 0 deg to +360 deg).  Prior to this PR, the longitude wrap angle would get set to the desired value if a frame was created with a `(Unit)SphericalRepresentation`.  However, that meant that if the frame was created with a `CartesianRepresentation`, and then *converted* to a `SphericalRepresentation`, the longitude wrap angle would not get set.  This happens frequently after frame transformations, such as for `AIAMap.observer_coordinate`, which gets converted from HEC coordinates and often shows HGS longitudes of ~359.99 deg rather than a small negative number.

This PR takes a different approach.  Rather than modifying the representation as it goes into the frame, the approach is to modify the representation as it comes out.  That is, the internal data can be whatever, but whenever the user asks for it as a `(Unit)SphericalRepresentation`, it is provided with the desired wrap angle.