### PR TITLE
Fixed bugs with some transformations when `obstime` is `None` on the destination frame

### DIFF
--- a/changelog/3576.bugfix.rst
+++ b/changelog/3576.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug with some coordinate transformations when ``obstime`` is ``None`` on one end and should have been copied from the other end.

--- a/changelog/3576.bugfix.rst
+++ b/changelog/3576.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed bug with some coordinate transformations when ``obstime`` is ``None`` on one end and should have been copied from the other end.
+Fixed bugs with some coordinate transformations when ``obstime`` is ``None`` on the destination frame but can be assumed to be the same as the ``obstime`` of the source frame.

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -8,7 +8,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import ICRS, get_body_barycentric
 
 from sunpy.time import parse_time
-from ..frames import Helioprojective, HeliographicStonyhurst
+from ..frames import Helioprojective, HeliographicStonyhurst, HeliocentricInertial
 from ..frameattributes import TimeFrameAttributeSunPy, ObserverCoordinateAttribute
 from sunpy.coordinates import get_earth, frames
 
@@ -16,6 +16,11 @@ from sunpy.coordinates import get_earth, frames
 @pytest.fixture
 def attr():
     return TimeFrameAttributeSunPy()
+
+
+@pytest.fixture
+def oca():
+    return ObserverCoordinateAttribute(HeliographicStonyhurst)
 
 
 def test_now(attr):
@@ -80,16 +85,21 @@ def test_on_frame_error2():
 # ObserverCoordinateAttribute
 
 
-def test_string_coord():
-
-    oca = ObserverCoordinateAttribute(HeliographicStonyhurst)
-
+def test_string_coord(oca):
     obstime = "2011-01-01"
     coord = oca._convert_string_to_coord("earth", obstime)
 
     assert isinstance(coord, HeliographicStonyhurst)
 
     assert coord.obstime == parse_time(obstime)
+
+
+def test_observer_not_hgs(oca):
+    observer = HeliocentricInertial(0*u.deg, 0*u.deg, 1*u.AU, obstime='2001-01-01')
+    result, converted = oca.convert_input(observer)
+
+    assert isinstance(result, HeliographicStonyhurst)
+    assert converted
 
 
 def test_coord_get():

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -713,3 +713,22 @@ def test_array_obstime():
 
     t2 = a.transform_to(Helioprojective(obstime=["2019-01-03", "2019-01-04"]))
     assert isinstance(t2.frame, Helioprojective)
+
+
+_frameset1 = [HeliographicStonyhurst, HeliographicCarrington, HeliocentricInertial]
+_frameset2 = [Heliocentric, Helioprojective]
+
+
+@pytest.mark.parametrize("start_class", _frameset1 + _frameset2)
+@pytest.mark.parametrize("end_class", _frameset1)
+def test_no_obstime_on_one_end(start_class, end_class):
+    start_obstime = Time("2001-01-01")
+
+    if hasattr(start_class, 'observer'):
+        coord = start_class(CartesianRepresentation(0, 0, 0)*u.km,
+                            obstime=start_obstime, observer="earth")
+    else:
+        coord = start_class(CartesianRepresentation(0, 0, 0)*u.km, obstime=start_obstime)
+
+    result = coord.transform_to(end_class)
+    assert result.obstime == start_obstime

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -203,7 +203,7 @@ def hgs_to_hgc(hgscoord, hgcframe):
     total_matrix = _rotation_matrix_hgs_to_hgc(int_coord.obstime)
     newrepr = int_coord.cartesian.transform(total_matrix)
 
-    return hgcframe.realize_frame(newrepr)
+    return hgcframe._replicate(newrepr, obstime=int_coord.obstime)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
@@ -220,7 +220,7 @@ def hgc_to_hgs(hgccoord, hgsframe):
     total_matrix = matrix_transpose(_rotation_matrix_hgs_to_hgc(int_coord.obstime))
     newrepr = int_coord.cartesian.transform(total_matrix)
 
-    return hgsframe.realize_frame(newrepr)
+    return hgsframe._replicate(newrepr, obstime=int_coord.obstime)
 
 
 def _matrix_hcc_to_hpc():
@@ -526,7 +526,9 @@ def hgs_to_hgs(from_coo, to_frame):
     """
     Convert between two Heliographic Stonyhurst frames.
     """
