### PR TITLE
Correctly document TimeSeries peek() args/kwargs

### DIFF
--- a/changelog/3378.breaking.rst
+++ b/changelog/3378.breaking.rst
@@ -1,0 +1,2 @@
+:meth:`NOAAIndicesTimeSeries.peek()` now checks that the `type` argument is a
+valid string, and raises a `ValueError` if it isn't.

--- a/changelog/3378.breaking.rst
+++ b/changelog/3378.breaking.rst
@@ -1,2 +1,2 @@
-:meth:`NOAAIndicesTimeSeries.peek()` now checks that the `type` argument is a
+`NOAAIndicesTimeSeries.peek` now checks that the `type` argument is a
 valid string, and raises a `ValueError` if it isn't.

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -61,6 +61,15 @@ class ESPTimeSeries(GenericTimeSeries):
 
     @peek_show
     def peek(self, title='EVE/ESP Level1', **kwargs):
+        """
+        Parameters
+        ----------
+        title : str, optional
+            Plot title.
+        **kwargs : dict
+            Additional plot keyword arguments that are handed to
+            :meth:`pandas.DataFrame.plot`.
+        """
 
         self._validate_data_for_plotting()
 
@@ -180,9 +189,10 @@ class EVESpWxTimeSeries(GenericTimeSeries):
         Parameters
         ----------
         column : `str`, optional
-            The column to display. Defaults to `None`, so it will display all.
+            The column to display. Defaults to ``None``, so it will display all.
         **kwargs : `dict`
-            Any additional plot arguments that should be used when plotting.
+            Additional plot keyword arguments that are handed to
+            :meth:`pandas.DataFrame.plot`.
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -64,11 +64,10 @@ class ESPTimeSeries(GenericTimeSeries):
         """
         Parameters
         ----------
-        title : str, optional
+        title : `str`, optional
             Plot title.
-        **kwargs : dict
-            Additional plot keyword arguments that are handed to
-            :meth:`pandas.DataFrame.plot`.
+        **kwargs : `dict`
+            Additional plot keyword arguments that are handed to `pandas.DataFrame.plot`.
         """
 
         self._validate_data_for_plotting()
@@ -111,7 +110,8 @@ class ESPTimeSeries(GenericTimeSeries):
         colnames = ['QD', 'CH_18', 'CH_26', 'CH_30', 'CH_36']
 
         all_data = [hdulist[1].data[x] for x in colnames]
-        data = DataFrame(np.array(all_data).T, index=times.isot.astype('datetime64'), columns=colnames)
+        data = DataFrame(np.array(all_data).T, index=times.isot.astype(
+            'datetime64'), columns=colnames)
         data.sort_index(inplace=True)
 
         units = OrderedDict([('QD', u.W/u.m**2),

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -70,8 +70,6 @@ class XRSTimeSeries(GenericTimeSeries):
         ----------
         title : `str`. optional
             The title of the plot. Defaults to "GOES Xray Flux".
-        **kwargs : `dict`
-            Any additional plot arguments that should be used when plotting.
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -73,7 +73,8 @@ class LYRATimeSeries(GenericTimeSeries):
         names : `int`, optional
             The number of columns to plot. Defaults to 3.
         **kwargs : `dict`
-            Any additional plot arguments that should be used when plotting.
+            Additional plot keyword arguments that are handed to
+            :meth:`pandas.DataFrame.plot`.
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
@@ -93,10 +94,10 @@ class LYRATimeSeries(GenericTimeSeries):
                 name = lyranames[0][i] + ' \n (' + lyranames[1][i] + ')'
             axes[i].set_ylabel(f"{name} \n (W/m**2)", fontsize=9.5)
 
-        axes[0].set_title("LYRA ({0:{1}})".format(self.data.index[0],TIME_FORMAT))
+        axes[0].set_title("LYRA ({0:{1}})".format(self.data.index[0], TIME_FORMAT))
         axes[-1].set_xlabel("Time")
         for axe in axes:
-            axe.locator_params(axis='y',nbins=6)
+            axe.locator_params(axis='y', nbins=6)
 
         return figure
 

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -65,7 +65,7 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
 
         Parameters
         ----------
-        type : `str`, optional
+        type : {'sunspot SWO', 'sunspot RI', 'sunspot compare', 'radio', 'geo'}, optional
             The type of plot required. Defaults to "sunspot SWO".
         """
         # Check we have a timeseries valid for plotting
@@ -78,22 +78,24 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
             axes = self.data['sunspot SWO'].plot()
             self.data['sunspot SWO smooth'].plot()
             axes.set_ylabel('Sunspot Number')
-        if type == 'sunspot RI':
+        elif type == 'sunspot RI':
             axes = self.data['sunspot RI'].plot()
             self.data['sunspot RI smooth'].plot()
             axes.set_ylabel('Sunspot Number')
-        if type == 'sunspot compare':
+        elif type == 'sunspot compare':
             axes = self.data['sunspot RI'].plot()
             self.data['sunspot SWO'].plot()
             axes.set_ylabel('Sunspot Number')
-        if type == 'radio':
+        elif type == 'radio':
             axes = self.data['radio flux'].plot()
             self.data['radio flux smooth'].plot()
             axes.set_ylabel('Radio Flux [sfu]')
-        if type == 'geo':
+        elif type == 'geo':
             axes = self.data['geomagnetic ap'].plot()
             self.data['geomagnetic ap smooth'].plot()
             axes.set_ylabel('Geomagnetic AP Index')
+        else:
+            raise ValueError(f'Got unknown plot type "{type}"')
 
         axes.set_ylim(0)
         axes.set_title('Solar Cycle Progression')
@@ -205,7 +207,7 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         Parameters
         ----------
         **plot_args : `dict`
-            Any additional plot arguments that should be used when plotting.
+            Unused.
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
@@ -227,7 +229,6 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         axes.legend()
 
         return figure
-
 
     @staticmethod
     def _parse_file(filepath):

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -409,7 +409,8 @@ class GenericTimeSeries:
             If provided the image will be plotted on the given axes.
             Defaults to `None`, so the current axes will be used.
         **plot_args : `dict`, optional
-            Any additional plot arguments that should be used when plotting.
+            Additional plot keyword arguments that are handed to
+            :meth:`pandas.DataFrame.plot`.
 
         Returns
         -------


### PR DESCRIPTION
Sort of xref #2420. This

- Tidies and clarifies docstrings for all the `peek()` methods in timeseries sources.
- For `noaa` does a check for plot type, and errors if it's not a recognised type
- A couple of small PEP8 fixes

At some point we should standardise these (ie. always have `**plot_kwargs), but this just makes the docs align with the code.