### PR TITLE
Fixed the mysterious change of logging level during testing

### DIFF
--- a/docs/guide/logger.rst
+++ b/docs/guide/logger.rst
@@ -50,7 +50,7 @@ or also by::
 
 The threshold level for messages can be set with::
 
-    >>> log.setLevel('DEBUG')
+    >>> log.setLevel('DEBUG')  #doctest: +SKIP
 
 This will display DEBUG and all messages with that level and above. If you'd like to see the fewest
 relevant messages you'd set the logging level to WARNING or above.


### PR DESCRIPTION
I figured it out!  Test builds have been failing because the logging level was mysteriously getting changed to "debug" and breaking doctests (e.g., https://github.com/sunpy/sunpy/pull/3339#issuecomment-528707764).  It turns out:

- The guide for our logging has example code for how to change the logging level to "debug", so the doctest of that line changed the logging level for the remainder of the testing.
- The weirdness with doctests sometimes still passing was because of how the tests are farmed out to parallel processes.  If the doctests happened to be split across multiple processes, the change in the logging level wouldn't affect some of the doctests.

This PR simply skips the doctest for that problematic line.