### PR TITLE
Improve numpy pinnings for 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel", "numpy==1.14.5"]
+requires = [
+         "setuptools",
+         "setuptools_scm",
+         "wheel",
+         "numpy==1.14.5; python_version<='3.7'",
+         "numpy==1.17.3; python_version>='3.8'",
+         ]
 build-backend = 'setuptools.build_meta'
 
 [ tool.sunpy-bot ]


### PR DESCRIPTION
This should massively increase the build time for 3.8 as it wont have to compile numpy from source.

fixes #3541 