### PR TITLE
Apply expanduser before passing to glob in map factory

### DIFF
--- a/changelog/3477.bugfix.rst
+++ b/changelog/3477.bugfix.rst
@@ -1,0 +1,2 @@
+Apply `os.path.expanduser` to `sunpy.map.MapFactory` input
+before passing to `glob.glob`

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -222,8 +222,8 @@ class MapFactory(BasicRegistrationFactory):
                     raise ValueError(f'{path} is neither a file nor a directory')
 
             # Glob
-            elif isinstance(arg, str) and glob.glob(arg):
-                for afile in sorted(glob.glob(arg)):
+            elif isinstance(arg, str) and glob.glob(os.path.expanduser(arg)):
+                for afile in sorted(glob.glob(os.path.expanduser(arg))):
                     data_header_pairs += self._read_file(afile, **kwargs)
 
             # Already a Map


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description

Apply `os.path.expanduser` before passing a pattern to glob. This allows for passing patterns like `~/sunpy/data/aia*.fits` to the MapFactory.

Fixes #3476 
