### PR TITLE
Use exact rotation to transform from Carrington > Carrington frames

### DIFF
--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -331,9 +331,10 @@ def test_hgc_hgc():
     old = SkyCoord(90*u.deg, 10*u.deg, 1*u.AU, frame=HeliographicCarrington(obstime=obstime))
     new = old.transform_to(HeliographicCarrington(obstime=obstime + 1*u.day))
 
-    assert_quantity_allclose(new.lon, old.lon - 14.1844*u.deg, atol=1e-4*u.deg)  # solar rotation
-    assert_quantity_allclose(new.lat, old.lat, atol=1e-4*u.deg)
-    assert_quantity_allclose(new.radius, old.radius, atol=1e-5*u.AU)
+    assert_quantity_allclose(new.lon, 76.82974*u.deg, atol=1e-4*u.deg)  # solar rotation
+    # Lattitude and radius shouldn't change
+    assert_quantity_allclose(new.lat, old.lat, atol=1e-10*u.deg)
+    assert_quantity_allclose(new.radius, old.radius, atol=1e-10*u.R_sun)
 
 
 def test_hcc_hcc():

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -333,8 +333,8 @@ def test_hgc_hgc():
 
     assert_quantity_allclose(new.lon, 76.82974*u.deg, atol=1e-4*u.deg)  # solar rotation
     # Lattitude and radius shouldn't change
-    assert_quantity_allclose(new.lat, old.lat, atol=1e-10*u.deg)
-    assert_quantity_allclose(new.radius, old.radius, atol=1e-10*u.R_sun)
+    assert_quantity_allclose(new.lat, old.lat, atol=0*u.deg)
+    assert_quantity_allclose(new.radius, old.radius, atol=0*u.m)
 
 
 def test_hcc_hcc():

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -542,8 +542,14 @@ def hgc_to_hgc(from_coo, to_frame):
     if np.all(from_coo.obstime == to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
-        return from_coo.transform_to(HeliographicStonyhurst(obstime=from_coo.obstime)).\
-               transform_to(to_frame)
+        # Import here to avoid a circular import
+        from .sun import L0
+        # Difference in Carrington longitude
+        from_l0 = L0(from_coo.obstime)
+        to_l0 = L0(to_frame.obstime)
+        R = rotation_matrix(-(to_l0 - from_l0), 'z')
+        newrepr = from_coo.cartesian.transform(R)
+        return to_frame.realize_frame(newrepr)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,


### PR DESCRIPTION
Fixes #3530.

This introduces an exact rotation matrix transformation for going between two HeliographicCarrington frames, which removes the inaccuracies of going through various other transformations.

This allows the accuracy of the latitude and radius of the transformation in the tests to be beaten down to zero, as it should be.