### PR TITLE
Explicitly sort maps for glob and directory patterns

### DIFF
--- a/changelog/3408.feature.1.rst
+++ b/changelog/3408.feature.1.rst
@@ -1,0 +1,2 @@
+The returned list of `~sunpy.map.Map` objects is now sorted by filename when
+passing a directory or glob pattern to `~sunpy.map.MapFactory`.

--- a/changelog/3408.feature.2.rst
+++ b/changelog/3408.feature.2.rst
@@ -1,0 +1,2 @@
+Single character wildcards and character ranges can now be passed as
+glob patterns to `~sunpy.map.Map`.

--- a/changelog/3408.feature.3.rst
+++ b/changelog/3408.feature.3.rst
@@ -1,0 +1,2 @@
+`~sunpy.map.Map` now accepts filenames and directories as `pathlib.Path`
+objects.

--- a/changelog/3408.feature.rst
+++ b/changelog/3408.feature.rst
@@ -1,4 +1,0 @@
-The returned list of `sunpy.map.Map` objects is now sorted by filename when passing a
-directory or glob pattern to `sunpy.map.MapFactory`. Single character wildcards and
-character ranges can now also be used as glob patterns. `sunpy.map.Map` also now accepts
-`pathlib.Path` objects, in addition to `str`, when passing a file system path.

--- a/changelog/3408.feature.rst
+++ b/changelog/3408.feature.rst
@@ -1,0 +1,4 @@
+The returned list of `sunpy.map.Map` objects is now sorted by filename when passing a
+directory or glob pattern to `sunpy.map.MapFactory`. Single character wildcards and
+character ranges can now also be used as glob patterns. `sunpy.map.Map` also now accepts
+`pathlib.Path` objects, in addition to `str`, when passing a file system path.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -207,13 +207,13 @@ class MapFactory(BasicRegistrationFactory):
             elif (isinstance(arg, str) and
                   os.path.isdir(os.path.expanduser(arg))):
                 path = os.path.expanduser(arg)
-                files = [os.path.join(path, elem) for elem in os.listdir(path)]
+                files = sorted([os.path.join(path, elem) for elem in os.listdir(path)])
                 for afile in files:
                     data_header_pairs += self._read_file(afile, **kwargs)
 
             # Glob
             elif (isinstance(arg, str) and '*' in arg):
-                files = glob.glob(os.path.expanduser(arg))
+                files = sorted(glob.glob(os.path.expanduser(arg)))
                 for afile in files:
                     data_header_pairs += self._read_file(afile, **kwargs)
 

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -125,6 +125,8 @@ class MapFactory(BasicRegistrationFactory):
 
         # File gets read here.  This needs to be generic enough to seamlessly
         # call a fits file or a jpeg2k file, etc
+        # NOTE: use os.fspath so that fname can be either a str or pathlib.Path
+        # This can be removed once read_file supports pathlib.Path
         pairs = read_file(os.fspath(fname), **kwargs)
 
         new_pairs = []
@@ -210,7 +212,7 @@ class MapFactory(BasicRegistrationFactory):
                     raise ValueError(f'{path} is neither a file nor a directory')
 
             # Glob
-            elif isinstance(arg, str) and len(glob.glob(arg)) >= 1:
+            elif isinstance(arg, str) and len(glob.glob(arg)):
                 for afile in sorted(glob.glob(arg)):
                     data_header_pairs += self._read_file(afile, **kwargs)
 

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -1,7 +1,7 @@
 import os
-import glob
 from collections import OrderedDict
 import warnings
+import pathlib
 
 import numpy as np
 import astropy.io.fits
@@ -124,7 +124,7 @@ class MapFactory(BasicRegistrationFactory):
 
         # File gets read here.  This needs to be generic enough to seamlessly
         # call a fits file or a jpeg2k file, etc
-        pairs = read_file(fname, **kwargs)
+        pairs = read_file(os.fspath(fname), **kwargs)
 
         new_pairs = []
         for pair in pairs:
@@ -197,23 +197,22 @@ class MapFactory(BasicRegistrationFactory):
                     i += 1    # an extra increment to account for the data-header pairing
 
             # File name
-            elif (isinstance(arg, str) and
-                  os.path.isfile(os.path.expanduser(arg))):
-                path = os.path.expanduser(arg)
+            elif (isinstance(arg, str) and pathlib.Path(arg).expanduser().is_file()):
+                path = pathlib.Path(arg).expanduser()
                 pairs = self._read_file(path, **kwargs)
                 data_header_pairs += pairs
 
             # Directory
