### PR TITLE
Context manager to ignore the inertial motion of the Sun for transformations

### DIFF
--- a/changelog/3540.feature.rst
+++ b/changelog/3540.feature.rst
@@ -1,0 +1,1 @@
+Added a context manager (`~sunpy.coordinates.transform_with_sun_center`) to ignore the motion of the center of the Sun for coordinate transformations.

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -20,10 +20,10 @@ below (see `astropy.coordinates.builtin_frames`).
 
 from .frames import *
 from .offset_frame import *
-from . import transformations
+from .transformations import transform_with_sun_center, _make_sunpy_graph
 from .ephemeris import *
 from . import sun
 
 from .wcs_utils import *
 
-__doc__ += transformations._make_sunpy_graph()
+__doc__ += _make_sunpy_graph()


### PR DESCRIPTION
Normally, our coordinates machinery assumes that a coordinate points to a location in inertial space (at rest relative to the solar-system barycenter).  When one transforms a coordinate between frames with different `obstime` values, the representation changes because the origin and orientation of the coordinate frames are different, but the location in inertial space itself does not change.  However, this behavior is awkward for coordinates that are intended to point to locations on the Sun itself, because the Sun moves around in inertial space.  Thus, a coordinate that is on the Sun's surface at one time is no longer exactly on the surface at a different time.  In the following example, note that the point is no longer at the Sun's radius after the HGS->HGC transformation with a one-week difference.

```python
>>> import sunpy.coordinates.frames as f
>>> import astropy.units as u

>>> loc = f.HeliographicStonyhurst(0*u.deg, 0*u.deg, obstime='2001-01-01')
>>> print(loc)
<HeliographicStonyhurst Coordinate (obstime=2001-01-01T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
    (0., 0., 695700.)>

>>> print(loc.transform_to(f.HeliographicCarrington(obstime='2001-01-08')))
<HeliographicCarrington Coordinate (obstime=2001-01-08T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
    (117.35959212, 0.08151069, 690181.02067937)>
```

This PR provides the capability – as a context manager – to ignore this inertial motion of the Sun for transformations.  In essence, coordinates behave as if they move along with Sun over time.  While this would be appropriate for coordinates for Sun features, it would not be appropriate for other solar-system objects (e.g., planets or spacecraft).  When the same transformation in the previous example is performed using the context manager, note that the point remains at the Sun's radius.

```python
>>> from sunpy.coordinates import transform_with_sun_center

>>> with transform_with_sun_center():
>>>     print(loc.transform_to(f.HeliographicCarrington(obstime='2001-01-08')))
<HeliographicCarrington Coordinate (obstime=2001-01-08T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
    (117.98984699, 0., 695700.)>
```

Due to the implementation approach, this context manager works for only five of our coordinate frames and transformations between them:

- `HeliographicStonyhurst`
- `HeliographicCarrington`
- `HeliocentricInertial`
- `Heliocentric`
- `Helioprojective`

Fortunately, it would be rare to identify a Sun feature using a frame other than one of these five.

Still needs:
- [x] Settle on the name
- [x] Decide whether to have this available in the `sunpy.coordinates` namespace
- [x] Documentation example
- [x] Tests

Addresses #3530 and #3532