### PR TITLE
Block `graphviz` version 2.42 on RTD due to the bug with scaling

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -30,6 +30,7 @@ dependencies:
   - sphinx-astropy
   - sphinx-gallery
   - towncrier
+  - graphviz!=2.42.*
   - pip:
     - sunpy-sphinx-theme
     - jplephem

--- a/changelog/3548.doc.rst
+++ b/changelog/3548.doc.rst
@@ -1,0 +1,1 @@
+Fixed an issue with the scaling of class-inheritance diagrams in the online documentation by blocking the versions of `graphviz` containing a bug.


### PR DESCRIPTION
Fixes #3545

The solution is to block `graphviz` version 2.42.x on RTD.  I confirmed that this solution works  through a test branch on the main repo.