### PR TITLE
Fix markup in Map example gallery README

### DIFF
--- a/examples/map/README.txt
+++ b/examples/map/README.txt
@@ -1,5 +1,5 @@
 Map
 ===
 
-This section contains any examples which showcase how SunPy's :class:`~sunpy.map.Map`
-can be used to with solar data.
+This section contains any examples which showcase how SunPy's
+`Map <sunpy.map.map_factory.MapFactory>` can be used to with solar data.

--- a/examples/map/README.txt
+++ b/examples/map/README.txt
@@ -1,4 +1,5 @@
 Map
 ===
 
-This section contains any examples which showcase how SunPy's ~`sunpy.map.Map` can be used to with solar data.
+This section contains any examples which showcase how SunPy's :class:`~sunpy.map.Map`
+can be used to with solar data.


### PR DESCRIPTION
This should fix the link to `sunpy.map.Map`.