### PR TITLE
Use Giles over SunPy bot for milestones and changelogs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,4 +180,4 @@ workflows:
 
 notify:
   webhooks:
-    - url: https://giles.cadair.com/circleci
+    - url: https://giles.cadair.dev/circleci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,50 +8,32 @@ requires = [
          ]
 build-backend = 'setuptools.build_meta'
 
-[ tool.sunpy-bot ]
-  # disable astropy checks
-  changelog_check = false
-  autoclose_stale_pull_request = false
+[ tool.gilesbot ]
+  [ tool.gilesbot.circleci_artifacts ]
+    enabled = true
 
-  # SunPy Checks
-  check_towncrier_changelog = true
-  check_milestone = true
-  post_pr_comment = true
+  [ tool.gilesbot.circleci_artifacts.giles ]
+    url = "html/index.html"
+    message = "Click details to preview the HTML documentation."
 
-  all_passed_message = """
+  [ tool.gilesbot.pull_requests ]
+    enabled = true
 
-  Thanks for the pull request @{pr_handler.user}! Everything looks great!
-"""
-
-  [ tool.sunpy-bot.towncrier_changelog ]
+  [ tool.gilesbot.towncrier_changelog ]
+    enabled = true
     verify_pr_number = true
     changelog_skip_label = "No Changelog Entry Needed"
-    help_url = "https://github.com/Cadair/sunpy/blob/towncrier/changelog/README.rst"
+    help_url = "https://github.com/sunpy/sunpy/blob/master/changelog/README.rst"
 
-    missing_file_message = """
+    changelog_missing_long = "There isn't a changelog file in this pull request. Please add a changelog file to the `changelog/` directory following the instructions in the changelog [README](https://github.com/sunpy/sunpy/blob/master/changelog/README.rst)."
 
+    type_incorrect_long = "The changelog file you added is not one of the allowed types. Please use one of the types described in the changelog [README](https://github.com/sunpy/sunpy/blob/master/changelog/README.rst)"
 
-* I didn't detect a changelog file in this pull request. Please add a changelog file to the `changelog/` directory following the instructions in the changelog [README](https://github.com/sunpy/sunpy/blob/master/changelog/README.rst).
-"""
-    wrong_type_message = """
+    number_incorrect_long = "The number in the changelog file you added does not match the number of this pull request. Please rename the file."
 
-
-* The changelog file you added is not one of the allowed types. Please use one of the types described in the changelog [README](https://github.com/sunpy/sunpy/blob/master/changelog/README.rst)
-"""
-
-    wrong_number_message = """
-
-
-* The number in the changelog file you added does not match the number of this pull request. Please rename the file.
-"""
-
-  [ tool.sunpy-bot.milestone_checker ]
-
-    missing_message = """
-
-
-* This pull request does not have a milestone assigned to it. Only maintainers can change this, so you don't need to worry about it. :smile:
-"""
+  [ tool.gilesbot.milestones ]
+    enabled = true
+    missing_message_long = "This pull request does not have a milestone assigned to it. Only maintainers can change this, so you don't need to worry about it. :smile:"
 
 [tool.towncrier]
     package = "sunpy"


### PR DESCRIPTION
The main advantage to doing this is no more comment from SunPyBot which means no more *multiple* comments from SunPyBot.

All the info that it put in the comment is now shown on the checks page, and we can make the checks page even more detailed.