-            elif (isinstance(arg, str) and
-                  os.path.isdir(os.path.expanduser(arg))):
-                path = os.path.expanduser(arg)
-                files = sorted([os.path.join(path, elem) for elem in os.listdir(path)])
+            elif (isinstance(arg, str) and pathlib.Path(arg).expanduser().is_dir()):
+                path = pathlib.Path(arg).expanduser()
+                files = sorted(list(path.glob('*')))
                 for afile in files:
                     data_header_pairs += self._read_file(afile, **kwargs)
 
             # Glob
             elif (isinstance(arg, str) and '*' in arg):
-                files = sorted(glob.glob(os.path.expanduser(arg)))
+                path = pathlib.Path(arg).expanduser().parent
+                files = sorted(list(path.glob('*')))
                 for afile in files:
                     data_header_pairs += self._read_file(afile, **kwargs)
 

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -2,6 +2,7 @@ import os
 from collections import OrderedDict
 import warnings
 import pathlib
+import glob
 
 import numpy as np
 import astropy.io.fits
@@ -211,8 +212,7 @@ class MapFactory(BasicRegistrationFactory):
 
             # Glob
             elif (isinstance(arg, str) and '*' in arg):
-                path = pathlib.Path(arg).expanduser().parent
-                files = sorted(list(path.glob('*')))
+                files = sorted(glob.glob(arg))
                 for afile in files:
                     data_header_pairs += self._read_file(afile, **kwargs)
 

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -9,6 +9,7 @@ import astropy.io.fits
 from astropy.wcs import WCS
 
 import sunpy
+from sunpy import log
 from sunpy.map.mapbase import GenericMap, MapMetaValidationError
 from sunpy.map.compositemap import CompositeMap
 from sunpy.map.mapsequence import MapSequence
@@ -98,6 +99,14 @@ class MapFactory(BasicRegistrationFactory):
 
     >>> mymap = sunpy.map.Map('local_dir/sub_dir')   # doctest: +SKIP
 
+    * A filesystem path expressed as a `pathlib.Path`
+
+    >>> import pathlib
+    >>> mymap = sunpy.map.Map(pathlib.Path('file1.fits'))   # doctest: +SKIP
+    >>> sub_dir = pathlib.Path('local_dir/sub_dir')
+    >>> mymap = sunpy.map.Map(sub_dir)   # doctest: +SKIP
+    >>> mymap = sunpy.map.Map(sub_dir / 'file3.fits')   # doctest: +SKIP
+
     * Some regex globs
 
     >>> mymap = sunpy.map.Map('eit_*.fits')   # doctest: +SKIP
@@ -127,6 +136,7 @@ class MapFactory(BasicRegistrationFactory):
         # call a fits file or a jpeg2k file, etc
         # NOTE: use os.fspath so that fname can be either a str or pathlib.Path
         # This can be removed once read_file supports pathlib.Path
+        log.debug(f'Reading {fname}')
         pairs = read_file(os.fspath(fname), **kwargs)
 
         new_pairs = []
@@ -159,8 +169,8 @@ class MapFactory(BasicRegistrationFactory):
         * data, header not in a tuple
         * data, wcs object in a tuple
         * data, wcs object not in a tuple
-        * filename, which will be read
-        * directory, from which all files will be read
+        * filename, as a str or pathlib.Path, which will be read
+        * directory, as a str or pathlib.Path, from which all files will be read
         * glob, from which all files will be read
         * url, which will be downloaded and read
         * lists containing any of the above.
@@ -212,7 +222,7 @@ class MapFactory(BasicRegistrationFactory):
                     raise ValueError(f'{path} is neither a file nor a directory')
 
             # Glob
-            elif isinstance(arg, str) and len(glob.glob(arg)):
+            elif isinstance(arg, str) and glob.glob(arg):
                 for afile in sorted(glob.glob(arg)):
                     data_header_pairs += self._read_file(afile, **kwargs)
 

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -57,6 +57,14 @@ class TestMap:
         maps_sorted = [sunpy.map.Map(os.fspath(f)) for f in files_sorted]
         assert all([m.date == m_s.date for m, m_s in zip(maps, maps_sorted)])
 
