### PR TITLE
Fixed HCRS<->HGS transformations to work with changing observation times

### DIFF
--- a/changelog/3246.bugfix.rst
+++ b/changelog/3246.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with the handling of changing observation times for transformations between `~astropy.coordinates.HCRS` and `~sunpy.coordinates.frames.HeliographicStonyhurst`, which also indirectly affected other transformations when changing observation times.

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -300,8 +300,8 @@ def test_hgs_hgs():
     new = old.transform_to(HeliographicStonyhurst(obstime=obstime + 1*u.day))
 
     assert_quantity_allclose(new.lon, old.lon - 1*u.deg, atol=0.1*u.deg)  # due to Earth motion
-    assert_quantity_allclose(new.lat, old.lat)
-    assert_quantity_allclose(new.radius, old.radius)
+    assert_quantity_allclose(new.lat, old.lat, atol=1e-3*u.deg)
+    assert_quantity_allclose(new.radius, old.radius, atol=1e-5*u.AU)
 
 
 def test_hgc_hgc():
@@ -311,8 +311,8 @@ def test_hgc_hgc():
     new = old.transform_to(HeliographicCarrington(obstime=obstime + 1*u.day))
 
     assert_quantity_allclose(new.lon, old.lon - 14.1844*u.deg, atol=1e-4*u.deg)  # solar rotation
-    assert_quantity_allclose(new.lat, old.lat)
-    assert_quantity_allclose(new.radius, old.radius)
+    assert_quantity_allclose(new.lat, old.lat, atol=1e-4*u.deg)
+    assert_quantity_allclose(new.radius, old.radius, atol=1e-5*u.AU)
 
 
 def test_hgs_hcrs_sunspice():


### PR DESCRIPTION
FIxes #3187 

The transformations are now `AffineTransform` rather than `DynamicMatrixTransform` to take into account the small origin shift.