### PR TITLE
add __repr__ for mapsequence objects

### DIFF
--- a/changelog/3636.feature.rst
+++ b/changelog/3636.feature.rst
@@ -1,0 +1,2 @@
+Add ``__repr__`` for `~sunpy.map.MapSequence` objects  so that users can view the
+critical information of all the ``Map`` objects, in a concise manner.

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -85,9 +85,7 @@ class MapSequence:
 
     def __repr__(self):
         names = set([m.__class__.__name__ for m in self.maps])
-
-        no_of_elements = len(self.maps)
-        return f'MapSequence of {no_of_elements} elements, with maps from {", ".join(names)}'
+        return f'MapSequence of {len(self.maps)} elements, with maps from {", ".join(names)}'
 
     # Sorting methods
     @classmethod

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -83,6 +83,12 @@ class MapSequence:
         """Return the number of maps in a mapsequence."""
         return len(self.maps)
 
+    def __repr__(self):
+        names = set([m.__class__.__name__ for m in self.maps])
+
+        no_of_elements = len(self.maps)
+        return f'MapSequence of {no_of_elements} elements, with maps from {", ".join(names)}'
+
     # Sorting methods
     @classmethod
     def _sort_by_date(cls):

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -54,7 +54,9 @@ def mapsequence_all_the_same(aia_map):
 
 @pytest.fixture
 def mapsequence_different_maps(aia_map, eit_map):
-    """ Simple `sunpy.map.mapsequence` for testing, in which there are differnt maps"""
+    """
+    Simple `sunpy.map.mapsequence` for testing, in which there are different maps
+    """
     return sunpy.map.Map([aia_map, eit_map], sequence=True)
 
 
@@ -164,8 +166,10 @@ def test_all_meta(mapsequence_all_the_same):
 
 
 def test_repr(mapsequence_all_the_same, mapsequence_different_maps):
-    """ Tests that overidden __repr__ functionality works as expected. Test
-    for mapsequence of same maps as well that of different maps"""
+    """
+    Tests that overidden __repr__ functionality works as expected. Test
+    for mapsequence of same maps as well that of different maps.
+    """
     # Test the case of MapSequence having same maps
     expected_out = f'MapSequence of 2 elements, with maps from AIAMap'
     obtained_out = repr(mapsequence_all_the_same)

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -23,6 +23,16 @@ def aia_map():
 
 
 @pytest.fixture
+def eit_map():
+    """
+    Load SunPy's test EIT image.
+    """
+    testpath = sunpy.data.test.rootdir
+    eit_file = os.path.join(testpath, "EIT", "efz20040301.020010_s.fits")
+    return sunpy.map.Map(eit_file)
+
+
+@pytest.fixture
 def masked_aia_map(aia_map):
     """
     Put a simple mask in the test AIA image.  A rectangular (not square) block
@@ -40,6 +50,12 @@ def masked_aia_map(aia_map):
 def mapsequence_all_the_same(aia_map):
     """ Simple `sunpy.map.mapsequence` for testing."""
     return sunpy.map.Map([aia_map, aia_map], sequence=True)
+
+
+@pytest.fixture
+def mapsequence_different_maps(aia_map, eit_map):
+    """ Simple `sunpy.map.mapsequence` for testing, in which there are differnt maps"""
+    return sunpy.map.Map([aia_map, eit_map], sequence=True)
 
 
 @pytest.fixture
@@ -145,6 +161,23 @@ def test_all_meta(mapsequence_all_the_same):
     assert len(meta) == 2
     assert np.all(np.asarray([isinstance(h, MetaDict) for h in meta]))
     assert np.all(np.asarray([meta[i] == mapsequence_all_the_same[i].meta for i in range(0, len(meta))]))
+
+
+def test_repr(mapsequence_all_the_same, mapsequence_different_maps):
+    """ Tests that overidden __repr__ functionality works as expected. Test
+    for mapsequence of same maps as well that of different maps"""
+    # Test the case of MapSequence having same maps
+    expected_out = f'MapSequence of 2 elements, with maps from AIAMap'
+    obtained_out = repr(mapsequence_all_the_same)
+    assert len(mapsequence_all_the_same) == 2
+    assert obtained_out == expected_out
+
+    # Test the case of MapSequence having different maps
+    expected_out1 = f'MapSequence of 2 elements, with maps from AIAMap, EITMap'
+    expected_out2 = f'MapSequence of 2 elements, with maps from EITMap, AIAMap'
+    obtained_out = repr(mapsequence_different_maps)
+    assert len(mapsequence_different_maps) == 2
+    assert obtained_out == expected_out1 or obtained_out == expected_out2
 
 
 def test_derotate():


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Overrides the default ``__repr__`` for MapSequence objects so that users can view the critical information in a concise manner

Fixes #3506
Similar to #3542 