### PR TITLE
Fixed bug with trying to shift a layer relative to itself

### DIFF
--- a/changelog/3255.bugfix.rst
+++ b/changelog/3255.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `~sunpy.physics.solar_rotation.calculate_solar_rotate_shift` so that it does not calculate a shift between the reference layer and itself, which would sometimes incorrectly result in a shift of a pixel due to numerical precision.

--- a/sunpy/physics/solar_rotation.py
+++ b/sunpy/physics/solar_rotation.py
@@ -64,6 +64,10 @@ def calculate_solar_rotate_shift(mc, layer_index=0, **kwargs):
 
     # Calculate the rotations and the shifts
     for i, m in enumerate(mc):
+        # Skip the reference layer
+        if i == layer_index:
+            continue
+
         # Calculate the rotation of the center of the map 'm' at its
         # observation time to the observation time of the reference layer
         # indicated by "layer_index".

--- a/sunpy/physics/tests/test_solar_rotation.py
+++ b/sunpy/physics/tests/test_solar_rotation.py
@@ -69,7 +69,6 @@ def test_calculate_solar_rotate_shift(aia171_test_mapsequence, known_displacemen
     assert_allclose(test_output['y'].to('arcsec').value, known_displacements_layer_index1['y'], rtol=5e-2, atol=1e-5)
 
 
-@skip_32bit
 def test_mapsequence_solar_derotate(aia171_test_mapsequence, aia171_test_submap):
     # Test that a mapsequence is returned when the clipping is False.
     tmc = mapsequence_solar_derotate(aia171_test_mapsequence, clip=False)
@@ -84,7 +83,7 @@ def test_mapsequence_solar_derotate(aia171_test_mapsequence, aia171_test_submap)
     assert(isinstance(tmc, sunpy.map.MapSequence))
 
     # Test that the shape of data is correct when clipped
-    clipped_shape = (25, 18)
+    clipped_shape = (25, 19)
     for m in tmc:
         assert(m.data.shape == clipped_shape)
 


### PR DESCRIPTION
`calculate_solar_rotate_shift()` doesn't need to do anything with the reference layer.  See https://github.com/sunpy/sunpy/issues/3224#issuecomment-503170708 for the full context and why it causes issues.

Fixes #3224