### PR TITLE
Make Map work with WISPR Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,4 +220,7 @@ tags
 
 # Release script
 .github_cache
+
+# Misc Stuff
 .history
+*.orig

--- a/changelog/3501.feature.rst
+++ b/changelog/3501.feature.rst
@@ -1,1 +1,5 @@
-Sunpy Maps now can read WISPR Data.
+`sunpy.map.GenericMap.wcs` now uses the full FITS header to construct the WCS.
+This adds support for instruments with more complex projections, such as WISPR,
+however does mean that Map will be more sensative to incorrect or invalid FITS
+headers. If you are using custom headers with SunPy Map you might encounter
+issues relating to this change.

--- a/changelog/3501.feature.rst
+++ b/changelog/3501.feature.rst
@@ -1,0 +1,1 @@
+Sunpy Maps now can read WISPR Data.

--- a/changelog/3501.feature.rst
+++ b/changelog/3501.feature.rst
@@ -1,5 +1,5 @@
 `sunpy.map.GenericMap.wcs` now uses the full FITS header to construct the WCS.
 This adds support for instruments with more complex projections, such as WISPR,
-however does mean that Map will be more sensative to incorrect or invalid FITS
+however does mean that Map will be more sensitive to incorrect or invalid FITS
 headers. If you are using custom headers with SunPy Map you might encounter
 issues relating to this change.

--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -212,6 +212,11 @@ def header_to_fits(header):
             elif k != '':
                 fits_header.append(fits.Card(k, str(v).split('\n')))
 
+        # For some horrific reason, we save a list to the wavelnth key in
+        # sources/rhessi.py. This is the least invasive fix for that stupidity.
+        elif isinstance(v, list):
+            v = str(v)
+
         else:
             fits_header.append(fits.Card(k, v))
 

--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -200,6 +200,7 @@ def header_to_fits(header):
     key_comments = header.pop('KEYCOMMENTS', False)
 
     for k, v in header.items():
+        # Drop any keys which are too long to save into FITS
         if len(k) > 8:
             warnings.warn(f"The meta key {k} is too long, dropping from the FITS header.", SunpyUserWarning)
             continue

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from collections import OrderedDict
 
 import pytest
@@ -124,3 +125,14 @@ def test_write_with_metadict_header_astropy(tmpdir):
     temp_file = tmpdir / "temp.fits"
     sunpy.io.fits.write(str(temp_file), data, meta_header)
     assert temp_file.exists()
+
+
+def test_fitsheader():
+    extensions = ('fts', 'fits')
+    for ext in extensions:
+        for ffile in Path(testpath).glob(f"*.{ext}*"):
+            fits_file = fits.open(ffile)
+            fits_file.verify("fix")
+            data, header = fits_file[0].data, fits_file[0].header
+            meta_header = MetaDict(OrderedDict(header))
+            sunpy.io.fits.header_to_fits(meta_header)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -128,6 +128,7 @@ def test_write_with_metadict_header_astropy(tmpdir):
 
 
 def test_fitsheader():
+    """Test that all test data can be converted back to a FITS header."""
     extensions = ('fts', 'fits')
     for ext in extensions:
         for ffile in Path(testpath).glob(f"*.{ext}*"):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -272,7 +272,7 @@ class GenericMap(NDData):
 
         # If the FITS header is > 2D pick the first 2 and move on.
         # This will require the FITS header to be valid.
-        if w2.naxis != 2:
+        if w2.naxis > 2:
             w2 = w2.sub([1, 2])
 
         w2.wcs.crpix = u.Quantity(self.reference_pixel)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -273,7 +273,7 @@ class GenericMap(NDData):
         # If the FITS header is > 2D pick the first 2 and move on.
         # This will require the FITS header to be valid.
         if w2.naxis != 2:
-            w2 = w2.sub([1,2])
+            w2 = w2.sub([1, 2])
 
         w2.wcs.crpix = u.Quantity(self.reference_pixel)
         # Make these a quantity array to prevent the numpy setting element of
@@ -303,6 +303,8 @@ class GenericMap(NDData):
         if {'HPLN', 'HPLT'} <= ctypes or {'SOLX', 'SOLY'} <= ctypes:
             w2.heliographic_observer = self.observer_coordinate
 
+        # Validate the WCS here.
+        w2.wcs.set()
         return w2
 
     @property

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -266,7 +266,15 @@ class GenericMap(NDData):
         """
         The `~astropy.wcs.WCS` property of the map.
         """
