### PR TITLE
More helpful error message for Map(fname) when fname doesn't exist

### DIFF
--- a/changelog/3568.feature.rst
+++ b/changelog/3568.feature.rst
@@ -1,0 +1,2 @@
+Added a more helpful error message when trying to load a file or directory
+that doesn't exist with `Map`.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -219,7 +219,7 @@ class MapFactory(BasicRegistrationFactory):
                 data_header_pairs += pairs
 
             # File system path (file or directory or glob)
-            elif _is_path(arg):
+            elif _possibly_a_path(arg):
                 path = pathlib.Path(arg).expanduser()
                 if _is_file(path):
                     pairs = self._read_file(path, **kwargs)
@@ -349,7 +349,7 @@ def _is_url(arg):
     return True
 
 
-def _is_path(arg):
+def _possibly_a_path(arg):
     """
     Check if arg can be coerced into a Path object.
     Does *not* check if the path exists.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -221,15 +221,17 @@ class MapFactory(BasicRegistrationFactory):
             # File system path (file or directory or glob)
             elif _is_path(arg):
                 path = pathlib.Path(arg).expanduser()
-                if path.is_file():
+                if _is_file(path):
                     pairs = self._read_file(path, **kwargs)
                     data_header_pairs += pairs
-                elif path.is_dir():
+                elif _is_dir(path):
                     for afile in sorted(path.glob('*')):
                         data_header_pairs += self._read_file(afile, **kwargs)
                 elif glob.glob(os.path.expanduser(arg)):
                     for afile in sorted(glob.glob(os.path.expanduser(arg))):
+                        print(afile)
                         data_header_pairs += self._read_file(afile, **kwargs)
+
                 else:
                     raise ValueError(f'Did not find any files at {arg}')
 
@@ -355,6 +357,24 @@ def _is_path(arg):
     try:
         is_path = pathlib.Path(arg)
         return True
+    except Exception:
+        return False
+
+
+# In python<3.8 paths with un-representable chars (ie. '*' on windows)
+# raise an error, so make our own version that returns False instead of
+# erroring. These can be removed when we support python >= 3.8
+# https://docs.python.org/3/library/pathlib.html#methods
+def _is_file(path):
+    try:
+        return path.is_file()
+    except Exception:
+        return False
+
+
+def _is_dir(path):
+    try:
+        return path.is_dir()
     except Exception:
         return False
 

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -229,7 +229,6 @@ class MapFactory(BasicRegistrationFactory):
                         data_header_pairs += self._read_file(afile, **kwargs)
                 elif glob.glob(os.path.expanduser(arg)):
                     for afile in sorted(glob.glob(os.path.expanduser(arg))):
-                        print(afile)
                         data_header_pairs += self._read_file(afile, **kwargs)
 
                 else:

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -148,6 +148,10 @@ class TestMap:
         with pytest.raises(ValueError, match=nonexist_dir):
             maps = sunpy.map.Map(os.fspath(directory))
 
+        with pytest.raises(ValueError, match='Invalid input: 78'):
+            # Check a random unsupported type (int) fails
+            sunpy.map.Map(78)
+
     # requires dask array to run properly
     def test_dask_array(self):
         dask_array = pytest.importorskip('dask.array')

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -141,6 +141,13 @@ class TestMap:
         pair_map = sunpy.map.Map(data, header)
         assert isinstance(pair_map, sunpy.map.GenericMap)
 
+    def test_errors(self):
+        # If directory doesn't exist, make sure it's listed in the error msg
+        nonexist_dir = 'nonexist'
+        directory = pathlib.Path(filepath, nonexist_dir)
+        with pytest.raises(ValueError, match=nonexist_dir):
+            maps = sunpy.map.Map(os.fspath(directory))
+
     # requires dask array to run properly
     def test_dask_array(self):
         dask_array = pytest.importorskip('dask.array')


### PR DESCRIPTION
Fixes #3552

- Check if `arg` can be co-erced into a `Path` object.
- If so, step through checking if it is a file, dir, or glob, and use appropriate logic in each case
- Add a test that `arg` is included in the error message when it's not available.