### PR TITLE
Shifted the axis for calculation of edges_to_centers for LineAnimator

### DIFF
--- a/changelog/3283.bugfix.rst
+++ b/changelog/3283.bugfix.rst
@@ -1,0 +1,1 @@
+Shifted the axis for calculation of ``edges_to_centers_nd`` about ``0`` for 1D array

--- a/changelog/3283.bugfix.rst
+++ b/changelog/3283.bugfix.rst
@@ -1,1 +1,1 @@
-Shifted the axis for calculation of ``edges_to_centers_nd`` about ``0`` for 1D array
+Stop crash when ``LineAnimator`` ``axes_ranges`` entry given as ``1D`` array when data is ``>1D``, i.e. as an independent axis.

--- a/examples/plotting/imageanimatorwcs.py
+++ b/examples/plotting/imageanimatorwcs.py
@@ -45,7 +45,7 @@ wcs_input_dict = {f'{key}{n+1}': map_sequence.all_meta()[0].get(f'{key}{n}')
 # Now we need to get the time difference between the two observations.
 t0, t1 = map(parse_time, [k['date-obs'] for k in map_sequence.all_meta()])
 time_diff = (t1 - t0).to(u.s)
-wcs_input_dict.update({'CTYPE1': 'Time', 'CUNIT1': time_diff.unit.name, 'CDELT1': time_diff.value})
+wcs_input_dict.update({'CTYPE1': 'TIME', 'CUNIT1': time_diff.unit.name, 'CDELT1': time_diff.value})
 
 # We can now just pass this into astropy.wcs.WCS to create our WCS header.
 wcs = astropy.wcs.WCS(wcs_input_dict)
@@ -77,7 +77,7 @@ wcs_anim = ImageAnimatorWCS(sequence_array, wcs=wcs, vmax=1000, image_axes=[0, 1
 # of ``wcs_anim`` allows us to set various properties.
 # We assign them to a easy to remember variable name.
 # Note the order of assignment out from ``wcs_anim.axes.coords``.
-time, solar_y, solar_x = wcs_anim.axes.coords
+solar_y, solar_x = wcs_anim.axes.coords
 
 # Now we can label the X and Y axes.
 solar_x.set_axislabel('Solar X (arsec)')

--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -535,17 +535,26 @@ class ArrayAnimator(BaseFuncAnimator, metaclass=abc.ABCMeta):
         # For each axis validate and translate the axis_ranges.
         for i in self.slider_axes:
             if axis_ranges[i] is None:
+                # If axis range not supplied, set pixel center values as integers starting at 0.
                 axis_ranges[i] = np.arange(data_shape[i])
             else:
                 axis_ranges[i] = np.array(axis_ranges[i])
                 if len(axis_ranges[i]) == 2:
+                    # If axis range given as a min, max pair, derive the center of each pixel
+                    # assuming they are equally spaced.
+
                     axis_ranges[i] = np.linspace(axis_ranges[i][0], axis_ranges[i][-1],
                                                  data_shape[i]+1)
                     axis_ranges[i] = edges_to_centers_nd(axis_ranges[i], i)
                 elif axis_ranges[i].ndim == 1 and len(axis_ranges[i]) == data_shape[i]+1:
-                    # If array of individual pixel edges supplied, convert to pixel centers.
+                    # If axis range given as 1D array of pixel edges (i.e. axis is independent),
+                    # derive pixel centers.
+
                     axis_ranges[i] = edges_to_centers_nd(np.asarray(axis_ranges[i]), 0)
                 elif axis_ranges[i].ndim == ndim and axis_ranges[i].shape[i] == data_shape[i]+1:
+                    # If axis range given as array of pixel edges the same shape as
+                    # the data array (i.e. axis is not independent), derive pixel centers.
+
                     axis_ranges[i] = edges_to_centers_nd(np.asarray(axis_ranges[i]), i)
                 else:
                     raise ValueError(incompatible_axis_ranges_error_message(i))

--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -536,17 +536,19 @@ class ArrayAnimator(BaseFuncAnimator, metaclass=abc.ABCMeta):
         for i in self.slider_axes:
             if axis_ranges[i] is None:
                 axis_ranges[i] = np.arange(data_shape[i])
-            elif len(axis_ranges[i]) == 2:
-                axis_ranges[i] = np.linspace(axis_ranges[i][0], axis_ranges[i][-1],
-                                             data_shape[i]+1)
-                axis_ranges[i] = edges_to_centers_nd(axis_ranges[i], i)
-            elif axis_ranges[i].ndim == 1 and len(axis_ranges[i]) == data_shape[i]+1:
-                # If array of individual pixel edges supplied, convert to pixel centers.
-                axis_ranges[i] = edges_to_centers_nd(np.asarray(axis_ranges[i]), 0)
-            elif axis_ranges[i].ndim == ndim and axis_ranges[i].shape[i] == data_shape[i]+1:
-                axis_ranges[i] = edges_to_centers_nd(np.asarray(axis_ranges[i]), i)
             else:
-                raise ValueError(incompatible_axis_ranges_error_message(i))
+                axis_ranges[i] = np.array(axis_ranges[i])
+                if len(axis_ranges[i]) == 2:
+                    axis_ranges[i] = np.linspace(axis_ranges[i][0], axis_ranges[i][-1],
+                                                data_shape[i]+1)
+                    axis_ranges[i] = edges_to_centers_nd(axis_ranges[i], i)
+                elif axis_ranges[i].ndim == 1 and len(axis_ranges[i]) == data_shape[i]+1:
+                    # If array of individual pixel edges supplied, convert to pixel centers.
+                    axis_ranges[i] = edges_to_centers_nd(np.asarray(axis_ranges[i]), 0)
+                elif axis_ranges[i].ndim == ndim and axis_ranges[i].shape[i] == data_shape[i]+1:
+                    axis_ranges[i] = edges_to_centers_nd(np.asarray(axis_ranges[i]), i)
+                else:
+                    raise ValueError(incompatible_axis_ranges_error_message(i))
 
         return axis_ranges, extent
 

--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -540,7 +540,7 @@ class ArrayAnimator(BaseFuncAnimator, metaclass=abc.ABCMeta):
                 axis_ranges[i] = np.array(axis_ranges[i])
                 if len(axis_ranges[i]) == 2:
                     axis_ranges[i] = np.linspace(axis_ranges[i][0], axis_ranges[i][-1],
-                                                data_shape[i]+1)
+                                                 data_shape[i]+1)
                     axis_ranges[i] = edges_to_centers_nd(axis_ranges[i], i)
                 elif axis_ranges[i].ndim == 1 and len(axis_ranges[i]) == data_shape[i]+1:
                     # If array of individual pixel edges supplied, convert to pixel centers.

--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -540,8 +540,10 @@ class ArrayAnimator(BaseFuncAnimator, metaclass=abc.ABCMeta):
                 axis_ranges[i] = np.linspace(axis_ranges[i][0], axis_ranges[i][-1],
                                              data_shape[i]+1)
                 axis_ranges[i] = edges_to_centers_nd(axis_ranges[i], i)
-            elif len(axis_ranges[i]) == data_shape[i]+1:
+            elif axis_ranges[i].ndim == 1 and len(axis_ranges[i]) == data_shape[i]+1:
                 # If array of individual pixel edges supplied, convert to pixel centers.
+                axis_ranges[i] = edges_to_centers_nd(np.asarray(axis_ranges[i]), 0)
+            elif axis_ranges[i].ndim == ndim and axis_ranges[i].shape[i] == data_shape[i]+1:
                 axis_ranges[i] = edges_to_centers_nd(np.asarray(axis_ranges[i]), i)
             else:
                 raise ValueError(incompatible_axis_ranges_error_message(i))

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -95,10 +95,18 @@ class LineAnimator(ArrayAnimator):
             axis_ranges = None
         if axis_ranges is None or axis_ranges[self.plot_axis_index] is None:
             self.xdata = np.arange(data.shape[self.plot_axis_index])
+        # Else derive the xdata as the centers of the pixel/bin edges
+        # supplied by the user for the plotted axis.
         else:
-            # Else derive the xdata as the centers of the pixel/bin edges
-            # supplied by the user for the plotted axis.
-            self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]),
+            # If the shape of the array is a 1D array, get the centers about axis=0
+            if len(np.asarray(axis_ranges[self.plot_axis_index]).shape) == 1:
+                self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]),
+                                             0)
+            # Else calculate the centers across the plot_axis_index
+            # Note that we expect the axis_ranges[plot_axis_index] to be of same shape as of data
+            # i.e. axis_ranges[plot_axis_index].shape == data.shape
+            else:
+                self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]),
                                              plot_axis_index)
         if ylim is None:
             ylim = (data.min(), data.max())

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -95,17 +95,14 @@ class LineAnimator(ArrayAnimator):
             axis_ranges = None
         if axis_ranges is None or axis_ranges[self.plot_axis_index] is None:
             self.xdata = np.arange(data.shape[self.plot_axis_index])
