### PR TITLE
Put back version.py

### DIFF
--- a/sunpy/__init__.py
+++ b/sunpy/__init__.py
@@ -31,10 +31,7 @@ except NameError:
     import builtins
     builtins._SUNPY_SETUP_ = False
 
-try:
-    from .version import version as __version__
-except ImportError:
-    __version__ = ''
+from .version import version as __version__
 
 
 def _get_bibtex():

--- a/sunpy/version.py
+++ b/sunpy/version.py
@@ -1,0 +1,12 @@
+version = 'unknown.dev'
+try:
+    from importlib_metadata import version as _version, PackageNotFoundError
+    version = _version('sunpy')
+except ImportError:
+    from pkg_resources import get_distribution, DistributionNotFound
+    try:
+        version = get_distribution("sunpy").version
+    except DistributionNotFound:
+        pass
+except PackageNotFoundError:
+    pass


### PR DESCRIPTION
This shouldn't have been deleted... `from .version import version` should always work, so get rid of the try... except... so if someone tries to do this again it's caught!