### PR TITLE
Pin glymur to avoid gdal dependency

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - parfive
   - sqlalchemy
   - scikit-image
-  - glymur
+  - glymur<0.9
   - beautifulsoup4
   - drms
   - python-dateutil

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - parfive
   - sqlalchemy
   - scikit-image
-  - glymur
+  - glymur<0.9
   - beautifulsoup4
   - drms
   - python-dateutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
 [options.extras_require]
 database = sqlalchemy
 image = scikit-image
-jpeg2000 = glymur
+jpeg2000 = glymur<0.9
 net =
   beautifulsoup4
   drms

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ conda_deps =
     beautifulsoup4
     dask
     drms
-    glymur
+    glymur<0.9
     hypothesis
     jinja2
     lxml


### PR DESCRIPTION
This PR pins `glymur<0.9` as the recently released v0.9 has a dependency on `gdal` and this is causing CI installation issues. See osgeo/gdal#2166.

Though it does not seem to be affecting conda installations,  I've pinned it in the binder and RTD conda environments as well.