### PR TITLE
Add function to compute start time of a Carrington rotation

### DIFF
--- a/changelog/3360.feature.rst
+++ b/changelog/3360.feature.rst
@@ -1,0 +1,2 @@
+Added the `sunpy.coordinates.sun.carrington_rotation_starttime` function to
+compute the start time of a given Carrington rotation number.

--- a/changelog/3360.feature.rst
+++ b/changelog/3360.feature.rst
@@ -1,2 +1,2 @@
-Added the `sunpy.coordinates.sun.carrington_rotation_starttime` function to
-compute the start time of a given Carrington rotation number.
+Added the `sunpy.coordinates.sun.carrington_rotation_time` function to
+compute the time of a given Carrington rotation number.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -74,9 +74,9 @@ def sky_position(t='now', equinox_of_date=True):
     return ra, dec
 
 
-# Time in Julian Days of the start of CR1
+# Time in Julian Days (TT) of the start of the first Carrington rotation
 _FIRST_CROT_JD = 2398167.4
-# Length of a carrington rotation in days
+# Length of a Carrington rotation in days
 _CARRINGTON_ROTATION_PERIOD = 27.2753
 
 
@@ -94,13 +94,15 @@ def carrington_rotation_time(crot):
     """
     estimate = (_CARRINGTON_ROTATION_PERIOD * (crot - 1)) + _FIRST_CROT_JD
 
-    # The above estimate is wrong (see comments below in carrington_rotation_number),
-    # so put the estimate into carrington_rotaiton_number to get the fraction correction needed
+    # The above estimate is inaccurate (see comments below in carrington_rotation_number),
+    # so put the estimate into carrington_rotation_number to determine a correction amount
     def refine(estimate):
         crot_estimate = carrington_rotation_number(t=Time(estimate, format='jd'))
         dcrot = crot - crot_estimate
-        # Correct to match the value given by carrington_rotation_number
+        # Correct the estimate using a linear fraction of the Carrington rotation period
         return estimate + (dcrot * _CARRINGTON_ROTATION_PERIOD)
+
+    # Perform two iterations of the correction to achieve sub-second accuracy
     estimate = refine(estimate)
     estimate = refine(estimate)
     return parse_time(estimate, format='jd')

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -97,7 +97,7 @@ def carrington_rotation_time(crot):
     # The above estimate is inaccurate (see comments below in carrington_rotation_number),
     # so put the estimate into carrington_rotation_number to determine a correction amount
     def refine(estimate):
-        crot_estimate = carrington_rotation_number(t=Time(estimate, format='jd'))
+        crot_estimate = carrington_rotation_number(t=Time(estimate, scale='tt', format='jd'))
         dcrot = crot - crot_estimate
         # Correct the estimate using a linear fraction of the Carrington rotation period
         return estimate + (dcrot * _CARRINGTON_ROTATION_PERIOD)
@@ -105,7 +105,7 @@ def carrington_rotation_time(crot):
     # Perform two iterations of the correction to achieve sub-second accuracy
     estimate = refine(estimate)
     estimate = refine(estimate)
-    return parse_time(estimate, format='jd')
+    return Time(estimate, scale='tt', format='jd')
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -30,6 +30,7 @@ __email__ = "ayshih@gmail.com"
 
 __all__ = [
     "angular_radius", "sky_position", "carrington_rotation_number",
+    "carrington_rotation_time",
     "true_longitude", "apparent_longitude", "true_latitude", "apparent_latitude",
     "mean_obliquity_of_ecliptic", "true_rightascension", "true_declination",
     "true_obliquity_of_ecliptic", "apparent_rightascension", "apparent_declination",
@@ -84,7 +85,7 @@ def carrington_rotation_time(crot):
     Return the time of a given Carrington rotation.
 
     The round-trip from this method to `carrington_rotation_number` has
-    absolute errors of < 45 seconds at all times.
+    absolute errors of < 0.11 seconds.
 
     Parameters
     ----------
@@ -92,13 +93,17 @@ def carrington_rotation_time(crot):
         Carrington rotation number. Can be a fractional cycle number.
     """
     estimate = (_CARRINGTON_ROTATION_PERIOD * (crot - 1)) + _FIRST_CROT_JD
+
     # The above estimate is wrong (see comments below in carrington_rotation_number),
     # so put the estimate into carrington_rotaiton_number to get the fraction correction needed
-    crot_estimate = carrington_rotation_number(t=parse_time(estimate, format='jd'))
-    dcrot = crot - crot_estimate
-    # Correct to match the value given by carrington_rotation_number
-    julian_days = estimate + (dcrot * _CARRINGTON_ROTATION_PERIOD)
-    return parse_time(julian_days, format='jd')
+    def refine(estimate):
+        crot_estimate = carrington_rotation_number(t=Time(estimate, format='jd'))
+        dcrot = crot - crot_estimate
+        # Correct to match the value given by carrington_rotation_number
+        return estimate + (dcrot * _CARRINGTON_ROTATION_PERIOD)
+    estimate = refine(estimate)
+    estimate = refine(estimate)
+    return parse_time(estimate, format='jd')
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -263,8 +263,7 @@ def test_carrington_rotation_number(date, day_fraction, rotation_number):
                           ])
 def test_carrington_rotation_starttime(crot, julian_days):
     # Stated precision in the docstring is 0.11 seconds
