### PR TITLE
Change treatment of non-finite entries before image coalignment

### DIFF
--- a/changelog/3287.removal.rst
+++ b/changelog/3287.removal.rst
@@ -1,0 +1,1 @@
+Removed the step of reparing images (replacing non-finite entries with local mean) before coaligning them. The user is expected to do this themselves before coaligning images. If NaNs/non-finite entries are present, a warning is thrown.

--- a/changelog/3287.removal.rst
+++ b/changelog/3287.removal.rst
@@ -1,1 +1,2 @@
 Removed the step of reparing images (replacing non-finite entries with local mean) before coaligning them. The user is expected to do this themselves before coaligning images. If NaNs/non-finite entries are present, a warning is thrown.
+The function repair_image_nonfinite is deprecated.

--- a/changelog/3287.removal.rst
+++ b/changelog/3287.removal.rst
@@ -1,2 +1,2 @@
 Removed the step of reparing images (replacing non-finite entries with local mean) before coaligning them. The user is expected to do this themselves before coaligning images. If NaNs/non-finite entries are present, a warning is thrown.
-The function repair_image_nonfinite is deprecated.
+The function `sunpy.image.coalignment.repair_image_nonfinite` is deprecated.

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -423,7 +423,8 @@ def apply_shifts(mc, yshift: u.pix, xshift: u.pix, clip=True, **kwargs):
 
 
 def calculate_match_template_shift(mc, template=None, layer_index=0,
-                                   func=_default_fmap_function):
+                                   func=_default_fmap_function,
+                                   repair_nonfinite=True):
     """
     Calculate the arcsecond shifts necessary to co-register the layers in a
     `~sunpy.map.MapSequence` according to a template taken from that
@@ -493,7 +494,8 @@ def calculate_match_template_shift(mc, template=None, layer_index=0,
         this_layer = func(m.data)
 
         # Calculate the y and x shifts in pixels
-        yshift, xshift = calculate_shift(this_layer, tplate)
+        yshift, xshift = calculate_shift(this_layer, tplate,
+            repair_nonfinite=repair_nonfinite)
 
         # Keep shifts in pixels
         yshift_keep[i] = yshift
@@ -515,7 +517,7 @@ def calculate_match_template_shift(mc, template=None, layer_index=0,
 # Coalignment by matching a template
 def mapsequence_coalign_by_match_template(mc, template=None, layer_index=0,
                                           func=_default_fmap_function, clip=True,
-                                          shift=None, **kwargs):
+                                          shift=None, repair_nonfinite=True, **kwargs):
     """
     Co-register the layers in a `~sunpy.map.MapSequence` according to a
     template taken from that `~sunpy.map.MapSequence`. This method REQUIRES
@@ -594,7 +596,8 @@ def mapsequence_coalign_by_match_template(mc, template=None, layer_index=0,
     if shift is None:
         shifts = calculate_match_template_shift(mc, template=template,
                                                 layer_index=layer_index,
-                                                func=func)
+                                                func=func,
+                                                repair_nonfinite=repair_nonfinite)
         xshift_arcseconds = shifts['x']
         yshift_arcseconds = shifts['y']
     else:

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -299,14 +299,10 @@ def check_for_nonfinite_entries(layer_image, template_image):
     template_image : `numpy.ndarray`
         A two-dimensional `numpy.ndarray`.
     """
-
-    bad_index_layer = np.where(np.logical_not(np.isfinite(layer_image)))
-    bad_index_template = np.where(np.logical_not(np.isfinite(template_image)))
-
-    if bad_index_layer[0].size != 0:
+    if not np.all(np.isfinite(layer_image)):
         warnings.warn("The layer image has noninfinite entries.", SunpyUserWarning)
 
-    if bad_index_template[0].size != 0:
+    if not np.all(np.isfinite(template_image)):
         warnings.warn("The template image has noninfinite entries.", SunpyUserWarning)
 
 

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -27,7 +27,7 @@ import astropy.units as u
 
 import sunpy.map
 from sunpy.map.mapbase import GenericMap
-from sunpy.util import (SunpyUserWarning, deprecated)
+from sunpy.util import (SunpyUserWarning, SunpyDeprecationWarning, deprecated)
 
 __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'match_template_to_layer', 'find_best_match_location',
@@ -47,7 +47,7 @@ def _default_fmap_function(data):
     return np.float64(data)
 
 
-def calculate_shift(this_layer, template):
+def calculate_shift(this_layer, template, repair_nonfinite=True):
     """
     Calculates the pixel shift required to put the template in the "best"
     position on a layer.
