### PR TITLE
Explicitly set the clipping to False for the default normalizers for Map sources

### DIFF
--- a/changelog/3427.bugfix.rst
+++ b/changelog/3427.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where clipping behavior had been enabled by default in the plotting normalizers for ``Map`` objects.  Clipping needs to be disabled to make use of the over/under/masked colors in the colormap.

--- a/sunpy/map/sources/mlso.py
+++ b/sunpy/map/sources/mlso.py
@@ -42,7 +42,7 @@ class KCorMap(GenericMap):
         self._nickname = self.detector
 
         self.plot_settings['cmap'] = self._get_cmap_name()
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
         # Negative value pixels can appear that lead to ugly looking images.
         # This can be fixed by setting the lower limit of the normalization.
         self.plot_settings['norm'].vmin = 0.0

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -54,7 +54,7 @@ class AIAMap(GenericMap):
         self.meta['detector'] = self.meta.get('detector', "AIA")
         self._nickname = self.detector
         self.plot_settings['cmap'] = self._get_cmap_name()
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, AsinhStretch(0.01)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, AsinhStretch(0.01)), clip=False)
 
     @property
     def _supported_observer_coordinates(self):

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -51,7 +51,7 @@ class EITMap(GenericMap):
         self._nickname = self.detector
         self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(
-            stretch=source_stretch(self.meta, PowerStretch(0.5)))
+            stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
     @property
     def detector(self):
@@ -128,7 +128,7 @@ class LASCOMap(GenericMap):
         self._nickname = self.instrument + "-" + self.detector
         self.plot_settings['cmap'] = 'soholasco{det!s}'.format(det=self.detector[1])
         self.plot_settings['norm'] = ImageNormalize(
-            stretch=source_stretch(self.meta, PowerStretch(0.5)))
+            stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
     @property
     def measurement(self):

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -36,7 +36,7 @@ class EUVIMap(GenericMap):
         GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'sohoeit{wl:d}'.format(wl=int(self.wavelength.value))
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
         self.meta['waveunit'] = 'Angstrom'
 
         # Try to identify when the FITS meta data does not have the correct
@@ -102,7 +102,7 @@ class CORMap(GenericMap):
 
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'stereocor{det!s}'.format(det=self.detector[-1])
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
         # Try to identify when the FITS meta data does not have the correct
         # date FITS keyword
@@ -146,7 +146,7 @@ class HIMap(GenericMap):
         GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'stereohi{det!s}'.format(det=self.detector[-1])
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
 
         # Try to identify when the FITS meta data does not have the correct
         # date FITS keyword

--- a/sunpy/map/sources/suvi.py
+++ b/sunpy/map/sources/suvi.py
@@ -81,7 +81,7 @@ class SUVIMap(GenericMap):
         self._nickname = self.detector
         self.plot_settings["cmap"] = self._get_cmap_name()
         self.plot_settings["norm"] = ImageNormalize(
-            stretch=source_stretch(self.meta, AsinhStretch(0.01))
+            stretch=source_stretch(self.meta, AsinhStretch(0.01)), clip=False
         )
 
     @property

--- a/sunpy/map/sources/tests/test_aia_source.py
+++ b/sunpy/map/sources/tests/test_aia_source.py
@@ -48,3 +48,8 @@ def test_measurement(createAIAMap):
     """Tests the measurement property of the AIAMap object."""
     assert createAIAMap.measurement.value in [171, 193]
     # aiaimg has 171, jp2path has 193.
+
+
+def test_norm_clip(createAIAMap):
+    # Tests that the default normalizer has clipping disabled
+    assert createAIAMap.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_cor_source.py
+++ b/sunpy/map/sources/tests/test_cor_source.py
@@ -32,3 +32,8 @@ def test_measurement():
 def test_observatory():
     """Tests the observatory property of the CORMap object."""
     assert cor.observatory == "STEREO A"
+
+
+def test_norm_clip():
+    # Tests that the default normalizer has clipping disabled
+    assert cor.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_eit_source.py
+++ b/sunpy/map/sources/tests/test_eit_source.py
@@ -52,3 +52,8 @@ def test_measurement(createEIT):
 def test_rsun(createEIT):
     """Tests the measurement property of the EITMap object."""
     assert u.allclose(createEIT.rsun_obs, 979.0701*u.arcsec)
+
+
+def test_norm_clip(createEIT):
+    # Tests that the default normalizer has clipping disabled
+    assert createEIT.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -43,3 +43,8 @@ def test_rsun_missing():
     euvi_no_rsun = Map(fitspath)
     euvi_no_rsun.meta['rsun'] = None
     assert euvi_no_rsun.rsun_obs.value == sun.angular_radius(euvi.date).to('arcsec').value
