### PR TITLE
Report incorrect filetype in write_file() error message

### DIFF
--- a/changelog/3469.feature.rst
+++ b/changelog/3469.feature.rst
@@ -1,0 +1,1 @@
+`sunpy.io.write_file()` now accepts `~pathlib.Path` objects as filename inputs.

--- a/sunpy/instr/tests/test_aia.py
+++ b/sunpy/instr/tests/test_aia.py
@@ -46,7 +46,7 @@ def test_aiaprep(original, prep_map):
 def test_filesave(prep_map):
     # Test that adjusted header values are still correct after saving the map
     # and reloading it.
-    afilename = tempfile.NamedTemporaryFile(suffix='fits').name
+    afilename = tempfile.NamedTemporaryFile(suffix='.fits').name
     with pytest.warns(
             VerifyWarning, match="The 'BLANK' keyword is only applicable to integer data"):
         prep_map.save(afilename, overwrite=True)

--- a/sunpy/io/file_tools.py
+++ b/sunpy/io/file_tools.py
@@ -2,6 +2,7 @@
 This module provides a generic file reader.
 """
 import os
+import pathlib
 import re
 
 try:
@@ -144,18 +145,15 @@ def write_file(fname, data, header, filetype='auto', **kwargs):
     * This routine currently only supports saving a single HDU.
     """
     if filetype == 'auto':
-        if not isinstance(fname, str):
-            raise ValueError("Can not automatically detect filetype for non-string fname argument")
-        for extension, readername in _known_extensions.items():
-            if fname.endswith(extension):
-                return _readers[readername].write(fname, data, header, **kwargs)
-    else:
-        for extension, readername in _known_extensions.items():
-            if filetype in extension:
-                return _readers[readername].write(fname, data, header, **kwargs)
+        # Get the extension without the leading dot
+        filetype = pathlib.Path(fname).suffix[1:]
+
+    for extension, readername in _known_extensions.items():
+        if filetype in extension:
+            return _readers[readername].write(fname, data, header, **kwargs)
 
     # Nothing has matched, report an error
-    raise ValueError("This filetype is not supported")
+    raise ValueError(f"The filetype provided ({filetype}) is not supported")
 
 
 def _detect_filetype(filepath):

--- a/sunpy/io/tests/test_filetools.py
+++ b/sunpy/io/tests/test_filetools.py
@@ -1,4 +1,7 @@
 import os
+import pathlib
+
+import pytest
 
 import numpy as np
 
@@ -76,10 +79,12 @@ class TestFiletools:
         assert len(hlist) == 1
         assert isinstance(hlist[0], sunpy.io.header.FileHeader)
 
-    def test_write_file_fits(self):
+    @pytest.mark.parametrize('fname', ['aia_171_image.fits',
+                                       pathlib.Path('aia_171_image.fits')])
+    def test_write_file_fits(self, fname):
         # Test write FITS
         aiapair = sunpy.io.read_file(AIA_171_IMAGE)[0]
-        sunpy.io.write_file("aia_171_image.fits", aiapair[0], aiapair[1],
+        sunpy.io.write_file(fname, aiapair[0], aiapair[1],
                             overwrite=True)
         assert os.path.exists("aia_171_image.fits")
         outpair = sunpy.io.read_file(AIA_171_IMAGE)[0]


### PR DESCRIPTION
As well as including a more descriptive error message,

- Remove code duplication
- Use pathlib to get the file extension
- Allow pathlib objects to go through `write_file()`