@@ -66,8 +66,16 @@ def calculate_shift(this_layer, template):
         Pixel shifts ``(yshift, xshift)`` relative to the offset of the template
         to the input array.
     """
-    # Warn user if any NANs, Infs, etc are present in the layer or the template
-    check_for_nonfinite_entries(this_layer, template)
+    if repair_nonfinite:
+        # Repair any NANs, Infs, etc in the layer and the template
+        # This behaviour is deprecated
+        warnings.warn('The value True for the repair_nonfinite kwarg is deprecated',
+            SunpyDeprecationWarning)
+        this_layer = repair_image_nonfinite(this_layer)
+        template = repair_image_nonfinite(template)
+    else:
+        # Warn user if any NANs, Infs, etc are present in the layer or the template
+        check_for_nonfinite_entries(this_layer, template)
 
     # Calculate the correlation array matching the template to this layer
     corr = match_template_to_layer(this_layer, template)

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -27,7 +27,7 @@ import astropy.units as u
 
 import sunpy.map
 from sunpy.map.mapbase import GenericMap
-from sunpy.util import (SunpyUserWarning, SunpyDeprecationWarning)
+from sunpy.util import (SunpyUserWarning, deprecated)
 
 __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'match_template_to_layer', 'find_best_match_location',
@@ -306,6 +306,7 @@ def check_for_nonfinite_entries(layer_image, template_image):
         warnings.warn('The template image has noninfinite entries.', SunpyUserWarning)
 
 
+@deprecated("1.1")
 def repair_image_nonfinite(image):
     """
     Return a new image in which all the nonfinite entries of the original image
@@ -325,7 +326,6 @@ def repair_image_nonfinite(image):
         the next non-finite value is replaced by the mean of its finite
         valued nearest neighbors.
     """
-    warnings.warn('This function has been deprecated.', SunpyDeprecationWarning)
     repaired_image = deepcopy(image)
     nx = repaired_image.shape[1]
     ny = repaired_image.shape[0]

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -69,8 +69,10 @@ def calculate_shift(this_layer, template, repair_nonfinite=True):
     if repair_nonfinite:
         # Repair any NANs, Infs, etc in the layer and the template
         # This behaviour is deprecated
-        warnings.warn('The value True for the repair_nonfinite kwarg is deprecated',
-            SunpyDeprecationWarning)
+        warnings.warn('The repairing of nonfinite values is deprecated '
+                      'and will be removed in future versions. '
+                      'You can disable this behaviour by setting the '
+                      'repair_nonfinite kwarg to False.', SunpyDeprecationWarning)
         this_layer = repair_image_nonfinite(this_layer)
         template = repair_image_nonfinite(template)
     else:
@@ -308,10 +310,18 @@ def check_for_nonfinite_entries(layer_image, template_image):
         A two-dimensional `numpy.ndarray`.
     """
     if not np.all(np.isfinite(layer_image)):
-        warnings.warn('The layer image has noninfinite entries.', SunpyUserWarning)
+        warnings.warn('The layer image has nonfinite entries. '
+                      'This could cause errors when calculating shift between two '
+                      'images. Please make sure there are no infinity or '
+                      'Not a Number values. For instance, replacing them with a '
+                      'local mean.', SunpyUserWarning)
 
     if not np.all(np.isfinite(template_image)):
-        warnings.warn('The template image has noninfinite entries.', SunpyUserWarning)
+        warnings.warn('The template image has nonfinite entries. '
+                      'This could cause errors when calculating shift between two '
+                      'images. Please make sure there are no infinity or '
+                      'Not a Number values. For instance, replacing them with a '
+                      'local mean.', SunpyUserWarning)
 
 
 @deprecated("1.1")
