### PR TITLE
Squelch possible return value from `plot_coord` in a doctest

### DIFF
--- a/docs/guide/units-coordinates.rst
+++ b/docs/guide/units-coordinates.rst
@@ -229,7 +229,7 @@ Using Coordinates with SunPy Map
    >>> ax = plt.subplot(projection=m)  # doctest: +REMOTE_DATA
    >>> m.plot()  # doctest: +REMOTE_DATA
    <matplotlib.image.AxesImage object at ...>
-   >>> ax.plot_coord(c, 'o');  # doctest: +REMOTE_DATA
+   >>> _ = ax.plot_coord(c, 'o')  # doctest: +REMOTE_DATA
 
 For more information on coordinates see :ref:`sunpy-coordinates` section of
 the :ref:`reference`.


### PR DESCRIPTION
See #3616.  This is a second attempt, because #3616 didn't solve the problem.  Apparently doctests don't behave the same as interactive shells with respect to multiple statements separated by semicolons in that the output for each statement is still shown.

Here, I instead explicitly trash the return value if one is returned.  It's slightly ugly, but I think still preferable to doing something more complicated.