### PR TITLE
Reduce the number of files we upload after doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,17 @@ jobs:
       - run: *sudo-apt-install
       - run: pip install -U tox
       - run: tox -e build_docs
+      - run:
+          name: Prepare for upload
+          command: |
+            # If it's not a PR, don't upload
+            if [ -z "${CIRCLE_PULL_REQUEST}" ]; then
+              rm -r docs/_build/html/*
+            else
+              # If it is a PR, delete sources, because it's a lot of files
+              # which we don't really need to upload
+              rm -r docs/_build/html/_sources
+            fi
       - store_artifacts:
           path: docs/_build/html
       - run:

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
     astropy
     astroquery
     jplephem
-commands = sphinx-build docs docs/_build/html -W -b html
+commands = sphinx-build docs docs/_build/html -W -b html -d docs/_build/.doctrees
 
 # This env requires tox-conda.
 [testenv:figure]


### PR DESCRIPTION
This should hopefully speed up the build on circle ci, and does three things:

1) Changes the location of the `.doctrees` pickles, so we don't end up uploading them.
2) Deletes the `_sources` folder which is a *lot* of files and is isn't involved in the main rendering of the docs.
3) Only uploads on PRs (credit @bsipocz astropy/astropy#9426)

@bsipocz If this works I will PR a version to Astropy.