-        w2 = astropy.wcs.WCS(naxis=2)
+        # Construct the WCS based on the FITS header, but don't "do_set" which
+        # analyses the FITS header for correctness.
+        w2 = astropy.wcs.WCS(header=self.fits_header, _do_set=False)
+
+        # If the FITS header is > 2D pick the first 2 and move on.
+        # This will require the FITS header to be valid.
+        if w2.naxis != 2:
+            w2 = w2.sub([1,2])
+
         w2.wcs.crpix = u.Quantity(self.reference_pixel)
         # Make these a quantity array to prevent the numpy setting element of
         # array with sequence error.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -270,7 +270,10 @@ class GenericMap(NDData):
 
         # Construct the WCS based on the FITS header, but don't "do_set" which
         # analyses the FITS header for correctness.
-        w2 = astropy.wcs.WCS(header=self.fits_header, _do_set=False)
+        with warnings.catch_warnings():
+            # Ignore warnings we may raise when constructing the fits header about dropped keys.
+            warnings.simplefilter("ignore", SunpyUserWarning)
+            w2 = astropy.wcs.WCS(header=self.fits_header, _do_set=False)
 
         # If the FITS header is > 2D pick the first 2 and move on.
         # This will require the FITS header to be valid.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -266,6 +266,8 @@ class GenericMap(NDData):
         """
         The `~astropy.wcs.WCS` property of the map.
         """
+
+
         # Construct the WCS based on the FITS header, but don't "do_set" which
         # analyses the FITS header for correctness.
         w2 = astropy.wcs.WCS(header=self.fits_header, _do_set=False)
@@ -273,6 +275,12 @@ class GenericMap(NDData):
         # If the FITS header is > 2D pick the first 2 and move on.
         # This will require the FITS header to be valid.
         if w2.naxis > 2:
+            # We have to change this or else the WCS doesn't parse properly, even
+            # though we don't care about the third dimension. This applies to both
+            # EIT and IRIS data, it is here to reduce the chances of silly errors.
+            if self.meta.get('cdelt3', None) == 0:
+                self.meta['cdelt3'] = 1e-10
+
             w2 = w2.sub([1, 2])
 
         w2.wcs.crpix = u.Quantity(self.reference_pixel)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -279,7 +279,7 @@ class GenericMap(NDData):
             # though we don't care about the third dimension. This applies to both
             # EIT and IRIS data, it is here to reduce the chances of silly errors.
             if self.meta.get('cdelt3', None) == 0:
-                self.meta['cdelt3'] = 1e-10
+                w2.wcs.cdelt[2] = 1e-10
 
             w2 = w2.sub([1, 2])
 

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -1,11 +1,6 @@
-import copy
-
 import numpy as np
 
-import astropy.wcs
-
 from sunpy.map import GenericMap
-from sunpy.util.metadata import MetaDict
 
 __all__ = ['SJIMap']
 
@@ -53,7 +48,7 @@ class SJIMap(GenericMap):
 
         # We have to change this or else the WCS doesn't parse properly, even
         # though we don't care about the third dimension.
-        if self.meta['cdelt3'] == 0:
+        if self.meta.get('cdelt3', None) == 0:
             self.meta['cdelt3'] = 1e-10
 
     @classmethod

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -46,11 +46,6 @@ class SJIMap(GenericMap):
         self.meta['waveunit'] = "Angstrom"
         self.meta['wavelnth'] = header['twave1']
 
