### PR TITLE
Reverted the return arguments for ImageAnimatorWCS example

### DIFF
--- a/examples/plotting/imageanimatorwcs.py
+++ b/examples/plotting/imageanimatorwcs.py
@@ -77,7 +77,7 @@ wcs_anim = ImageAnimatorWCS(sequence_array, wcs=wcs, vmax=1000, image_axes=[0, 1
 # of ``wcs_anim`` allows us to set various properties.
 # We assign them to a easy to remember variable name.
 # Note the order of assignment out from ``wcs_anim.axes.coords``.
-solar_y, solar_x = wcs_anim.axes.coords
+time, solar_y, solar_x = wcs_anim.axes.coords
 
 # Now we can label the X and Y axes.
 solar_x.set_axislabel('Solar X (arsec)')


### PR DESCRIPTION
This PR fixes the return arguments of `ImageAnimatorWCS` example in `examples/plotting/imageanimatorwcs.py`.