### PR TITLE
Fixed `get_horizons_coord()` to work with `Time` array input

### DIFF
--- a/changelog/3227.bugfix.rst
+++ b/changelog/3227.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug where `~sunpy.coordinates.ephemeris.get_horizons_coord` was unable to accept `~astropy.time.Time` arrays as input.

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -10,6 +10,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 
 from sunpy.coordinates.ephemeris import *
+from sunpy.time import parse_time
 
 
 def test_get_body_heliographic_stonyhurst():
@@ -20,8 +21,7 @@ def test_get_body_heliographic_stonyhurst():
     assert_quantity_allclose(e1.radius, 0.9832947*u.AU, atol=5e-7*u.AU)
 
     e2 = get_body_heliographic_stonyhurst('earth', '2013-Sep-01')
-    # https://github.com/sunpy/sunpy/issues/2727
-    assert_quantity_allclose((e2.lon+1*u.deg)%(360*u.deg), 1*u.deg, atol=1e-12*u.deg)
+    assert_quantity_allclose(e2.lon, 0*u.deg, atol=1e-12*u.deg)
     assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)
 
@@ -61,18 +61,45 @@ def test_get_horizons_coord(tmpdir):
     # get_horizons_coord() depends on astroquery
     astroquery = pytest.importorskip("astroquery")
 
+    # Validate against published values from the Astronomical Almanac (2013)
     with set_temp_cache(tmpdir):
-        # Validate against published values from the Astronomical Almanac (2013)
         e1 = get_horizons_coord('Geocenter', '2013-Jan-01')
-    assert_quantity_allclose((e1.lon + 1*u.deg) % (360*u.deg), 1*u.deg, atol=5e-6*u.deg)
+    assert_quantity_allclose(e1.lon, 0*u.deg, atol=5e-6*u.deg)
     assert_quantity_allclose(e1.lat, -3.03*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e1.radius, 0.9832947*u.AU, atol=5e-7*u.AU)
 
     with set_temp_cache(tmpdir):
         e2 = get_horizons_coord('Geocenter', '2013-Sep-01')
-    assert_quantity_allclose((e2.lon + 1*u.deg) % (360*u.deg), 1*u.deg, atol=5e-6*u.deg)
+    assert_quantity_allclose(e1.lon, 0*u.deg, atol=5e-6*u.deg)
     assert_quantity_allclose(e2.lat, 7.19*u.deg, atol=5e-3*u.deg)
     assert_quantity_allclose(e2.radius, 1.0092561*u.AU, atol=5e-7*u.AU)
+
+
+@pytest.mark.remote_data
+def test_get_horizons_coord_array_time(tmpdir):
+    # get_horizons_coord() depends on astroquery
+    astroquery = pytest.importorskip("astroquery")
+
+    # Validate against published values from the Astronomical Almanac (2013, C8-C13)
+    array_time = Time(['2013-05-01', '2013-06-01', '2013-04-01', '2013-03-01'])
+    with set_temp_cache(tmpdir):
+        e = get_horizons_coord('Geocenter', array_time)
+
+    assert_quantity_allclose(e[0].lon, 0*u.deg, atol=5e-6*u.deg)
+    assert_quantity_allclose(e[0].lat, -4.17*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e[0].radius, 1.0075271*u.AU, atol=5e-7*u.AU)
+
+    assert_quantity_allclose(e[1].lon, 0*u.deg, atol=5e-6*u.deg)
+    assert_quantity_allclose(e[1].lat, -0.66*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e[1].radius, 1.0140013*u.AU, atol=5e-7*u.AU)
+
+    assert_quantity_allclose(e[2].lon, 0*u.deg, atol=5e-6*u.deg)
+    assert_quantity_allclose(e[2].lat, -6.54*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e[2].radius, 0.9992311*u.AU, atol=5e-7*u.AU)
+
+    assert_quantity_allclose(e[3].lon, 0*u.deg, atol=5e-6*u.deg)
+    assert_quantity_allclose(e[3].lat, -7.22*u.deg, atol=5e-3*u.deg)
+    assert_quantity_allclose(e[3].radius, 0.9908173*u.AU, atol=5e-7*u.AU)
 
 
 @pytest.mark.remote_data
@@ -81,7 +108,8 @@ def test_consistency_with_horizons(tmpdir):
     astroquery = pytest.importorskip("astroquery")
 
     # Check whether the location of Earth is the same between Astropy and JPL HORIZONS
-    e1 = get_earth()
+    now = parse_time('now')
+    e1 = get_earth(now)
     with set_temp_cache(tmpdir):
-        e2 = get_horizons_coord('Geocenter')
+        e2 = get_horizons_coord('Geocenter', now)
     assert_quantity_allclose(e1.separation_3d(e2), 0*u.km, atol=35*u.km)


### PR DESCRIPTION
Previously, `get_horizons_coord()` would crash if provided a `Time` array.  Now it doesn't.