### PR TITLE
Fixing transformations to handle a change in observation time and to handle velocities

### DIFF
--- a/changelog/3247.bugfix.1.rst
+++ b/changelog/3247.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fixed all coordinate transformations to properly handle a change in observation time.

--- a/changelog/3247.bugfix.2.rst
+++ b/changelog/3247.bugfix.2.rst
@@ -1,0 +1,1 @@
+Fixed the handling of coordinates with velocity information when transforming between Astropy frames and SunPy frames.

--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -130,8 +130,8 @@ coordinates is::
    <SkyCoord (Helioprojective: obstime=2017-07-26T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty) in arcsec
        (0., 0.)>
    >>> c.transform_to(frames.HeliographicCarrington)
-   <SkyCoord (HeliographicCarrington: obstime=2017-07-26T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
-      (283.95274241, 5.31701821, 695700.00000125)>
+   <SkyCoord (HeliographicCarrington: obstime=2017-07-26T00:00:00.000): (lon, lat, radius) in (deg, deg, AU)
+      (283.95274241, 5.31701821, 0.00465047)>
 
 It is also possible to transform to any coordinate system implemented in Astropy. This can be used to find the position of the solar limb in AltAz equatorial coordinates::
 

--- a/docs/guide/units-coordinates.rst
+++ b/docs/guide/units-coordinates.rst
@@ -189,8 +189,8 @@ one observer to a coordinate seen by another::
 
   >>> hpc1.transform_to(frames.Helioprojective(observer="venus",
   ...                                          obstime="2017-07-26"))
-  <SkyCoord (Helioprojective: obstime=2017-07-26T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'venus'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
-      (-1285.47497992, 106.20918654, 1.0831774e+08)>
+  <SkyCoord (Helioprojective: obstime=2017-07-26T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'venus'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+      (-1285.47497992, 106.20918654, 0.72405937)>
 
 
 Using Coordinates with SunPy Map

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -4,7 +4,9 @@ import pytest
 import astropy.units as u
 from astropy.tests.helper import quantity_allclose, assert_quantity_allclose
 from astropy.coordinates import (SkyCoord, get_body_barycentric, Angle,
-                                 ConvertError, Longitude, CartesianRepresentation)
+                                 ConvertError, Longitude, CartesianRepresentation,
+                                 get_body_barycentric_posvel,
+                                 CartesianDifferential, SphericalDifferential)
 # Versions of Astropy that do not have HeliocentricMeanEcliptic have the same frame
 # with the misleading name HeliocentricTrueEcliptic
 try:
@@ -384,3 +386,41 @@ def test_hgs_hcc_sunspice():
     assert_quantity_allclose(new.x, 800000.00*u.km, atol=1e-2*u.km)
     assert_quantity_allclose(new.y, 908797.89*u.km, atol=1e-2*u.km)
     assert_quantity_allclose(new.z, 688539.32*u.km, atol=1e-2*u.km)
+
+
+def test_velocity_hcrs_hgs():
+    # Obtain the position/velocity of Earth in ICRS
+    obstime = Time(['2019-01-01', '2019-04-01', '2019-07-01', '2019-10-01'])
+    pos, vel = get_body_barycentric_posvel('earth', obstime)
+    loc = pos.with_differentials(vel.represent_as(CartesianDifferential))
+    earth = SkyCoord(loc, frame='icrs', obstime=obstime)
+
+    # The velocity of Earth in HGS should be very close to zero.  The velocity in the HGS Y
+    # direction is slightly further away from zero because there is true latitudinal motion.
+    new = earth.heliographic_stonyhurst
+    assert_quantity_allclose(new.velocity.d_x, 0*u.km/u.s, atol=1e-15*u.km/u.s)
+    assert_quantity_allclose(new.velocity.d_y, 0*u.km/u.s, atol=1e-14*u.km/u.s)
+    assert_quantity_allclose(new.velocity.d_x, 0*u.km/u.s, atol=1e-15*u.km/u.s)
+
+    # Test the loopback to ICRS
+    newer = new.icrs
+    assert_quantity_allclose(newer.velocity.d_x, vel.x)
+    assert_quantity_allclose(newer.velocity.d_y, vel.y)
+    assert_quantity_allclose(newer.velocity.d_z, vel.z)
+
+
+def test_velocity_hgs_hgc():
+    # Construct a simple HGS coordinate with zero velocity
+    obstime = Time(['2019-01-01', '2019-04-01', '2019-07-01', '2019-10-01'])
+    pos = CartesianRepresentation(1, 0, 0)*u.AU
+    vel = CartesianDifferential(0, 0, 0)*u.km/u.s
+    loc = (pos.with_differentials(vel))._apply('repeat', obstime.size)
+    coord = SkyCoord(HeliographicStonyhurst(loc, obstime=obstime))
+
+    # The induced velocity in HGC should be entirely longitudinal, and approximately equal to one
+    # full rotation every mean synodic period (27.2753 days)
+    new = coord.heliographic_carrington
+    new_vel = new.data.differentials['s'].represent_as(SphericalDifferential, new.data)
+    assert_quantity_allclose(new_vel.d_lon, -360*u.deg / (27.27253*u.day), rtol=1e-2)
+    assert_quantity_allclose(new_vel.d_lat, 0*u.deg/u.s)
+    assert_quantity_allclose(new_vel.d_distance, 0*u.km/u.s, atol=1e-7*u.km/u.s)

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -156,11 +156,11 @@ def test_hgs_hcrs():
 def test_hgs_hgc_roundtrip():
     obstime = "2011-01-01"
 
-    hgsin = HeliographicStonyhurst(lat=0*u.deg, lon=0*u.deg, obstime=obstime)
+    hgsin = HeliographicStonyhurst(lat=10*u.deg, lon=20*u.deg, obstime=obstime)
     hgcout = hgsin.transform_to(HeliographicCarrington(obstime=obstime))
 
     assert_quantity_allclose(hgsin.lat, hgcout.lat)
-    assert_quantity_allclose(hgcout.lon, sun.L0(obstime))
+    assert_quantity_allclose(hgsin.lon + sun.L0(obstime), hgcout.lon)
 
     hgsout = hgcout.transform_to(HeliographicStonyhurst(obstime=obstime))
 

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -99,7 +99,7 @@ class GreatArc(object):
         self.default_points = self._points_handler(points)
 
         # Units of the start point
-        self.distance_unit = self.start.transform_to(frames.Heliocentric).cartesian.xyz.unit
+        self.distance_unit = u.km
 
         # Co-ordinate frame
         self.start_frame = self.start.frame

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -209,8 +209,8 @@ def test_coordinate_frame(aia171_test_map):
 
 
 def test_heliographic_longitude_crln(hmi_test_map):
-    assert hmi_test_map.heliographic_longitude == hmi_test_map.carrington_longitude - \
-                                                  sun.L0(hmi_test_map.date)
+    assert_quantity_allclose(hmi_test_map.heliographic_longitude,
+                             hmi_test_map.carrington_longitude - sun.L0(hmi_test_map.date))
 
 
 def test_remove_observers(aia171_test_map):

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -223,13 +223,13 @@ def solar_rotate_coordinate(coordinate, observer=None, time=None, **diff_rot_kwa
     >>> c = SkyCoord(-570*u.arcsec, 120*u.arcsec, obstime=start_time, frame=Helioprojective)
     >>> solar_rotate_coordinate(c, time=end_time)
     <SkyCoord (Helioprojective: obstime=2010-09-11T13:34:56.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2010-09-11T13:34:56.000): (lon, lat, radius) in (deg, deg, AU)
-        (-5.08888749e-14, 7.24318962, 1.00669016)>): (Tx, Ty, distance) in (arcsec, arcsec, km)
-        (-363.04027419, 104.87807178, 1.499598e+08)>
+        (9.40248797e-16, 7.24318962, 1.00669016)>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+        (-363.04027419, 104.87807178, 1.00241935)>
     >>> new_observer = get_body("earth", end_time)
     >>> solar_rotate_coordinate(c, observer=new_observer)
     <SkyCoord (Helioprojective: obstime=2010-09-11T13:34:56.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2010-09-11T13:34:56.000): (lon, lat, radius) in (deg, deg, AU)
-        (-5.08888749e-14, 7.24318962, 1.00669016)>): (Tx, Ty, distance) in (arcsec, arcsec, km)
-        (-363.04027419, 104.87807178, 1.499598e+08)>
+        (-5.08888749e-14, 7.24318962, 1.00669016)>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+        (-363.04027419, 104.87807178, 1.00241935)>
     """
     # Check the input and create the new observer
     new_observer = _get_new_observer(coordinate.obstime, observer, time)


### PR DESCRIPTION
- The following transformations can now handle a change in observation time (which means all of ours now can)
  - HGS<->HGC
  - HGS<->HCC
  - HCC<->HPC
- The above transformations are now `FunctionTransformWithFiniteDifference` rather than `FunctionTransform` to support velocities.  (Incidentally, the underlying implementations are now the combination of matrix transforms and affine transforms, so someone in the future could "easily" re-implement everything as `AffineTransform`, but that is not done here.)
- Fixed the handling of velocities so that they are handled properly by the HCRS<->HGS transformations, so that anyone already using velocities with Astropy frames won't encounter any issues when walking into/through a SunPy frame.  (We won't tell users broadly that velocities are supported until SunPy 1.1.)