-    if np.all(from_coo.obstime == to_frame.obstime):
+    if to_frame.obstime is None:
+        return from_coo.replicate()
+    elif np.all(from_coo.obstime == to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
         return from_coo.transform_to(HCRS(obstime=from_coo.obstime)).transform_to(to_frame)
@@ -731,7 +733,7 @@ def hgs_to_hci(hgscoord, hciframe):
     total_matrix = _rotation_matrix_hgs_to_hci(int_coord.obstime)
     newrepr = int_coord.cartesian.transform(total_matrix)
 
-    return hciframe.realize_frame(newrepr)
+    return hciframe._replicate(newrepr, obstime=int_coord.obstime)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
@@ -748,7 +750,7 @@ def hci_to_hgs(hcicoord, hgsframe):
     total_matrix = matrix_transpose(_rotation_matrix_hgs_to_hci(int_coord.obstime))
     newrepr = int_coord.cartesian.transform(total_matrix)
 
-    return hgsframe.realize_frame(newrepr)
+    return hgsframe._replicate(newrepr, obstime=int_coord.obstime)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -250,7 +250,7 @@ def hcc_to_hpc(helioccoord, heliopframe):
     observer = _transform_obstime(heliopframe.observer, heliopframe.obstime)
 
     # Loopback transform HCC coord to obstime and observer of HPC frame
-    int_frame = Heliocentric(obstime=heliopframe.obstime, observer=observer)
+    int_frame = Heliocentric(obstime=observer.obstime, observer=observer)
     int_coord = helioccoord.transform_to(int_frame)
 
     # Shift the origin from the Sun to the observer
@@ -287,7 +287,7 @@ def hpc_to_hcc(heliopcoord, heliocframe):
     newrepr += CartesianRepresentation(0*u.m, 0*u.m, distance)
 
     # Complete the conversion of HPC to HCC at the obstime and observer of the HPC coord
-    int_coord = Heliocentric(newrepr, obstime=heliopcoord.obstime, observer=observer)
+    int_coord = Heliocentric(newrepr, obstime=observer.obstime, observer=observer)
 
     # Loopback transform HCC as needed
     return int_coord.transform_to(heliocframe)
@@ -328,7 +328,7 @@ def hcc_to_hgs(helioccoord, heliogframe):
 
     # Transform from HCC to HGS at the HCC obstime
     newrepr = helioccoord.cartesian.transform(total_matrix)
-    int_coord = HeliographicStonyhurst(newrepr, obstime=helioccoord.obstime)
+    int_coord = HeliographicStonyhurst(newrepr, obstime=hcc_observer_at_hcc_obstime.obstime)
 
     # Loopback transform HGS if there is a change in obstime
     return _transform_obstime(int_coord, heliogframe.obstime)
@@ -347,7 +347,7 @@ def hgs_to_hcc(heliogcoord, heliocframe):
     int_coord = _transform_obstime(heliogcoord, heliocframe.obstime)
 
     # Transform the HCC observer (in HGS) to the HCC obstime in case it's different
-    hcc_observer_at_hcc_obstime = _transform_obstime(heliocframe.observer, heliocframe.obstime)
+    hcc_observer_at_hcc_obstime = _transform_obstime(heliocframe.observer, int_coord.obstime)
 
     total_matrix = matrix_transpose(_rotation_matrix_hcc_to_hgs(hcc_observer_at_hcc_obstime.lon,
                                                                 hcc_observer_at_hcc_obstime.lat))
@@ -728,7 +728,7 @@ def hgs_to_hci(hgscoord, hciframe):
     int_coord = _transform_obstime(hgscoord, hciframe.obstime)
 
     # Rotate from HGS to HCI
-    total_matrix = _rotation_matrix_hgs_to_hci(hciframe.obstime)
+    total_matrix = _rotation_matrix_hgs_to_hci(int_coord.obstime)
     newrepr = int_coord.cartesian.transform(total_matrix)
 
     return hciframe.realize_frame(newrepr)
@@ -745,7 +745,7 @@ def hci_to_hgs(hcicoord, hgsframe):
     int_coord = _transform_obstime(hcicoord, hgsframe.obstime)
 
     # Rotate from HCI to HGS
-    total_matrix = matrix_transpose(_rotation_matrix_hgs_to_hci(hgsframe.obstime))
+    total_matrix = matrix_transpose(_rotation_matrix_hgs_to_hci(int_coord.obstime))
     newrepr = int_coord.cartesian.transform(total_matrix)
 
     return hgsframe.realize_frame(newrepr)


### PR DESCRIPTION
There's a bug where some coordinate-frame transformations do not succeed when `obstime` is `None` on the destination frame but can be assumed to be the same as the `obstime` of the source frame (which happens automatically when using `SkyCoord`s).  This assumption is "reasonable" when the destination frame is an observer-independent frame.  For implementation reasons, I have difficulty dealing with this situation when crossing the HGS<->HCRS transformation leg, but I can at least fix it for the subgraph of HGS, HGC, HCI, HCC, and HPC.  I think any user encountering this bug would be working within this subgraph.

I encountered this bug when providing a non-HGS coordinate for the `observer` frame attribute, because it gets auto-converted to HGS with `obstime=None` as the destination frame.  That's why there's a test in `frameattributes.py`.