### PR TITLE
Corrected docstring for _B0

### DIFF
--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -223,7 +223,7 @@ def _B0(time='now'):
     Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
     of the center of the disk of the Sun as seen from Earth. The range of B0 is +/-7.23 degrees.
 
-    Section 7 of `Thompson, A&A 449, 791-803 (2006) <https://doi.org/10.1051/0004-6361:20054262>__`
+    Table 1 of `Thompson, A&A 449, 791-803 (2006) <https://doi.org/10.1051/0004-6361:20054262>__`
     defines it as: "Tilt of the solar North rotational axis toward the
     observer (heliographic latitude of the observer)"
 

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -223,9 +223,9 @@ def _B0(time='now'):
     Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
     of the center of the disk of the Sun as seen from Earth. The range of B0 is +/-7.23 degrees.
 
-    Table 1 of `Thompson, A&A 449, 791-803 (2006) <https://doi.org/10.1051/0004-6361:20054262>__`
-    defines it as: "Tilt of the solar North rotational axis toward the
-    observer (heliographic latitude of the observer)"
+    Equivalent definitions include:
+        * The heliographic latitude of Earth
+        * The tilt of the solar North rotational axis toward Earth
 
 
     Parameters

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -88,7 +88,7 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None):
             emitted_time = obstime - light_travel_time
 
         log.info(f"Apparent body location accounts for {light_travel_time.to('s').value:.2f}"
-                  " seconds of light travel time")
+                 " seconds of light travel time")
 
     body_hgs = ICRS(body_icrs).transform_to(HGS(obstime=obstime))
 
@@ -220,11 +220,14 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
 @add_common_docstring(**_variables_for_parse_time_docstring())
 def _B0(time='now'):
     """
-    Return the B0 angle for the Sun at a specified time, which is the tilt of the solar North rotational
-    axis toward the observer (heliographic latitude of the observer).  The range of B0 is +/-7.23 degrees.
-    Ref: see section 7 of Thompson, A&A 449, 791-803 (2006), 
-         https://www.aanda.org/articles/aa/abs/2006/14/aa4262-05/aa4262-05.html
-    
+    Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
+    of the center of the disk of the Sun as seen from Earth. The range of B0 is +/-7.23 degrees.
+
+    Section 7 of `Thompson, A&A 449, 791-803 (2006) <https://doi.org/10.1051/0004-6361:20054262>__`
+    defines it as: "Tilt of the solar North rotational axis toward the
+    observer (heliographic latitude of the observer)"
+
+
     Parameters
     ----------
     time : {parse_time_types}

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -220,9 +220,11 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
 @add_common_docstring(**_variables_for_parse_time_docstring())
 def _B0(time='now'):
     """
-    Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
-    Sun-disk center as seen from Earth.  The range of B0 is +/-7.23 degrees.
-
+    Return the B0 angle for the Sun at a specified time, which is the tilt of the solar North rotational
+    axis toward the observer (heliographic latitude of the observer).  The range of B0 is +/-7.23 degrees.
+    Ref: see section 7 of Thompson, A&A 449, 791-803 (2006), 
+         https://www.aanda.org/articles/aa/abs/2006/14/aa4262-05/aa4262-05.html
+    
     Parameters
     ----------
     time : {parse_time_types}


### PR DESCRIPTION
Original description was:
"Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the Sun-disk center as seen from Earth. "
which has the opposite sense as the revised docstring:
"Return the B0 angle for the Sun at a specified time, which is the tilt of the solar North rotational axis toward the observer (heliographic latitude of the observer)."

<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