+        # Pathlib
+        path = pathlib.Path(a_fname)
+        eitmap = sunpy.map.Map(path)
+        assert isinstance(eitmap, sunpy.map.GenericMap)
+        maps = sunpy.map.Map(directory)
+        assert isinstance(maps, list)
+        assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
+
         # Glob
         pattern = os.path.join(filepath, "EIT", "*")
         maps = sunpy.map.Map(pattern)

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -49,14 +49,24 @@ class TestMap:
         assert isinstance(eitmap, sunpy.map.GenericMap)
 
         # Directory
-        maps = sunpy.map.Map(os.path.join(filepath, "EIT"))
+        directory = os.path.join(filepath, "EIT")
+        maps = sunpy.map.Map(directory)
         assert isinstance(maps, list)
         assert ([isinstance(amap,sunpy.map.GenericMap) for amap in maps])
+        # Test that returned maps are sorted
+        files_sorted = sorted([os.path.join(directory, f) for f in os.listdir(directory)])
+        maps_sorted = [sunpy.map.Map(f) for f in files_sorted]
+        assert all([m.date == m_s.date for m, m_s in zip(maps, maps_sorted)])
 
         # Glob
-        maps = sunpy.map.Map(os.path.join(filepath, "EIT", "*"))
+        pattern = os.path.join(filepath, "EIT", "*")
+        maps = sunpy.map.Map(pattern)
         assert isinstance(maps, list)
         assert ([isinstance(amap,sunpy.map.GenericMap) for amap in maps])
+        # Test that returned maps are sorted
+        files_sorted = sorted(glob.glob(pattern))
+        maps_sorted = [sunpy.map.Map(f) for f in files_sorted]
+        assert all([m.date == m_s.date for m, m_s in zip(maps, maps_sorted)])
 
         # Already a Map
         amap = sunpy.map.Map(maps[0])

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -58,12 +58,12 @@ class TestMap:
         assert all([m.date == m_s.date for m, m_s in zip(maps, maps_sorted)])
 
         # Glob
-        pattern = pathlib.Path(filepath, "EIT", "*")
-        maps = sunpy.map.Map(os.fspath(pattern))
+        pattern = os.path.join(filepath, "EIT", "*")
+        maps = sunpy.map.Map(pattern)
         assert isinstance(maps, list)
         assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
         # Test that returned maps are sorted
