### PR TITLE
[Backport 1.0] Explicitly set the clipping to False for the default normalizers for Map sources

### DIFF
--- a/changelog/3427.bugfix.rst
+++ b/changelog/3427.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where clipping behavior had been enabled by default in the plotting normalizers for ``Map`` objects.  Clipping needs to be disabled to make use of the over/under/masked colors in the colormap.

--- a/sunpy/map/sources/mlso.py
+++ b/sunpy/map/sources/mlso.py
@@ -44,7 +44,7 @@ class KCorMap(GenericMap):
         self._nickname = self.detector
 
         self.plot_settings['cmap'] = plt.get_cmap(self._get_cmap_name())
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
         # Negative value pixels can appear that lead to ugly looking images.
         # This can be fixed by setting the lower limit of the normalization.
         self.plot_settings['norm'].vmin = 0.0

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -56,7 +56,7 @@ class AIAMap(GenericMap):
         self.meta['detector'] = self.meta.get('detector', "AIA")
         self._nickname = self.detector
         self.plot_settings['cmap'] = plt.get_cmap(self._get_cmap_name())
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, AsinhStretch(0.01)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, AsinhStretch(0.01)), clip=False)
 
     @property
     def _supported_observer_coordinates(self):

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -52,7 +52,7 @@ class EITMap(GenericMap):
         self._nickname = self.detector
         self.plot_settings['cmap'] = plt.get_cmap(self._get_cmap_name())
         self.plot_settings['norm'] = ImageNormalize(
-            stretch=source_stretch(self.meta, PowerStretch(0.5)))
+            stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
     @property
     def detector(self):
@@ -129,7 +129,7 @@ class LASCOMap(GenericMap):
         self._nickname = self.instrument + "-" + self.detector
         self.plot_settings['cmap'] = plt.get_cmap('soholasco{det!s}'.format(det=self.detector[1]))
         self.plot_settings['norm'] = ImageNormalize(
-            stretch=source_stretch(self.meta, PowerStretch(0.5)))
+            stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
     @property
     def measurement(self):

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -37,7 +37,7 @@ class EUVIMap(GenericMap):
         GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = plt.get_cmap('sohoeit{wl:d}'.format(wl=int(self.wavelength.value)))
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
         self.meta['waveunit'] = 'Angstrom'
 
         # Try to identify when the FITS meta data does not have the correct
@@ -103,7 +103,7 @@ class CORMap(GenericMap):
 
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = plt.get_cmap('stereocor{det!s}'.format(det=self.detector[-1]))
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
         # Try to identify when the FITS meta data does not have the correct
         # date FITS keyword
@@ -147,7 +147,7 @@ class HIMap(GenericMap):
         GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = plt.get_cmap('stereohi{det!s}'.format(det=self.detector[-1]))
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
 
         # Try to identify when the FITS meta data does not have the correct
         # date FITS keyword

--- a/sunpy/map/sources/tests/test_aia_source.py
+++ b/sunpy/map/sources/tests/test_aia_source.py
@@ -48,3 +48,8 @@ def test_measurement(createAIAMap):
     """Tests the measurement property of the AIAMap object."""
     assert createAIAMap.measurement.value in [171, 193]
     # aiaimg has 171, jp2path has 193.
+
+
+def test_norm_clip(createAIAMap):
+    # Tests that the default normalizer has clipping disabled
+    assert createAIAMap.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_cor_source.py
+++ b/sunpy/map/sources/tests/test_cor_source.py
@@ -32,3 +32,8 @@ def test_measurement():
 def test_observatory():
     """Tests the observatory property of the CORMap object."""
     assert cor.observatory == "STEREO A"
+
+
+def test_norm_clip():
+    # Tests that the default normalizer has clipping disabled
+    assert cor.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_eit_source.py
+++ b/sunpy/map/sources/tests/test_eit_source.py
@@ -52,3 +52,8 @@ def test_measurement(createEIT):
 def test_rsun(createEIT):
     """Tests the measurement property of the EITMap object."""
     assert u.allclose(createEIT.rsun_obs, 979.0701*u.arcsec)
+
+
+def test_norm_clip(createEIT):
+    # Tests that the default normalizer has clipping disabled
+    assert createEIT.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -43,3 +43,8 @@ def test_rsun_missing():
     euvi_no_rsun = Map(fitspath)
     euvi_no_rsun.meta['rsun'] = None
     assert euvi_no_rsun.rsun_obs.value == sun.angular_radius(euvi.date).to('arcsec').value
+
+
+def test_norm_clip():
+    # Tests that the default normalizer has clipping disabled
+    assert euvi.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_hi_source.py
+++ b/sunpy/map/sources/tests/test_hi_source.py
@@ -31,3 +31,7 @@ def test_observatory():
     """Tests the observatory property of the HIMap object."""
     assert hi.observatory == "STEREO A"
 
+
+def test_norm_clip():
+    # Tests that the default normalizer has clipping disabled
+    assert hi.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_kcor_source.py
+++ b/sunpy/map/sources/tests/test_kcor_source.py
@@ -45,3 +45,8 @@ def test_measurement(kcor):
 def test_observatory(kcor):
     """Tests the observatory property of the KCorMap object."""
     assert kcor.observatory == "MLSO"
+
+
+def test_norm_clip(kcor):
+    # Tests that the default normalizer has clipping disabled
+    assert kcor.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_lasco_source.py
+++ b/sunpy/map/sources/tests/test_lasco_source.py
@@ -32,3 +32,8 @@ def test_measurement():
 def test_observatory():
     """Tests the observatory property of the LASCOMap object."""
     assert lasco.observatory == "SOHO"
+
+
+def test_norm_clip():
+    # Tests that the default normalizer has clipping disabled
+    assert lasco.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/tests/test_trace_source.py
+++ b/sunpy/map/sources/tests/test_trace_source.py
@@ -37,3 +37,8 @@ def test_measurement(createTRACE):
 def test_observatory(createTRACE):
     """Tests the observatory property of the TRACEMap object."""
     assert createTRACE.observatory == "TRACE"
+
+
+def test_norm_clip(createTRACE):
+    # Tests that the default normalizer has clipping disabled
+    assert createTRACE.plot_settings['norm'].clip == False

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -61,7 +61,7 @@ class TRACEMap(GenericMap):
         self._nickname = self.detector
         # Colour maps
         self.plot_settings['cmap'] = plt.get_cmap('trace' + str(self.meta['WAVE_LEN']))
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, LogStretch()))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, LogStretch()), clip=False)
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/yohkoh.py
+++ b/sunpy/map/sources/yohkoh.py
@@ -48,7 +48,7 @@ class SXTMap(GenericMap):
         self.meta['detector'] = "SXT"
         self.meta['telescop'] = "Yohkoh"
         self.plot_settings['cmap'] = plt.get_cmap(name='yohkohsxt' + self.measurement[0:2].lower())
-        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)))
+        self.plot_settings['norm'] = ImageNormalize(stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
         # 2012/12/19 - the SXT headers do not have a value of the distance from
         # the spacecraft to the center of the Sun.  The FITS keyword 'DSUN_OBS'


### PR DESCRIPTION
Manual backport of #3427