### PR TITLE
Store colormap names instead of Colormap objects

### DIFF
--- a/changelog/3412.breaking.rst
+++ b/changelog/3412.breaking.rst
@@ -1,0 +1,4 @@
+The colormap stored in SunPy's Map subclasses (ie. ``map.plot_settings['cmap']``)
+can now be colormap string instead of the full `matplotlib.colormap.Colormap`
+object. To get the full `Colormap` object use the new attribute
+``map.cmap``.

--- a/changelog/3412.feature
+++ b/changelog/3412.feature
@@ -1,2 +1,2 @@
-`Map` objects now have a `.cmap` attribute, which returns the full colormap
+`~sunpy.map.GenericMap` objects now have a ``.cmap`` attribute, which returns the full `~matplotlib.colormap.Colormap`.
 object.

--- a/changelog/3412.feature
+++ b/changelog/3412.feature
@@ -1,0 +1,2 @@
+`Map` objects now have a `.cmap` attribute, which returns the full colormap
+object.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -478,9 +478,10 @@ very easily when initializing the normalization variable. For example::
 This clips out many of the brightest pixels. If you'd like to see what areas of
 your images got clipped set the following values::
 
-    >>> cmap = cmap.plot_settings['cmap']  # doctest: +SKIP
+    >>> cmap = map.cmap  # doctest: +SKIP
     >>> cmap.set_over('red', 1.0)  # doctest: +SKIP
     >>> cmap.set_under('green', 1.0)  # doctest: +SKIP
+    >>> map.cmap = cmap   # doctest: +SKIP
 
 This will color the areas above and below in red and green respectively
 (similar to this `example <https://matplotlib.org/examples/pylab_examples/image_masked.html>`_).
@@ -520,7 +521,7 @@ will mean that the bright regions look 'saturated'. This is achieved in the foll
     import matplotlib.colors as colors
     import sunpy.data.sample
     smap = sunpy.map.Map(sunpy.data.sample.AIA_193_CUTOUT01_IMAGE)
-    cmap = smap.plot_settings['cmap']
+    cmap = smap.cmap
     cmap.set_over('blue', 1.0)
     cmap.set_under('purple', 1.0)
     norm = colors.Normalize(vmin=0, vmax=smap.mean() + 5 * smap.std())

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -481,7 +481,6 @@ your images got clipped set the following values::
     >>> cmap = map.cmap  # doctest: +SKIP
     >>> cmap.set_over('red', 1.0)  # doctest: +SKIP
     >>> cmap.set_under('green', 1.0)  # doctest: +SKIP
-    >>> map.cmap = cmap   # doctest: +SKIP
 
 This will color the areas above and below in red and green respectively
 (similar to this `example <https://matplotlib.org/examples/pylab_examples/image_masked.html>`_).

--- a/examples/computer_vision_techniques/mask_disk.py
+++ b/examples/computer_vision_techniques/mask_disk.py
@@ -30,7 +30,7 @@ r = np.sqrt(hpc_coords.Tx ** 2 + hpc_coords.Ty ** 2) / aia.rsun_obs
 # the solar radius are masked. We also make a slight change to the colormap
 # so that masked values are shown as black instead of the default white.
 mask = ma.masked_less_equal(r, 1)
-palette = aia.plot_settings['cmap']
+palette = aia.cmap
 palette.set_bad('black')
 
 ###############################################################################

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -202,7 +202,7 @@ class GenericMap(NDData):
             norm = colors.Normalize()
 
         # Visualization attributes
