### PR TITLE
Delay the map import in the asdf tag

### DIFF
--- a/changelog/3313.bugfix.rst
+++ b/changelog/3313.bugfix.rst
@@ -1,0 +1,1 @@
+Delay import of sunpy.map into the read method of the asdf Tag.

--- a/sunpy/io/special/asdf/tags/map/generic_map.py
+++ b/sunpy/io/special/asdf/tags/map/generic_map.py
@@ -3,7 +3,6 @@ import numpy as np
 import astropy.units as u
 from asdf.yamlutil import custom_tree_to_tagged_tree
 
-import sunpy.map
 from sunpy.io.special.asdf.types import SunPyType
 
 __all__ = ['GenericMapType']
@@ -17,6 +16,7 @@ class GenericMapType(SunPyType):
 
     @classmethod
     def from_tree(cls, node, ctx):
+        import sunpy.map
         # Use the factory here to get the correct subclass back
         out_map = sunpy.map.Map(np.asarray(node['data']), node['meta'])
         out_map.shift(*node['shift'])


### PR DESCRIPTION
This code is imported when the asdf entrypoint is loaded, and the map import has many dependencies and takes some time, so this is just a little performance improvement.