### PR TITLE
Make rotate respect Dask arrays

### DIFF
--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -119,7 +119,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
             warnings.warn("Setting NaNs to 0 for SciPy rotation.", SunpyUserWarning)
         # Transform the image using the scipy affine transform
         if use_dask:
-            delayed_rotated_image = dask.delayed(scipy.ndimage.interpolation)(
+            delayed_rotated_image = dask.delayed(scipy.ndimage.interpolation.affine_transform)(
                 nan_to_num_func(image).T, rmatrix, offset=shift, order=order,
                 mode='constant', cval=missing)
             rotated_image = dask.array.from_delayed(delayed_rotated_image, dtype=image.dtype,

--- a/sunpy/instr/aia.py
+++ b/sunpy/instr/aia.py
@@ -54,7 +54,7 @@ def aiaprep(aiamap):
         scale = 0.6 * u.arcsec  # pragma: no cover # can't test this because it needs a full res image
     scale_factor = aiamap.scale[0] / scale
 
-    tempmap = aiamap.rotate(recenter=True, scale=scale_factor.value, missing=aiamap.min())
+    tempmap = aiamap.rotate(recenter=True, scale=scale_factor.value, missing=0.0)
 
     # extract center from padded aiamap.rotate output
     # crpix1 and crpix2 will be equal (recenter=True), as aiaprep does not work with submaps


### PR DESCRIPTION
Fixes #3266 

This PR makes a few minor changes in `Map.rotate()` to allow a Dask array to pass through without being brought into memory. This means that `.rotate()` returns a lazily evaluated Dask array rather than a NumPy array if the underlying data in Map is represented as a Dask array.