-    atol = 0.11 / (60 * 60 * 24)
-    assert_allclose(sun.carrington_rotation_time(crot).tt.jd, julian_days, atol=atol)
+    assert_quantity_allclose(sun.carrington_rotation_time(crot).tt.jd * u.day, julian_days * u.day, atol=0.11*u.s)
 
 
 def test_carrington_rotation_roundtrip():
@@ -272,6 +271,5 @@ def test_carrington_rotation_roundtrip():
     crot = sun.carrington_rotation_number(t)
     t_roundtrip = sun.carrington_rotation_time(crot)
     dt = t - t_roundtrip
-    dt.format = 'sec'
     # Stated precision in the docstring is 0.11 seconds
-    assert np.abs(dt.value) < 0.11
+    assert_quantity_allclose(dt.to(u.s), 0*u.s, atol=0.11*u.s)

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -262,8 +262,8 @@ def test_carrington_rotation_number(date, day_fraction, rotation_number):
                           (1860, 2448872.027509),
                           ])
 def test_carrington_rotation_starttime(crot, julian_days):
-    # Stated precision in the docstring is 45 seconds
-    atol = 45 / (60 * 60 * 24)
+    # Stated precision in the docstring is 0.11 seconds
+    atol = 0.11 / (60 * 60 * 24)
     assert_allclose(sun.carrington_rotation_time(crot).tt.jd, julian_days, atol=atol)
 
 
@@ -273,5 +273,5 @@ def test_carrington_rotation_roundtrip():
     t_roundtrip = sun.carrington_rotation_time(crot)
     dt = t - t_roundtrip
     dt.format = 'sec'
-    # Stated precision in the docstring is 45 seconds
-    assert np.abs(dt.value) < 45
+    # Stated precision in the docstring is 0.11 seconds
+    assert np.abs(dt.value) < 0.11

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -1,5 +1,6 @@
 import pytest
 
+import numpy as np
 from numpy.testing import assert_allclose
 
 from astropy.coordinates import Angle, EarthLocation, SkyCoord
@@ -253,3 +254,24 @@ def test_orientation():
 def test_carrington_rotation_number(date, day_fraction, rotation_number):
     assert_allclose(sun.carrington_rotation_number(Time(date, scale='tt') + day_fraction*u.day),
                     rotation_number, rtol=0, atol=2e-4)
+
+
+@pytest.mark.parametrize("crot, julian_days",
+                         [(1, 2398167.4),
+                          (2, 2398194.6756),
+                          (1860, 2448872.027509),
+                          ])
+def test_carrington_rotation_starttime(crot, julian_days):
+    # Stated precision in the docstring is 45 seconds
+    atol = 45 / (60 * 60 * 24)
+    assert_allclose(sun.carrington_rotation_time(crot).tt.jd, julian_days, atol=atol)
+
+
+def test_carrington_rotation_roundtrip():
+    t = Time('2010-1-1')
+    crot = sun.carrington_rotation_number(t)
+    t_roundtrip = sun.carrington_rotation_time(crot)
+    dt = t - t_roundtrip
+    dt.format = 'sec'
+    # Stated precision in the docstring is 45 seconds
+    assert np.abs(dt.value) < 45


### PR DESCRIPTION
This adds the inverse of `carrington_rotation_number(time)`. The error on the roundtrip is as follows:
![Figure_1](https://user-images.githubusercontent.com/6197628/66269001-1c7a4380-e83b-11e9-8294-af8066677e44.png)

```python
import numpy as np
import matplotlib.pyplot as plt
from sunpy.coordinates import sun
from sunpy.time import parse_time
from datetime import datetime, timedelta

ts = [datetime(1853, 11, 6) + timedelta(days=i) for i in range(0, 365 * 160, 20)]
ts = parse_time(ts)

cnums = sun.carrington_rotation_number(ts)
ts_inverted = sun.carrington_rotation_time(cnums)
dt = ts_inverted - ts

fig, axs = plt.subplots(sharex=True, nrows=2)
ax = axs[0]
ax.plot(cnums, ts.datetime)
ax.set_ylabel('Date')

ax = axs[1]
dt.format = 'sec'
ax.plot(cnums, dt.value, lw=1)
ax.set_xlabel('Carrington rotation number')
ax.set_ylabel(r'Roundtrip $\Delta t$ (seconds)')

fig.tight_layout()

plt.show()
```