### PR TITLE
Add Debug logging to VSOClient 

### DIFF
--- a/changelog/3330.breaking.rst
+++ b/changelog/3330.breaking.rst
@@ -1,0 +1,2 @@
+The `sunpy.net.vso.vso.get_online_vso_url` function has been broken into two components, the new `sunpy.net.vso.vso.get_online_vso_url` function takes no arguments (it used to take three) and now only returns an online VSO mirror or None.
+The construction of a `zeep.Client` object is now handled by `sunpy.net.vso.vso.build_client` which has a more flexible API for customising the `zeep.Client` interface.

--- a/changelog/3330.feature.rst
+++ b/changelog/3330.feature.rst
@@ -1,0 +1,2 @@
+Log all VSO XML requests and responses to the SunPy logger at the ``DEBUG``
+level.

--- a/sunpy/net/tests/test_vso.py
+++ b/sunpy/net/tests/test_vso.py
@@ -8,7 +8,7 @@ from parfive import Results
 from sunpy.time import TimeRange, parse_time
 from sunpy.net import vso
 from sunpy.net.vso import attrs as va
-from sunpy.net.vso.vso import VSOClient, get_online_vso_url
+from sunpy.net.vso.vso import VSOClient, get_online_vso_url, build_client
 from sunpy.net.vso import QueryResponse
 from sunpy.net import attr
 from sunpy.tests.mocks import MockObject
@@ -443,7 +443,7 @@ def test_get_online_vso_url(mock_urlopen):
     """
     No wsdl links returned valid HTTP response? Return None
     """
-    assert get_online_vso_url(None, None, None) is None
+    assert get_online_vso_url() is None
 
 
 @mock.patch('sunpy.net.vso.vso.get_online_vso_url', return_value=None)
@@ -453,3 +453,14 @@ def test_VSOClient(mock_vso_url):
     """
     with pytest.raises(ConnectionError):
         VSOClient()
+
+
+@mock.patch('sunpy.net.vso.vso.check_connection', return_value=None)
+def test_build_client(mock_vso_url):
+    with pytest.raises(ConnectionError):
+        build_client(url="http://notathing.com/", port_name="spam")
+
+
+def test_build_client_params():
+    with pytest.raises(ValueError):
+        build_client(url="http://notathing.com/")

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -396,7 +396,7 @@ class Sample(SimpleAttr):
     @u.quantity_input
     def __init__(self, value: u.s):
         super().__init__(value)
-        self.value = value.to(u.s).value
+        self.value = value.to_value(u.s)
 
 
 class Quicklook(SimpleAttr):

--- a/sunpy/net/vso/zeep_plugins.py
+++ b/sunpy/net/vso/zeep_plugins.py
@@ -1,0 +1,16 @@
+from lxml import etree
+from zeep import Plugin
+
+from sunpy import log
+
+__all__ = ['SunPyLoggingZeepPlugin']
+
+
+class SunPyLoggingZeepPlugin(Plugin):
+    def ingress(self, envelope, http_headers, operation):
+        log.debug("VSO Response:\n " + etree.tostring(envelope, pretty_print=True).decode("utf-8"))
+        return envelope, http_headers
+
+    def egress(self, envelope, http_headers, operation, binding_options):
+        log.debug("VSO Request:\n " + etree.tostring(envelope, pretty_print=True).decode("utf-8"))
+        return envelope, http_headers


### PR DESCRIPTION
This logs at the DEBUG level all the VSO envelopes that are sent between our client and the VSO. You can enable it by setting the sunpy logger to debug:

```python
>>> from sunpy.net import Fido, attrs as a
>>> import astropy.units as u
>>> from sunpy import log

>>> log.setLevel("DEBUG")                                                                                                                                                                                        

>>> Fido.search(a.Time('2012-03-04','2012-03-06'), a.Instrument("EUVI"), a.Wavelength(304*u.AA), a.Sample(100*u.min))                                
```
```                                                                                                                                                      
DEBUG: VSO Request:
 <soap-env:Envelope xmlns:VSO="http://virtualsolar.org/VSO/VSOi" xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
  <soap-env:Body>
    <VSO:Query>
      <body>
        <block>
          <time>
            <start>20120304000000</start>
            <end>20120306000000</end>
          </time>
          <instrument>EUVI</instrument>
          <wave>
            <wavemin>304.0</wavemin>
            <wavemax>304.0</wavemax>
            <waveunit>Angstrom</waveunit>
          </wave>
          <sample>6000.0</sample>
        </block>
      </body>
    </VSO:Query>
  </soap-env:Body>
</soap-env:Envelope>
 [sunpy.net.vso.zeep_plugins]
DEBUG: VSO Response:
 <soap:Envelope xmlns:VSO="http://virtualsolar.org/VSO/VSOi" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <soap:Body>
    <VSO:QueryResponse>
      <body>
        <provideritem>
          <provider>SSC</provider>
          <error>VSO-D404 Bad Request -- Invalid Time Sample : contains non digit</error>
          <version>1</version>
        </provideritem>
      </body>
    </VSO:QueryResponse>
  </soap:Body>
</soap:Envelope>
 [sunpy.net.vso.zeep_plugins]
Out[2]: 
<sunpy.net.fido_factory.UnifiedResponse object at 0x7efbf7608790>
Results from 1 Provider:

0 Results from the VSOClient:
Start Time End Time  Source Instrument   Type 
 float64   float64  float64  float64   float64
---------- -------- ------- ---------- -------
