### PR TITLE
Fixed bug resulting from 8-bit floats in AIA test data

### DIFF
--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -37,7 +37,7 @@ def aia171_test_shift():
 
 @pytest.fixture
 def aia171_test_map_layer(aia171_test_map):
-    return aia171_test_map.data
+    return aia171_test_map.data.astype('float32')  # SciPy 1.4 requires at least 16-bit floats
 
 
 @pytest.fixture


### PR DESCRIPTION
SciPy 1.4 has new FFT code, which now requires floating-point arrays to have depth 16 bits or greater.  This FFT code is used by scikit-image's `match_template`, which is used by our image co-alignment code.

For some reason, our AIA test file has 8-bit floats.  Thus, the tests for the image co-alignment code need to increase the bit depth of the array.