### PR TITLE
Add shape property to TimeSeries

### DIFF
--- a/changelog/3380.feature.rst
+++ b/changelog/3380.feature.rst
@@ -1,0 +1,1 @@
+Add `shape` property to TimeSeries.

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -771,6 +771,10 @@ def test_ts_index(generic_ts):
     assert (generic_ts.index == generic_ts.data.index).all()
 
 
+def test_ts_shape(generic_ts):
+    assert generic_ts.shape == generic_ts.data.shape
+
+
 def test_ts_sort_index(generic_ts):
     assert generic_ts.sort_index().data.equals(generic_ts.data.sort_index())
 

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -142,6 +142,13 @@ class GenericTimeSeries:
         return self.data.index
 
     @property
+    def shape(self):
+        """
+        The shape of the data, a tuple (nrows, ncols).
+        """
+        return self.data.shape
+
+    @property
     def time_range(self):
         """
         The start and end times of the TimeSeries as a `~sunpy.time.TimeRange`.


### PR DESCRIPTION
This PR adds a `shape` property to the `GenericTimeSeries` class returning the shape of the data.

Fixes #3375
