### PR TITLE
Added a semicolon to squelch a return value from `plot_coord`

### DIFF
--- a/docs/guide/units-coordinates.rst
+++ b/docs/guide/units-coordinates.rst
@@ -229,7 +229,7 @@ Using Coordinates with SunPy Map
    >>> ax = plt.subplot(projection=m)  # doctest: +REMOTE_DATA
    >>> m.plot()  # doctest: +REMOTE_DATA
    <matplotlib.image.AxesImage object at ...>
-   >>> ax.plot_coord(c, 'o')  # doctest: +REMOTE_DATA
+   >>> ax.plot_coord(c, 'o');  # doctest: +REMOTE_DATA
 
 For more information on coordinates see :ref:`sunpy-coordinates` section of
 the :ref:`reference`.


### PR DESCRIPTION
`plot_coord()` from `wcsaxes` returns a value in Astropy 4.0, but doesn't return a value in earlier versions.  One line in our documentation would print out a return value if given, so I added a semicolon so that the return is squelched.