### PR TITLE
[Backport 1.0] Fixed bugs with some transformations when `obstime` is `None` on the destination frame

### DIFF
--- a/changelog/3576.bugfix.rst
+++ b/changelog/3576.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug with some coordinate transformations when ``obstime`` is ``None`` on one end and should have been copied from the other end.

--- a/changelog/3576.bugfix.rst
+++ b/changelog/3576.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed bug with some coordinate transformations when ``obstime`` is ``None`` on one end and should have been copied from the other end.
+Fixed bugs with some coordinate transformations when ``obstime`` is ``None`` on the destination frame but can be assumed to be the same as the ``obstime`` of the source frame.

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -18,6 +18,11 @@ def attr():
     return TimeFrameAttributeSunPy()
 
 
+@pytest.fixture
+def oca():
+    return ObserverCoordinateAttribute(HeliographicStonyhurst)
+
+
 def test_now(attr):
     """ We can't actually test the value independantly """
     result, converted = attr.convert_input('now')
@@ -80,16 +85,22 @@ def test_on_frame_error2():
 # ObserverCoordinateAttribute
 
 
-def test_string_coord():
-
-    oca = ObserverCoordinateAttribute(HeliographicStonyhurst)
-
+def test_string_coord(oca):
     obstime = "2011-01-01"
     coord = oca._convert_string_to_coord("earth", obstime)
 
     assert isinstance(coord, HeliographicStonyhurst)
 
     assert coord.obstime == parse_time(obstime)
+
+
+def test_observer_not_hgs(oca):
+    # Use the location of Earth specified in HPC rather than HGS
+    observer = Helioprojective(0*u.deg, 0*u.deg, 0*u.AU, observer="earth", obstime='2001-01-01')
+    result, converted = oca.convert_input(observer)
+
+    assert isinstance(result, HeliographicStonyhurst)
+    assert converted
 
 
 def test_coord_get():

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -524,3 +524,22 @@ def test_array_obstime():
 
     t2 = a.transform_to(Helioprojective(obstime=["2019-01-03", "2019-01-04"]))
     assert isinstance(t2.frame, Helioprojective)
+
+
+_frameset1 = [HeliographicStonyhurst, HeliographicCarrington]
+_frameset2 = [Heliocentric, Helioprojective]
+
+
+@pytest.mark.parametrize("start_class", _frameset1 + _frameset2)
+@pytest.mark.parametrize("end_class", _frameset1)
+def test_no_obstime_on_one_end(start_class, end_class):
+    start_obstime = Time("2001-01-01")
+
+    if hasattr(start_class, 'observer'):
+        coord = start_class(CartesianRepresentation(0, 0, 0)*u.km,
+                            obstime=start_obstime, observer="earth")
+    else:
+        coord = start_class(CartesianRepresentation(0, 0, 0)*u.km, obstime=start_obstime)
+
+    result = coord.transform_to(end_class)
+    assert result.obstime == start_obstime

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -111,7 +111,7 @@ def hgs_to_hgc(hgscoord, hgcframe):
     total_matrix = _rotation_matrix_hgs_to_hgc(int_coord.obstime)
     newrepr = int_coord.cartesian.transform(total_matrix)
 
-    return hgcframe.realize_frame(newrepr)
+    return hgcframe._replicate(newrepr, obstime=int_coord.obstime)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
@@ -127,7 +127,7 @@ def hgc_to_hgs(hgccoord, hgsframe):
     total_matrix = matrix_transpose(_rotation_matrix_hgs_to_hgc(int_coord.obstime))
     newrepr = int_coord.cartesian.transform(total_matrix)
 
-    return hgsframe.realize_frame(newrepr)
+    return hgsframe._replicate(newrepr, obstime=int_coord.obstime)
 
 
 def _matrix_hcc_to_hpc():
@@ -410,7 +410,9 @@ def hgs_to_hgs(from_coo, to_frame):
     """
     Convert between two Heliographic Stonyhurst frames.
     """
-    if np.all(from_coo.obstime == to_frame.obstime):
+    if to_frame.obstime is None:
+        return from_coo.replicate()
+    elif np.all(from_coo.obstime == to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
         return from_coo.transform_to(HCRS(obstime=from_coo.obstime)).transform_to(to_frame)

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -153,7 +153,7 @@ def hcc_to_hpc(helioccoord, heliopframe):
     observer = _transform_obstime(heliopframe.observer, heliopframe.obstime)
 
     # Loopback transform HCC coord to obstime and observer of HPC frame
-    int_frame = Heliocentric(obstime=heliopframe.obstime, observer=observer)
+    int_frame = Heliocentric(obstime=observer.obstime, observer=observer)
     int_coord = helioccoord.transform_to(int_frame)
 
     # Shift the origin from the Sun to the observer
@@ -191,7 +191,7 @@ def hpc_to_hcc(heliopcoord, heliocframe):
     newrepr += CartesianRepresentation(0*u.m, 0*u.m, distance)
 
     # Complete the conversion of HPC to HCC at the obstime and observer of the HPC coord
-    int_coord = Heliocentric(newrepr, obstime=heliopcoord.obstime, observer=observer)
+    int_coord = Heliocentric(newrepr, obstime=observer.obstime, observer=observer)
 
     # Loopback transform HCC as needed
     return int_coord.transform_to(heliocframe)
@@ -234,7 +234,7 @@ def hcc_to_hgs(helioccoord, heliogframe):
 
     # Transform from HCC to HGS at the HCC obstime
     newrepr = helioccoord.cartesian.transform(total_matrix)
-    int_coord = HeliographicStonyhurst(newrepr, obstime=helioccoord.obstime)
+    int_coord = HeliographicStonyhurst(newrepr, obstime=hcc_observer_at_hcc_obstime.obstime)
 
     # Loopback transform HGS if there is a change in obstime
     return _transform_obstime(int_coord, heliogframe.obstime)
@@ -255,7 +255,7 @@ def hgs_to_hcc(heliogcoord, heliocframe):
     int_coord = _transform_obstime(heliogcoord, heliocframe.obstime)
 
     # Transform the HCC observer (in HGS) to the HCC obstime in case it's different
-    hcc_observer_at_hcc_obstime = _transform_obstime(heliocframe.observer, heliocframe.obstime)
+    hcc_observer_at_hcc_obstime = _transform_obstime(heliocframe.observer, int_coord.obstime)
 
     total_matrix = matrix_transpose(_rotation_matrix_hcc_to_hgs(hcc_observer_at_hcc_obstime.lon,
                                                                 hcc_observer_at_hcc_obstime.lat))


### PR DESCRIPTION
Manual backport of #3576