-        # Else derive the xdata as the centers of the pixel/bin edges
-        # supplied by the user about the plotted axis. Currently we expect the
-        # axis_ranges[plot_axis_index] to be an array of pixel_edges.
+        # Else derive the xdata as pixel centers from the pixel edges supplied by the user in axis_ranges[plot_axis_index]
         else:
             # If the shape of the array is a 1D array, get the centers about axis=0
             if np.asarray(axis_ranges[self.plot_axis_index]).ndim == 1:
                 self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), 0)
 
-            # Else calculate the centers across the plot_axis_index
-            # Note that we expect the axis_ranges[plot_axis_index] to be of same shape as of data
-            # i.e. axis_ranges[plot_axis_index].shape == data.shape
+            # Else derive the xdata as pixel centers from the pixel edges supplied by the user in axis_ranges[plot_axis_index]
+            # about axis=plot_axis_index
             else:
                 self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), plot_axis_index)
         if ylim is None:

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -95,16 +95,18 @@ class LineAnimator(ArrayAnimator):
             axis_ranges = None
         if axis_ranges is None or axis_ranges[self.plot_axis_index] is None:
             self.xdata = np.arange(data.shape[self.plot_axis_index])
-        # Else derive the xdata as pixel centers from the pixel edges supplied by the user in axis_ranges[plot_axis_index]
+        # Else derive the xdata as pixel centers from the pixel edges supplied by
+        # the user in axis_ranges[plot_axis_index]
         else:
             # If the shape of the array is a 1D array, get the centers about axis=0
             if np.asarray(axis_ranges[self.plot_axis_index]).ndim == 1:
                 self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), 0)
 
