### PR TITLE
Make WCS creation and header creation more lenient

### DIFF
--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -200,9 +200,9 @@ def header_to_fits(header):
     key_comments = header.pop('KEYCOMMENTS', False)
 
     for k, v in header.items():
-        # Drop any keys which are too long to save into FITS
-        if len(k) > 8:
-            warnings.warn(f"The meta key {k} is too long, dropping from the FITS header.", SunpyUserWarning)
+        # Drop any keys which are too long to save into FITS, or have non-ascii characters
+        if len(k) > 8 or not fits.Card._ascii_text_re.match(str(v)):
+            warnings.warn(f"The meta key {k} is too long or value not ascii, dropping from the FITS header.", SunpyUserWarning)
             continue
         if k.upper() in ('COMMENT', 'HV_COMMENT'):
             comments = str(v).split('\n')

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -271,7 +271,11 @@ class GenericMap(NDData):
         with warnings.catch_warnings():
             # Ignore warnings we may raise when constructing the fits header about dropped keys.
             warnings.simplefilter("ignore", SunpyUserWarning)
-            w2 = astropy.wcs.WCS(header=self.fits_header, _do_set=False)
+            try:
+                w2 = astropy.wcs.WCS(header=self.fits_header, _do_set=False)
+            except Exception:
+                warnings.warn("Unable to treat `.meta` as a FITS header, assuming a simple WCS.")
+                w2 = astropy.wcs.WCS(naxis=2)
 
         # If the FITS header is > 2D pick the first 2 and move on.
         # This will require the FITS header to be valid.


### PR DESCRIPTION
@jmason86 found that the new WCS header parsing was failing on LASCO data. This is a double pronged fix, which a) makes it more likely we can generate a valid FITS header from a map meta and b) falls back to generating a simple 2D WCS like we used to if we can't.