### PR TITLE
Coordinate frames that include solar differential rotation

### DIFF
--- a/changelog/3537.feature.rst
+++ b/changelog/3537.feature.rst
@@ -1,0 +1,1 @@
+Added `~sunpy.coordinates.metaframes.RotatedSunFrame` for defining coordinate frames that account for solar rotation.

--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -351,6 +351,9 @@ which is equivalent to::
 .. automodapi:: sunpy.coordinates.frames
     :headings: ^#
 
+.. automodapi:: sunpy.coordinates.metaframes
+    :headings: ^#
+
 .. automodapi:: sunpy.coordinates.transformations
     :headings: ^#
 
@@ -358,9 +361,6 @@ which is equivalent to::
     :headings: ^#
 
 .. automodapi:: sunpy.coordinates.sun
-    :headings: ^#
-
-.. automodapi:: sunpy.coordinates.offset_frame
     :headings: ^#
 
 .. automodapi:: sunpy.coordinates.wcs_utils

--- a/docs/code_ref/coordinates/index.rst
+++ b/docs/code_ref/coordinates/index.rst
@@ -311,59 +311,27 @@ then transform to a projective frame with an ``rsun`` attribute, it will not
 match the ``radius`` coordinate in the Heliographic frame. This is because you may
 mean to be describing a point above the defined 'surface' of the Sun.
 
+More Detailed Information
+-------------------------
 
-Coordinates and WCS
--------------------
+.. toctree::
+   :maxdepth: 1
 
-The `sunpy.coordinates` sub-package provides a mapping between FITS-WCS CTYPE
-convention and the coordinate frames as defined in `sunpy.coordinates`. This is
-used via the `astropy.wcs.utils.wcs_to_celestial_frame` function, with which the
-SunPy frames are registered upon being imported. This list is used by packages
-such as ``wcsaxes`` to convert from `astropy.wcs.WCS` objects to coordinate
-frames.
+   rotatedsunframe
+   wcs
+   other_api
 
-The `sunpy.map.GenericMap` class creates `astropy.wcs.WCS` objects as
-``amap.wcs``, however, it adds some extra attributes to the `~astropy.wcs.WCS`
-object to be able to fully specify the coordinate frame. It adds
-``heliographic_observer`` and ``rsun``.
 
-If you want to obtain a un-realized coordinate frame corresponding to a
-`~sunpy.map.GenericMap` object you can do the following::
-
-  >>> import sunpy.map
-  >>> from sunpy.data.sample import AIA_171_IMAGE  # doctest: +REMOTE_DATA
-  >>> amap = sunpy.map.Map(AIA_171_IMAGE)  # doctest: +REMOTE_DATA
-  >>> amap.observer_coordinate  # doctest: +REMOTE_DATA
-    <SkyCoord (HeliographicStonyhurst: obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
-        (-0.00406308, 0.04787238, 1.51846026e+11)>
-
-which is equivalent to::
-
-  >>> from astropy.wcs.utils import wcs_to_celestial_frame # doctest: +REMOTE_DATA
-  >>> wcs_to_celestial_frame(amap.wcs)  # doctest: +REMOTE_DATA
-    <Helioprojective Frame (obstime=2011-06-07T06:33:02.770, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
-        (-0.00406308, 0.04787238, 1.51846026e+11)>)>
-
+Reference/API
+-------------
 
 .. automodapi:: sunpy.coordinates
-    :headings: ^#
-
-.. automodapi:: sunpy.coordinates.frames
-    :headings: ^#
-
-.. automodapi:: sunpy.coordinates.metaframes
-    :headings: ^#
-
-.. automodapi:: sunpy.coordinates.transformations
     :headings: ^#
 
 .. automodapi:: sunpy.coordinates.ephemeris
     :headings: ^#
 
 .. automodapi:: sunpy.coordinates.sun
-    :headings: ^#
-
-.. automodapi:: sunpy.coordinates.wcs_utils
     :headings: ^#
 
 

--- a/docs/code_ref/coordinates/other_api.rst
+++ b/docs/code_ref/coordinates/other_api.rst
@@ -1,0 +1,18 @@
+.. _sunpy-coordinates-other-api:
+
+Reference/API for supporting coordinates modules
+================================================
+
+The parts of the following modules that are useful to a typical user are already imported into the `sunpy.coordinates` namespace.
+
+.. automodapi:: sunpy.coordinates.frames
+    :headings: ^#
+
+.. automodapi:: sunpy.coordinates.metaframes
+    :headings: ^#
+
+.. automodapi:: sunpy.coordinates.transformations
+    :headings: ^#
+
+.. automodapi:: sunpy.coordinates.wcs_utils
+    :headings: ^#

--- a/docs/code_ref/coordinates/rotatedsunframe.rst
+++ b/docs/code_ref/coordinates/rotatedsunframe.rst
@@ -104,6 +104,12 @@ Note that the points closer to the equator (latitude of 0 degrees) have evolved 
        (112.80904447,  45., 695700.), (111.70697161,  60., 695700.),
        (110.7550473 ,  75., 695700.)]>
 
+.. testsetup::
+  # The next test is run with fixed-precision printing to ensure no whitespace appears when tested
+  >>> import numpy as np
+  >>> old_floatmode = np.get_printoptions()['floatmode']
+  >>> np.set_printoptions(floatmode='fixed')
+
 In the specific case of `~sunpy.coordinates.frames.HeliographicCarrington`, this frame rotates with the Sun, but in a non-differential manner.
 The Carrington longitude approximately follows the rotation of the Sun.
 One can transform to the coordinate frame of 1 day in the future to see the difference between Carrington rotation and differential rotation.
