### PR TITLE
Do not assume the type of header entries

### DIFF
--- a/changelog/3497.bugfix.rst
+++ b/changelog/3497.bugfix.rst
@@ -1,0 +1,2 @@
+Fix multiple instances of `sunpy.map.sources` assuming the type of FITS Header
+values.

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -117,7 +117,7 @@ demonstrated by the following example.
        @classmethod
        def is_datasource_for(cls, data, header, **kwargs):
             """Determines if header corresponds to an AIA image"""
-            return header.get('instrume', '').startswith('FUTURESCOPE')
+            return str(header.get('instrume', '')).startswith('FUTURESCOPE')
 
 
 This class will now be available through the `Map <sunpy.map.map_factory.MapFactory>` factory as long as this

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -49,7 +49,7 @@ class SJIMap(GenericMap):
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an IRIS SJI image"""
-        tele = header.get('TELESCOP', '').startswith('IRIS')
-        obs = header.get('INSTRUME', '').startswith('SJI')
+        tele = str(header.get('TELESCOP', '')).startswith('IRIS')
+        obs = str(header.get('INSTRUME', '')).startswith('SJI')
         level = header.get('lvl_num') == 1
         return tele and obs

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -76,7 +76,7 @@ class AIAMap(GenericMap):
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an AIA image"""
-        return header.get('instrume', '').startswith('AIA')
+        return str(header.get('instrume', '')).startswith('AIA')
 
 
 class HMIMap(GenericMap):
@@ -121,4 +121,4 @@ class HMIMap(GenericMap):
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an HMI image"""
-        return header.get('instrume', '').startswith('HMI')
+        return str(header.get('instrume', '')).startswith('HMI')

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -120,7 +120,7 @@ class CORMap(GenericMap):
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an COR image"""
-        return header.get('detector', '').startswith('COR')
+        return str(header.get('detector', '')).startswith('COR')
 
 
 class HIMap(GenericMap):
@@ -164,4 +164,4 @@ class HIMap(GenericMap):
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an COR image"""
-        return header.get('detector', '').startswith('HI')
+        return str(header.get('detector', '')).startswith('HI')

--- a/sunpy/map/sources/suvi.py
+++ b/sunpy/map/sources/suvi.py
@@ -104,6 +104,6 @@ class SUVIMap(GenericMap):
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an AIA image"""
-        return header.get("instrume", "").startswith(
+        return str(header.get("instrume", "")).startswith(
             "GOES-R Series Solar Ultraviolet Imager"
         )

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -131,6 +131,16 @@ class TestMap:
         pair_map = sunpy.map.Map(data, header)
         assert isinstance(pair_map, sunpy.map.GenericMap)
 
+        # Common keys not strings
+        data = np.arange(0, 100).reshape(10, 10)
+        header = {'cdelt1': 10, 'cdelt2': 10,
+                  'telescop': 100,
+                  'detector': 1,
+                  'instrume': 50,
+                  'cunit1': 'arcsec', 'cunit2': 'arcsec'}
+        pair_map = sunpy.map.Map(data, header)
+        assert isinstance(pair_map, sunpy.map.GenericMap)
+
     # requires dask array to run properly
     def test_dask_array(self):
         dask_array = pytest.importorskip('dask.array')


### PR DESCRIPTION
Don't ever assume that a FITS key is a string, **especially** not in `is_datasource_for`.

Fixes #3496 