### PR TITLE
Great Arc now calculable when two different observers are defined

### DIFF
--- a/changelog/3334.bugfix.rst
+++ b/changelog/3334.bugfix.rst
@@ -1,1 +1,1 @@
-GreatArc now accounts for the start and end points of the arc having different observers.
+`~sunpy.coordinates.utils.GreatArc` now accounts for the start and end points of the arc having different observers.

--- a/changelog/3334.bugfix.rst
+++ b/changelog/3334.bugfix.rst
@@ -1,0 +1,1 @@
+GreatArc now accounts for the start and end points of the arc having different observers.

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -32,8 +32,20 @@ def test_great_arc_calculable(start, end):
                  observer=frames.HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU))
     gc = GreatArc(c, d)
 
-    assert gc.start == c
-    assert gc.end == d
+    assert gc.start.x == c.transform_to(frames.Heliocentric).x
+    assert gc.start.y == c.transform_to(frames.Heliocentric).y
+    assert gc.start.z == c.transform_to(frames.Heliocentric).z
+    assert gc.start.observer.lat == 0*u.deg
+    assert gc.start.observer.lon == 0*u.deg
+    assert gc.start.observer.radius == 1 * u.AU
+
+    assert gc.end.x == d.transform_to(frames.Heliocentric(observer=c.observer)).x
+    assert gc.end.y == d.transform_to(frames.Heliocentric(observer=c.observer)).y
+    assert gc.end.z == d.transform_to(frames.Heliocentric(observer=c.observer)).z
+    assert gc.end.observer.lat == 0*u.deg
+    assert gc.end.observer.lon == 0*u.deg
+    assert gc.end.observer.radius == 1 * u.AU
+
     np.testing.assert_almost_equal(gc.inner_angle.to('deg').value, 45.0)
     np.testing.assert_almost_equal(gc.radius.to('km').value, sun.constants.radius.to('km').value)
     np.testing.assert_almost_equal(gc.distance.to('km').value, sun.constants.radius.to('km').value * 2 * np.pi/8, decimal=1)
