### PR TITLE
Fix top_right and bottom_left coordinates

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -509,16 +509,22 @@ class GenericMap(NDData):
     @property
     def bottom_left_coord(self):
         """
-        The physical coordinate for the bottom left [0,0] pixel.
+        The physical coordinate for the bottom left corner of the [0,0] pixel.
         """
-        return self.pixel_to_world(0*u.pix, 0*u.pix)
+        # (0, 0) is the centre of the pixel, so offset by half a pixel to get
+        # corner.
+        return self.pixel_to_world(-0.5*u.pix, -0.5*u.pix)
 
     @property
     def top_right_coord(self):
         """
-        The physical coordinate for the top left pixel.
+        The physical coordinate for the top right corner of the top right ([-1, -1]) pixel.
         """
-        return self.pixel_to_world(*self.dimensions)
+        # self.dimensions is the centre of the pixel, so offset by half a pixel to get
+        # corner.
+        x, y = self.dimensions
+        x, y = x + 0.5 * u.pix, y + 0.5 * u.pix
+        return self.pixel_to_world(x, y)
 
     @property
     def center(self):


### PR DESCRIPTION
Fixes #2908

This correctly selects the bottom left and top left coordinates of the map, such that the square defined by these coordinates is the bounding box of the image. The issue was needing an extra 0.5 pixel offset, to account for the pixel coordinates labeling the centre of the pixels.

This modifies a few figure tests, but I think in a good way, because some axis labels that weren't previously shown are now shown. There's quite a big change in one of the resampled AIA image figures, which needs checking to make sure the change is correct.

Also clarified the doc wording, to hopefully make clear what these properties actually return.