+
+
+def test_norm_clip():
+    # Tests that the default normalizer has clipping disabled
+    assert euvi.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_hi_source.py
+++ b/sunpy/map/sources/tests/test_hi_source.py
@@ -31,3 +31,7 @@ def test_observatory():
     """Tests the observatory property of the HIMap object."""
     assert hi.observatory == "STEREO A"
 
+
+def test_norm_clip():
+    # Tests that the default normalizer has clipping disabled
+    assert hi.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_kcor_source.py
+++ b/sunpy/map/sources/tests/test_kcor_source.py
@@ -45,3 +45,8 @@ def test_measurement(kcor):
 def test_observatory(kcor):
     """Tests the observatory property of the KCorMap object."""
     assert kcor.observatory == "MLSO"
+
+
+def test_norm_clip(kcor):
+    # Tests that the default normalizer has clipping disabled
+    assert kcor.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_lasco_source.py
+++ b/sunpy/map/sources/tests/test_lasco_source.py
@@ -32,3 +32,8 @@ def test_measurement():
 def test_observatory():
     """Tests the observatory property of the LASCOMap object."""
     assert lasco.observatory == "SOHO"
+
+
+def test_norm_clip():
+    # Tests that the default normalizer has clipping disabled
+    assert lasco.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_suvi_source.py
+++ b/sunpy/map/sources/tests/test_suvi_source.py
@@ -42,3 +42,8 @@ def test_observatory(suvi):
 def test_detector(suvi):
     """Tests the detector property of the SUVIMap object."""
     assert suvi.detector == "SUVI"
+
+
+def test_norm_clip(suvi):
+    # Tests that the default normalizer has clipping disabled
+    assert suvi.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_trace_source.py
+++ b/sunpy/map/sources/tests/test_trace_source.py
@@ -37,3 +37,8 @@ def test_measurement(createTRACE):
 def test_observatory(createTRACE):
     """Tests the observatory property of the TRACEMap object."""
     assert createTRACE.observatory == "TRACE"
+
+
+def test_norm_clip(createTRACE):
+    # Tests that the default normalizer has clipping disabled
+    assert createTRACE.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -59,7 +59,7 @@ class TRACEMap(GenericMap):
         self._nickname = self.detector
         # Colour maps
         self.plot_settings['cmap'] = 'trace' + str(self.meta['WAVE_LEN'])
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, LogStretch()))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, LogStretch()), clip=False)
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/yohkoh.py
+++ b/sunpy/map/sources/yohkoh.py
@@ -47,7 +47,7 @@ class SXTMap(GenericMap):
         self.meta['detector'] = "SXT"
         self.meta['telescop'] = "Yohkoh"
         self.plot_settings['cmap'] = 'yohkohsxt' + self.measurement[0:2].lower()
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
         # 2012/12/19 - the SXT headers do not have a value of the distance from
         # the spacecraft to the center of the Sun.  The FITS keyword 'DSUN_OBS'


### PR DESCRIPTION
When looking at [our documentation for clipping Map data when plotting](https://docs.sunpy.org/en/latest/guide/data_types/maps.html#masking-and-clipping-data), I thought that it could be updated to incorporate the `clip_interval` functionality.  However, I was initially befuddled why the over/under functionality of colormaps didn't appear to work.  It turns out that the documentation explicitly uses Matplotlib's `Normalize`, which has a clipping keyword that defaults to `False`, while our default normalizers use Astropy's derived `ImageNormalize`, which changes the default value of the clipping keyword to `True` (as of astropy/astropy#7800 a year ago).  As noted in [Matplotlib's documentation for `Normalize`](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.colors.Normalize.html), setting the clipping keyword to `True` "silently defeats the purpose of setting the over, under, and masked colors in the colormap, so it is likely to lead to surprises".  I completely agree, and I have created an issue on Astropy (astropy/astropy#9449).

This PR explicitly sets the clipping to `False` for the default normalizers for Map sources.

Example code for what this PR enables:
```python
from sunpy.map import Map
from sunpy.data.sample import AIA_171_IMAGE
import astropy.units as u

m = Map(AIA_171_IMAGE)
m.plot_settings['cmap'].set_over('blue')
m.plot_settings['cmap'].set_under('red')
m.peek(clip_interval=[0.01, 0.99]*u.one)
```
![Figure_1](https://user-images.githubusercontent.com/991759/67405091-48f3c680-f582-11e9-98fd-967dba3a1073.png)