### PR TITLE
Remove pytest warnings capture

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ testpaths = "sunpy" "docs"
 norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "astropy_helpers" "examples" "sunpy[\/]data"
 doctest_plus = enabled
 doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
-addopts = -p no:warnings --doctest-rst -m "not figure"
+addopts = --doctest-rst -m "not figure"
 markers =
     online: marks this test function as needing online connectivity.
     figure: marks this test function as using hash-based Matplotlib figure verification. This mark is not meant to be directly applied, but is instead automatically applied when a test function uses the @sunpy.tests.helpers.figure_test decorator.


### PR DESCRIPTION
xref #2886 - I think the time may have come to face up to the test suite warnings, and not just silently ignore them. There's still a handful to fix, but maybe others will feel more motivated to fix them if they see them in their test logs 😉 