### PR TITLE
[1.0] Revert "skip a test on 1.0 only as it's causing the release to stall."

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,21 @@
+Sunpy v1.0.4 (2019-10-21)
+=========================
+
+Bug Fixes
+---------
+
+- Fix off by one error in `sunpy.map.make_fitswcs_header` where when using the
+  default ``reference_pixel=None`` keyword argument the pixel coordinate of the
+  reference pixel was off by +1. (`#3356 <https://github.com/sunpy/sunpy/pull/3356>`__)
+- Updated the URL for Fermi spacecraft-pointing files to use an HTTPS connection to HEASARC. (`#3381 <https://github.com/sunpy/sunpy/pull/3381>`__)
+
+
+Improved Documentation
+----------------------
+
+- Improved the contributing guide by updating commands and highlighting text. (`#3394 <https://github.com/sunpy/sunpy/pull/3394>`__)
+
+
 Sunpy v1.0.3 (2019-08-29)
 =========================
 

--- a/changelog/3356.bugfix.rst
+++ b/changelog/3356.bugfix.rst
@@ -1,3 +1,0 @@
-Fix off by one error in `sunpy.map.make_fitswcs_header` where when using the
-default ``reference_pixel=None`` keyword argument the pixel coordinate of the
-reference pixel was off by +1.

--- a/changelog/3381.bugfix.rst
+++ b/changelog/3381.bugfix.rst
@@ -1,1 +1,0 @@
-Updated the URL for Fermi spacecraft-pointing files to use an HTTPS connection to HEASARC.

--- a/changelog/3394.doc.rst
+++ b/changelog/3394.doc.rst
@@ -1,1 +1,0 @@
-Improved the contributing guide by updating commands and highlighting text. 

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -441,7 +441,6 @@ def test_entry_from_query_results_with_none_wave(qr_with_none_waves):
     list(entries_from_query_result(qr_with_none_waves))
 
 
-@pytest.mark.xfail
 @pytest.mark.remote_data
 def test_entry_from_query_results_with_none_wave_and_default_unit(
         qr_with_none_waves):

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -441,6 +441,7 @@ def test_entry_from_query_results_with_none_wave(qr_with_none_waves):
     list(entries_from_query_result(qr_with_none_waves))
 
 
+@pytest.mark.xfail
 @pytest.mark.remote_data
 def test_entry_from_query_results_with_none_wave_and_default_unit(
         qr_with_none_waves):


### PR DESCRIPTION
In the process of releasing 1.0.4 I skipped this test that was returning no data from the VSO. This is to un-skip it once the online build passes again.