### PR TITLE
Remove u.Quantity calls from examples

### DIFF
--- a/examples/map/map_from_numpy_array.py
+++ b/examples/map/map_from_numpy_array.py
@@ -32,8 +32,8 @@ coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime='2013-10-28 08:24', observer='e
 # scale sets the size of the pixels. You can also to set a number of other
 # metadata as well such as the instrument name and wavelength.
 header = sunpy.map.header_helper.make_fitswcs_header(data, coord,
-                                                     reference_pixel=u.Quantity([0, 0]*u.pixel),
-                                                     scale=u.Quantity([2, 2]*u.arcsec/u.pixel),
+                                                     reference_pixel=[0, 0]*u.pixel,
+                                                     scale=[2, 2]*u.arcsec/u.pixel,
                                                      telescope='Fake Telescope', instrument='UV detector',
                                                      wavelength=1000*u.angstrom)
 

--- a/examples/map/map_resampling_and_superpixels.py
+++ b/examples/map/map_resampling_and_superpixels.py
@@ -22,7 +22,7 @@ aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 # To reduce the angular resolution of the map you can use the `~sunpy.map.GenericMap.resample` method,
 # specifying the new dimensions in pixels. By default, this method uses linear interpolation
 # but this can be changed with the `method` argument (‘neighbor’, ‘nearest’, ‘linear’ or ‘spline’)
-new_dimensions = u.Quantity([40, 40], u.pixel)
+new_dimensions = [40, 40] * u.pixel
 aia_resampled_map = aia_map.resample(new_dimensions)
 
 ##############################################################################

--- a/examples/plotting/simple_differential_rotation.py
+++ b/examples/plotting/simple_differential_rotation.py
@@ -29,7 +29,7 @@ from sunpy.physics.differential_rotation import diff_rot, solar_rotate_coordinat
 # Next lets explore solar differential rotation by replicating Figure 1
 # in Beck 1999
 
-latitudes = u.Quantity(np.arange(0, 90, 1), 'deg')
+latitudes = np.arange(0, 90, 1) * u.deg
 dt = 1 * u.day
 rotation_rate = [diff_rot(dt, this_lat) / dt for this_lat in latitudes]
 rotation_period = [360 * u.deg / this_rate for this_rate in rotation_rate]
@@ -50,7 +50,7 @@ aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 ##############################################################################
 # Let's define our starting coordinates
 
-hpc_y = u.Quantity(np.arange(-700, 800, 100), u.arcsec)
+hpc_y = np.arange(-700, 800, 100) * u.arcsec
 hpc_x = np.zeros_like(hpc_y)
 
 ##############################################################################

--- a/examples/saving_and_loading_data/coordinates_in_asdf.py
+++ b/examples/saving_and_loading_data/coordinates_in_asdf.py
@@ -68,7 +68,7 @@ def semi_circular_loop(length: u.m, theta0: u.deg=0*u.deg):
 
     return SkyCoord(
         x=r.to(u.cm) * np.sin(phi.to(u.radian)),
-        y=u.Quantity(r.shape[0] * [0 * u.cm]),
+        y=r.shape[0] * u.cm * 0,
         z=r.to(u.cm) * np.cos(phi.to(u.radian)),
         frame=hcc_frame).transform_to('heliographic_stonyhurst')
 

--- a/examples/time_series/timeseries_example.py
+++ b/examples/time_series/timeseries_example.py
@@ -230,15 +230,15 @@ print(qua)
 # You can add or overwrite a column using the add_column method.
 # This method ascepts an astropy quantity and will convert to the intended units
 # if necessary.
-qua_new = u.Quantity(qua.value * 0.01, ts_eve.units[colname])
+qua_new = qua.value * 0.01 * ts_eve.units[colname]
 print(qua_new)
 ts_eve = ts_eve.add_column(colname, qua_new, overwrite=True)
 # Otherwise you can also use a numpy array and it assume you're using the original
 # units:
-arr_new = u.Quantity(qua.value * 0.1, ts_eve.units[colname]).value
+arr_new = (qua.value * 0.1 * ts_eve.units[colname]).value
 ts_eve = ts_eve.add_column(colname, qua_new, overwrite=True)
 # Finally, if you want to change the units used, you can specify a new unit for
 # the column using the unit keyword:
-qua_new = u.Quantity(qua.value * 0.00001, ts_eve.units[colname])
+qua_new = qua.value * 0.00001 * ts_eve.units[colname]
 unit = u.W / (u.km**2)
 ts_eve = ts_eve.add_column(colname, qua_new, unit=unit, overwrite=True)


### PR DESCRIPTION
Most of the calls can be simplified using normal multiplication with units, which I think makes the code a bit nicer/readable.