### PR TITLE
Print all possible map loading errors in MapFactory

### DIFF
--- a/changelog/3646.breaking.rst
+++ b/changelog/3646.breaking.rst
@@ -1,0 +1,4 @@
+`sunpy.map.Map` is now more strict when the metadata of a map cannot be validated, and
+an error is now thrown instead of a warning if metadata cannot be validated. In order to
+load maps that previously loaded without error you may need to pass ``silence_errors=True``
+to `sunpy.map.Map`.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -37,9 +37,6 @@ try:
 except ImportError:
     pass
 
-__authors__ = ["Russell Hewett, Stuart Mumford"]
-__email__ = "stuart@mumford.me.uk"
-
 __all__ = ['Map', 'MapFactory']
 
 
@@ -286,13 +283,11 @@ class MapFactory(BasicRegistrationFactory):
             try:
                 new_map = self._check_registered_widgets(data, meta, **kwargs)
                 new_maps.append(new_map)
-            except (NoMatchError, MultipleMatchError, ValidationFunctionError):
+            except (NoMatchError, MultipleMatchError,
+                    ValidationFunctionError, MapMetaValidationError) as e:
                 if not silence_errors:
                     raise
-            except MapMetaValidationError as e:
                 warnings.warn(f"One of the data, header pairs failed to validate with: {e}")
-            except Exception:
-                raise
 
         new_maps += already_maps
 

--- a/sunpy/map/sources/tests/test_iris_source.py
+++ b/sunpy/map/sources/tests/test_iris_source.py
@@ -13,7 +13,7 @@ import sunpy.data.test
 
 path = sunpy.data.test.rootdir
 fitspath = glob.glob(os.path.join(path, "iris_l2_20130801_074720_4040000014_SJI_1400_t000.fits"))
-irismap = Map(fitspath)
+irismap = Map(fitspath, silence_errors=True)
 
 
 # IRIS Tests

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -152,6 +152,17 @@ class TestMap:
             # Check a random unsupported type (int) fails
             sunpy.map.Map(78)
 
+    @pytest.mark.parametrize('silence,error,match',
+                             [(True, RuntimeError, 'No maps loaded'),
+                              (False, sunpy.map.mapbase.MapMetaValidationError,
+                               'Image coordinate units for axis 1 not present in metadata.')])
+    def test_silence_errors(self, silence, error, match):
+        # Check that the correct errors are raised depending on silence_errors value
+        data = np.arange(0, 100).reshape(10, 10)
+        header = {}
+        with pytest.raises(error, match=match):
+            pair_map = sunpy.map.Map(data, header, silence_errors=silence)
+
     # requires dask array to run properly
     def test_dask_array(self):
         dask_array = pytest.importorskip('dask.array')


### PR DESCRIPTION
Sort of inspired by #3622, I *think* we should be printing warnings whenever a map fails to validate for any reason. None of the other errors seem to be triggered at all in the test suite, so I'm not really sure how to trigger them to check the warnings work as intended.

I've labelled this as a technically breaking change, as the code is now more strict when metadata validation failed (e.g. on the IRIS file I edited in the tests).