### PR TITLE
Use a faster library to get the package version

### DIFF
--- a/changelog/3449.trivial.rst
+++ b/changelog/3449.trivial.rst
@@ -1,0 +1,1 @@
+Switched to "importlib_metadata" to get package version to speed up import of SunPy.

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
   pandas
   astropy>=3.1
   parfive[ftp]
-  importlib_resources;python_version<"3.7"
+  importlib_resources;python_version<"3.8"
 
 [options.extras_require]
 database = sqlalchemy

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,9 @@ classifiers =
 python_requires = >=3.6
 packages = find:
 include_package_data = True
-setup_requires = setuptools_scm
+setup_requires =
+  setuptools_scm
+  importlib_resources;python_version<"3.7"
 install_requires =
   numpy>=1.14.5
   scipy
@@ -37,6 +39,7 @@ install_requires =
   pandas
   astropy>=3.1
   parfive[ftp]
+  importlib_resources;python_version<"3.7"
 
 [options.extras_require]
 database = sqlalchemy

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ packages = find:
 include_package_data = True
 setup_requires =
   setuptools_scm
-  importlib_resources;python_version<"3.7"
 install_requires =
   numpy>=1.14.5
   scipy

--- a/sunpy/version.py
+++ b/sunpy/version.py
@@ -1,6 +1,13 @@
 # This file is for compatibility with astropy_helpers
-from pkg_resources import get_distribution, DistributionNotFound
+version = 'unknown.dev'
 try:
-    version = get_distribution("sunpy").version
-except DistributionNotFound:
-    version = 'unknown.dev'
+    from importlib_metadata import version as _version, PackageNotFoundError
+    version = _version('sunpy')
+except ImportError:
+    from pkg_resources import get_distribution, DistributionNotFound
+    try:
+        version = get_distribution("sunpy").version
+    except DistributionNotFound:
+        pass
+except PackageNotFoundError:
+    pass


### PR DESCRIPTION
This PR uses `importlib_metadata` instead of `pkg_resources` to get the package version, and reduces the time to import `sunpy` by ~0.4 s (see #3445).  This library is standard in Python 3.8, but is a separate package in earlier versions of Python.  I don't know how conceivable it is that it wouldn't be installed, but I kept a `pkg_resources` fallback to be safe.