### PR TITLE
Fix Python version for requiring importlib_resources

### DIFF
--- a/changelog/3683.trivial.rst
+++ b/changelog/3683.trivial.rst
@@ -1,0 +1,1 @@
+Fix Python version for requiring importlib_resources

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
   pandas
   astropy>=3.1
   parfive[ftp]
-  importlib_resources;python_version<"3.8"
+  importlib_resources;python_version<"3.7"
 
 [options.extras_require]
 database = sqlalchemy


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description

The `importlib_resources` is replaces by `importlib.resources` already in Python 3.7; so the requirement is adjusted accordingly. Otherwise, the tests fail on Python 3.7 on Debian, since we don't have an `importlib_resources` package.