@@ -495,7 +505,7 @@ def calculate_match_template_shift(mc, template=None, layer_index=0,
 
         # Calculate the y and x shifts in pixels
         yshift, xshift = calculate_shift(this_layer, tplate,
-            repair_nonfinite=repair_nonfinite)
+                                         repair_nonfinite=repair_nonfinite)
 
         # Keep shifts in pixels
         yshift_keep[i] = yshift

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -226,19 +226,22 @@ def test_calculate_match_template_shift(aia171_test_mc,
     nx = aia171_test_map_layer_shape[1]
 
     # Test to see if the code can recover the displacements.
-    test_displacements = calculate_match_template_shift(aia171_test_mc)
+    with pytest.warns(SunpyDeprecationWarning):
+        test_displacements = calculate_match_template_shift(aia171_test_mc)
     assert_allclose(test_displacements['x'], aia171_mc_arcsec_displacements['x'], rtol=5e-2, atol=0)
     assert_allclose(test_displacements['y'], aia171_mc_arcsec_displacements['y'], rtol=5e-2, atol=0)
 
     # Test setting the template as a ndarray
     template_ndarray = aia171_test_map_layer[ny // 4: 3 * ny // 4, nx // 4: 3 * nx // 4]
-    test_displacements = calculate_match_template_shift(aia171_test_mc, template=template_ndarray)
+    with pytest.warns(SunpyDeprecationWarning):
+        test_displacements = calculate_match_template_shift(aia171_test_mc, template=template_ndarray)
     assert_allclose(test_displacements['x'], aia171_mc_arcsec_displacements['x'], rtol=5e-2, atol=0)
     assert_allclose(test_displacements['y'], aia171_mc_arcsec_displacements['y'], rtol=5e-2, atol=0)
 
     # Test setting the template as GenericMap
     submap = aia171_test_map.submap([nx / 4, ny / 4]*u.pix, [3 * nx / 4, 3 * ny / 4]*u.pix)
-    test_displacements = calculate_match_template_shift(aia171_test_mc, template=submap)
+    with pytest.warns(SunpyDeprecationWarning):
+        test_displacements = calculate_match_template_shift(aia171_test_mc, template=submap)
     assert_allclose(test_displacements['x'], aia171_mc_arcsec_displacements['x'], rtol=5e-2, atol=0)
     assert_allclose(test_displacements['y'], aia171_mc_arcsec_displacements['y'], rtol=5e-2, atol=0)
 
@@ -255,7 +258,8 @@ def test_mapsequence_coalign_by_match_template(aia171_test_mc,
     nx = aia171_test_map_layer_shape[1]
 
     # Get the calculated test displacements
-    test_displacements = calculate_match_template_shift(aia171_test_mc)
+    with pytest.warns(SunpyDeprecationWarning):
+        test_displacements = calculate_match_template_shift(aia171_test_mc)
 
     # Test passing in displacements
     test_mc = mapsequence_coalign_by_match_template(aia171_test_mc, shift=test_displacements)
@@ -265,14 +269,16 @@ def test_mapsequence_coalign_by_match_template(aia171_test_mc,
 
     # Test returning with no clipping.  Output layers should have the same size
     # as the original input layer.
-    test_mc = mapsequence_coalign_by_match_template(aia171_test_mc, clip=False)
+    with pytest.warns(SunpyDeprecationWarning):
+        test_mc = mapsequence_coalign_by_match_template(aia171_test_mc, clip=False)
     assert(test_mc[0].data.shape == aia171_test_map_layer_shape)
     assert(test_mc[1].data.shape == aia171_test_map_layer_shape)
 
     # Test the returned mapsequence using the default - clipping on.
     # All output layers should have the same size
     # which is smaller than the input by a known amount
-    test_mc = mapsequence_coalign_by_match_template(aia171_test_mc)
+    with pytest.warns(SunpyDeprecationWarning):
+        test_mc = mapsequence_coalign_by_match_template(aia171_test_mc)
     x_displacement_pixels = test_displacements['x'] / test_mc[0].scale[0]
     y_displacement_pixels = test_displacements['y'] / test_mc[0].scale[1]
     expected_clipping = calculate_clipping(y_displacement_pixels, x_displacement_pixels)
@@ -284,7 +290,8 @@ def test_mapsequence_coalign_by_match_template(aia171_test_mc,
     # Test the returned mapsequence explicitly using clip=True.
     # All output layers should have the same size
     # which is smaller than the input by a known amount
-    test_mc = mapsequence_coalign_by_match_template(aia171_test_mc, clip=True)
+    with pytest.warns(SunpyDeprecationWarning):
+        test_mc = mapsequence_coalign_by_match_template(aia171_test_mc, clip=True)
     x_displacement_pixels = test_displacements['x'] / test_mc[0].scale[0]
     y_displacement_pixels = test_displacements['y'] / test_mc[0].scale[1]
     expected_clipping = calculate_clipping(y_displacement_pixels, x_displacement_pixels)

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -80,13 +80,13 @@ def test_check_for_nonfinite_entries():
             b = a.reshape(3, 3)
 
             with pytest.warns(SunpyUserWarning,
-                match='The layer image has noninfinite entries.') as warning_list:
+                              match='The layer image has noninfinite entries.') as warning_list:
                 check_for_nonfinite_entries(b, np.ones((3, 3)))
 
             assert len(warning_list) == 1
 
             with pytest.warns(SunpyUserWarning,
-                match='The template image has noninfinite entries.') as warning_list:
+                              match='The template image has noninfinite entries.') as warning_list:
                 check_for_nonfinite_entries(np.ones((3, 3)), b)
 
             assert len(warning_list) == 1

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -72,7 +72,7 @@ def test_repair_image_nonfinite():
             a = np.ones(9)
             a[i] = non_number
             b = a.reshape(3, 3)
-            with pytest.warns(SunpyDeprecationWarning, match='This function has been deprecated.'):
+            with pytest.warns(SunpyDeprecationWarning):
                 c = repair_image_nonfinite(b)
 
             assert(np.isfinite(c).all())

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -93,13 +93,13 @@ def test_check_for_nonfinite_entries():
             b = a.reshape(3, 3)
 
             with pytest.warns(SunpyUserWarning,
-                              match='The layer image has noninfinite entries.') as warning_list:
+                              match='The layer image has nonfinite entries.') as warning_list:
                 check_for_nonfinite_entries(b, np.ones((3, 3)))
 
             assert len(warning_list) == 1
 
             with pytest.warns(SunpyUserWarning,
-                              match='The template image has noninfinite entries.') as warning_list:
+                              match='The template image has nonfinite entries.') as warning_list:
                 check_for_nonfinite_entries(np.ones((3, 3)), b)
 
             assert len(warning_list) == 1

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -13,9 +13,10 @@ from sunpy.image.coalignment import (_default_fmap_function, _lower_clip, _upper
                                      calculate_clipping, calculate_match_template_shift, clip_edges,
                                      find_best_match_location, get_correlation_shifts,
                                      mapsequence_coalign_by_match_template, match_template_to_layer,
-                                     parabolic_turning_point, check_for_nonfinite_entries)
+                                     parabolic_turning_point, check_for_nonfinite_entries,
+                                     repair_image_nonfinite)
 from sunpy.map import Map, MapSequence
-from sunpy.util import SunpyUserWarning
+from sunpy.util import (SunpyUserWarning, SunpyDeprecationWarning)
 
 
 @pytest.fixture
@@ -63,6 +64,18 @@ def aia171_test_template_shape(aia171_test_template):
 
 def test_parabolic_turning_point():
     assert(parabolic_turning_point(np.asarray([6.0, 2.0, 0.0])) == 1.5)
+
+
+def test_repair_image_nonfinite():
+    for i in range(0, 9):
+        for non_number in [np.nan, np.inf]:
+            a = np.ones(9)
+            a[i] = non_number
+            b = a.reshape(3, 3)
+            with pytest.warns(SunpyDeprecationWarning, match='This function has been deprecated.'):
+                c = repair_image_nonfinite(b)
+
+            assert(np.isfinite(c).all())
 
 
 def test_check_for_nonfinite_entries():


### PR DESCRIPTION
### Description

This PR removes the step of reparing images (replacing non-finite entries with local mean) before coaligning them and throws a warning if any of the images has NaNs/non-finite entries.

Fixes #3277
