### PR TITLE
Removing ".fits" from path kwarg for Fido.fetch()

### DIFF
--- a/changelog/3399.doc .rst
+++ b/changelog/3399.doc .rst
@@ -1,0 +1,1 @@
+Removing `.fits` from the end of path kwargs in `sunpy.net.FIDO.fetch` docs to change output file extension from `{file}.fits.fits` to `{file}.fits`.

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -221,16 +221,16 @@ of where the files have been downloaded to.
 
 You can also specify the path to which you want the data downloaded::
 
-  >>> downloaded_files = Fido.fetch(results, path='/ThisIs/MyPath/to/Data/{file}.fits')  # doctest: +SKIP
+  >>> downloaded_files = Fido.fetch(results, path='/ThisIs/MyPath/to/Data/{file}')  # doctest: +SKIP
 
 This downloads the query results into the directory
 ``/ThisIs/MyPath/to/Data``, naming each downloaded file with the
-filename ``{file}`` obtained from the client, and appended with the suffix
-``.fits``. You can also use other properties of the returned query
+filename ``{file}`` obtained from the client.
+You can also use other properties of the returned query
 to define the path where the data is saved.  For example, to save the
 data to a subdirectory named after the instrument, use::
 
-    >>> downloaded_files = Fido.fetch(results, path='./{instrument}/{file}.fits')  # doctest: +SKIP
+    >>> downloaded_files = Fido.fetch(results, path='./{instrument}/{file}')  # doctest: +SKIP
 
 You can see the list of options that can be specified in path for all the files
 to be downloaded with ``results.response_block_properties``.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->
Removing ".fits" from FIDO.fetch() example
Fixes  #3294