-        self.plot_settings = {'cmap': cm.gray,
+        self.plot_settings = {'cmap': 'gray',
                               'norm': norm,
                               'interpolation': 'nearest',
                               'origin': 'lower'
@@ -1414,6 +1414,19 @@ class GenericMap(NDData):
         return new_map
 
 # #### Visualization #### #
+
+    @property
+    def cmap(self):
+        """
+        Return the `matplotlib.colors.Colormap` instance this map uses.
+        """
+        cmap = self.plot_settings['cmap']
+        if isinstance(cmap, str):
+            cmap = plt.get_cmap(cmap)
+            # Set the colormap to be this specific instance so we are not
+            # returning a copy
+            self.plot_settings['cmap'] = cmap
+        return cmap
 
     @u.quantity_input
     def draw_grid(self, axes=None, grid_spacing: u.deg = 15*u.deg, **kwargs):

--- a/sunpy/map/sources/hinode.py
+++ b/sunpy/map/sources/hinode.py
@@ -4,8 +4,6 @@
 __author__ = ["Jack Ireland, Jose Ivan Campos-Rozo, David Perez-Suarez"]
 __email__ = "jack.ireland@nasa.gov"
 
-import matplotlib.pyplot as plt
-
 from sunpy.map import GenericMap
 
 __all__ = ['XRTMap', 'SOTMap']
@@ -64,7 +62,7 @@ class XRTMap(GenericMap):
         self.meta['detector'] = "XRT"
 #        self.meta['instrume'] = "XRT"
         self.meta['telescop'] = "Hinode"
-        self.plot_settings['cmap'] = plt.get_cmap(name='hinodexrt')
+        self.plot_settings['cmap'] = 'hinodexrt'
 
     @property
     def measurement(self):
@@ -130,7 +128,7 @@ class SOTMap(GenericMap):
                  'SOT/SP': 'intensity',  # For the 1st 2 dimensions
                  }
 
-        self.plot_settings['cmap'] = plt.get_cmap('hinodesot' + color[self.instrument])
+        self.plot_settings['cmap'] = 'hinodesot' + color[self.instrument]
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/mlso.py
+++ b/sunpy/map/sources/mlso.py
@@ -1,5 +1,3 @@
-import matplotlib.pyplot as plt
-
 from astropy.visualization.mpl_normalize import ImageNormalize
 from astropy.visualization import PowerStretch
 import astropy.units as u
@@ -43,7 +41,7 @@ class KCorMap(GenericMap):
         self.meta['hgln_obs'] = 0.0
         self._nickname = self.detector
 
-        self.plot_settings['cmap'] = plt.get_cmap(self._get_cmap_name())
+        self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
         # Negative value pixels can appear that lead to ugly looking images.
         # This can be fixed by setting the lower limit of the normalization.

--- a/sunpy/map/sources/proba2.py
+++ b/sunpy/map/sources/proba2.py
@@ -4,8 +4,6 @@
 __author__ = "Keith Hughitt"
 __email__ = "keith.hughitt@nasa.gov"
 
-import matplotlib.pyplot as plt
-
 from sunpy.map import GenericMap
 
 __all__ = ['SWAPMap']
@@ -39,7 +37,7 @@ class SWAPMap(GenericMap):
         self.meta['obsrvtry'] = "PROBA2"
 
         self._nickname = self.detector
-        self.plot_settings['cmap'] = plt.get_cmap(name='sdoaia171')
+        self.plot_settings['cmap'] = 'sdoaia171'
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/rhessi.py
+++ b/sunpy/map/sources/rhessi.py
@@ -4,8 +4,6 @@
 __author__ = "Steven Christe"
 __email__ = "steven.d.christe@nasa.gov"
 
-import matplotlib.pyplot as plt
-
 from sunpy.map import GenericMap
 
 
@@ -57,7 +55,7 @@ class RHESSIMap(GenericMap):
 
         self.meta['waveunit'] = 'keV'
         self.meta['wavelnth'] = [self.meta['energy_l'], self.meta['energy_h']]
-        self.plot_settings['cmap'] = plt.get_cmap('rhessi')
+        self.plot_settings['cmap'] = 'rhessi'
 
     @property
     def detector(self):

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -1,7 +1,5 @@
 """SDO Map subclass definitions"""
 
-import matplotlib.pyplot as plt
-
 from astropy.coordinates import CartesianRepresentation, SkyCoord
 # Versions of Astropy that do not have HeliocentricMeanEcliptic have the same frame
 # with the misleading name HeliocentricTrueEcliptic
@@ -55,7 +53,7 @@ class AIAMap(GenericMap):
         # Fill in some missing info
         self.meta['detector'] = self.meta.get('detector', "AIA")
         self._nickname = self.detector
-        self.plot_settings['cmap'] = plt.get_cmap(self._get_cmap_name())
+        self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, AsinhStretch(0.01)))
 
     @property

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -1,6 +1,5 @@
 """SOHO Map subclass definitions"""
 
-import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import colors
 
@@ -50,7 +49,7 @@ class EITMap(GenericMap):
         super().__init__(data, header, **kwargs)
 
         self._nickname = self.detector
-        self.plot_settings['cmap'] = plt.get_cmap(self._get_cmap_name())
+        self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, PowerStretch(0.5)))
 
@@ -127,7 +126,7 @@ class LASCOMap(GenericMap):
         if 'date_obs' in self.meta:
             self.meta['date_obs'] = self.meta['date-obs']
         self._nickname = self.instrument + "-" + self.detector