-        files_sorted = sorted(list(pattern.parent.glob('*')))
+        files_sorted = sorted(list(pathlib.Path(pattern).parent.glob('*')))
         maps_sorted = [sunpy.map.Map(os.fspath(f)) for f in files_sorted]
         assert all([m.date == m_s.date for m, m_s in zip(maps, maps_sorted)])
 

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -5,8 +5,8 @@ Created on Fri Jun 21 15:05:09 2013
 @author: stuart
 """
 import os
-import glob
 import tempfile
+import pathlib
 
 import pytest
 import numpy as np
@@ -19,7 +19,7 @@ import sunpy.data.test
 
 
 filepath = sunpy.data.test.rootdir
-a_list_of_many = glob.glob(os.path.join(filepath, "EIT", "*"))
+a_list_of_many = [os.fspath(f) for f in pathlib.Path(filepath, "EIT").glob("*")]
 a_fname = a_list_of_many[0]
 
 AIA_171_IMAGE = os.path.join(filepath, 'aia_171_level1.fits')
@@ -48,23 +48,23 @@ class TestMap:
         assert isinstance(eitmap, sunpy.map.GenericMap)
 
         # Directory
-        directory = os.path.join(filepath, "EIT")
-        maps = sunpy.map.Map(directory)
+        directory = pathlib.Path(filepath, "EIT")
+        maps = sunpy.map.Map(os.fspath(directory))
         assert isinstance(maps, list)
         assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
         # Test that returned maps are sorted
-        files_sorted = sorted([os.path.join(directory, f) for f in os.listdir(directory)])
-        maps_sorted = [sunpy.map.Map(f) for f in files_sorted]
+        files_sorted = sorted(list(directory.glob('*')))
+        maps_sorted = [sunpy.map.Map(os.fspath(f)) for f in files_sorted]
         assert all([m.date == m_s.date for m, m_s in zip(maps, maps_sorted)])
 
         # Glob
-        pattern = os.path.join(filepath, "EIT", "*")
-        maps = sunpy.map.Map(pattern)
+        pattern = pathlib.Path(filepath, "EIT", "*")
+        maps = sunpy.map.Map(os.fspath(pattern))
         assert isinstance(maps, list)
         assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
         # Test that returned maps are sorted
-        files_sorted = sorted(glob.glob(pattern))
-        maps_sorted = [sunpy.map.Map(f) for f in files_sorted]
+        files_sorted = sorted(list(pattern.parent.glob('*')))
+        maps_sorted = [sunpy.map.Map(os.fspath(f)) for f in files_sorted]
         assert all([m.date == m_s.date for m, m_s in zip(maps, maps_sorted)])
 
         # Already a Map

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -31,14 +31,13 @@ RHESSI_IMAGE = os.path.join(filepath, 'hsi_image_20101016_191218.fits')
 #==============================================================================
 class TestMap:
     def test_mapsequence(self):
-        #Test making a MapSequence
+        # Test making a MapSequence
         sequence = sunpy.map.Map(a_list_of_many, sequence=True)
         assert isinstance(sequence, sunpy.map.MapSequence)
 
     def test_composite(self):
-        #Test making a CompositeMap
-        comp = sunpy.map.Map(AIA_171_IMAGE, RHESSI_IMAGE,
-                         composite=True)
+        # Test making a CompositeMap
+        comp = sunpy.map.Map(AIA_171_IMAGE, RHESSI_IMAGE, composite=True)
         assert isinstance(comp, sunpy.map.CompositeMap)
 
     def test_patterns(self):
@@ -52,7 +51,7 @@ class TestMap:
         directory = os.path.join(filepath, "EIT")
         maps = sunpy.map.Map(directory)
         assert isinstance(maps, list)
-        assert ([isinstance(amap,sunpy.map.GenericMap) for amap in maps])
+        assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
         # Test that returned maps are sorted
         files_sorted = sorted([os.path.join(directory, f) for f in os.listdir(directory)])
         maps_sorted = [sunpy.map.Map(f) for f in files_sorted]
@@ -62,7 +61,7 @@ class TestMap:
         pattern = os.path.join(filepath, "EIT", "*")
         maps = sunpy.map.Map(pattern)
         assert isinstance(maps, list)
-        assert ([isinstance(amap,sunpy.map.GenericMap) for amap in maps])
+        assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
         # Test that returned maps are sorted
         files_sorted = sorted(glob.glob(pattern))
         maps_sorted = [sunpy.map.Map(f) for f in files_sorted]
@@ -75,7 +74,7 @@ class TestMap:
         # A list of filenames
         maps = sunpy.map.Map(a_list_of_many)
         assert isinstance(maps, list)
-        assert ([isinstance(amap,sunpy.map.GenericMap) for amap in maps])
+        assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
 
         # Data-header pair in a tuple
         pair_map = sunpy.map.Map((amap.data, amap.meta))
@@ -137,7 +136,7 @@ class TestMap:
         assert isinstance(amap, sunpy.map.GenericMap)
 
     def test_save(self):
-        #Test save out
+        # Test save out
         eitmap = sunpy.map.Map(a_fname)
         afilename = tempfile.NamedTemporaryFile(suffix='fits').name
         eitmap.save(afilename, filetype='fits', overwrite=True)
@@ -148,48 +147,54 @@ class TestMap:
 # Sources Tests
 #==============================================================================
     def test_sdo(self):
-        #Test an AIAMap
+        # Test an AIAMap
         aia = sunpy.map.Map(AIA_171_IMAGE)
-        assert isinstance(aia,sunpy.map.sources.AIAMap)
-        #Test a HMIMap
+        assert isinstance(aia, sunpy.map.sources.AIAMap)
+        # TODO: Test a HMIMap
 
     def test_soho(self):
-        #Test EITMap, LASCOMap & MDIMap
+        # Test EITMap, LASCOMap & MDIMap
         eit = sunpy.map.Map(os.path.join(filepath, "EIT", "efz20040301.000010_s.fits"))
-        assert isinstance(eit,sunpy.map.sources.EITMap)
+        assert isinstance(eit, sunpy.map.sources.EITMap)
 
         lasco = sunpy.map.Map(os.path.join(filepath, "lasco_c2_25299383_s.fts"))
-        assert isinstance(lasco,sunpy.map.sources.LASCOMap)
+        assert isinstance(lasco, sunpy.map.sources.LASCOMap)
 
         mdi_c = sunpy.map.Map(os.path.join(filepath, "mdi_fd_Ic_6h_01d.5871.0000_s.fits"))
-        assert isinstance(mdi_c,sunpy.map.sources.MDIMap)
+        assert isinstance(mdi_c, sunpy.map.sources.MDIMap)
 
         mdi_m = sunpy.map.Map(os.path.join(filepath, "mdi_fd_M_96m_01d.5874.0005_s.fits"))
-        assert isinstance(mdi_m,sunpy.map.sources.MDIMap)
+        assert isinstance(mdi_m, sunpy.map.sources.MDIMap)
 
     def test_stereo(self):
-        #Test EUVIMap & CORMap & HIMap
+        # Test EUVIMap & CORMap & HIMap
         euvi = sunpy.map.Map(os.path.join(filepath, "euvi_20090615_000900_n4euA_s.fts"))
-        assert isinstance(euvi,sunpy.map.sources.EUVIMap)
+        assert isinstance(euvi, sunpy.map.sources.EUVIMap)
 
         cor = sunpy.map.Map(os.path.join(filepath, "cor1_20090615_000500_s4c1A.fts"))
-        assert isinstance(cor,sunpy.map.sources.CORMap)
+        assert isinstance(cor, sunpy.map.sources.CORMap)
 
-        hi = sunpy.map.Map(os.path.join(filepath,"hi_20110910_114721_s7h2A.fts"))
-        assert isinstance(hi,sunpy.map.sources.HIMap)
+        hi = sunpy.map.Map(os.path.join(filepath, "hi_20110910_114721_s7h2A.fts"))
+        assert isinstance(hi, sunpy.map.sources.HIMap)
 
     def test_rhessi(self):
-        #Test RHESSIMap
+        # Test RHESSIMap
         rhessi = sunpy.map.Map(RHESSI_IMAGE)
-        assert isinstance(rhessi,sunpy.map.sources.RHESSIMap)
+        assert isinstance(rhessi, sunpy.map.sources.RHESSIMap)
 
     def test_sot(self):
-        #Test SOTMap
-        sot = sunpy.map.Map(os.path.join(filepath , "FGMG4_20110214_030443.7.fits"))
-        assert isinstance(sot,sunpy.map.sources.SOTMap)
+        # Test SOTMap
+        sot = sunpy.map.Map(os.path.join(filepath, "FGMG4_20110214_030443.7.fits"))
+        assert isinstance(sot, sunpy.map.sources.SOTMap)
 
-        #Test SWAPMap
+    def test_swap(self):
+        # Test SWAPMap
+        swap = sunpy.map.Map(os.path.join(filepath, "swap_lv1_20140606_000113.fits"))
+        assert isinstance(swap, sunpy.map.sources.SWAPMap)
 
-        #Test XRTMap
+    def test_xrt(self):
+        # Test XRTMap
+        xrt = sunpy.map.Map(os.path.join(filepath, "HinodeXRT.fits"))
+        assert isinstance(xrt, sunpy.map.sources.XRTMap)
 
-        #Test SXTMap
+    # TODO: Test SXTMap

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -74,6 +74,18 @@ class TestMap:
         files_sorted = sorted(list(pathlib.Path(pattern).parent.glob('*')))
         maps_sorted = [sunpy.map.Map(os.fspath(f)) for f in files_sorted]
         assert all([m.date == m_s.date for m, m_s in zip(maps, maps_sorted)])
+        # Single character wildcard (?)
+        pattern = os.path.join(filepath, "EIT", "efz20040301.0?0010_s.fits")
+        maps = sunpy.map.Map(pattern)
+        assert isinstance(maps, list)
+        assert len(maps) == 7
+        assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
+        # Character ranges
+        pattern = os.path.join(filepath, "EIT", "efz20040301.0[2-6]0010_s.fits")
+        maps = sunpy.map.Map(pattern)
+        assert isinstance(maps, list)
+        assert len(maps) == 4
+        assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
 
         # Already a Map
         amap = sunpy.map.Map(maps[0])


### PR DESCRIPTION
# Description 
Fixes #3318 by explicitly sorting maps that are created when passing in a directory or glob.

Also fixes minor pep8 issues in `test_map_factory.py` and adds factory tests for SWAP and XRT maps.
