### PR TITLE
Adds support for passing TimeSeriesMetaData object to timeseries_factory and associated validation tests.

### DIFF
--- a/changelog/3639.bugfix.rst
+++ b/changelog/3639.bugfix.rst
@@ -1,0 +1,1 @@
+Added support for passing ``TimeSeriesMetaData`` object to ``timeseries_factory`` and associated validation tests.

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -273,6 +273,7 @@ class TestTimeSeries:
         base = parse_time(datetime.datetime.today())
         times = base - TimeDelta(np.arange(24 * 60)*u.minute)
         intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+        tr = sunpy.time.TimeRange(times[0], times[-1])
 
         # Create the data DataFrame, header MetaDict and units OrderedDict
         data = DataFrame(intensity, index=times, columns=['intensity'])
@@ -280,13 +281,16 @@ class TestTimeSeries:
         meta_md = MetaDict({'key': 'value'})
         meta_di = {'key': 'value'}
         meta_od = OrderedDict({'key': 'value'})
+        meta_obj = sunpy.timeseries.TimeSeriesMetaData(timerange=tr, colnames=['GOES'],
+                                                       meta=MetaDict({'key': 'value'}))
 
         # Create TS using different dictionary meta types
         ts_md = sunpy.timeseries.TimeSeries(data, meta_md, units)
         ts_di = sunpy.timeseries.TimeSeries(data, meta_di, units)
         ts_od = sunpy.timeseries.TimeSeries(data, meta_od, units)
-        assert ts_md == ts_di == ts_od
-        assert ts_md.meta.metadata[0][2] == ts_di.meta.metadata[0][2] == ts_od.meta.metadata[0][2]
+        ts_obj = sunpy.timeseries.TimeSeries(data, meta_obj, units)
+        assert ts_md == ts_di == ts_od == ts_obj
+        assert ts_md.meta.metadata[0][2] == ts_di.meta.metadata[0][2] == ts_od.meta.metadata[0][2] == ts_obj.meta.metadata[0][2]
 
     def test_generic_construction_ts_list(self):
         # Generate the data and the corrisponding dates
@@ -431,6 +435,9 @@ class TestTimeSeries:
         assert sunpy.timeseries.TimeSeries._validate_meta(valid_meta_1)
         valid_meta_2 = OrderedDict({'key': 'value'})
         assert sunpy.timeseries.TimeSeries._validate_meta(valid_meta_2)
+        time_range = sunpy.time.TimeRange('2020-01-01 12:00', '2020-01-02 12:00')
+        valid_meta_3 = sunpy.timeseries.TimeSeriesMetaData(time_range)
+        assert sunpy.timeseries.TimeSeries._validate_meta(valid_meta_3)
         invalid_meta = []
         assert not sunpy.timeseries.TimeSeries._validate_meta(invalid_meta)
 

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -150,6 +150,8 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             return True
         elif isinstance(meta, dict):
             return True
+        elif isinstance(meta, sunpy.timeseries.TimeSeriesMetaData):
+            return True
         else:
             return False
 
@@ -287,7 +289,11 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                                 # to preserve multi-line comments
                                 if isinstance(args[i+1], astropy.io.fits.header.Header):
                                     args[i+1] = MetaDict(sunpy.io.header.FileHeader(args[i+1]))
-                                meta.update(args[i+1])
+                                if isinstance(args[i+1], sunpy.timeseries.TimeSeriesMetaData):
+                                    for j in args[i+1].metas:
+                                        meta.update(j)
+                                else:
+                                    meta.update(args[i+1])
                                 i += 1  # an extra increment to account for the meta
 
                 # Add a 3-tuple for this TimeSeries.


### PR DESCRIPTION
Adds support for passing ``TimeSeriesMetaData`` object to ``timeseries_factory`` and associated validation tests.

<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3295
