### PR TITLE
Package maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,45 @@
+sunpy/cm/                         @sunpy/cm
+docs/code_ref/cm.rst              @sunpy/cm
+
+sunpy/coordiantes/                @sunpy/coordinates
+docs/code_ref/coordinates.rst     @sunpy/coordinates
+
+sunpy/database/                   @sunpy/database
+docs/code_ref/database.rst        @sunpy/database
+
+sunpy/image/                      @sunpy/image
+docs/code_ref/image.rst           @sunpy/image
+
+sunpy/instr/                      @sunpy/instr
+docs/code_ref/instr.rst           @sunpy/instr
+
+sunpy/io/                         @sunpy/io
+docs/code_ref/io.rst              @sunpy/io
+
+sunpy/map/                        @sunpy/map
+docs/code_ref/map.rst             @sunpy/map
+
+sunpy/net/                        @sunpy/net
+docs/code_ref/net.rst             @sunpy/net
+
+sunpy/physics/                    @sunpy/physics
+docs/code_ref/physics.rst         @sunpy/physics
+
+sunpy/roi/                        @sunpy/roi
+docs/code_ref/roi.rst             @sunpy/roi
+
+sunpy/sun/                        @sunpy/sun
+docs/code_ref/sun.rst             @sunpy/sun
+
+sunpy/time/                       @sunpy/time
+docs/code_ref/time.rst            @sunpy/time
+
+sunpy/timeseries/                 @sunpy/timeseries
+docs/code_ref/timeseries.rst      @sunpy/timeseries
+
+sunpy/visualization/              @sunpy/visualization
+docs/code_ref/visualization.rst   @sunpy/visualization
+
+docs/guide            @sunpy/documentation/user
+docs/dev_guide        @sunpy/documentation/developer
+examples/             @sunpy/documentation/gallery

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 sunpy/cm/                         @sunpy/cm
 docs/code_ref/cm.rst              @sunpy/cm
 
-sunpy/coordiantes/                @sunpy/coordinates
+sunpy/coordinates/                @sunpy/coordinates
 docs/code_ref/coordinates.rst     @sunpy/coordinates
 
 sunpy/database/                   @sunpy/database

--- a/docs/dev_guide/pr_review_procedure.rst
+++ b/docs/dev_guide/pr_review_procedure.rst
@@ -68,8 +68,7 @@ The membership of this group is at the discretion of the Lead Developer, but sha
 This group has `subgroups <https://github.com/orgs/sunpy/teams/sunpy-maintainers/teams>`__ for each section of the repository that has `maintainers <https://sunpy.org/team#maintainer-list>`__.
 The members of these groups will automatically be requested to review all PRs which change files in that subpackage.
 
-In general commit rights (and maintainer status) will be rescinded if more than three months passes without any activity on the SunPy repositories.
-This is still at the discretion of the lead developer and informing them you are taking a break would almost certainly lead to maintaining membership of the groups.
+Membership of the SunPy Maintainers group will be reviewed every six months, people who have not been active for this time may have their membership suspended until they return.
 
 
 SunPy Developers

--- a/docs/dev_guide/pr_review_procedure.rst
+++ b/docs/dev_guide/pr_review_procedure.rst
@@ -26,7 +26,7 @@ Before the "merge" button is clicked the following criteria must be met:
 
 * All the continuous integration must pass unless there is a known issue.
 
-* At least two members (not the author of the PR) of the "sunpy-developers" group must have approved the PR, one should be a subpackage maintainer.
+* At least two members (not the author of the PR) of the "sunpy-developers" group must have approved the PR, one should be a relevant subpackage maintainer.
 
 * All comments posted on the thread must be resolved.
 

--- a/docs/dev_guide/pr_review_procedure.rst
+++ b/docs/dev_guide/pr_review_procedure.rst
@@ -47,10 +47,6 @@ Currently we have a variety of services that respond or activate on an opened pu
 
 * `CodeCov <https://codecov.io/gh/sunpy/sunpy/>`_: Checks how many lines of the code lack test coverage.
 
-This one is ran daily and does not affect pull requests:
-
-* `Travis <https://travis-ci.org/sunpy/sunpy>`_: Runs our test suite against developer versions of Astropy and NumPy.
-
 SunPy GitHub Groups
 ===================
 
@@ -68,6 +64,13 @@ SunPy Maintainers
 
 This is the group of people who have push access to the main SunPy repository.
 The membership of this group is at the discretion of the Lead Developer, but shall generally be made up of people who have demonstrated themselves to be trust worthy and active contributors to the project.
+
+This group has `subgroups <https://github.com/orgs/sunpy/teams/sunpy-maintainers/teams>`__ for each section of the repository that has `maintainers <https://sunpy.org/team#maintainer-list>`__.
+The members of these groups will automatically be requested to review all PRs which change files in that subpackage.
+
+In general commit rights (and maintainer status) will be rescinded if more than three months passes without any activity on the SunPy repositories.
+This is still at the discretion of the lead developer and informing them you are taking a break would almost certainly lead to maintaining membership of the groups.
+
 
 SunPy Developers
 ----------------

--- a/docs/dev_guide/pr_review_procedure.rst
+++ b/docs/dev_guide/pr_review_procedure.rst
@@ -24,9 +24,9 @@ Review Process
 
 Before the "merge" button is clicked the following criteria must be met:
 
-* All the continuous integration pass unless there is a known issue.
+* All the continuous integration must pass unless there is a known issue.
 
-* At least two members (not the author of the PR) of the "sunpy-developers" group have approved the PR.
+* At least two members (not the author of the PR) of the "sunpy-developers" group must have approved the PR, one should be a subpackage maintainer.
 
 * All comments posted on the thread must be resolved.
 
@@ -68,7 +68,6 @@ The membership of this group is at the discretion of the Lead Developer, but sha
 This group has `subgroups <https://github.com/orgs/sunpy/teams/sunpy-maintainers/teams>`__ for each section of the repository that has `maintainers <https://sunpy.org/team#maintainer-list>`__.
 The members of these groups will automatically be requested to review all PRs which change files in that subpackage.
 
-Membership of the SunPy Maintainers group will be reviewed every six months, people who have not been active for this time may have their membership suspended until they return.
 
 
 SunPy Developers


### PR DESCRIPTION
This adds a [CODEOWNERS](https://help.github.com/en/articles/about-code-owners) file which will automatically request reviews from people in the [maintainers teams](https://github.com/orgs/sunpy/teams/sunpy-maintainers/teams).

In addition to this it modifies the dev docs about membership of these groups and add as no activity timeout guideline to commit rights (three months is proposed).