### PR TITLE
Use `parfive.Results`, not `downloader.download()`

### DIFF
--- a/changelog/3298.bugfix.rst
+++ b/changelog/3298.bugfix.rst
@@ -1,1 +1,1 @@
-Fix parfive using the same loop once it's closed once.
+VSO client `fetch` should not download when `wait` keyword argument is specified.

--- a/changelog/3298.bugfix.rst
+++ b/changelog/3298.bugfix.rst
@@ -1,0 +1,1 @@
+Fix parfive using the same loop once it's closed once.

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -375,7 +375,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
                                                   downloader=downloader,
                                                   wait=False, **kwargs))
 
-        results = downloader.download()
+        results = Results()
         # Combine the results objects from all the clients into one Results
         # object.
         for result in reslist:

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -375,7 +375,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
                                                   downloader=downloader,
                                                   wait=False, **kwargs))
 
-        results = Results()
+        results = downloader.download()
         # Combine the results objects from all the clients into one Results
         # object.
         for result in reslist:

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -617,6 +617,8 @@ class VSOClient(BaseClient):
 
         fileids = VSOClient.by_fileid(query_response)
         if not fileids:
+            if not wait:
+                return Results()
             return downloader.download()
         # Adding the site parameter to the info
         info = {}

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -617,9 +617,7 @@ class VSOClient(BaseClient):
 
         fileids = VSOClient.by_fileid(query_response)
         if not fileids:
-            if not wait:
-                return Results()
-            return downloader.download()
+            return downloader.download() if wait else Results()
         # Adding the site parameter to the info
         info = {}
         if site is not None:


### PR DESCRIPTION
Fixes #3292. The error was raised because the loop was used and closed once
before.