-        # We have to change this or else the WCS doesn't parse properly, even
-        # though we don't care about the third dimension.
-        if self.meta.get('cdelt3', None) == 0:
-            self.meta['cdelt3'] = 1e-10
-
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an IRIS SJI image"""

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -1,6 +1,11 @@
+import copy
+
 import numpy as np
 
+import astropy.wcs
+
 from sunpy.map import GenericMap
+from sunpy.util.metadata import MetaDict
 
 __all__ = ['SJIMap']
 
@@ -40,11 +45,16 @@ class SJIMap(GenericMap):
         # Assume pixel units are arcesc if not given
         header['cunit1'] = header.get('cunit1', 'arcsec')
         header['cunit2'] = header.get('cunit2', 'arcsec')
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         self.meta['detector'] = "SJI"
         self.meta['waveunit'] = "Angstrom"
         self.meta['wavelnth'] = header['twave1']
+
+        # We have to change this or else the WCS doesn't parse properly, even
+        # though we don't care about the third dimension.
+        if self.meta['cdelt3'] == 0:
+            self.meta['cdelt3'] = 1e-10
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/rhessi.py
+++ b/sunpy/map/sources/rhessi.py
@@ -40,7 +40,7 @@ class RHESSIMap(GenericMap):
         header['cunit1'] = header.get('cunit1', 'arcsec')
         header['cunit2'] = header.get('cunit2', 'arcsec')
 
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         self._nickname = self.detector
         # TODO Currently (8/29/2011), cannot read fits files containing more

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -97,15 +97,13 @@ def test_wcs(aia171_test_map):
 
     assert all(wcs.wcs.crpix ==
                [aia171_test_map.reference_pixel.x.value, aia171_test_map.reference_pixel.y.value])
-    assert all(wcs.wcs.cdelt == [aia171_test_map.scale.axis1.value,
-                                 aia171_test_map.scale.axis2.value])
-    assert all(
-        wcs.wcs.crval ==
-        [aia171_test_map._reference_longitude.value, aia171_test_map._reference_latitude.value])
+    assert u.allclose(wcs.wcs.cdelt * (u.Unit(wcs.wcs.cunit[0])/u.pix),
+                      u.Quantity(aia171_test_map.scale))
+    assert u.allclose(wcs.wcs.crval * u.Unit(wcs.wcs.cunit[0]),
+                      u.Quantity([aia171_test_map._reference_longitude, aia171_test_map._reference_latitude]))
     assert set(wcs.wcs.ctype) == {
         aia171_test_map.coordinate_system.axis1, aia171_test_map.coordinate_system.axis2}
     np.testing.assert_allclose(wcs.wcs.pc, aia171_test_map.rotation_matrix)
-    assert set(wcs.wcs.cunit) == {u.Unit(a) for a in aia171_test_map.spatial_units}
 
 
 def test_no_observer_wcs(heliographic_test_map):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -99,7 +99,6 @@ def test_wcs(aia171_test_map):
                [aia171_test_map.reference_pixel.x.value, aia171_test_map.reference_pixel.y.value])
     assert all(wcs.wcs.cdelt == [aia171_test_map.scale.axis1.value,
                                  aia171_test_map.scale.axis2.value])
-
     assert all(
         wcs.wcs.crval ==
         [aia171_test_map._reference_longitude.value, aia171_test_map._reference_latitude.value])

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -98,7 +98,8 @@ def test_wcs(aia171_test_map):
     assert all(wcs.wcs.crpix ==
                [aia171_test_map.reference_pixel.x.value, aia171_test_map.reference_pixel.y.value])
     assert all(wcs.wcs.cdelt == [aia171_test_map.scale.axis1.value,
-                                 aia171_test_map.scale.axis1.value])
+                                 aia171_test_map.scale.axis2.value])
+
     assert all(
         wcs.wcs.crval ==
         [aia171_test_map._reference_longitude.value, aia171_test_map._reference_latitude.value])

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -793,7 +793,7 @@ class VSOClient(BaseClient):
                             qr[dataitem.fileiditem.fileid[0]]
                         )
                     except NoData:
-                        results.add_error('', DownloadFailed(dresponse))
+                        results.add_error('', '', DownloadFailed(dresponse))
                         continue
 
             elif code == '300' or code == '412' or code == '405':
@@ -803,7 +803,7 @@ class VSOClient(BaseClient):
                             dresponse.method.methodtype, dresponse
                         )
                     except NoData:
-                        results.add_error('', MultipleChoices(dresponse))
+                        results.add_error('', '', MultipleChoices(dresponse))
                         continue
                 elif code == '412':
                     try:
@@ -811,13 +811,13 @@ class VSOClient(BaseClient):
                             info, dresponse.info
                         )
                     except NoData:
-                        results.add_error('', MissingInformation(dresponse))
+                        results.add_error('', '', MissingInformation(dresponse))
                         continue
                 elif code == '405':
                     try:
                         methods = self.unknown_method(dresponse)
                     except NoData:
-                        results.add_error('', UnknownMethod(dresponse))
+                        results.add_error('', '', UnknownMethod(dresponse))
                         continue
 
                 files = []
@@ -833,7 +833,7 @@ class VSOClient(BaseClient):
                     qr, info
                 )
             else:
-                results.add_error(UnknownStatus(dresponse))
+                results.add_error('', '', UnknownStatus(dresponse))
 
         return results
 


### PR DESCRIPTION
Fixes #3496 

This makes the following changes:

* Change `GenericMap.wcs` to use the raw FITS header, this is so we can get the extra parameters from the FITS headers for the unusual projections in WISPR data. This is a *large* change in approach, although I am reasonably confident it shouldn't break anything.
* Fix IRIS so that the above change dosen't completely destroy it.
* Fix some parfive incompatibility issues in `vso.py`

requires #3497  to actually make WISPR data load.