@@ -111,17 +117,20 @@ Note that equator rotates slightly faster than the Carrington rotation rate (its
 
   >>> meridian.transform_to(f.HeliographicCarrington(obstime="2001-01-02"))
   <HeliographicCarrington Coordinate (obstime=2001-01-02T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
-      [( 96.50790846, -7.48914278e+01, 695909.38247254),
-       ( 97.49463421, -5.98996150e+01, 696243.38561962),
-       ( 98.60552101, -4.49146239e+01, 696540.31843083),
-       ( 99.48029415, -2.99354294e+01, 696780.00438298),
-       ( 99.97427245, -1.49606149e+01, 696946.17523076),
-       (100.12423256,  1.15298509e-02, 697027.56204653),
-       ( 99.97381379,  1.49828932e+01, 697018.64842723),
-       ( 99.47937935,  2.99554157e+01, 696920.03844654),
-       ( 98.60439605,  4.49309606e+01, 696738.41638666),
-       ( 97.49378223,  5.99111888e+01, 696486.10075649),
-       ( 96.50761602,  7.48974456e+01, 696180.22046675)]>
+      [( 96.50790846, -74.89142779, 695909.38247254),
+       ( 97.49463421, -59.89961500, 696243.38561962),
+       ( 98.60552101, -44.91462387, 696540.31843083),
+       ( 99.48029415, -29.93542937, 696780.00438298),
+       ( 99.97427245, -14.96061485, 696946.17523076),
+       (100.12423256,   0.01152985, 697027.56204653),
+       ( 99.97381379,  14.98289320, 697018.64842723),
+       ( 99.47937935,  29.95541572, 696920.03844654),
+       ( 98.60439605,  44.93096060, 696738.41638666),
+       ( 97.49378223,  59.91118882, 696486.10075649),
+       ( 96.50761602,  74.89744559, 696180.22046675)]>
+
+.. testcleanup::
+  >>> np.set_printoptions(floatmode=old_floatmode)
 
 Be aware that transformations with a change in ``obstime`` will also contend with a translation of the center of the Sun.
 Note that the ``radius`` component above is no longer precisely on the surface of the Sun.
@@ -132,17 +141,17 @@ Using the context manager, the ``radius`` component stays as the solar radius as
   >>> with transform_with_sun_center():
   ...     print(meridian.transform_to(f.HeliographicCarrington(obstime="2001-01-02")))
   <HeliographicCarrington Coordinate (obstime=2001-01-02T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
-      [( 96.5706473 , -7.50000000e+01, 695700.),
-       ( 97.52257161, -6.00000000e+01, 695700.),
-       ( 98.62464447, -4.50000000e+01, 695700.),
-       ( 99.49776339, -3.00000000e+01, 695700.),
-       ( 99.99177983, -1.50000000e+01, 695700.),
-       (100.14192838,  4.79380955e-15, 695700.),
-       ( 99.99177983,  1.50000000e+01, 695700.),
-       ( 99.49776339,  3.00000000e+01, 695700.),
-       ( 98.62464447,  4.50000000e+01, 695700.),
-       ( 97.52257161,  6.00000000e+01, 695700.),
-       ( 96.5706473 ,  7.50000000e+01, 695700.)]>
+      [( 96.5706473 , -75., 695700.),
+       ( 97.52257161, -60., 695700.),
+       ( 98.62464447, -45., 695700.),
+       ( 99.49776339, -30., 695700.),
+       ( 99.99177983, -15., 695700.),
+       (100.14192838,   0., 695700.),
+       ( 99.99177983,  15., 695700.),
+       ( 99.49776339,  30., 695700.),
+       ( 98.62464447,  45., 695700.),
+       ( 97.52257161,  60., 695700.),
+       ( 96.5706473 ,  75., 695700.)]>
 
 Transforming multiple durations of rotation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/code_ref/coordinates/rotatedsunframe.rst
+++ b/docs/code_ref/coordinates/rotatedsunframe.rst
@@ -1,0 +1,385 @@
+.. _sunpy-coordinates-rotatedsunframe:
+
+Differential rotation using coordinate frames
+=============================================
+
+Normally, coordinates refer to a point in inertial space (relative to the barycenter of the solar system).
+Transforming to a different observation time does not move the point at all, but rather only updates the coordinate representation as needed for the origin and axis orientations at the new observation time.
+However, the Sun both moves translationally in inertial space and rotates about its axis over time.
+Thus, a coordinate that points to a solar feature (e.g., the center of the Sun or an active region on its surface) will not continue to point to the same solar feature at other observation times.
+
+To evolve a coordinate in time such that it accounts for the rotational motion of the Sun, one can use the `~sunpy.coordinates.metaframes.RotatedSunFrame` "metaframe" class as described below.
+This machinery will take into account the latitude-dependent rotation rate of the solar surface, also known as differential rotation.
+
+In addition, one may want to account for the translational motion of the Sun as well, and that can be achieved by also using the context manager `~sunpy.coordinates.transform_with_sun_center` for desired coordinate transformations.
+
+Basics of the RotatedSunFrame class
+-----------------------------------
+In a nutshell, the `~sunpy.coordinates.metaframes.RotatedSunFrame` class allows one to specify coordinates in a coordinate frame prior to an amount of solar (differential) rotation being applied.
+That is, the coordinate will point to a location in inertial space at some time, but will use a coordinate system at a *different* time to refer to that point, while accounting for the differential rotation between those two times.
+
+Technical note: ``RotatedSunFrame`` is not itself a coordinate frame, but is instead a "metaframe".
+A new frame class is created on the fly corresponding to each base coordinate frame class.
+This tutorial will refer to these new classes as ``RotatedSun*`` frames.
+
+Creating coordinates
+^^^^^^^^^^^^^^^^^^^^
+
+``RotatedSunFrame`` requires two inputs: the base coordinate frame and the duration of solar rotation.
+The base coordinate frame needs to be fully specified, which means a defined ``obstime`` and, if relevant, a defined ``observer``.
+Note that the ``RotatedSun*`` frame that is created in this example is appropriately named ``RotatedSunHeliographicStonyhurst``::
+
+  >>> from astropy.coordinates import SkyCoord
+  >>> import astropy.units as u
+  >>> from sunpy.coordinates import RotatedSunFrame
+  >>> import sunpy.coordinates.frames as f
+
+  >>> rs_hgs = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime="2001-01-01"), duration=1*u.day)
+  >>> rs_hgs
+  <RotatedSunHeliographicStonyhurst Frame (base=<HeliographicStonyhurst Frame (obstime=2001-01-01T00:00:00.000)>, duration=1.0 d, rotation_model=howard)>
+
+Once a ``RotatedSun*`` frame is created, it can be used in the same manner as other frames.  Here, we create a `~astropy.coordinates.SkyCoord` using the ``RotatedSun*`` frame::
+
+  >>> SkyCoord(0*u.deg, 0*u.deg, frame=rs_hgs)
+  <SkyCoord (RotatedSunHeliographicStonyhurst: base=<HeliographicStonyhurst Frame (obstime=2001-01-01T00:00:00.000)>, duration=1.0 d, rotation_model=howard): (lon, lat, radius) in (deg, deg, km)
+      (0., 0., 695700.)>
+
+Instead of explicitly specifying the duration of solar rotation, one can use the keyword argument ``rotated_time``.
+The duration will be automatically calculated from the difference between ``rotated_time`` and the ``obstime`` value of the base coordinate frame.
+Here, we also include coordinate data in the supplied base coordinate frame::
+
+  >>> rs_hgc = RotatedSunFrame(base=f.HeliographicCarrington(10*u.deg, 20*u.deg, obstime="2020-03-04 00:00"),
+  ...                         rotated_time="2020-03-06 12:00")
+  >>> rs_hgc
+  <RotatedSunHeliographicCarrington Coordinate (base=<HeliographicCarrington Frame (obstime=2020-03-04T00:00:00.000)>, duration=2.5 d, rotation_model=howard): (lon, lat, radius) in (deg, deg, km)
+      (10., 20., 695700.)>
+
+A ``RotatedSun*`` frame containing coordinate data can be supplied to ``SkyCoord`` as normal::
+
+  >>> SkyCoord(rs_hgc)
+  <SkyCoord (RotatedSunHeliographicCarrington: base=<HeliographicCarrington Frame (obstime=2020-03-04T00:00:00.000)>, duration=2.5 d, rotation_model=howard): (lon, lat, radius) in (deg, deg, km)
+      (10., 20., 695700.)>
+
+It is important to understand that the ``RotatedSun*`` coordinate *already* has differential rotation applied.
+If one converts the ``RotatedSun*`` coordinate to a "real" coordinate frame, even the base coordinate frame used in the ``RotatedSun*`` frame, one sees that the longitude for the coordinate is different from the initial representation (in this case, ~45 degrees instead of 10 degrees)::
+
+  >>> rs_hgc.transform_to(rs_hgc.base)
+  <HeliographicCarrington Coordinate (obstime=2020-03-04T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
+      (45.13354448, 20., 695700.)>
+
+The above examples used the default differential-rotation model, but any of the models available through `sunpy.physics.diff_rot` are selectable.
+For example, instead of the default ("howard"), one can specify "allen" using the keyword argument ``rotation_model``.
+Note the slight difference in the "real" longitude compared to the output above::
+
+  >>> allen = RotatedSunFrame(base=f.HeliographicCarrington(10*u.deg, 20*u.deg, obstime="2020-03-04 00:00"),
+  ...                         rotated_time="2020-03-06 12:00", rotation_model="allen")
+  >>> allen.transform_to(allen.base)
+  <HeliographicCarrington Coordinate (obstime=2020-03-04T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
+      (45.22266666, 20., 695700.)>
+
+Transforming coordinate arrays
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+For another transformation example, we define a meridan with a Carrington longitude of 100 degrees, plus 1 day of differential rotation.
+Again, the coordinates are already differentially rotated in inertial space; the ``RotatedSun*`` frame allows one to represent the coordinates in a frame *prior* to the differential rotation::
+
+  >>> meridian = RotatedSunFrame([100]*11*u.deg, range(-75, 90, 15)*u.deg,
+  ...                            base=f.HeliographicCarrington(obstime="2001-01-01"),
+  ...                            duration=1*u.day)
+  >>> meridian
+  <RotatedSunHeliographicCarrington Coordinate (base=<HeliographicCarrington Frame (obstime=2001-01-01T00:00:00.000)>, duration=1.0 d, rotation_model=howard): (lon, lat, radius) in (deg, deg, km)
+      [(100., -75., 695700.), (100., -60., 695700.), (100., -45., 695700.),
+       (100., -30., 695700.), (100., -15., 695700.), (100.,   0., 695700.),
+       (100.,  15., 695700.), (100.,  30., 695700.), (100.,  45., 695700.),
+       (100.,  60., 695700.), (100.,  75., 695700.)]>
+
+An easy way to "see" the differential rotation is to transform the coordinates to the base coordinate frame.
+Note that the points closer to the equator (latitude of 0 degrees) have evolved farther in longitude than the points at high latitudes::
+
+  >>> meridian.transform_to(meridian.base)
+  <HeliographicCarrington Coordinate (obstime=2001-01-01T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
+      [(110.7550473 , -75., 695700.), (111.70697161, -60., 695700.),
+       (112.80904447, -45., 695700.), (113.68216339, -30., 695700.),
+       (114.17617983, -15., 695700.), (114.32632838,   0., 695700.),
+       (114.17617983,  15., 695700.), (113.68216339,  30., 695700.),
+       (112.80904447,  45., 695700.), (111.70697161,  60., 695700.),
+       (110.7550473 ,  75., 695700.)]>
+
+In the specific case of `~sunpy.coordinates.frames.HeliographicCarrington`, this frame rotates with the Sun, but in a non-differential manner.
+The Carrington longitude approximately follows the rotation of the Sun.
+One can transform to the coordinate frame of 1 day in the future to see the difference between Carrington rotation and differential rotation.
+Note that equator rotates slightly faster than the Carrington rotation rate (its longitude is now greater than 100 degrees), but most latitudes rotate slower than the Carrington rotation rate::
+
+  >>> meridian.transform_to(f.HeliographicCarrington(obstime="2001-01-02"))
+  <HeliographicCarrington Coordinate (obstime=2001-01-02T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
+      [( 96.50790846, -7.48914278e+01, 695909.38247254),
+       ( 97.49463421, -5.98996150e+01, 696243.38561962),
+       ( 98.60552101, -4.49146239e+01, 696540.31843083),
+       ( 99.48029415, -2.99354294e+01, 696780.00438298),
+       ( 99.97427245, -1.49606149e+01, 696946.17523076),
+       (100.12423256,  1.15298509e-02, 697027.56204653),
+       ( 99.97381379,  1.49828932e+01, 697018.64842723),
+       ( 99.47937935,  2.99554157e+01, 696920.03844654),
+       ( 98.60439605,  4.49309606e+01, 696738.41638666),
+       ( 97.49378223,  5.99111888e+01, 696486.10075649),
+       ( 96.50761602,  7.48974456e+01, 696180.22046675)]>
+
+Be aware that transformations with a change in ``obstime`` will also contend with a translation of the center of the Sun.
+Note that the ``radius`` component above is no longer precisely on the surface of the Sun.
+For precise transformations of solar features, one should also use the context manager `~sunpy.coordinates.transformations.transform_with_sun_center` to account for the translational motion of the Sun.
+Using the context manager, the ``radius`` component stays as the solar radius as desired::
+
+  >>> from sunpy.coordinates import transform_with_sun_center
+  >>> with transform_with_sun_center():
+  ...     print(meridian.transform_to(f.HeliographicCarrington(obstime="2001-01-02")))
+  <HeliographicCarrington Coordinate (obstime=2001-01-02T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
+      [( 96.5706473 , -7.50000000e+01, 695700.),
+       ( 97.52257161, -6.00000000e+01, 695700.),
+       ( 98.62464447, -4.50000000e+01, 695700.),
+       ( 99.49776339, -3.00000000e+01, 695700.),
+       ( 99.99177983, -1.50000000e+01, 695700.),
+       (100.14192838,  4.79380955e-15, 695700.),
+       ( 99.99177983,  1.50000000e+01, 695700.),
+       ( 99.49776339,  3.00000000e+01, 695700.),
+       ( 98.62464447,  4.50000000e+01, 695700.),
+       ( 97.52257161,  6.00000000e+01, 695700.),
+       ( 96.5706473 ,  7.50000000e+01, 695700.)]>
+
+Transforming multiple durations of rotation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Another common use case for differential rotation is to track a solar feature over a sequence of time steps.
+Let's track an active region that starts at `~sunpy.coordinates.frames.Helioprojective` coordinates (-123 arcsec, 456 arcsec), as seen from Earth, and we will look both backwards and forwards in time.
+We specify a range of durations from -5 days to +5 days, stepping at 1-day increments::
+
+  >>> durations = range(-5, 6, 1)*u.day
+  >>> ar_start = f.Helioprojective([-123]*len(durations)*u.arcsec, [456]*len(durations)*u.arcsec,
+  ...                              obstime=["2001-01-01"]*len(durations), observer="earth")
+  >>> ar = RotatedSunFrame(base=ar_start, duration=durations)
+  >>> ar
+  <RotatedSunHelioprojective Coordinate (base=<Helioprojective Frame (obstime=['2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000'], rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>)>, duration=[-5. -4. -3. -2. -1.  0.  1.  2.  3.  4.  5.] d, rotation_model=howard): (Tx, Ty) in arcsec
+      [(-123., 456.), (-123., 456.), (-123., 456.), (-123., 456.),
+       (-123., 456.), (-123., 456.), (-123., 456.), (-123., 456.),
+       (-123., 456.), (-123., 456.), (-123., 456.)]>
+
+Let's convert to the base coordinate frame to reveal the motion of the active region over time::
+
+  >>> ar.transform_to(ar.base)
+  <Helioprojective Coordinate (obstime=['2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-01 00:00:00.000'], rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+      [(-865.54956344, 418.10284813, 0.98251245),
+       (-794.6736101 , 429.25935934, 0.98154904),
+       (-676.99949185, 439.15848306, 0.98069504),
+       (-519.35479485, 447.21239117, 0.98000079),
+       (-330.98303969, 452.94056372, 0.97950733),
+       (-123.        , 456.        , 0.97924388),
+       (  92.27675962, 456.20707835, 0.97922605),
+       ( 302.0813494 , 453.54935963, 0.9794549 ),
+       ( 493.98430821, 448.18638939, 0.97991687),
+       ( 656.65386199, 440.43943386, 0.98058459),
+       ( 780.54121099, 430.77097352, 0.98141858)]>
+
+Be aware that these coordinates are represented in the ``Helioprojective`` coordinates as seen from Earth at the base time.
+Since the Earth moves in its orbit around the Sun, one may be more interested in representing these coordinates as they would been seen by an Earth observer at each time step.
+Note that the active region moves slightly slower across the disk of the Sun because the Earth orbits in the same direction as the Sun rotates, thus reducing the apparent rotation of the Sun::
+
+  >>> earth_hpc = f.Helioprojective(obstime=ar.base.obstime + durations, observer="earth")
+  >>> ar.transform_to(earth_hpc)
+  <Helioprojective Coordinate (obstime=['2000-12-27 00:00:00.000' '2000-12-28 00:00:00.000'
+   '2000-12-29 00:00:00.000' '2000-12-30 00:00:00.000'
+   '2000-12-31 00:00:00.000' '2001-01-01 00:00:00.000'
+   '2001-01-02 00:00:00.000' '2001-01-03 00:00:00.000'
+   '2001-01-04 00:00:00.000' '2001-01-05 00:00:00.000'
+   '2001-01-06 00:00:00.000'], rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+      [(-847.35767803, 419.05107437, 0.9822281 ),
+       (-764.81081635, 428.25724753, 0.9813374 ),
+       (-644.29157717, 437.09454986, 0.98056026),
+       (-491.84018851, 445.01082595, 0.97993388),
+       (-315.11434361, 451.4724754 , 0.97948809),
+       (-123.        , 456.        , 0.97924388),
+       (  74.8471119 , 458.20167789, 0.97921235),
+       ( 268.50338021, 457.80291945, 0.97939415),
+       ( 448.29323287, 454.66911128, 0.97977955),
+       ( 605.28861971, 448.82020568, 0.98034895),
+       ( 731.76302454, 440.43591752, 0.98107395)]>
+
+Transforming into RotatedSun frames
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+So far, all of the examples show transformations with the ``RotatedSun*`` frame as the starting frame.
+The ``RotatedSun*`` frame can also be the destination frame, which can be more intuitive in some situations and even necessary in some others (due to API limitations).
+Let's use a coordinate from earlier, which represents the coordinate in a "real" coordinate frame::
+
+  >>> coord = rs_hgc.transform_to(rs_hgc.base)
+  >>> coord
+  <HeliographicCarrington Coordinate (obstime=2020-03-04T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
+      (45.13354448, 20., 695700.)>
+
+If we create a ``RotatedSun*`` frame for a different base time, we can represent that same point using coordinates prior to differential rotation::
+
+  >>> rs_frame = RotatedSunFrame(base=f.HeliographicCarrington(obstime=coord.obstime), rotated_time="2020-03-06 12:00")
+  >>> rs_frame
+  <RotatedSunHeliographicCarrington Frame (base=<HeliographicCarrington Frame (obstime=2020-03-04T00:00:00.000)>, duration=2.5 d, rotation_model=howard)>
+
+  >>> new_coord = coord.transform_to(rs_frame)
+  >>> new_coord
+  <RotatedSunHeliographicCarrington Coordinate (base=<HeliographicCarrington Frame (obstime=2020-03-04T00:00:00.000)>, duration=2.5 d, rotation_model=howard): (lon, lat, radius) in (deg, deg, km)
+      (10., 20., 695700.)>
+
+There coordinates are stored in the ``RotatedSun*`` frame, but it can be useful to "pop off" this extra layer and retain only the coordinate representation in the base coordinate frame.
+There is a convenience method called `~sunpy.coordinates.metaframes.RotatedSunFrame.as_base()` to do exactly that.
+Be aware the resulting coordinate does *not* point to the same location in inertial space, despite the superficial similarity.
+Essentially, the component values have been copied from one coordinate frame to a different coordinate frame, and thus this is not merely a transformation between coordinate frames::
+
+  >>> new_coord.as_base()
+  <HeliographicCarrington Coordinate (obstime=2020-03-04T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
+      (10., 20., 695700.)>
+
+Advanced uses of RotatedSunFrame
+--------------------------------
+
+Here are advanced examples of how to use ``RotatedSunFrame``.
+
+Plotting differentially rotated coordinates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Coordinates in a ``RotatedSun*`` frame can be plotted onto a map in the same manner as a normal coordinate.
+Here, we plot the differentially rotated locations of a solar feature from -5 days to +5 days.
+
+.. plot::
+   :include-source:
+
+   from astropy.coordinates import SkyCoord
+   import astropy.units as u
+   import matplotlib.pyplot as plt
+
+   from sunpy.coordinates import RotatedSunFrame
+   from sunpy.data.sample import AIA_171_IMAGE
+   from sunpy.map import Map
+
+   m = Map(AIA_171_IMAGE)
+
+   fig = plt.figure()
+   ax = plt.subplot(projection=m)
+   m.plot(clip_interval=(1., 99.95)*u.percent)
+
+   durations = range(-5, 6, 1)*u.day
+   point = SkyCoord([187]*len(durations)*u.arcsec, [283]*len(durations)*u.arcsec, frame=m.coordinate_frame)
+   diffrot_point = RotatedSunFrame(base=point, duration=durations)
+
+   middle = len(durations) // 2
+   ax.plot_coord(diffrot_point[middle], 'ro', fillstyle='none')
+   ax.plot_coord(diffrot_point[:middle], 'bo', fillstyle='none')
+   ax.plot_coord(diffrot_point[middle+1:], 'bo', fillstyle='none')
+
+   plt.show()
+
+Grid overlay on a Map
+^^^^^^^^^^^^^^^^^^^^^
+
+We can use the ``RotatedSun*`` frame to straightforwardly plot grid overlays.
+Here, we plot normal ``HeliographicStonyhurst`` longitude lines in white and ``RotatedSunHeliographicStonyhurst`` longitude lines (with 27 days of differential rotation) in blue.
+
+.. plot::
+   :include-source:
+
+   import astropy.units as u
+   import matplotlib.pyplot as plt
+
+   from sunpy.coordinates import RotatedSunFrame, HeliographicStonyhurst
+   from sunpy.data.sample import AIA_171_IMAGE
+   from sunpy.map import Map
+
+   m = Map(AIA_171_IMAGE)
+
+   fig = plt.figure()
+   ax = plt.subplot(projection=m)
+   m.plot(clip_interval=(1., 99.95)*u.percent)
+
+   overlay = ax.get_coords_overlay('heliographic_stonyhurst')
+   overlay[0].set_ticks(spacing=15. * u.deg)
+   overlay[1].set_ticks(spacing=90. * u.deg)
+   overlay.grid(ls='-', color='white')
+
+   rs_hgs = RotatedSunFrame(base=HeliographicStonyhurst(obstime=m.date), duration=27*u.day)
+   overlay = ax.get_coords_overlay(rs_hgs)
+   overlay[0].set_ticks(spacing=15. * u.deg)
+   overlay[1].set_ticks(spacing=90. * u.deg)
+   overlay.grid(ls='-', color='blue')
+
+   plt.show()
+
+Be aware that the distorted ``RotatedSunHeliographicStonyhurst`` longitude lines are plotted on the original coordinate frame, and thus use the ``Helioprojective`` coordinate frame for the location of AIA at the original observation time (as opposed to 27 days later).
+
+Differentially rotating a Map
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+   This example requires `reproject` 0.6 or later to be installed.
+
+Here is an example of reprojecting a map to another time with an observer at a different location.
+To achieve the reprojection, one needs to transform from the original frame to the ``RotatedSun*`` version of the output frame with ``rotated_time`` set to the time of the original frame.
+When reprojecting across a change in time, it is generally advisable to use the `~sunpy.coordinates.transform_with_sun_center` context manager.
+
+.. plot::
+   :include-source:
+
+   from astropy.coordinates import SkyCoord
+   import astropy.units as u
+   from astropy.wcs import WCS
+   import matplotlib.pyplot as plt
+   from reproject import reproject_interp
+
+   from sunpy.coordinates import Helioprojective, RotatedSunFrame, HeliographicStonyhurst, transform_with_sun_center
+   from sunpy.data.sample import AIA_171_IMAGE
+   from sunpy.map import Map, make_fitswcs_header
+
+   # Load the map and define the output time with +5 days of differential rotation
+   m = Map(AIA_171_IMAGE)
+   in_time = m.date
+   out_time = in_time + 5*u.day
+
+   # Define the output real frame with an associated new observer (at Earth)
+   out_frame = Helioprojective(observer='earth', obstime=out_time)
+
+   # Define the output RotatedSunFrame (its `duration` will be -5 days)
+   rot_frame = RotatedSunFrame(base=out_frame, rotated_time=in_time)
+
+   # Construct a WCS object for the output map with the output RotatedSunFrame specified
+   out_shape = m.data.shape
+   out_center = SkyCoord(0*u.arcsec, 0*u.arcsec, frame=out_frame)
+   header = make_fitswcs_header(out_shape, out_center, scale=u.Quantity(m.scale))
+   out_wcs = WCS(header)
+   out_wcs.coordinate_frame = rot_frame
+
+   # Reproject the map from the input frame to the output RotatedSunFrame while following Sun center
+   with transform_with_sun_center():
+       arr, _ = reproject_interp(m, out_wcs, out_shape)
+
+   # Create the output map and preserve the original map's plot settings
+   out_warp = Map(arr, out_wcs)
+   out_warp.plot_settings = m.plot_settings
+
+   # Plot the output map next to the original map
+   fig = plt.figure(figsize=(12, 4))
+
+   ax1 = fig.add_subplot(1, 2, 1, projection=m)
+   m.plot(vmin=0, vmax=20000, title='Original map')
+   plt.colorbar()
+
+   ax2 = fig.add_subplot(1, 2, 2, projection=out_warp)
+   out_warp.plot(vmin=0, vmax=20000,
+                 title=f"Reprojected to an Earth observer {(out_time - in_time).to('day')} later")
+   plt.colorbar()
+
+   plt.show()
+
+Instead of the steps to construct a custom WCS object, one can instead use the WCS from an actual ``Map`` object at the desired output time (e.g., the actual AIA observation at the later time).

--- a/docs/code_ref/coordinates/wcs.rst
+++ b/docs/code_ref/coordinates/wcs.rst
@@ -1,0 +1,33 @@
+.. _sunpy-coordinates-wcs:
+
+Coordinates and WCS
+===================
+
+The `sunpy.coordinates` sub-package provides a mapping between FITS-WCS CTYPE
+convention and the coordinate frames as defined in `sunpy.coordinates`. This is
+used via the `astropy.wcs.utils.wcs_to_celestial_frame` function, with which the
+SunPy frames are registered upon being imported. This list is used by packages
+such as ``wcsaxes`` to convert from `astropy.wcs.WCS` objects to coordinate
+frames.
+
+The `sunpy.map.GenericMap` class creates `astropy.wcs.WCS` objects as
+``amap.wcs``, however, it adds some extra attributes to the `~astropy.wcs.WCS`
+object to be able to fully specify the coordinate frame. It adds
+``heliographic_observer`` and ``rsun``.
+
+If you want to obtain a un-realized coordinate frame corresponding to a
+`~sunpy.map.GenericMap` object you can do the following::
+
+  >>> import sunpy.map
+  >>> from sunpy.data.sample import AIA_171_IMAGE  # doctest: +REMOTE_DATA
+  >>> amap = sunpy.map.Map(AIA_171_IMAGE)  # doctest: +REMOTE_DATA
+  >>> amap.observer_coordinate  # doctest: +REMOTE_DATA
+    <SkyCoord (HeliographicStonyhurst: obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
+        (-0.00406308, 0.04787238, 1.51846026e+11)>
+
+which is equivalent to::
+
+  >>> from astropy.wcs.utils import wcs_to_celestial_frame # doctest: +REMOTE_DATA
+  >>> wcs_to_celestial_frame(amap.wcs)  # doctest: +REMOTE_DATA
+    <Helioprojective Frame (obstime=2011-06-07T06:33:02.770, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
+        (-0.00406308, 0.04787238, 1.51846026e+11)>)>

--- a/docs/code_ref/index.rst
+++ b/docs/code_ref/index.rst
@@ -8,7 +8,7 @@ Code Reference
    :maxdepth: 2
 
    sunpy
-   coordinates
+   coordinates/index
    data
    database
    image

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -19,7 +19,7 @@ below (see `astropy.coordinates.builtin_frames`).
 """
 
 from .frames import *
-from .offset_frame import *
+from .metaframes import *
 from .transformations import transform_with_sun_center, _make_sunpy_graph
 from .ephemeris import *
 from . import sun

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -125,6 +125,14 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
             data.lon.wrap_angle = self._wrap_angle
         return data
 
+    @property
+    def size(self):
+        """
+        Returns the size of the underlying data if it exists, else returns 0.  This overrides the
+        property in `~astropy.coordinates.BaseCoordinateFrame`.
+        """
+        return self.data.size if self.has_data else 0
+
     def __str__(self):
         """
         We override this here so that when you print a SkyCoord it shows the

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -207,7 +207,11 @@ class RotatedSunFrame:
         # Move data out from the base frame
         if self.base.has_data:
             if not self.has_data:
-                self._data = self.base.data
+                # If the duration is an array but the data is scalar, upgrade data to an array
+                if self.base.data.isscalar and not self.duration.isscalar:
+                    self._data = self.base.data._apply('repeat', self.duration.shape)
+                else:
+                    self._data = self.base.data
             self._base = self.base.replicate_without_data()
 
     def as_base(self):
@@ -220,3 +224,10 @@ class RotatedSunFrame:
         space that is being pointed to.
         """
         return self.base.realize_frame(self.data)
+
+    @property
+    def rotated_time(self):
+        """
+        Returns the sum of the base frame's observation time and the rotation of duration.
+        """
+        return self.base.obstime + self.duration

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -1,0 +1,209 @@
+"""
+Coordinate frames that are defined relative to other frames
+"""
+
+from astropy import units as u
+from astropy.coordinates.transformations import FunctionTransform
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.attributes import Attribute, QuantityAttribute
+from astropy.coordinates import SphericalRepresentation
+
+from sunpy import log
+from .frames import SunPyBaseCoordinateFrame, HeliocentricInertial
+from .transformations import _transformation_debug
+from sunpy.time import parse_time
+from sunpy.time.time import _variables_for_parse_time_docstring
+from sunpy.util.decorators import add_common_docstring
+
+__all__ = ['NorthOffsetFrame', 'RotatedSunFrame']
+
+
+from .offset_frame import NorthOffsetFrame
+vars()['NorthOffsetFrame'].__module__ = __name__  # so that docs think that the class is local
+
+
+_rotatedsun_cache = {}
+
+
+def _make_rotatedsun_cls(framecls):
+    """
+    Create a new class that is the rotated-Sun frame for a specific class of
+    base frame. If such a class has already been created for this frame, the
+    same class will be returned.
+
+    This function is necessary because frame transformations depend
+    on connection between specific frame *classes*.  So each type of frame
+    needs its own distinct rotated-Sun frame class.  This function generates
+    just that class, as well as ensuring that only one example of such a class
+    actually gets created in any given Python session.
+    """
+    # This code reuses significant code from Astropy's implementation of SkyOffsetFrame
+
+    if framecls in _rotatedsun_cache:
+        return _rotatedsun_cache[framecls]
+
+    # the class of a class object is the metaclass
+    framemeta = framecls.__class__
+
+    class RotatedSunMeta(framemeta):
+        """
+        This metaclass renames the class to be "RotatedSun<framecls>".
+        """
+        def __new__(cls, name, bases, members):
+            # This has to be done because FrameMeta will set these attributes
+            # to the defaults from BaseCoordinateFrame when it creates the base
+            # RotatedSunFrame class initially.
+            members['_default_representation'] = framecls._default_representation
+            members['_default_differential'] = framecls._default_differential
+
+            newname = name[:-5] if name.endswith('Frame') else name
+            newname += framecls.__name__
+
+            return super().__new__(cls, newname, bases, members)
+
+    # We need this to handle the intermediate metaclass correctly, otherwise we could
+    # just subclass RotatedSunFrame.
+    _RotatedSunFramecls = RotatedSunMeta('RotatedSunFrame',
+                                         (RotatedSunFrame, framecls),
+                                         {'__doc__': RotatedSunFrame.__doc__})
+
+    @frame_transform_graph.transform(FunctionTransform, _RotatedSunFramecls, _RotatedSunFramecls)
+    @_transformation_debug(f"{_RotatedSunFramecls.__name__}->{_RotatedSunFramecls.__name__}")
+    def rotatedsun_to_rotatedsun(from_rotatedsun_coord, to_rotatedsun_frame):
+        """Transform between two rotated-Sun frames."""
+        # This transform goes through the parent frames on each side.
+        # from_frame -> from_frame.base -> to_frame.base -> to_frame
+        intermediate_from = from_rotatedsun_coord.transform_to(from_rotatedsun_coord.base)
+        intermediate_to = intermediate_from.transform_to(to_rotatedsun_frame.base)
+        return intermediate_to.transform_to(to_rotatedsun_frame)
+
+    @frame_transform_graph.transform(FunctionTransform, framecls, _RotatedSunFramecls)
+    @_transformation_debug(f"{framecls.__name__}->{_RotatedSunFramecls.__name__}")
+    def reference_to_rotatedsun(reference_coord, rotatedsun_frame):
+        # Transform to HCI
+        hci_frame = HeliocentricInertial(obstime=rotatedsun_frame.base.obstime)
+        hci_coord = reference_coord.transform_to(hci_frame)
+        oldrepr = hci_coord.spherical
+
+        # Rotate the coordinate in HCI
+        from sunpy.physics.differential_rotation import diff_rot
+        log.debug(f"Applying {rotatedsun_frame.duration} of solar rotation")
+        newlon = oldrepr.lon - diff_rot(rotatedsun_frame.duration,
+                                        oldrepr.lat,
+                                        rot_type=rotatedsun_frame.rotation_model,
+                                        frame_time='sidereal')
+        newrepr = SphericalRepresentation(newlon, oldrepr.lat, oldrepr.distance)
+
+        # Transform back from HCI
+        new_coord = hci_coord.realize_frame(newrepr).transform_to(rotatedsun_frame.base)
+        return rotatedsun_frame.realize_frame(new_coord.data)
+
+    @frame_transform_graph.transform(FunctionTransform, _RotatedSunFramecls, framecls)
+    @_transformation_debug(f"{_RotatedSunFramecls.__name__}->{framecls.__name__}")
+    def rotatedsun_to_reference(rotatedsun_coord, reference_frame):
+        # Transform to HCI
+        from_coord = rotatedsun_coord.base.realize_frame(rotatedsun_coord.data)
+        hci_coord = from_coord.transform_to(HeliocentricInertial(obstime=reference_frame.obstime))
+        oldrepr = hci_coord.spherical
+
+        # Rotate the coordinate in HCI
+        from sunpy.physics.differential_rotation import diff_rot
+        log.debug(f"Applying {rotatedsun_coord.duration} of solar rotation")
+        newlon = oldrepr.lon + diff_rot(rotatedsun_coord.duration,
+                                        oldrepr.lat,
+                                        rot_type=rotatedsun_coord.rotation_model,
+                                        frame_time='sidereal')
+        newrepr = SphericalRepresentation(newlon, oldrepr.lat, oldrepr.distance)
+
+        # Transform back from HCI
+        hci_coord = HeliocentricInertial(newrepr, obstime=reference_frame.obstime)
+        return hci_coord.transform_to(reference_frame)
+
+    _rotatedsun_cache[framecls] = _RotatedSunFramecls
+    return _RotatedSunFramecls
+
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+class RotatedSunFrame:
+    """
+    A frame that applies solar rotation to a base coordinate frame.
+
+    In essence, the coordinate axes of the frame are distorted by differential solar rotation.
+    This allows using a coordinate representation at one time (at the ``obstime`` of the base
+    coordinate frame) to point to a location at a different time that has been differentially
+    rotated by the time difference (``duration``).
+
+    Parameters
+    ----------
+    representation : `~astropy.coordinates.BaseRepresentation` or ``None``
+        A representation object or ``None`` to have no data.  Alternatively, use coordinate
+        component keyword arguments, which depend on the base frame.
+    base : `~astropy.coordinates.SkyCoord` or low-level coordinate object.
+        The coordinate which specifies the base coordinate frame.  The frame must be a SunPy frame.
+    duration : `~astropy.units.Quantity`
+        The duration of solar rotation (defaults to zero days).
+    rotated_time : {parse_time_types}
+        The time to rotate the Sun to.  If provided, ``duration`` will be set to the difference
+        between this time and the observation time in ``base``.
+    rotation_model : `str`
+        Accepted model names are ``'howard'`` (default), ``'snodgrass'``, and ``'allen'``.
+
+    Notes
+    -----
+    ``RotatedSunFrame`` is a factory class.  That is, the objects that it
+    yields are *not* actually objects of class ``RotatedSunFrame``.  Instead,
+    distinct classes are created on-the-fly for whatever the frame class is
+    of ``base``.
+    """
+    # This code reuses significant code from Astropy's implementation of SkyOffsetFrame
+
+    base = Attribute()  # cannot use CoordinateAttribute here
+    duration = QuantityAttribute(default=0*u.day)
+    rotation_model = Attribute(default='howard')
+
+    def __new__(cls, *args, **kwargs):
+        # We don't want to call this method if we've already set up
+        # an rotated-Sun frame for this class.
+        if not (issubclass(cls, RotatedSunFrame) and cls is not RotatedSunFrame):
+            # We get the base argument, and handle it here.
+            try:
+                base_frame = kwargs['base']
+            except KeyError:
+                raise TypeError("Can't initialize a RotatedSunFrame without a `base` keyword.")
+
+            # If a SkyCoord is provided, use the underlying frame
+            if hasattr(base_frame, 'frame'):
+                base_frame = base_frame.frame
+
+            # The base frame needs to be a SunPy frame to have the overridden size() property
+            if not isinstance(base_frame, SunPyBaseCoordinateFrame):
+                raise TypeError("Only SunPy coordinate frames are currently supported.")
+
+            newcls = _make_rotatedsun_cls(base_frame.__class__)
+            return newcls.__new__(newcls, *args, **kwargs)
+
+        # http://stackoverflow.com/questions/19277399/why-does-object-new-work-differently-in-these-three-cases
+        # See above for why this is necessary. Basically, because some child
+        # may override __new__, we must override it here to never pass
+        # arguments to the object.__new__ method.
+        if super().__new__ is object.__new__:
+            return super().__new__(cls)
+        return super().__new__(cls, *args, **kwargs)
+
+    def __init__(self, *args, **kwargs):
+        # Validate inputs
+        if kwargs['base'].obstime is None:
+            raise ValueError("The base coordinate frame must have a defined `obstime`.")
+
+        if 'rotated_time' in kwargs:
+            rotated_time = parse_time(kwargs['rotated_time'])
+            kwargs['duration'] = (rotated_time - kwargs['base'].obstime).to('day')
+            kwargs.pop('rotated_time')
+
+        super().__init__(*args, **kwargs)
+
+        # Move data out from the base frame
+        if self.base.has_data:
+            if not self.has_data:
+                self._data = self.base.data
+            self._base = self.base.replicate_without_data()

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -41,24 +41,20 @@ def _make_rotatedsun_cls(framecls):
     actually gets created in any given Python session.
     """
     # This code reuses significant code from Astropy's implementation of SkyOffsetFrame
+    # See licenses/ASTROPY.rst
 
     if framecls in _rotatedsun_cache:
         return _rotatedsun_cache[framecls]
 
-    # the class of a class object is the metaclass
+    # Obtain the base frame's metaclass by getting the type of the base frame's class
     framemeta = type(framecls)
 
+    # Subclass the metaclass for the RotatedSunFrame from the base frame's metaclass
     class RotatedSunMeta(framemeta):
         """
         This metaclass renames the class to be "RotatedSun<framecls>".
         """
         def __new__(cls, name, bases, members):
-            # This has to be done because FrameMeta will set these attributes
-            # to the defaults from BaseCoordinateFrame when it creates the base
-            # RotatedSunFrame class initially.
-            members['_default_representation'] = framecls._default_representation
-            members['_default_differential'] = framecls._default_differential
-
             newname = name[:-5] if name.endswith('Frame') else name
             newname += framecls.__name__
 
@@ -159,8 +155,13 @@ class RotatedSunFrame:
     of ``base``.
     """
     # This code reuses significant code from Astropy's implementation of SkyOffsetFrame
+    # See licenses/ASTROPY.rst
 
-    base = Attribute()  # cannot use CoordinateAttribute here
+    # Even though the frame attribute `base` is a coordinate frame, we use `Attribute` instead of
+    # `CoordinateAttribute` because we are preserving the supplied frame rather than converting to
+    # a common frame.
+    base = Attribute()
+
     duration = QuantityAttribute(default=0*u.day)
     rotation_model = Attribute(default='howard')
 

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -209,3 +209,14 @@ class RotatedSunFrame:
             if not self.has_data:
                 self._data = self.base.data
             self._base = self.base.replicate_without_data()
+
+    def as_base(self):
+        """
+        Returns a coordinate with the current representation and in the base coordinate frame.
+
+        This method can be thought of as "removing" the
+        `~sunpy.coordinates.metaframe.RotatedSunFrame` layer.  Be aware that this method is not
+        merely a coordinate transformation, because this method changes the location in inertial
+        space that is being pointed to.
+        """
+        return self.base.realize_frame(self.data)

--- a/sunpy/coordinates/tests/strategies.py
+++ b/sunpy/coordinates/tests/strategies.py
@@ -1,0 +1,37 @@
+"""
+Provide a set of hypothesis strategies for various coordinates-related tests.
+"""
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from astropy.coordinates import Longitude, Latitude
+import astropy.units as u
+
+from sunpy.time import parse_time
+
+
+@u.quantity_input
+@st.composite
+def latitudes(draw, min_lat: u.deg = -90*u.deg, max_lat: u.deg = 90*u.deg):
+    lat = st.floats(min_value=min_lat.to_value(u.deg),
+                    max_value=max_lat.to_value(u.deg),
+                    allow_nan=False, allow_infinity=False)
+    return Latitude(draw(lat) * u.deg)
+
+
+@u.quantity_input
+@st.composite
+def longitudes(draw, min_lon: u.deg = -180*u.deg, max_lon: u.deg = 180*u.deg,
+        wrap_angle: u.deg = 180*u.deg):
+    lon = st.floats(min_value=min_lon.to_value(u.deg),
+                    max_value=max_lon.to_value(u.deg),
+                    allow_nan=False, allow_infinity=False)
+    return Longitude(draw(lon) * u.deg, wrap_angle=wrap_angle)
+
+
+@st.composite
+def times(draw, min_time='1960-01-01', max_time='2024-01-01'):
+    days = st.floats(min_value=0,
+                     max_value=(parse_time(max_time) - parse_time(min_time)).to(u.day).value,
+                     allow_nan=False, allow_infinity=False)
+    return parse_time(min_time) + draw(days) * u.day

--- a/sunpy/coordinates/tests/test_metaframes.py
+++ b/sunpy/coordinates/tests/test_metaframes.py
@@ -1,0 +1,135 @@
+import pytest
+
+import astropy.units as u
+from astropy.coordinates import BaseCoordinateFrame, SkyCoord, frame_transform_graph
+from astropy.tests.helper import assert_quantity_allclose
+
+import sunpy.coordinates.frames as f
+from sunpy.coordinates.metaframes import RotatedSunFrame, _rotatedsun_cache
+
+
+# NorthOffsetFrame is tested in test_offset_frame.py
+
+
+@pytest.fixture
+def rot_frames():
+    return {'hgs': RotatedSunFrame(lon=1*u.deg, lat=2*u.deg, radius=3*u.AU,
+                   base=f.HeliographicStonyhurst(obstime='2001-01-01'),
+                   duration=4*u.day),
+            'hgc': RotatedSunFrame(lon=1*u.deg, lat=2*u.deg, radius=3*u.AU,
+                   base=f.HeliographicCarrington(obstime='2001-01-01'),
+                   duration=4*u.day),
+            'hci': RotatedSunFrame(lon=1*u.deg, lat=2*u.deg, distance=3*u.AU,
+                   base=f.HeliocentricInertial(obstime='2001-01-01'),
+                   duration=4*u.day),
+            'hcc': RotatedSunFrame(x=1*u.AU, y=2*u.AU, z=3*u.AU,
+                   base=f.Heliocentric(observer='earth', obstime='2001-01-01'),
+                   duration=4*u.day),
+            'hpc': RotatedSunFrame(Tx=1*u.deg, Ty=2*u.deg, distance=3*u.AU,
+                   base=f.Helioprojective(observer='earth', obstime='2001-01-01'),
+                   duration=4*u.day),
+           }
+
+
+@pytest.fixture
+def base_classes():
+    return {'hgs': f.HeliographicStonyhurst,
+            'hgc': f.HeliographicCarrington,
+            'hci': f.HeliocentricInertial,
+            'hcc': f.Heliocentric,
+            'hpc': f.Helioprojective,
+            }
+
+
+def test_class_creation(rot_frames, base_classes):
+    for rot_frame, base_class in [(rot_frames[key], base_classes[key]) for key in rot_frames.keys()]:
+        rot_class = type(rot_frame)
+
+        # Check that that the RotatedSunFrame metaclass is derived from the frame's metaclass
+        assert issubclass(type(rot_class), type(base_class))
+
+        # Check that the RotatedSunFrame class name has both 'RotatedSun' and the name of the base
+        assert 'RotatedSun' in rot_class.__name__
+        assert base_class.__name__ in rot_class.__name__
+
+        # Check that the base class is in fact the spcified class
+        assert type(rot_frame.base) == base_class
+
+        # Check that one-leg transformations have been created
+        assert len(frame_transform_graph.get_transform(rot_class, rot_class).transforms) == 1
+        assert len(frame_transform_graph.get_transform(base_class, rot_class).transforms) == 1
+        assert len(frame_transform_graph.get_transform(rot_class, base_class).transforms) == 1
+
+        # Check that the base frame is in the cache
+        assert base_class in _rotatedsun_cache
+
+        # Check that the component data has been migrated
+        assert rot_frame.has_data
+        assert not rot_frame.base.has_data
+
+
+def test_as_base(rot_frames):
+    # Check the as_base() method
+    rot_hgs = rot_frames['hgs']
+    a = rot_hgs.as_base()
+
+    assert type(a) == type(rot_hgs.base)
+
+    assert_quantity_allclose(a.lon, rot_hgs.lon)
+    assert_quantity_allclose(a.lat, rot_hgs.lat)
+    assert_quantity_allclose(a.radius, rot_hgs.radius)
+
+
+def test_no_base():
+    with pytest.raises(TypeError):
+        RotatedSunFrame()
+
+
+def test_no_sunpy_frame():
+    with pytest.raises(TypeError):
+        RotatedSunFrame(base=BaseCoordinateFrame)
+
+
+def test_no_obstime():
+    with pytest.raises(ValueError):
+        RotatedSunFrame(base=f.HeliographicStonyhurst(obstime=None))
+
+
+def test_default_duration():
+    r = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime='2001-01-01'))
+    assert_quantity_allclose(r.duration, 0*u.day)
+
+
+def test_rotated_time_to_duration():
+    r1 = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime='2001-01-02'),
+                         rotated_time='2001-01-03')
+    assert_quantity_allclose(r1.duration, 1*u.day)
+
+    r2 = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime='2001-01-02'),
+                         rotated_time='2001-01-01')
+    assert_quantity_allclose(r2.duration, -1*u.day)
+
+
+def test_base_skycoord(rot_frames):
+    # Check that RotatedSunFrame can be instantiated from a SkyCoord
+    s = SkyCoord(1*u.deg, 2*u.deg, 3*u.AU, frame=f.HeliographicStonyhurst, obstime='2001-01-01')
+    r = RotatedSunFrame(base=s)
+
+    assert type(r) == type(rot_frames['hgs'])
+    assert r.has_data
+    assert not r.base.has_data
+
+    assert_quantity_allclose(r.lon, s.lon)
+    assert_quantity_allclose(r.lat, s.lat)
+    assert_quantity_allclose(r.radius, s.radius)
+
+
+def test_default_rotation_model():
+    r = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime='2001-01-01'))
+    assert r.rotation_model == "howard"
+
+
+def test_alternate_rotation_model():
+    r = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime='2001-01-01'),
+                        rotation_model="allen")
+    assert r.rotation_model == "allen"

--- a/sunpy/coordinates/tests/test_metaframes.py
+++ b/sunpy/coordinates/tests/test_metaframes.py
@@ -3,6 +3,7 @@ import pytest
 import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord, frame_transform_graph
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.time import Time
 
 import sunpy.coordinates.frames as f
 from sunpy.coordinates.metaframes import RotatedSunFrame, _rotatedsun_cache
@@ -108,6 +109,25 @@ def test_rotated_time_to_duration():
     r2 = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime='2001-01-02'),
                          rotated_time='2001-01-01')
     assert_quantity_allclose(r2.duration, -1*u.day)
+
+
+def test_rotated_time_property():
+    r1 = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime='2001-01-02'), duration=1*u.day)
+    assert r1.rotated_time == Time('2001-01-03')
+
+    r2 = RotatedSunFrame(base=f.HeliographicStonyhurst(obstime='2001-01-02'), duration=-1*u.day)
+    assert r2.rotated_time == Time('2001-01-01')
+
+
+def test_scalar_base_and_array_duration():
+    scalar_base = f.HeliographicStonyhurst(1*u.deg, 2*u.deg, obstime='2001-01-02')
+    array_duration = [1, -1]*u.day
+    r = RotatedSunFrame(base=scalar_base, duration=array_duration)
+
+    assert not r.data.isscalar
+    assert r.data.shape == array_duration.shape
+    assert_quantity_allclose(r.cartesian[0].xyz, scalar_base.cartesian.xyz)
+    assert_quantity_allclose(r.cartesian[1].xyz, scalar_base.cartesian.xyz)
 
 
 def test_base_skycoord(rot_frames):

--- a/sunpy/coordinates/tests/test_offset_frame.py
+++ b/sunpy/coordinates/tests/test_offset_frame.py
@@ -1,6 +1,5 @@
 import pytest
-import hypothesis.strategies as st
-from hypothesis import given, settings
+from hypothesis import given
 import numpy as np
 
 import astropy.units as u
@@ -8,18 +7,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import SkyCoord, SkyOffsetFrame
 
 from sunpy.coordinates import NorthOffsetFrame
-
-
-@st.composite
-def latitude(draw, lat=st.floats(min_value=-90, max_value=90,
-                                 allow_nan=False, allow_infinity=False)):
-    return draw(lat) * u.deg
-
-
-@st.composite
-def longitude(draw, lon=st.floats(min_value=-180, max_value=180,
-                                 allow_nan=False, allow_infinity=False)):
-    return draw(lon) * u.deg
+from .strategies import longitudes, latitudes
 
 
 def test_null():
@@ -33,8 +21,7 @@ def test_null():
     assert off.origin.lon == 0*u.deg
 
 
-@given(lon=longitude(), lat=latitude())
-@settings(deadline=5000)
+@given(lon=longitudes(), lat=latitudes())
 def test_transform(lon, lat):
     """
     Test that the north pole in the new frame transforms back to the given

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -15,6 +15,9 @@ def solar_wcs_frame_mapping(wcs):
     type values in the `astropy.wcs.utils.wcs_to_celestial_frame` registry.
     """
 
+    if hasattr(wcs, "coordinate_frame"):
+        return wcs.coordinate_frame
+
     dateobs = wcs.wcs.dateobs or None
 
     # SunPy Map adds 'heliographic_observer' and 'rsun' attributes to the WCS


### PR DESCRIPTION
This PR integrates solar (differential) rotation into the coordinates framework.  The approach here is to enable defining a frame that is a modified version of a base coordinate frame by a duration of solar (differential) rotation.  The class factory `RotatedSunFrame` is supplied the "base" coordinate frame, and creates a base-specific rotated-Sun frame class.

Closes #3357

Still needs:
- [x] Add tutorial ([see this recent build](https://30287-2165383-gh.circle-artifacts.com/0/home/circleci/project/docs/_build/html/code_ref/coordinates/rotatedsunframe.html))
- [x] Finish writing tests
- [x] Support array `obstime`/`duration`/`rotated_time`

# Walkthrough
```python
>>> import astropy.units as u
>>> from sunpy.coordinates import RotatedSunFrame
>>> import sunpy.coordinates.frames as f
```

## Propagating a coordinate
Let's define a coordinate array of points in a rotated-Sun frame that in the base HGS frame were on the meridian as seen from Earth.  Here, the rotated-Sun frame applies +1 day of solar rotation.
```python
>>> hgs = f.HeliographicStonyhurst(obstime='2001-01-01')
>>> rotated_arc = RotatedSunFrame([0]*11*u.deg, range(-75, 90, 15)*u.deg, base=hgs, duration=1*u.day)
>>> rotated_arc
<RotatedSunHeliographicStonyhurst Coordinate (base=<HeliographicStonyhurst Frame (obstime=2001-01-01T00:00:00.000)>, duration=1.0 d, rotation_model=howard): (lon, lat, radius) in (deg, deg, km)
    [(0., -75., 695700.), (0., -60., 695700.), (0., -45., 695700.),
     (0., -30., 695700.), (0., -15., 695700.), (0.,   0., 695700.),
     (0.,  15., 695700.), (0.,  30., 695700.), (0.,  45., 695700.),
     (0.,  60., 695700.), (0.,  75., 695700.)]>
```
The coordinate components are relative to the distorted axes of the rotated-Sun frame, and thus are *already* differentially rotated in real space.  Convert the coordinate array back to the HGS frame to see what I mean.
```python
>>> rotated_arc.transform_to(hgs)
<HeliographicStonyhurst Coordinate (obstime=2001-01-01T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
    [(10.7550473 , -75., 695700.), (11.70697161, -60., 695700.),
     (12.80904447, -45., 695700.), (13.68216339, -30., 695700.),
     (14.17617983, -15., 695700.), (14.32632838,   0., 695700.),
     (14.17617983,  15., 695700.), (13.68216339,  30., 695700.),
     (12.80904447,  45., 695700.), (11.70697161,  60., 695700.),
     (10.7550473 ,  75., 695700.)]>
```

##  Another example
There are several ways to instantiate a `RotatedSunFrame` frame.  Here, the input supplied to `base` has the relevant coordinate data, so that data is automatically "moved" to the correct place in the resulting frame.  Also, instead of supplying `duration` directly, the `rotated_time` keyword is used to indirectly define the duration of rotation.
```python
>>> center = f.Helioprojective(0*u.arcsec, 0*u.arcsec, obstime='2001-01-01', observer='earth')
>>> rotated_center = RotatedSunFrame(base=center, rotated_time='2001-01-03')
>>> rotated_center
<RotatedSunHelioprojective Coordinate (base=<Helioprojective Frame (obstime=2001-01-01T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>)>, duration=2.0 d, rotation_model=howard): (Tx, Ty) in arcsec
    (0., 0.)>
```
No surprises here: The HPC center of the solar disk moves mostly in the X direction after +2 days of solar rotation.
```python
>>> rotated_center.transform_to(center)
<Helioprojective Coordinate (obstime=2001-01-01T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
    (468.86076705, -6.35238293, 0.97923501)>
```
Because `RotatedSunFrame` frames are in the transformation graph, you can do more creative transformations.  Here, we calculate what HPC coordinate when differentially rotated by -1 days corresponds to the disk center when differentially rotated by +2 days.
```python
>>> rotated_center.transform_to(RotatedSunFrame(base=center, duration=-1*u.day))
<RotatedSunHelioprojective Coordinate (base=<Helioprojective Frame (obstime=2001-01-01T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>)>, duration=-1.0 d, rotation_model=howard): (Tx, Ty, distance) in (arcsec, arcsec, AU)
    (666.1751848, -13.91351551, 0.97991384)>
```

## Grid overlay on a Map
```python
>>> from sunpy.map import Map
>>> from sunpy.data.sample import AIA_171_IMAGE
>>> m = Map(AIA_171_IMAGE)

>>> import matplotlib.pyplot as plt
>>> ax = plt.subplot(projection=m)
>>> m.plot()

>>> overlay = ax.get_coords_overlay('heliographic_stonyhurst')
>>> overlay[0].set_ticks(spacing=15. * u.deg)
>>> overlay[1].set_ticks(spacing=90. * u.deg)
>>> overlay.grid(ls='-', color='white')

>>> overlay = ax.get_coords_overlay(RotatedSunFrame(base=f.HeliographicStonyhurst(obstime=m.date), duration=27*u.day))
>>> overlay[0].set_ticks(spacing=15. * u.deg)
>>> overlay[1].set_ticks(spacing=90. * u.deg)
>>> overlay.grid(ls='-', color='blue')
```
![diffrot](https://user-images.githubusercontent.com/991759/69450788-f4cc3580-0d2b-11ea-84c3-5ab213ebaa92.png)