### PR TITLE
Fix transforming an array of observers to another array of observers

### DIFF
--- a/changelog/3455.bugfix.rst
+++ b/changelog/3455.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug with observer based frames that prevented a coordinate with an array of obstimes being transformed to other frames.

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -698,3 +698,18 @@ def test_no_observer():
                 f1.transform_to(f2)
             with pytest.raises(ConvertError):
                 f2.transform_to(f1)
+
+
+def test_array_obstime():
+    # Validate that you can transform from an array of obstimes to no obstimes,
+    # or different obstimes.
+    a = SkyCoord([10]*2, [10]*2, unit=u.deg,
+                 observer="earth",
+                 obstime=["2019-01-01", "2019-01-02"],
+                 frame="heliographic_carrington")
+
+    t = a.transform_to(Helioprojective)
+    assert isinstance(t, Helioprojective)
+
+    t2 = a.transform_to(Helioprojective(obstime=["2019-01-03", "2019-01-04"]))
+    assert isinstance(t2, Helioprojective)

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -709,7 +709,7 @@ def test_array_obstime():
                  frame="heliographic_carrington")
 
     t = a.transform_to(Helioprojective)
-    assert isinstance(t, Helioprojective)
+    assert isinstance(t.frame, Helioprojective)
 
     t2 = a.transform_to(Helioprojective(obstime=["2019-01-03", "2019-01-04"]))
-    assert isinstance(t2, Helioprojective)
+    assert isinstance(t2.frame, Helioprojective)


### PR DESCRIPTION
this fixes this:

```
In [1]: import astropy.units as u; import sunpy.coordinates; from astropy.coordinates import SkyCoord                                                                                                                              

In [2]: a = SkyCoord([10]*2, [10]*2, unit=u.deg, observer="earth", obstime=["2019-01-01", "2019-01-02"], frame="heliographic_carrington")                                                                                          

In [3]: a.transform_to(sunpy.coordinates.Helioprojective)                                                                                                                                                    
Out[3]: 
<SkyCoord (Helioprojective: obstime=['2019-01-01 00:00:00.000' '2019-01-02 00:00:00.000'], rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=['2019-01-01 00:00:00.000' '2019-01-02 00:00:00.000']): (lon, lat, radius) in (deg, deg, AU)
    [(0., -2.9727939 , 0.98331131), (0., -3.08980378, 0.98330419)]>): (Tx, Ty, distance) in (arcsec, arcsec, km)
    [(302.03191809, 121.35287096, 1.47756924e+08),
     ( 87.30363278, 117.03662775, 1.47788039e+08)]>

In [4]: a.transform_to(sunpy.coordinates.Helioprojective(obstime=["2019-01-03", "2019-01-04"]))
Out[4]: 
<SkyCoord (Helioprojective: obstime=['2019-01-03 00:00:00.000' '2019-01-04 00:00:00.000'], rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=['2019-01-03 00:00:00.000' '2019-01-04 00:00:00.000']): (lon, lat, radius) in (deg, deg, AU)
    [(0., -3.20584856, 0.98330126), (0., -3.32088992, 0.98330236)]>): (Tx, Ty, distance) in (arcsec, arcsec, km)
    [(337.02043248, 118.00670485, 1.47746684e+08),
     (123.97569666, 113.12524384, 1.47784367e+08)]>
```

tests to follow.