### PR TITLE
Improved the layout of the frame transform graph

### DIFF
--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -524,6 +524,13 @@ def _tweak_graph(docstr):
     for frame in sunpy_frames:
         output = output.replace(frame + ' [', frame + ' [fillcolor=white ')
 
+    # Set the rank direction to be left->right (as opposed to top->bottom)
+    # Force nodes for ICRS, HCRS, and "Other frames in Astropy" to be at the same rank
+    output = output.replace('        overlap=false',
+                            '        overlap=false\n'
+                            '        rankdir=LR\n'
+                            '        {rank=same; ICRS; HCRS; Astropy}')
+
     output = output.replace('<ul>\n\n',
                             '<ul>\n\n' +
                             _add_legend_row('SunPy frames', 'white') +


### PR DESCRIPTION
For improved readability, here's a new layout for the graph showing the coordinate frames and their transformations:
![graphLR](https://user-images.githubusercontent.com/991759/61382179-49d9d580-a87a-11e9-9c35-34049d643f63.png)