@@ -73,8 +85,12 @@ def test_great_arc_coordinates(points_requested, points_expected, first_point,
     assert isinstance(gc, GreatArc)
 
     # Test the properties of the GreatArc object
-    assert gc.start == a
-    assert gc.end == b
+    assert gc.start.x == a.transform_to(frames.Heliocentric).x
+    assert gc.start.y == a.transform_to(frames.Heliocentric).y
+    assert gc.start.z == a.transform_to(frames.Heliocentric).z
+    assert gc.end.x == b.transform_to(frames.Heliocentric(observer=a.observer)).x
+    assert gc.end.y == b.transform_to(frames.Heliocentric(observer=a.observer)).y
+    assert gc.end.z == b.transform_to(frames.Heliocentric(observer=a.observer)).z
     assert gc.distance_unit == u.km
     assert gc.observer == a.observer
     assert gc.center.x == 0 * u.km
@@ -184,17 +200,23 @@ def test_great_arc_different_observer():
 
     # The start and end points stored internally are Heliocentric
     start = gc.start
-    assert isinstance(start.observer, frames.Heliocentric)
+    assert isinstance(start.frame, frames.Heliocentric)
     end = gc.end
-    assert isinstance(end.observer, frames.Heliocentric)
+    assert isinstance(end.frame, frames.Heliocentric)
 
     # The start and end points stored internally have the same observer
-    assert start.observer.x == end.observer.x
-    assert start.observer.y == end.observer.y
-    assert start.observer.z == end.observer.z
+    assert start.observer.lon == end.observer.lon
+    assert start.observer.lat == end.observer.lat
+    assert start.observer.radius == end.observer.radius
 
     # The start point stored internally has the Heliocentric coordinates of the initial coordinate passed in.
     a2h = a.transform_to(frames.Heliocentric)
     assert start.x == a2h.x
     assert start.y == a2h.y
     assert start.z == a2h.z
+
+    # The end point stored internally has the Heliocentric coordinates of the initial coordinate passed in.
+    b2h = b.transform_to(frames.Heliocentric(observer=ma.observer_coordinate))
+    assert end.x == b2h.x
+    assert end.y == b2h.y
+    assert end.z == b2h.z

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -232,6 +232,7 @@ def test_great_arc_different_observer(aia171_test_map):
 
     # The end point stored internally has the Heliocentric coordinates of the initial coordinate passed in.
     b2h = b.transform_to(frames.Heliocentric(observer=aia171_test_map.observer_coordinate))
+
     # Missing an dp on b2h compared to end (TODO BUG?)
     np.testing.assert_almost_equal(end.x.value, b2h.x.value)
     np.testing.assert_almost_equal(end.y.value, b2h.y.value)

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -7,7 +7,8 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
-from sunpy.coordinates import frames
+from sunpy.coordinates import Heliocentric
+
 
 __all__ = ['GreatArc']
 
@@ -80,11 +81,18 @@ class GreatArc:
     """
 
     def __init__(self, start, end, center=None, points=None):
+
+        # Observer
+        self.observer = start.observer
+
+        # Co-ordinate frame of the starting point
+        self.start_frame = start.frame
+
         # Start point of the great arc
-        self.start = start
+        self.start = start.transform_to(Heliocentric)
 
         # End point of the great arc
-        self.end = end
+        self.end = end.transform_to(Heliocentric(observer=self.observer))
 
         # Parameterized location of points between the start and the end of the
         # great arc.
@@ -99,27 +107,22 @@ class GreatArc:
         self.default_points = self._points_handler(points)
 
         # Units of the start point
-        self.distance_unit = u.km
-
-        # Co-ordinate frame
-        self.start_frame = self.start.frame
-
-        # Observation time
-        self.obstime = self.start.obstime
-
-        # Observer
-        self.observer = self.start.observer
+        self.distance_unit = self.start.cartesian.xyz.unit
 
         # Set the center of the sphere
         if center is None:
             self.center = SkyCoord(0 * self.distance_unit,
                                    0 * self.distance_unit,
-                                   0 * self.distance_unit, frame=frames.Heliocentric)
+                                   0 * self.distance_unit,
+                                   frame=Heliocentric,
+                                   observer=self.observer)
+        else:
+            self.center = center.transform_to(Heliocentric(observer=self.observer))
 
         # Convert the start, end and center points to their Cartesian values
-        self.start_cartesian = self.start.transform_to(frames.Heliocentric).cartesian.xyz.to(self.distance_unit).value
-        self.end_cartesian = self.end.transform_to(frames.Heliocentric).cartesian.xyz.to(self.distance_unit).value
-        self.center_cartesian = self.center.transform_to(frames.Heliocentric).cartesian.xyz.to(self.distance_unit).value
+        self.start_cartesian = self.start.cartesian.xyz.to(self.distance_unit).value
+        self.end_cartesian = self.end.cartesian.xyz.to(self.distance_unit).value
+        self.center_cartesian = self.center.cartesian.xyz.to(self.distance_unit).value
 
         # Great arc properties calculation
         # Vector from center to first point
@@ -252,6 +255,4 @@ class GreatArc:
         return SkyCoord(great_arc_points_cartesian[:, 0],
                         great_arc_points_cartesian[:, 1],
                         great_arc_points_cartesian[:, 2],
-                        frame=frames.Heliocentric,
-                        obstime=self.obstime,
-                        observer=self.observer).transform_to(self.start_frame)
+                        frame=Heliocentric, observer=self.observer).transform_to(self.start_frame)

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -98,7 +98,7 @@ class GreatArc:
         self.start = start.transform_to(Heliocentric)
 
         # End point of the great arc
-        self.end = end.transform_to(Heliocentric(observer=self.observer))
+        self.end = end.transform_to(self.start_frame).transform_to(Heliocentric)
 
         # Parameterized location of points between the start and the end of the
         # great arc.
@@ -120,10 +120,11 @@ class GreatArc:
             self.center = SkyCoord(0 * self.distance_unit,
                                    0 * self.distance_unit,
                                    0 * self.distance_unit,
-                                   frame=Heliocentric,
-                                   observer=self.observer)
+                                   obstime=self.obstime,
+                                   observer=self.observer,
+                                   frame=Heliocentric)
         else:
-            self.center = center.transform_to(Heliocentric(observer=self.observer))
+            self.center = center.transform_to(self.start_frame).transform_to(Heliocentric)
 
         # Convert the start, end and center points to their Cartesian values
         self.start_cartesian = self.start.cartesian.xyz.to(self.distance_unit).value
@@ -262,4 +263,5 @@ class GreatArc:
                         great_arc_points_cartesian[:, 1],
                         great_arc_points_cartesian[:, 2],
                         obstime=self.obstime,
-                        frame=Heliocentric, observer=self.observer).transform_to(self.start_frame)
+                        observer=self.observer,
+                        frame=Heliocentric).transform_to(self.start_frame)

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -18,6 +18,9 @@ class GreatArc:
     Calculate the properties of a great arc at user-specified points between a
     start and end point on a sphere.
 
+    The coordinates of the great arc are returned with the observation time
+    and coordinate frame of the starting point of the arc.
+
     Parameters
     ----------
     start : `~astropy.coordinates.SkyCoord`
@@ -87,6 +90,9 @@ class GreatArc:
 
         # Co-ordinate frame of the starting point
         self.start_frame = start.frame
+
+        # Observation time
+        self.obstime = start.obstime
 
         # Start point of the great arc
         self.start = start.transform_to(Heliocentric)
@@ -255,4 +261,5 @@ class GreatArc:
         return SkyCoord(great_arc_points_cartesian[:, 0],
                         great_arc_points_cartesian[:, 1],
                         great_arc_points_cartesian[:, 2],
+                        obstime=self.obstime,
                         frame=Heliocentric, observer=self.observer).transform_to(self.start_frame)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Previously the great arc code could only generate arc coordinates if both the start and end point of the arcs had the same observer location.  This PR now allows users to pass in start and end coordinates that have different observers.  The coordinates are returned from the point of view of the start observer.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