-            # Else derive the xdata as pixel centers from the pixel edges supplied by the user in axis_ranges[plot_axis_index]
-            # along axis=plot_axis_index
+            # Else derive the xdata as pixel centers from the pixel edges supplied by
+            # the user in axis_ranges[plot_axis_index] along axis=plot_axis_index
             else:
-                self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), plot_axis_index)
+                self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]),
+                                                 plot_axis_index)
         if ylim is None:
             ylim = (data.min(), data.max())
         if xlim is None:

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -96,7 +96,8 @@ class LineAnimator(ArrayAnimator):
         if axis_ranges is None or axis_ranges[self.plot_axis_index] is None:
             self.xdata = np.arange(data.shape[self.plot_axis_index])
         # Else derive the xdata as the centers of the pixel/bin edges
-        # supplied by the user for the plotted axis.
+        # supplied by the user about the plotted axis. Currently we expect the
+        # axis_ranges[plot_axis_index] to be an array of pixel_edges.
         else:
             # If the shape of the array is a 1D array, get the centers about axis=0
             if np.asarray(axis_ranges[self.plot_axis_index]).ndim == 1:
@@ -106,8 +107,7 @@ class LineAnimator(ArrayAnimator):
             # Note that we expect the axis_ranges[plot_axis_index] to be of same shape as of data
             # i.e. axis_ranges[plot_axis_index].shape == data.shape
             else:
-                self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]),
-                                             plot_axis_index)
+                self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), plot_axis_index)
         if ylim is None:
             ylim = (data.min(), data.max())
         if xlim is None:

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -102,7 +102,7 @@ class LineAnimator(ArrayAnimator):
                 self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), 0)
 
             # Else derive the xdata as pixel centers from the pixel edges supplied by the user in axis_ranges[plot_axis_index]
-            # about axis=plot_axis_index
+            # along axis=plot_axis_index
             else:
                 self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), plot_axis_index)
         if ylim is None:

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -99,7 +99,7 @@ class LineAnimator(ArrayAnimator):
         # supplied by the user for the plotted axis.
         else:
             # If the shape of the array is a 1D array, get the centers about axis=0
-            if len(np.asarray(axis_ranges[self.plot_axis_index]).shape) == 1:
+            if np.asarray(axis_ranges[self.plot_axis_index]).ndim == 1:
                 self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), 0)
 
             # Else calculate the centers across the plot_axis_index

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -100,8 +100,8 @@ class LineAnimator(ArrayAnimator):
         else:
             # If the shape of the array is a 1D array, get the centers about axis=0
             if len(np.asarray(axis_ranges[self.plot_axis_index]).shape) == 1:
-                self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]),
-                                             0)
+                self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]), 0)
+
             # Else calculate the centers across the plot_axis_index
             # Note that we expect the axis_ranges[plot_axis_index] to be of same shape as of data
             # i.e. axis_ranges[plot_axis_index].shape == data.shape


### PR DESCRIPTION
This PR fixes a potential bug when one of the elements of `axes_ranges` is a `1D` array, due to which the `edges_to_centers_nd` breaks. 

Ping @DanRyanIrish @Cadair 
