### PR TITLE
Fix deprecation warning when reading JPEG2000 files

### DIFF
--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -31,7 +31,9 @@ def read(filepath, **kwargs):
     from glymur import Jp2k
     header = get_header(filepath)
 
-    data = Jp2k(filepath).read()[::-1]
+    data = Jp2k(filepath)[...]
+    # For some reason Jp2k doesn't like [::-1], so do directly on the array
+    data = data[::-1]
 
     return [HDPair(data, header[0])]
 


### PR DESCRIPTION
As of glymur 0.8 (Jan 11, 2015), `.read()` raises a deprecation error, which this fixes. As long as we're happy having this as a minimum dependency (should this be documented anywhere?), this is the correct fix.