### PR TITLE
Add some missing doc requirements to conf.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ jobs:
       - run: pip install -U pip
       - run: pip install --progress-bar off .[all,dev]
       - run: pip install -e .[all,dev]
-      - run: python setup.py develop
 
   32bit:
     docker:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-#
 # SunPy documentation build configuration file.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -25,6 +22,12 @@
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 
+# ITS THE WILD WEST IN HERE
+# flake8: noqa
+
+import sunpy.data.sample
+import numpy as np
+from pkg_resources import get_distribution
 import os
 import sys
 import pathlib
@@ -57,53 +60,45 @@ if on_rtd:
 try:
     import zeep
 except ImportError:
-    print('ERROR: zeep could not be imported. Building the documentation requires '
-          'the "zeep" package to be installed')
-    sys.exit(1)
+    raise Exception(e, 'ERROR: zeep could not be imported. Building the documentation requires '
+                    'the "zeep" package to be installed')
 
 try:
     import skimage
-except ImportError:
-    print('ERROR: skimage could not be imported. Building the documentation requires '
-          'the "scikit-image" package to be installed')
-    sys.exit(1)
+except ImportError as e:
+    raise Exception(e, 'ERROR: skimage could not be imported. Building the documentation requires '
+                    'the "scikit-image" package to be installed')
 
 try:
     import drms
-except ImportError:
-    print('ERROR: drms could not be imported. Building the documentation requires '
-          'the "drms" package to be installed')
-    sys.exit(1)
+except ImportError as e:
+    raise Exception(e, 'ERROR: drms could not be imported. Building the documentation requires '
+                    'the "drms" package to be installed')
 
 try:
     import glymur
-except ImportError:
-    print('ERROR: glymur could not be imported. Building the documentation requires '
-          'the "glymur" package to be installed')
-    sys.exit(1)
+except ImportError as e:
+    raise Exception(e, 'ERROR: glymur could not be imported. Building the documentation requires '
+                    'the "glymur" package to be installed')
 
 try:
     import sqlalchemy
-except ImportError:
-    print('ERROR: sqlalchemy could not be imported. Building the documentation requires '
-          'the "sqlalchemy" package to be installed')
-    sys.exit(1)
+except ImportError as e:
+    raise Exception(e, 'ERROR: sqlalchemy could not be imported. Building the documentation requires '
+                    'the "sqlalchemy" package to be installed')
 
 try:
     import astroquery
-except ImportError:
-    print('ERROR: astroquery could not be imported. Building the documentation requires '
-          'the "astroquery" package to be installed')
-    sys.exit(1)
+except ImportError as e:
+    raise Exception(e, 'ERROR: astroquery could not be imported. Building the documentation requires '
+                    'the "astroquery" package to be installed')
 
 try:
     import jplephem
-except ImportError:
-    print('ERROR: jplephem could not be imported. Building the documentation requires '
-          'the "jplephem" package to be installed')
-    sys.exit(1)
+except ImportError as e:
+    raise Exception(e, 'ERROR: jplephem could not be imported. Building the documentation requires '
+                    'the "jplephem" package to be installed')
 
-from pkg_resources import get_distribution
 versionmod = get_distribution('sunpy')
 
 # The version info for the project you're documenting, acts as replacement for
@@ -117,11 +112,9 @@ release = versionmod.version.split('+')[0]
 is_development = '.dev' in release
 
 # -- Shut up numpy warnings from WCSAxes --------------------------------------
-import numpy as np
 np.seterr(invalid='ignore')
 
 # -- Download Sample Data -----------------------------------------------------
-import sunpy.data.sample
 
 # -- General configuration ----------------------------------------------------
 
@@ -262,7 +255,8 @@ if has_sphinx_gallery:
     sphinx_gallery_conf = {
         'backreferences_dir':
         path.joinpath('generated', 'modules'),  # path to store the module using example template
-        'filename_pattern': '^((?!skip_).)*$',  # execute all examples except those that start with "skip_"
+        # execute all examples except those that start with "skip_"
+        'filename_pattern': '^((?!skip_).)*$',
         'examples_dirs': example_dir,  # path to the examples scripts
         'subsection_order': ExplicitOrder([(os.path.join('..', 'examples/acquiring_data')),
                                            (os.path.join('..', 'examples/map')),
@@ -271,7 +265,8 @@ if has_sphinx_gallery:
                                            (os.path.join('..', 'examples/plotting')),
                                            (os.path.join('..', 'examples/saving_and_loading_data')),
                                            (os.path.join('..', 'examples/computer_vision_techniques'))]),
-        'gallery_dirs': path.joinpath('generated', 'gallery'),  # path to save gallery generated examples
+        # path to save gallery generated examples
+        'gallery_dirs': path.joinpath('generated', 'gallery'),
         'default_thumb_file': path.joinpath('logo', 'sunpy_icon_128x128.png'),
         'abort_on_example_error': False,
         'plot_gallery': True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,9 +25,6 @@
 # ITS THE WILD WEST IN HERE
 # flake8: noqa
 
-import sunpy.data.sample
-import numpy as np
-from pkg_resources import get_distribution
 import os
 import sys
 import pathlib
@@ -99,6 +96,7 @@ except ImportError as e:
     raise Exception(e, 'ERROR: jplephem could not be imported. Building the documentation requires '
                     'the "jplephem" package to be installed')
 
+from pkg_resources import get_distribution  # noqa  isort:skip
 versionmod = get_distribution('sunpy')
 
 # The version info for the project you're documenting, acts as replacement for
@@ -112,9 +110,12 @@ release = versionmod.version.split('+')[0]
 is_development = '.dev' in release
 
 # -- Shut up numpy warnings from WCSAxes --------------------------------------
+import numpy as np  # noqa  isort:skip
+
 np.seterr(invalid='ignore')
 
 # -- Download Sample Data -----------------------------------------------------
+import sunpy.data.sample  # noqa  isort:skip
 
 # -- General configuration ----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,27 @@ except ImportError:
           'the "glymur" package to be installed')
     sys.exit(1)
 