-        self.plot_settings['cmap'] = plt.get_cmap('soholasco{det!s}'.format(det=self.detector[1]))
+        self.plot_settings['cmap'] = 'soholasco{det!s}'.format(det=self.detector[1])
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, PowerStretch(0.5)))
 

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -5,7 +5,6 @@ __author__ = "Keith Hughitt"
 __email__ = "keith.hughitt@nasa.gov"
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 from astropy.visualization import PowerStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
@@ -36,7 +35,7 @@ class EUVIMap(GenericMap):
 
         GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
-        self.plot_settings['cmap'] = plt.get_cmap('sohoeit{wl:d}'.format(wl=int(self.wavelength.value)))
+        self.plot_settings['cmap'] = 'sohoeit{wl:d}'.format(wl=int(self.wavelength.value))
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
         self.meta['waveunit'] = 'Angstrom'
 
@@ -102,7 +101,7 @@ class CORMap(GenericMap):
         GenericMap.__init__(self, data, header, **kwargs)
 
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
-        self.plot_settings['cmap'] = plt.get_cmap('stereocor{det!s}'.format(det=self.detector[-1]))
+        self.plot_settings['cmap'] = 'stereocor{det!s}'.format(det=self.detector[-1])
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)))
 
         # Try to identify when the FITS meta data does not have the correct
@@ -146,7 +145,7 @@ class HIMap(GenericMap):
 
         GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
-        self.plot_settings['cmap'] = plt.get_cmap('stereohi{det!s}'.format(det=self.detector[-1]))
+        self.plot_settings['cmap'] = 'stereohi{det!s}'.format(det=self.detector[-1])
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
 
         # Try to identify when the FITS meta data does not have the correct

--- a/sunpy/map/sources/suvi.py
+++ b/sunpy/map/sources/suvi.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, print_function, division
 __author__ = "Jack Ireland"
 __email__ = "jack.ireland@nasa.gov"
 
-import matplotlib.pyplot as plt
-
 from astropy.coordinates import CartesianRepresentation
 import astropy.units as u
 from astropy.visualization.mpl_normalize import ImageNormalize
@@ -81,7 +79,7 @@ class SUVIMap(GenericMap):
         self.meta["detector"] = "SUVI"
         self.meta["telescop"] = "GOES-R"
         self._nickname = self.detector
-        self.plot_settings["cmap"] = plt.get_cmap(self._get_cmap_name())
+        self.plot_settings["cmap"] = self._get_cmap_name()
         self.plot_settings["norm"] = ImageNormalize(
             stretch=source_stretch(self.meta, AsinhStretch(0.01))
         )

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -4,8 +4,6 @@
 __author__ = "Jack Ireland"
 __email__ = "jack.ireland@nasa.gov"
 
-import matplotlib.pyplot as plt
-
 from astropy.visualization import LogStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
 from sunpy.map import GenericMap
@@ -60,7 +58,7 @@ class TRACEMap(GenericMap):
         self.meta['obsrvtry'] = "TRACE"
         self._nickname = self.detector
         # Colour maps
-        self.plot_settings['cmap'] = plt.get_cmap('trace' + str(self.meta['WAVE_LEN']))
+        self.plot_settings['cmap'] = 'trace' + str(self.meta['WAVE_LEN'])
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, LogStretch()))
 
     @classmethod

--- a/sunpy/map/sources/yohkoh.py
+++ b/sunpy/map/sources/yohkoh.py
@@ -5,7 +5,6 @@ __author__ = "Jack Ireland"
 __email__ = "jack.ireland@nasa.gov"
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 from astropy.visualization import PowerStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
@@ -47,7 +46,7 @@ class SXTMap(GenericMap):
 
         self.meta['detector'] = "SXT"
         self.meta['telescop'] = "Yohkoh"
-        self.plot_settings['cmap'] = plt.get_cmap(name='yohkohsxt' + self.measurement[0:2].lower())
+        self.plot_settings['cmap'] = 'yohkohsxt' + self.measurement[0:2].lower()
         self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)))
 
         # 2012/12/19 - the SXT headers do not have a value of the distance from

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -199,6 +199,10 @@ def test_units(generic_map):
     generic_map.spatial_units == ('arcsec', 'arcsec')
 
 
+def test_cmap(generic_map):
+    assert generic_map.cmap == plt.get_cmap('gray')
+
+
 def test_coordinate_frame(aia171_test_map):
     frame = aia171_test_map.coordinate_frame
     assert isinstance(frame, sunpy.coordinates.Helioprojective)


### PR DESCRIPTION
Matplotlib doesn't care where a colormap is actually a `Colormap` or just a `str` that is in their internal colormap registry. This saves having to import Matplotlib in each different map source.