### PR TITLE
Force zero warnings in test suite

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,7 @@ addopts = --doctest-rst -m "not figure" --doctest-ignore-import-errors
 asdf_schema_tests_enabled = true
 asdf_schema_root = sunpy/io/special/asdf/schemas/
 markers =
+    remote_data: marks this test function as needing remote data.
     online: marks this test function as needing online connectivity.
     figure: marks this test function as using hash-based Matplotlib figure verification. This mark is not meant to be directly applied, but is instead automatically applied when a test function uses the @sunpy.tests.helpers.figure_test decorator.
     flaky

--- a/setup.cfg
+++ b/setup.cfg
@@ -128,6 +128,8 @@ filterwarnings =
     ignore:The private astropy._erfa module has been made into its own package
     # See https://github.com/astropy/astropy/pull/10570
     ignore:leap-second auto-update failed
+    # See https://github.com/astropy/extension-helpers/issues/23
+    ignore:Distutils was imported before Setuptools
 
 
 [pycodestyle]

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ remote_data_strict = True
 # Pin junit behaviour; we might want to update this to xunit2 at some point
 junit_family=xunit1
 filterwarnings =
-    ignore
+    error
     error::sunpy.util.exceptions.SunpyDeprecationWarning
     #
     # A list of warnings to ignore follows. If you add to this list, you MUST

--- a/sunpy/map/tests/test_compositemap.py
+++ b/sunpy/map/tests/test_compositemap.py
@@ -12,7 +12,8 @@ from sunpy.tests.helpers import figure_test
 testpath = sunpy.data.test.rootdir
 
 # Ignore missing metadata warnings
-pytestmark = pytest.mark.filterwarnings('ignore:Missing metadata for observer')
+pytestmark = [pytest.mark.filterwarnings('ignore:Missing metadata for observer'),
+              pytest.mark.filterwarnings(r'ignore:Unable to treat `\.meta` as a FITS header')]
 
 
 @pytest.fixture

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -61,7 +61,7 @@ class NoRHClient(GenericClient):
 
         # We allow queries with no Wavelength but error here so that the query
         # does not get passed to VSO and spit out garbage.
-        if 'wavelength' not in kwargs.keys() or not kwargs['wavelength']:
+        if 'wavelength' not in kwargs:
             raise ValueError("Queries to NORH should specify either 17GHz or 34GHz as a Wavelength."
                              "see https://solar.nro.nao.ac.jp/norh/doc/manuale/node65.html")
         else:

--- a/sunpy/net/dataretriever/sources/tests/test_goes_suvi.py
+++ b/sunpy/net/dataretriever/sources/tests/test_goes_suvi.py
@@ -47,6 +47,7 @@ def test_get_goes_sat_num(suvi_client):
     assert type(suvi_client._get_goes_sat_num(date)) is int
 
 
+@pytest.mark.filterwarnings('ignore:ERFA function')
 def test_get_goes_sat_num_error(suvi_client):
     date = parse_time('1800/06/11 00:00')
     with pytest.raises(ValueError):

--- a/sunpy/net/helio/tests/test_helio.py
+++ b/sunpy/net/helio/tests/test_helio.py
@@ -290,7 +290,7 @@ def test_select_table(client, monkeypatch):
 
 # Deprecation warning from astropy, fixed in 4.0.2
 # (https://github.com/astropy/astropy/pull/10085)
-@pytest.mark.filterwarnings('ignore:tostring() is deprecated')
+@pytest.mark.filterwarnings(r'ignore:tostring\(\) is deprecated')
 @pytest.mark.remote_data
 def test_time_query(client):
     start = '2005/01/03'

--- a/sunpy/net/helio/tests/test_helio.py
+++ b/sunpy/net/helio/tests/test_helio.py
@@ -288,6 +288,9 @@ def test_select_table(client, monkeypatch):
     assert client.select_table() is None
 
 
+# Deprecation warning from astropy, fixed in 4.0.2
+# (https://github.com/astropy/astropy/pull/10085)
+@pytest.mark.filterwarnings('ignore:tostring() is deprecated')
 @pytest.mark.remote_data
 def test_time_query(client):
     start = '2005/01/03'

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -671,6 +671,9 @@ def test_esp_peek(esp_test_ts):
     esp_test_ts.peek()
 
 
+# This warning is fixed in matplotlib, and the filter can be removed once
+# matplotlib 3.3.1 is released (https://github.com/matplotlib/matplotlib/pull/18101)
+@pytest.mark.filterwarnings('ignore:Support for multi-dimensional indexing.*is deprecated')
 @figure_test
 def test_fermi_gbm_peek(fermi_gbm_test_ts):
     fermi_gbm_test_ts.peek()


### PR DESCRIPTION
It would be great to consciously make sure the right warnings are being thrown in the right places, so lets try turning them all into errors! The test suite will probably 💥 , but I might leave this PR to keep chipping away at the warnings in the hope of one day squashing them all.