+try:
+    import sqlalchemy
+except ImportError:
+    print('ERROR: sqlalchemy could not be imported. Building the documentation requires '
+          'the "sqlalchemy" package to be installed')
+    sys.exit(1)
+
+try:
+    import astroquery
+except ImportError:
+    print('ERROR: astroquery could not be imported. Building the documentation requires '
+          'the "astroquery" package to be installed')
+    sys.exit(1)
+
+try:
+    import jplephem
+except ImportError:
+    print('ERROR: jplephem could not be imported. Building the documentation requires '
+          'the "jplephem" package to be installed')
+    sys.exit(1)
+
 from pkg_resources import get_distribution
 versionmod = get_distribution('sunpy')
 

--- a/docs/dev_guide/documentation.rst
+++ b/docs/dev_guide/documentation.rst
@@ -106,17 +106,19 @@ To build the documentation locally you must have all the dependencies (``pip ins
 
 In the root directory run::
 
-    $ python setup.py build_docs
+    $ tox -e build_docs
 
 This will generate HTML documentation for SunPy in the "docs/_build/html" directory.
 You can open the "index.html" file to browse the final product.
 The gallery examples are located under "docs/_build/html/generated/gallery".
 Sphinx builds documentation iteratively, only adding things that have changed.
-If you'd like to start from scratch then just delete the build directory or run::
+If you'd like to start from scratch then just delete the tox build directory::
 
-    $ python setup.py build_docs -l
+    $ rm .tox/build_docs/
 
-to clean previous builds before building new ones.
+or::
+
+    $ tox --recreate -e build_docs
 
 For more information on how to use Sphinx, consult the `Sphinx documentation <http://www.sphinx-doc.org/en/stable/contents.html>`_.
 

--- a/docs/dev_guide/tests.rst
+++ b/docs/dev_guide/tests.rst
@@ -33,62 +33,14 @@ If you want to see the current test dependencies, you check "extras_require" in 
 Running Tests
 -------------
 
-There are currently three different ways to invoke the SunPy tests.
+There are currently two different ways to invoke the SunPy tests.
+However, we strongly suggest using ``tox`` as the default one.
 Each method uses the widely-used ``pytest`` framework and are detailed below.
-
-``python setup.py test``
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-SunPy provides a ``test`` setup command, invoked by running ``python setup.py test`` while in the
-package root directory.
-Run ``python setup.py test --help`` to see the options to the test command.
-
-Note also that this test runner actually installs SunPy into a temporary directory and uses that for running the tests.
-This means that tests of things like entry points or data file paths should act just like they would once SunPy is installed.
-The other two approaches described below do **not** do this, and hence may give different results when ran.
-Hence, if you're running the tests because you've modified code that might be impacted by this, the ``python setup.py test`` approach is the recommended method.
-
-It is possible to run only the tests for a particular subpackage or set of subpackages.
-For example, to run only the "map" tests from the commandline::
-
-    $ python setup.py test -P map
-
-Or, to run only the "map" and "timeseries" tests::
-
-    $ python setup.py test -P map,timeseries
-
-You can also specify a single file to test from the commandline::
-
-    $ python setup.py test -t sunpy/map/tests/test_mapbase.py
-
-When the ``-t`` option is given a relative path, it is relative to  installed root of sunpy.
-When ``-t`` is given a relative path to a documentation ``.rst`` file to test, it is relative to the root of the documentation, i.e. the ``docs`` directory in the source tree.
-For example::
-
-    $ python setup.py test -t guide/index.rst
-
-Since ``python setup.py test`` wraps the ``pytest`` framework, you may want to pass options to the ``pytest`` command itself::
-
-    $ python setup.py test --args <pytest arg here>
-
-``pytest``
-^^^^^^^^^^
-
-The test suite can be run directly from the native ``pytest`` command.
-In this case, it is important for developers to be aware that they must manually rebuild any extensions by running ``python setup.py build_ext`` before testing.
-
-As shown for ``python setup.py test`` above, you can do the same for ``pytest``::
-
-    $ pytest sunpy/map/tests/test_mapbase.py
-
-If a test errors, you can use ``pdb`` to create a debugging session at test fail::
-
-    $ pytest --pdb
 
 ``tox``
 ^^^^^^^^
 
-The third method is to use `tox`_, which is a generic virtualenv management and test command line tool.
+The primary method is to use `tox`_, which is a generic virtualenv management and test command line tool.
 We have several environments within our "tox.ini" file and you can list them::
 
     $ tox -l
@@ -102,6 +54,32 @@ This is the method that our continuous integration uses.
 
 .. _tox: https://tox.readthedocs.io/en/latest/
 
+``pytest``
+^^^^^^^^^^
+
+The test suite can be run directly from the native ``pytest`` command.
+In this case, it is important for developers to be aware that they must manually rebuild any extensions by running ``python setup.py build_ext`` before testing.
+
+To run the entire suite with ``pytest``::
+
+    $ pytest
+
+will use the settings in ``setup.cfg``.
+
+If you want to run one specific test file::
+
+    $ pytest sunpy/map/tests/test_mapbase.py
+
+or one specific test in a test file::
+
+    $ pytest sunpy/map/tests/test_mapbase.py::<test_name>
+
+(This does not work with ``tox`` and is a known issue.)
+
+If a test errors, you can use ``pdb`` to create a debugging session at the moment the test fails::
+
+    $ pytest --pdb
+
 Test coverage reports
 ---------------------
 
@@ -111,10 +89,6 @@ This plugin can be installed using `pip`_::
     $ pip install pytest-cov
 
 To generate a test coverage report, use::
-
-    $ python setup.py test --coverage
-
-or::
 
     $ pytest --cov ./sunpy
 
@@ -137,15 +111,11 @@ This plugin can be installed using `pip`_::
 Once installed, tests can be run in parallel using the ``--parallel`` commandline option.
 For example, to use 4 processes::
 
-    $ python setup.py test --parallel=4
+    $ tox -e <name of environment> -- -n=4
 
 or::
 
     $ pytest -n 4 ./sunpy
-
-or::
-
-    $ tox -e <name of environment> -- -n=4
 
 .. _pytest-xdist: https://pypi.python.org/pypi/pytest-xdist
 .. _pip: https://pypi.org/project/pip/
@@ -231,7 +201,7 @@ Marking tests is pretty straightforward, use the decorator ``@pytest.mark.remote
 
 By default, no online tests are selected and so to run the online tests you have to::
 
-    $ python setup.py test --online
+    $ tox -e py37-online
 
 or::
 
@@ -287,10 +257,6 @@ Since the hashes are checked, we test figures against a fixed set of packages an
 
     $ tox -e figure
 
-To run the figure tests otherwise you can::
-
-    $ python setup.py test --figure-only
-
 or::
 
     $ pytest -m "figure"
@@ -305,7 +271,7 @@ To avoid running the tests::
 The output (regardless if via ``tox`` or ``pytest``) of these figure tests will be in a "figure_test_images" folder within your work folder.
 For example, "<local clone location>/figure_test_images" which is ignored by git.
 
-Writing Doctests
+Writing doctests
 ----------------
 
 Code examples in the documentation will also be run as tests and this helps to validate that the documentation is accurate and up to date.

--- a/sunpy/tests/helpers.py
+++ b/sunpy/tests/helpers.py
@@ -86,7 +86,7 @@ def figure_test(test_function):
             pytest.xfail("No directory to save figures to found")
 
         name = "{}.{}".format(test_function.__module__,
-                                test_function.__name__)
+                              test_function.__name__)
         # Run the test function and get the figure
         plt.figure()
         fig = test_function(*args, **kwargs)

--- a/sunpy/tests/tests/test_self_test.py
+++ b/sunpy/tests/tests/test_self_test.py
@@ -69,7 +69,7 @@ def test_main_include_remote_data(monkeypatch):
     monkeypatch.setattr(pytest, 'main', lambda args, **kwargs: args)
     args = sunpy.self_test(package='map', online=True)
     assert args in ([os.path.join('sunpy', 'map'), '--remote-data=any', '-m', 'not figure'],
-                    [os.path.join(root_dir, 'map'),'--remote-data=any',  '-m', 'not figure'])
+                    [os.path.join(root_dir, 'map'), '--remote-data=any',  '-m', 'not figure'])
 
 
 def test_main_only_remote_data(monkeypatch):


### PR DESCRIPTION
Building the docs in a new conda environment, these are the packages that I had to install to build wihtout errors. There must be a better way to do this than all of these try except blocks...