### PR TITLE
Bugfix in differential rotation when passing time

### DIFF
--- a/changelog/3225.bugfix.rst
+++ b/changelog/3225.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where passing a time or time interval to the differential rotation function threw an error because the new observer was not in HGS.

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -10,6 +10,7 @@ from astropy.time import TimeDelta
 from sunpy.coordinates import HeliographicStonyhurst, Helioprojective, Heliocentric
 from sunpy.map import (all_coordinates_from_map, contains_full_disk, coordinate_is_on_solar_disk,
                        is_all_off_disk, is_all_on_disk, map_edges, on_disk_bounding_coordinates)
+from sunpy.map.header_helper import get_observer_meta
 from sunpy.time import parse_time
 from sunpy.util import expand_list
 
@@ -579,9 +580,7 @@ def differential_rotate(smap, observer=None, time=None, **diff_rot_kwargs):
         out_meta.pop(key)
 
     # Add a new HGS observer
-    out_meta['hglt_obs'] = new_observer.transform_to('heliographic_stonyhurst').lat.value
-    out_meta['hgln_obs'] = new_observer.transform_to('heliographic_stonyhurst').lon.value
-    out_meta['dsun_obs'] = new_observer.transform_to('heliographic_stonyhurst').radius.to(u.m).value
+    out_meta.update(get_observer_meta(new_observer, out_meta['rsun_ref']*u.m))
 
     if is_sub_full_disk:
         # Define a new reference pixel and the value at the reference pixel.

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -579,9 +579,9 @@ def differential_rotate(smap, observer=None, time=None, **diff_rot_kwargs):
         out_meta.pop(key)
 
     # Add a new HGS observer
-    out_meta['hglt_obs'] = new_observer.lat.value
-    out_meta['hgln_obs'] = new_observer.lon.value
-    out_meta['dsun_obs'] = new_observer.radius.to(u.m).value
+    out_meta['hglt_obs'] = new_observer.transform_to('heliographic_stonyhurst').lat.value
+    out_meta['hgln_obs'] = new_observer.transform_to('heliographic_stonyhurst').lon.value
+    out_meta['dsun_obs'] = new_observer.transform_to('heliographic_stonyhurst').radius.to(u.m).value
 
     if is_sub_full_disk:
         # Define a new reference pixel and the value at the reference pixel.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

This is a reincarnation of #3190 because I did something awful to that PR...

Fixes #3189 

This PR addresses an issue with sunpy.physics.differential_rotation.differential_rotate where an error was thrown when passing a time because the new observer was not in HGS (see #3189).
