### PR TITLE
Refactoring sunpy.net.attrs

### DIFF
--- a/changelog/3714.removal.rst
+++ b/changelog/3714.removal.rst
@@ -1,0 +1,1 @@
+`sunpy.util.multimethod.MultiMethod` is deprecated, `functools.singledispatch` provides equivalent functionality in the standard library.

--- a/changelog/3714.trivial.rst
+++ b/changelog/3714.trivial.rst
@@ -1,0 +1,1 @@
+`sunpy.net.attr.AttrWalker` no longer uses `sunpy.util.multimethod.MultiMethod` it uses a derivative of `functools.singledispatch` `sunpy.util.functools.seconddispatch` which dispatches on the second argument.

--- a/docs/code_ref/net.rst
+++ b/docs/code_ref/net.rst
@@ -6,7 +6,7 @@ solar physics related web services. This submodule contains many layers. Most
 users should use `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`, which
 is an interface to multiple sources including all the sources implemented in
 `~sunpy.net.dataretriever` as well as `~sunpy.net.vso` and `~sunpy.net.jsoc`.
-Fido ~`sunpy.net.fido_factory.UnifiedDownloaderFactory` can be used like so::
+`Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` can be used like so::
 
     >>> from sunpy.net import Fido, attrs as a
     >>> results = Fido.search(a.Time("2012/1/1", "2012/1/2"), a.Instrument('lyra'))  # doctest: +REMOTE_DATA
@@ -15,7 +15,19 @@ Fido ~`sunpy.net.fido_factory.UnifiedDownloaderFactory` can be used like so::
 .. automodapi:: sunpy.net
    :no-heading:
 
+.. automodapi:: sunpy.net.attrs
+
 .. automodapi:: sunpy.net.fido_factory
+
+
+VSO
+---
+
+.. automodapi:: sunpy.net.vso
+   :headings: ^#
+
+.. automodapi:: sunpy.net.vso.attrs
+   :headings: #~
 
 
 Dataretriever
@@ -28,14 +40,7 @@ Dataretriever
 .. automodapi:: sunpy.net.dataretriever.sources
    :headings: #~
 
-
-VSO
----
-
-.. automodapi:: sunpy.net.vso
-   :headings: ^#
-
-.. automodapi:: sunpy.net.vso.attrs
+.. automodapi:: sunpy.net.dataretriever.attrs.goes
    :headings: #~
 
 JSOC
@@ -73,8 +78,15 @@ Helioviewer
 .. automodapi:: sunpy.net.helioviewer
     :headings: ^#
 
-Attr
-----
+
+Internal Classes and Functions
+------------------------------
+
+These classes and functions are designed to be used to help develop new clients
+for `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`.
+
+.. automodapi:: sunpy.net.base_client
+   :headings: ^#
 
 .. automodapi:: sunpy.net.attr
-   :no-heading:
+   :headings: ^#

--- a/docs/code_ref/util.rst
+++ b/docs/code_ref/util.rst
@@ -14,3 +14,5 @@ SunPy util
 .. automodapi:: sunpy.util.xml
 
 .. automodapi:: sunpy.util.scraper
+
+.. automodapi:: sunpy.util.functools

--- a/docs/guide/acquiring_data/database.rst
+++ b/docs/guide/acquiring_data/database.rst
@@ -257,7 +257,7 @@ though. If you want to add new entries using the VSO and also want to
 download files at the same time, take a look at the following two
 sections.
 
-    >>> from sunpy.net import vso
+    >>> from sunpy.net import vso, attrs as a
     >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
 
 .. testsetup:: *
@@ -276,8 +276,8 @@ sections.
 After initialising the VSO client:
 
     >>> qr = client.search(
-    ...     vso.attrs.Time('2011-05-08', '2011-05-08 00:00:05'),
-    ...     vso.attrs.Instrument('AIA'))  # doctest: +REMOTE_DATA
+    ...     a.Time('2011-05-08', '2011-05-08 00:00:05'),
+    ...     a.Instrument('AIA'))  # doctest: +REMOTE_DATA
     >>> len(qr)  # doctest: +REMOTE_DATA
     4
     >>> database.add_from_vso_query_result(qr)  # doctest: +REMOTE_DATA
@@ -308,8 +308,8 @@ In the next code snippet new data is downloaded as this query
 has not been downloaded before.
 
     >>> entries = database.fetch(
-    ...     vso.attrs.Time('2012-08-05', '2012-08-05 00:00:05'),
-    ...     vso.attrs.Instrument('AIA'))  # doctest: +REMOTE_DATA
+    ...     a.Time('2012-08-05', '2012-08-05 00:00:05'),
+    ...     a.Instrument('AIA'))  # doctest: +REMOTE_DATA
     >>> len(database)  # doctest: +REMOTE_DATA
     67
 
@@ -317,8 +317,8 @@ Any more identical fetch calls don't add any new entries to the database
 because they have already been downloaded.
 
     >>> entries = database.fetch(
-    ...     vso.attrs.Time('2012-08-05', '2012-08-05 00:00:05'),
-    ...     vso.attrs.Instrument('AIA'))  # doctest: +REMOTE_DATA
+    ...     a.Time('2012-08-05', '2012-08-05 00:00:05'),
+    ...     a.Instrument('AIA'))  # doctest: +REMOTE_DATA
     >>> len(database)  # doctest: +REMOTE_DATA
     67
 
@@ -326,8 +326,8 @@ However, this different fetch call downloads new files because there is a
 new date range whose files have not been downloaded yet.
 
     >>> entries = database.fetch(
-    ...     vso.attrs.Time('2013-08-05', '2013-08-05 00:00:05'),
-    ...     vso.attrs.Instrument('AIA'))  # doctest: +REMOTE_DATA
+    ...     a.Time('2013-08-05', '2013-08-05 00:00:05'),
+    ...     a.Instrument('AIA'))  # doctest: +REMOTE_DATA
     >>> len(database)  # doctest: +REMOTE_DATA
     71
 
@@ -337,8 +337,8 @@ following example, the query is new, but all of it's files have already been
 downloaded. This means no new files are downloaded.
 
     >>> entries = database.fetch(
-    ...     vso.attrs.Time('2012-08-05 00:00:00', '2012-08-05 00:00:01'),
-    ...     vso.attrs.Instrument('AIA'))  # doctest: +REMOTE_DATA
+    ...     a.Time('2012-08-05 00:00:00', '2012-08-05 00:00:01'),
+    ...     a.Instrument('AIA'))  # doctest: +REMOTE_DATA
     >>> len(database)  # doctest: +REMOTE_DATA
     71
 
@@ -681,19 +681,19 @@ with the EIT.
 
 7.1 Using VSO attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~
-Using the attributes from :mod:`sunpy.net.vso.attrs` is quite intuitive:
+Using the attributes from :mod:`sunpy.net.attrs` is quite intuitive:
 the simple attributes and the Time attribute work exactly as you expect.
 
 .. note::
 
-  The `near` parameter of :class:`sunpy.net.vso.attrs.Time` is ignored, because
+  The `near` parameter of :class:`sunpy.net.attrs.Time` is ignored, because
   it's behaviour is not documented and it is different depending on the
   server which is requested.
 
 The following query returns the data that was added in section 2.3.2:
 
     >>> print(display_entries(
-    ...     database.search(vso.attrs.Time('2012-08-05', '2012-08-05 00:00:05'), vso.attrs.Instrument('AIA')),
+    ...     database.search(a.Time('2012-08-05', '2012-08-05 00:00:05'), a.Instrument('AIA')),
     ...     ['id', 'observation_time_start', 'observation_time_end',
     ...      'instrument', 'wavemin', 'wavemax'], sort=True))   # doctest:  +REMOTE_DATA
      id observation_time_start observation_time_end instrument wavemin wavemax
@@ -707,7 +707,7 @@ The following query returns the data that was added in section 2.3.2:
     in sunpy.util.unit_conversion.to_angstrom (this is called by the
     __init__ of the Wave attribute)
 
-When using the :class:`sunpy.net.vso.attrs.Wave` attribute, you have to
+When using the :class:`sunpy.net.attrs.Wavelength` attribute, you have to
 specify a unit using `astropy.units.Quantity`. If not an error is
 raised. This also means that there is no default unit that is
 used by the class. To know how you can specify a detail using astropy
@@ -715,7 +715,7 @@ check `astropy.units`.
 
     >>> import astropy.units as u
     >>> print(display_entries(
-    ...     database.search(vso.attrs.Wavelength(1.0*u.nm, 2.0*u.nm)),
+    ...     database.search(a.Wavelength(1.0*u.nm, 2.0*u.nm)),
     ...     ['id', 'observation_time_start', 'observation_time_end',
     ...      'instrument', 'wavemin', 'wavemax'], sort=True))   # doctest:  +REMOTE_DATA
      id observation_time_start ...      wavemin            wavemax

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -57,7 +57,7 @@ variable set to the Fido search, in this case, result::
 Queries can be made more flexible or specific by adding more attrs objects to
 the `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` search. Specific
 passbands can be searched for by supplying an `~astropy.units.Quantity` to the
-`a.Wavelength <sunpy.net.vso.attrs.Wavelength>` attribute::
+`a.Wavelength <sunpy.net.attrs.Wavelength>` attribute::
 
     >>> import astropy.units as u
     >>> Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument('norh'),
@@ -77,15 +77,15 @@ passbands can be searched for by supplying an `~astropy.units.Quantity` to the
 
 Data of a given cadence can also be specified using the Sample attribute. To
 search for data at a given cadence use the
-`a.vso.Sample <sunpy.net.vso.attrs.Sample>` attribute.
-`a.vso.Sample <sunpy.net.vso.attrs.Sample>` is only supported by the
+`a.Sample <sunpy.net.attrs.Sample>` attribute.
+`a.Sample <sunpy.net.attrs.Sample>` is only supported by the
 `sunpy.net.vso.VSOClient` hence it has the ``a.vso`` prefix. Attributes
 like this which are client specific will result in
 `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` only searching that
 client for results, in this case VSO.::
 
     >>> Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument('aia'),
-    ...             a.Wavelength(171*u.angstrom), a.vso.Sample(10*u.minute))  # doctest: +REMOTE_DATA +ELLIPSIS
+    ...             a.Wavelength(171*u.angstrom), a.Sample(10*u.minute))  # doctest: +REMOTE_DATA +ELLIPSIS
     <sunpy.net.fido_factory.UnifiedResponse object at ...>
     Results from 1 Provider:
     <BLANKLINE>

--- a/docs/guide/tour.rst
+++ b/docs/guide/tour.rst
@@ -319,7 +319,7 @@ A simple example of this is shown below::
 
   >>> db = Database()
   >>> db.fetch(a.Time("2011-09-20T01:00:00", "2011-09-20T02:00:00"),
-  ...          a.Instrument('AIA'), a.vso.Sample(15*u.min))  # doctest: +REMOTE_DATA
+  ...          a.Instrument('AIA'), a.Sample(15*u.min))  # doctest: +REMOTE_DATA
   >>> db.commit()  # doctest: +REMOTE_DATA
 
   >>> db  # doctest: +SKIP
@@ -341,7 +341,7 @@ A simple example of this is shown below::
 If you then do a second query::
 
   >>> db.fetch(a.Time("2011-09-20T01:00:00", "2011-09-20T02:15:00"),
-  ...          a.Instrument('AIA'), a.vso.Sample(15*u.min))  # doctest: +REMOTE_DATA
+  ...          a.Instrument('AIA'), a.Sample(15*u.min))  # doctest: +REMOTE_DATA
   >>> db.commit()  # doctest: +REMOTE_DATA
   >>> db  # doctest: +SKIP
   <Table length=12>

--- a/examples/plotting/magnetogram_active_regions.py
+++ b/examples/plotting/magnetogram_active_regions.py
@@ -24,7 +24,7 @@ start_time = parse_time("2017-01-25")
 end_time = start_time + TimeDelta(23*u.hour + 59*u.minute + 59*u.second)
 results = Fido.search(a.Time(start_time, end_time),
                       a.Instrument('HMI') & a.vso.Physobs("LOS_magnetic_field"),
-                      a.vso.Sample(60 * u.second))
+                      a.Sample(60 * u.second))
 
 ##############################################################################
 # Let's select only the first file, download it and create a map.

--- a/examples/sunpy_other_packages/reprojection_aia_euvi_mosaic.py
+++ b/examples/sunpy_other_packages/reprojection_aia_euvi_mosaic.py
@@ -34,7 +34,7 @@ stereo = (a.Instrument('EUVI') &
           a.Time('2011-11-01', '2011-11-01T00:10:00'))
 
 aia = (a.Instrument('AIA') &
-       a.vso.Sample(24 * u.hour) &
+       a.Sample(24 * u.hour) &
        a.Time('2011-11-01', '2011-11-02'))
 
 wave = a.Wavelength(19.5 * u.nm, 19.5 * u.nm)

--- a/examples/sunpy_other_packages/reprojection_align_aia_hmi.py
+++ b/examples/sunpy_other_packages/reprojection_align_aia_hmi.py
@@ -29,7 +29,7 @@ plt.rcParams['figure.figsize'] = (16, 8)
 ######################################################################
 # We are going to download one AIA and one HMI magnetogram image.
 
-time = (a.vso.Sample(24 * u.hour) &
+time = (a.Sample(24 * u.hour) &
         a.Time('2010-08-19', '2010-08-19T00:10:00', '2010-08-19') &
         a.vso.Extent(0, 0, 0, 0, "FULLDISK"))
 aia = a.Instrument('AIA') & a.Wavelength(17 * u.nm, 18 * u.nm)

--- a/examples/sunpy_other_packages/reprojection_different_observers.py
+++ b/examples/sunpy_other_packages/reprojection_different_observers.py
@@ -36,7 +36,7 @@ stereo = (a.vso.Source('STEREO_A') &
           a.Instrument('EUVI') &
           a.Time('2010-08-19', '2010-08-19T00:10:00'))
 aia = (a.Instrument('AIA') &
-       a.vso.Sample(24 * u.hour) &
+       a.Sample(24 * u.hour) &
        a.Time('2010-08-19', '2010-08-19T00:10:00'))
 wave = a.Wavelength(17 * u.nm, 18 * u.nm)
 

--- a/examples/units_and_coordinates/AIA_limb_STEREO.py
+++ b/examples/units_and_coordinates/AIA_limb_STEREO.py
@@ -27,7 +27,7 @@ stereo = (a.vso.Source('STEREO_B') &
           a.Time('2011-01-01', '2011-01-01T00:10:00'))
 
 aia = (a.Instrument('AIA') &
-       a.vso.Sample(24 * u.hour) &
+       a.Sample(24 * u.hour) &
        a.Time('2011-01-01', '2011-01-02'))
 
 wave = a.Wavelength(30 * u.nm, 31 * u.nm)

--- a/examples/units_and_coordinates/SDO_to_STEREO_Coordinate_Conversion.py
+++ b/examples/units_and_coordinates/SDO_to_STEREO_Coordinate_Conversion.py
@@ -26,7 +26,7 @@ stereo = (a.vso.Source('STEREO_B') &
           a.Time('2011-01-01', '2011-01-01T00:10:00'))
 
 aia = (a.Instrument('AIA') &
-       a.vso.Sample(24 * u.hour) &
+       a.Sample(24 * u.hour) &
        a.Time('2011-01-01', '2011-01-02'))
 
 wave = a.Wavelength(30 * u.nm, 31 * u.nm)

--- a/sunpy/database/attrs.py
+++ b/sunpy/database/attrs.py
@@ -4,7 +4,7 @@ from sqlalchemy import or_, and_, not_
 from sunpy.time import parse_time
 from sunpy.net.vso import attrs as vso_attrs
 from sunpy.net.attr import (AttrWalker, Attr, ValueAttr,
-                            AttrAnd, AttrOr, SimpleAttr)
+                            AttrAnd, AttrOr, SimpleAttr, Range)
 from sunpy.database.tables import (DatabaseEntry,
                                    Tag as TableTag,
                                    FitsHeaderEntry as TableFitsHeaderEntry)
@@ -105,13 +105,13 @@ class Path(Attr):
 
 
 # TODO: support excluding ranges as soon as
-# vso_attrs._Range.__xor__ is fixed / renamed
-class DownloadTime(Attr, vso_attrs._Range):
+# attr.Range.__xor__ is fixed / renamed
+class DownloadTime(Range):
     def __init__(self, start, end):
         self.start = parse_time(start).datetime
         self.end = parse_time(end).datetime
         self.inverted = False
-        vso_attrs._Range.__init__(self, start, end, self.__class__)
+        super().__init__(start, end)
 
     def __invert__(self):
         download_time = self.__class__(self.start, self.end)

--- a/sunpy/database/attrs.py
+++ b/sunpy/database/attrs.py
@@ -2,7 +2,7 @@
 from sqlalchemy import or_, and_, not_
 
 from sunpy.time import parse_time
-from sunpy.net.vso import attrs as vso_attrs
+from sunpy.net import _attrs as core_attrs
 from sunpy.net.attr import (AttrWalker, Attr, ValueAttr,
                             AttrAnd, AttrOr, SimpleAttr, Range)
 from sunpy.database.tables import (DatabaseEntry,
@@ -254,12 +254,12 @@ def _convert(attr):
     return ValueAttr({(attr.__class__.__name__.lower(), ): attr.value})
 
 
-@walker.add_converter(vso_attrs.Wavelength)
+@walker.add_converter(core_attrs.Wavelength)
 def _convert(attr):
     return ValueAttr({('wave', ): (attr.min.value, attr.max.value, str(attr.unit))})
 
 
-@walker.add_converter(vso_attrs.Time)
+@walker.add_converter(core_attrs.Time)
 def _convert(attr):
     near = None if not attr.near else attr.near.datetime
     return ValueAttr({('time', ): (attr.start.datetime, attr.end.datetime, near)})

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -3,25 +3,25 @@
 # This module was developed with funding provided by
 # the Google Summer of Code (2013).
 
-import itertools
+import os.path
 import operator
+import itertools
 from datetime import datetime
 from contextlib import contextmanager
-import os.path
 
 from sqlalchemy import create_engine, exists
-from sqlalchemy.orm import sessionmaker, scoped_session
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 from astropy import units
 
 import sunpy
 from sunpy.database import commands, tables
-from sunpy.database.tables import _create_display_table
+from sunpy.database.attrs import walker
 from sunpy.database.caching import LRUCache
 from sunpy.database.commands import CompositeOperation
-from sunpy.database.attrs import walker
-from sunpy.net.hek2vso import H2VClient
+from sunpy.database.tables import _create_display_table
 from sunpy.net.attr import and_
+from sunpy.net.hek2vso import H2VClient
 from sunpy.net.vso import VSOClient
 
 __authors__ = ['Simon Liedtke', 'Rajul Srivastava']
@@ -142,19 +142,19 @@ def split_database(source_database, destination_database, *query_string):
     Examples
     --------
     The function call in the following example moves those entries from
-    database1 to database2 which have `~sunpy.net.vso.attrs.Instrument` = 'AIA' or
+    database1 to database2 which have `~sunpy.net.attrs.Instrument` = 'AIA' or
     'ERNE'.
 
     >>> from sunpy.database import Database, split_database
     >>> from sunpy.database.tables import display_entries
-    >>> from sunpy.net import vso
+    >>> from sunpy.net import vso, attrs as a
     >>> database1 = Database('sqlite:///:memory:')
     >>> database2 = Database('sqlite:///:memory:')
     >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
-    >>> qr = client.search(vso.attrs.Time('2011-05-08', '2011-05-08 00:00:05'))  # doctest: +REMOTE_DATA
+    >>> qr = client.search(a.Time('2011-05-08', '2011-05-08 00:00:05'))  # doctest: +REMOTE_DATA
     >>> database1.add_from_vso_query_result(qr)  # doctest: +REMOTE_DATA
     >>> database1, database2 = split_database(database1, database2,
-    ...            vso.attrs.Instrument('AIA') | vso.attrs.Instrument('ERNE'))  # doctest: +REMOTE_DATA
+    ...            a.Instrument('AIA') | a.Instrument('ERNE'))  # doctest: +REMOTE_DATA
     """
 
     query_string = and_(*query_string)
@@ -498,10 +498,10 @@ class Database:
 
         >>> from sunpy.database import Database
         >>> from sunpy.database.tables import display_entries
-        >>> from sunpy.net import vso
+        >>> from sunpy.net import vso, attrs as a
         >>> database = Database('sqlite:///:memory:')
-        >>> database.fetch(vso.attrs.Time('2012-08-05', '2012-08-05 00:00:05'),
-        ...                vso.attrs.Instrument('AIA'))  # doctest: +REMOTE_DATA
+        >>> database.fetch(a.Time('2012-08-05', '2012-08-05 00:00:05'),
+        ...                a.Instrument('AIA'))  # doctest: +REMOTE_DATA
         >>> print(display_entries(database,
         ...                       ['id', 'observation_time_start', 'observation_time_end',
         ...                        'instrument', 'wavemin', 'wavemax']))  # doctest: +REMOTE_DATA
@@ -511,8 +511,8 @@ class Database:
               2    2012-08-05 00:00:01  2012-08-05 00:00:02        AIA     9.4     9.4
               3    2012-08-05 00:00:02  2012-08-05 00:00:03        AIA    33.5    33.5
               4    2012-08-05 00:00:02  2012-08-05 00:00:03        AIA    33.5    33.5
-        >>> database.fetch(vso.attrs.Time('2012-08-05', '2012-08-05 00:00:01'),
-        ...                vso.attrs.Instrument('AIA'), overwrite=True)  # doctest: +REMOTE_DATA
+        >>> database.fetch(a.Time('2012-08-05', '2012-08-05 00:00:01'),
+        ...                a.Instrument('AIA'), overwrite=True)  # doctest: +REMOTE_DATA
         >>> print(display_entries(database,
         ...                       ['id', 'observation_time_start', 'observation_time_end',
         ...                        'instrument', 'wavemin', 'wavemax']))  # doctest: +REMOTE_DATA

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -286,12 +286,12 @@ class DatabaseEntry(DatabaseEntryType, Base):
 
         Examples
         --------
-        >>> from sunpy.net import vso
+        >>> from sunpy.net import vso, attrs as a
         >>> from sunpy.database.tables import DatabaseEntry
         >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
         >>> qr = client.search(
-        ...     vso.attrs.Time('2001/1/1', '2001/1/2'),
-        ...     vso.attrs.Instrument('eit'))  # doctest: +REMOTE_DATA
+        ...     a.Time('2001/1/1', '2001/1/2'),
+        ...     a.Instrument('eit'))  # doctest: +REMOTE_DATA
         >>> entry = DatabaseEntry._from_query_result_block(qr[0])  # doctest: +REMOTE_DATA
         >>> entry.source  # doctest: +REMOTE_DATA
         'SOHO'
@@ -513,12 +513,12 @@ def entries_from_query_result(qr, default_waveunit=None):
 
     Examples
     --------
-    >>> from sunpy.net import vso
+    >>> from sunpy.net import vso, attrs as a
     >>> from sunpy.database.tables import entries_from_query_result
     >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
     >>> qr = client.search(
-    ...     vso.attrs.Time('2001/1/1', '2001/1/2'),
-    ...     vso.attrs.Instrument('eit'))  # doctest: +REMOTE_DATA
+    ...     a.Time('2001/1/1', '2001/1/2'),
+    ...     a.Instrument('eit'))  # doctest: +REMOTE_DATA
     >>> entries = entries_from_query_result(qr)  # doctest: +REMOTE_DATA
     >>> entry = next(entries)  # doctest: +REMOTE_DATA
     >>> entry.source  # doctest: +REMOTE_DATA

--- a/sunpy/database/tests/test_attrs.py
+++ b/sunpy/database/tests/test_attrs.py
@@ -13,7 +13,7 @@ from sunpy.database import tables
 from sunpy.database.attrs import walker, Starred, Tag, Path, DownloadTime,\
     FitsHeaderEntry
 from sunpy.net.attr import DummyAttr, AttrAnd, AttrOr
-from sunpy.net import vso
+from sunpy.net import vso, attrs as a
 
 
 @pytest.fixture
@@ -48,8 +48,8 @@ def session():
 def vso_session():
     client = vso.VSOClient()
     qr = client.search(
-        vso.attrs.Time((2011, 9, 20, 1), (2011, 9, 20, 2)),
-        vso.attrs.Instrument('RHESSI'))
+        a.Time((2011, 9, 20, 1), (2011, 9, 20, 2)),
+        a.Instrument('RHESSI'))
     entries = tables.entries_from_query_result(qr)
     database = Database('sqlite:///:memory:')
     for entry in entries:
@@ -404,7 +404,7 @@ def test_walker_create_fitsheader_inverted(session):
 
 @pytest.mark.remote_data
 def test_walker_create_vso_instrument(vso_session):
-    entries = walker.create(vso.attrs.Instrument('RHESSI'), vso_session)
+    entries = walker.create(a.Instrument('RHESSI'), vso_session)
     expected = [
         tables.DatabaseEntry(id=1, source=u'RHESSI', provider=u'LSSP',
                              physobs=u'intensity',
@@ -427,15 +427,15 @@ def test_walker_create_vso_instrument(vso_session):
 
 @pytest.mark.remote_data
 def test_walker_create_wave(vso_session):
-    entries = walker.create(vso.attrs.Wavelength(0 * u.AA, 10 * u.AA), vso_session)
+    entries = walker.create(a.Wavelength(0 * u.AA, 10 * u.AA), vso_session)
     assert len(entries) == 2
-    entries = walker.create(vso.attrs.Wavelength(5 * u.AA, 10 * u.AA), vso_session)
+    entries = walker.create(a.Wavelength(5 * u.AA, 10 * u.AA), vso_session)
     assert len(entries) == 0
 
 
 @pytest.mark.remote_data
 def test_walker_create_time(vso_session):
-    time = vso.attrs.Time(
+    time = a.Time(
         datetime(2011, 9, 17, 0, 0, 0), datetime(2011, 9, 20, 0, 0, 0))
     entries = walker.create(time, vso_session)
     assert len(entries) == 1

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -73,29 +73,29 @@ def fido_search_result():
 @pytest.fixture
 def query_result():
     return vso.VSOClient().search(
-        vso.attrs.Time('20130801T200000', '20130801T200030'),
-        vso.attrs.Instrument('PLASTIC'))
+        net_attrs.Time('20130801T200000', '20130801T200030'),
+        net_attrs.Instrument('PLASTIC'))
 
 
 @pytest.fixture
 def download_qr():
     return vso.VSOClient().search(
-        vso.attrs.Time('2012-03-29', '2012-03-29'),
-        vso.attrs.Instrument('AIA'))
+        net_attrs.Time('2012-03-29', '2012-03-29'),
+        net_attrs.Instrument('AIA'))
 
 
 @pytest.fixture
 def empty_query():
     return [
-        vso.attrs.Time((2012, 7, 3), (2012, 7, 4)),
-        vso.attrs.Instrument('EIT')]
+        net_attrs.Time((2012, 7, 3), (2012, 7, 4)),
+        net_attrs.Instrument('EIT')]
 
 
 @pytest.fixture
 def download_query():
     return [
-        vso.attrs.Time((2013, 5, 19, 2), (2013, 5, 19, 2), (2013, 5, 19, 2)),
-        vso.attrs.Instrument('VIRGO') | vso.attrs.Instrument('SECCHI')]
+        net_attrs.Time((2013, 5, 19, 2), (2013, 5, 19, 2), (2013, 5, 19, 2)),
+        net_attrs.Instrument('VIRGO') | net_attrs.Instrument('SECCHI')]
 
 
 @pytest.fixture
@@ -950,8 +950,8 @@ def test_fetch_separate_filenames():
     db = Database('sqlite:///')
 
     download_query = [
-        vso.attrs.Time('2012-08-05', '2012-08-05 00:00:05'),
-        vso.attrs.Instrument('AIA')
+        net_attrs.Time('2012-08-05', '2012-08-05 00:00:05'),
+        net_attrs.Instrument('AIA')
     ]
 
     tmp_test_dir = os.path.join(
@@ -1045,7 +1045,7 @@ def split_function_database():
 def test_split_database(split_function_database, database):
     # Send all entries with instrument='EIA' to destination_database
     split_function_database, database = split_database(
-        split_function_database, database, vso.attrs.Instrument('EIA'))
+        split_function_database, database, net_attrs.Instrument('EIA'))
 
     observed_source_entries = split_function_database.search(
         vso.attrs.Provider('xyz'), sortby='id')

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -65,23 +65,23 @@ def query_result():
 @pytest.fixture
 def qr_with_none_waves():
     return vso.VSOClient().search(
-        vso.attrs.Time('20121224T120049.8', '20121224T120049.8'),
-        vso.attrs.Provider('SDAC'), vso.attrs.Instrument('VIRGO'))
+        net_attrs.Time('20121224T120049.8', '20121224T120049.8'),
+        vso.attrs.Provider('SDAC'), net_attrs.Instrument('VIRGO'))
 
 
 @pytest.fixture
 def qr_block_with_missing_physobs():
     return vso.VSOClient().search(
-        vso.attrs.Time('20130805T120000', '20130805T121000'),
-        vso.attrs.Instrument('SWAVES'), vso.attrs.Source('STEREO_A'),
-        vso.attrs.Provider('SSC'), vso.attrs.Wavelength(10 * u.kHz, 160 * u.kHz))[0]
+        net_attrs.Time('20130805T120000', '20130805T121000'),
+        net_attrs.Instrument('SWAVES'), vso.attrs.Source('STEREO_A'),
+        vso.attrs.Provider('SSC'), net_attrs.Wavelength(10 * u.kHz, 160 * u.kHz))[0]
 
 
 @pytest.fixture
 def qr_block_with_kev_unit():
     return vso.VSOClient().search(
-        vso.attrs.Time((2011, 9, 20, 1), (2011, 9, 20, 2)),
-        vso.attrs.Instrument('RHESSI'))[0]
+        net_attrs.Time((2011, 9, 20, 1), (2011, 9, 20, 2)),
+        net_attrs.Instrument('RHESSI'))[0]
 
 
 def test_fits_header_entry_equality():

--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -12,22 +12,25 @@ from sunpy.time import parse_time, TimeRange
 
 from .attr import Range, SimpleAttr
 
+from sunpy.util.decorators import add_common_docstring
+from sunpy.time.time import _variables_for_parse_time_docstring
 
 __all__ = ['Resolution', 'Detector', 'Sample', 'Level', 'Instrument', 'Wavelength', 'Time']
 
 
+@add_common_docstring(**_variables_for_parse_time_docstring())
 class Time(Range):
     """
     Specify the time range of the query.
 
     Parameters
     ----------
-    start : SunPy time string or `~sunpy.time.TimeRange`.
+    start : {parse_time_types}
         The start time in a format parseable by `~sunpy.time.parse_time` or
         a `sunpy.time.TimeRange` object.
-    end : SunPy Time String
+    end : {parse_time_types}
         The end time of the range.
-    near : SunPy Time String
+    near : {parse_time_types}
         Return a singular record closest in time to this value as possible,
         inside the start and end window. Note: not all providers support this
         functionality.

--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -25,10 +25,8 @@ class Time(Range):
     start : SunPy time string or `~sunpy.time.TimeRange`.
         The start time in a format parseable by `~sunpy.time.parse_time` or
         a `sunpy.time.TimeRange` object.
-
     end : SunPy Time String
         The end time of the range.
-
     near : SunPy Time String
         Return a singular record closest in time to this value as possible,
         inside the start and end window. Note: not all providers support this
@@ -86,7 +84,6 @@ class Wavelength(Range):
         ----------
         wavemin : `~astropy.units.Quantity`
             The lower bounds of the range.
-
         wavemax : `~astropy.units.Quantity`
             The upper bound of the range, if not specified it will default to
             the lower bound.
@@ -140,7 +137,7 @@ class Instrument(SimpleAttr):
 
     Parameters
     ----------
-    value : str
+    value : `str`
 
     Notes
     -----
@@ -162,7 +159,7 @@ class Level(SimpleAttr):
 
     Parameters
     ----------
-    value : float or str
+    value : `float` or `str`
 
         The value can be entered in of three ways:
 
@@ -196,7 +193,7 @@ class Detector(SimpleAttr):
 
     Parameters
     ----------
-    value : str
+    value : `str`
     """
     pass
 
@@ -207,7 +204,7 @@ class Resolution(SimpleAttr):
 
     Parameters
     ----------
-    value : float or str
+    value : `float` or `str`
 
         The value can be entered in of three ways:
 

--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -1,0 +1,229 @@
+"""
+Implementation of global attrs.
+
+These are defined in here to keep the `sunpy.net.attrs` namespace clean, and to
+prevent circular imports.
+"""
+import collections
+
+import astropy.units as u
+
+from sunpy.time import parse_time, TimeRange
+
+from .attr import Range, SimpleAttr
+
+
+__all__ = ['Resolution', 'Detector', 'Sample', 'Level', 'Instrument', 'Wavelength', 'Time']
+
+
+class Time(Range):
+    """
+    Specify the time range of the query.
+
+    Parameters
+    ----------
+    start : SunPy time string or `~sunpy.time.TimeRange`.
+        The start time in a format parseable by `~sunpy.time.parse_time` or
+        a `sunpy.time.TimeRange` object.
+
+    end : SunPy Time String
+        The end time of the range.
+
+    near : SunPy Time String
+        Return a singular record closest in time to this value as possible,
+        inside the start and end window. Note: not all providers support this
+        functionality.
+
+    """
+    def __init__(self, start, end=None, near=None):
+        if end is None and not isinstance(start, TimeRange):
+            raise ValueError("Specify start and end or start has to be a TimeRange")
+        if isinstance(start, TimeRange):
+            self.start = start.start
+            self.end = start.end
+        else:
+            self.start = parse_time(start)
+            self.end = parse_time(end)
+
+        if self.start > self.end:
+            raise ValueError("End time must be after start time.")
+        self.near = None if near is None else parse_time(near)
+
+        super().__init__(self.start, self.end)
+
+    def __hash__(self):
+        if not (isinstance(self.start, collections.Hashable) and
+                isinstance(self.end, collections.Hashable)):
+            # The hash is the hash of the start and end time
+            return hash((self.start.jd1, self.start.jd2, self.start.scale,
+                         self.end.jd1, self.end.jd2, self.end.scale))
+        else:
+            return super().__hash__()
+
+    def collides(self, other):
+        return isinstance(other, self.__class__)
+
+    def __xor__(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError
+        if self.near is not None or other.near is not None:
+            raise TypeError
+        return Range.__xor__(self, other)
+
+    def pad(self, timedelta):
+        return Time(self.start - timedelta, self.start + timedelta)
+
+    def __repr__(self):
+        return '<Time({s.start!r}, {s.end!r}, {s.near!r})>'.format(s=self)
+
+
+class Wavelength(Range):
+    def __init__(self, wavemin, wavemax=None):
+        """
+        Specifies the wavelength or spectral energy range of the detector.
+
+        Parameters
+        ----------
+        wavemin : `~astropy.units.Quantity`
+            The lower bounds of the range.
+
+        wavemax : `~astropy.units.Quantity`
+            The upper bound of the range, if not specified it will default to
+            the lower bound.
+
+        Notes
+        -----
+        The VSO understands the 'wavelength' in one of three units, Angstroms,
+        kHz or keV. Therefore any unit which is directly convertible to these
+        units is valid input.
+        """
+
+        if wavemax is None:
+            wavemax = wavemin
+
+        if not all(isinstance(var, u.Quantity) for var in [wavemin, wavemax]):
+            raise TypeError("Wave inputs must be astropy Quantities")
+
+        if not all([wavemin.isscalar, wavemax.isscalar]):
+            raise ValueError("Both wavemin and wavemax must be scalar values")
+
+        # VSO just accept inputs as Angstroms, kHz or keV, the following
+        # converts to any of these units depending on the spectral inputs
+        # Note: the website asks for GHz, however it seems that using GHz
+        # produces weird responses on VSO.
+        supported_units = [u.AA, u.kHz, u.keV]
+        for unit in supported_units:
+            if wavemin.unit.is_equivalent(unit):
+                break
+            else:
+                unit = None
+        if unit is None:
+            raise u.UnitsError(f"This unit is not convertable to any of {supported_units}")
+
+        wavemin, wavemax = sorted([wavemin.to(unit), wavemax.to(unit)])
+        self.unit = unit
+
+        super().__init__(wavemin, wavemax)
+
+    def collides(self, other):
+        return isinstance(other, self.__class__)
+
+    def __repr__(self):
+        return "<Wavelength({!r}, {!r}, '{!s}')>".format(self.min.value,
+                                                            self.max.value,
+                                                            self.unit)
+
+
+class Instrument(SimpleAttr):
+    """
+    Specifies the Instrument name for the search.
+
+    Parameters
+    ----------
+    value : str
+
+    Notes
+    -----
+    More information about each instrument supported by the VSO may be found
+    within the VSO Registry. For a list of instruments see
+    https://sdac.virtualsolar.org/cgi/show_details?keyword=INSTRUMENT.
+    """
+    def __init__(self, value):
+        if not isinstance(value, str):
+            raise ValueError("Instrument names must be strings")
+
+        super().__init__(value)
+
+
+class Level(SimpleAttr):
+    """
+    Specifies the data processing level to search for.  The data processing
+    level is specified by the instrument PI.  May not work with all archives.
+
+    Parameters
+    ----------
+    value : float or str
+
+        The value can be entered in of three ways:
+
+        #. May be entered as a string or any numeric type for equality matching
+        #. May be a string of the format '(min) - (max)' for range matching
+        #. May be a string of the form '(operator) (number)' where operator is\
+        one of: lt gt le ge < > <= >=
+
+    """
+    pass
+
+
+class Sample(SimpleAttr):
+    """
+    Time interval for data sampling.
+
+    Parameters
+    ----------
+    value : `astropy.units.Quantity`
+        A sampling rate convertible to seconds.
+    """
+    @u.quantity_input
+    def __init__(self, value: u.s):
+        super().__init__(value)
+        self.value = value.to_value(u.s)
+
+
+class Detector(SimpleAttr):
+    """
+    The detector from which the data comes from.
+
+    Parameters
+    ----------
+    value : str
+    """
+    pass
+
+
+class Resolution(SimpleAttr):
+    """
+    Resolution level of the data.
+
+    Parameters
+    ----------
+    value : float or str
+
+        The value can be entered in of three ways:
+
+        #. May be entered as a string or any numeric type for equality matching
+        #. May be a string of the format '(min) - (max)' for range matching
+        #. May be a string of the form '(operator) (number)' where operator is\
+        one of: lt gt le ge < > <= >=
+
+        This attribute is currently implemented for SDO/AIA and HMI only.
+        The "resolution" is a function of the highest level of data available.
+        If the CCD is 2048x2048, but is binned to 512x512 before downlink,
+        the 512x512 product is designated as '1'.  If a 2048x2048 and 512x512
+        product are both available, the 512x512 product is designated '0.25'.
+
+    References
+    ----------
+    Documentation in SSWIDL routine vso_search.pro.
+    """
+    pass

--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -250,7 +250,7 @@ class SimpleAttr(Attr):
        The value for the attribute to hold.
     """
     def __init__(self, value):
-        Attr.__init__(self)
+        super().__init__()
         self.value = value
 
     def collides(self, other):
@@ -259,6 +259,45 @@ class SimpleAttr(Attr):
     def __repr__(self):
         return "<{cname!s}({val!r})>".format(
             cname=self.__class__.__name__, val=self.value)
+
+
+class Range(Attr):
+    """
+    An attribute that represents a range of a value.
+
+    This type of attribute would be applicable for types like Wavelength or Time.
+    The range is inclusive of both the min and ma
+
+    Parameters
+    ----------
+    min_ : `object`
+        The lower bound of the range.
+
+    max_ : `object`
+        The upper bound of the range.
+    """
+    def __init__(self, min_, max_):
+        self.min = min_
+        self.max = max_
+
+        super().__init__()
+
+    def __xor__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        new = DummyAttr()
+        if self.min < other.min:
+            new |= type(self)(self.min, min(other.min, self.max))
+        if other.max < self.max:
+            new |= type(self)(other.max, self.max)
+        return new
+
+    def __contains__(self, other):
+        if isinstance(other, Range):
+            return self.min <= other.min and self.max >= other.max
+        else:
+            return self.min <= other <= self.max
 
 
 class AttrAnd(Attr):

--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -28,8 +28,8 @@ from sunpy.util.multimethod import MultiMethod
 _ATTR_TUPLE = namedtuple("attr", "name name_long desc")
 _REGEX = re.compile(r"^[\d]([^\d].*)?$")
 
-__all__ = ['Attr', 'DummyAttr', 'SimpleAttr', 'AttrAnd',
-           'AttrOr', 'ValueAttr', 'and_', 'or_']
+__all__ = ['Attr', 'DummyAttr', 'SimpleAttr', 'Range', 'AttrAnd', 'AttrOr',
+           'ValueAttr', 'and_', 'or_']
 
 
 def make_tuple():

--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -288,7 +288,6 @@ class Range(DataAttr):
     ----------
     min_ : `object`
         The lower bound of the range.
-
     max_ : `object`
         The upper bound of the range.
     """
@@ -448,6 +447,7 @@ class AttrWalker:
     @staticmethod
     def _unknown_type(*args, **kwargs):
         raise TypeError(f"{args[1]} or any of its parents have not been registered with the AttrWalker")
+
     def __init__(self):
         self.applymm = seconddispatch(self._unknown_type)
         self.createmm = seconddispatch(self._unknown_type)

--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -205,6 +205,22 @@ class Attr(metaclass=AttrMeta):
                                   "The value is not iterable or just a string.")
 
 
+class DataAttr(Attr):
+    """
+    A base class for attributes classes which contain data.
+
+    This is to differentiate them from classes like `sunpy.net.attr.AttrAnd` or
+    the base `sunpy.net.attr.Attr` class which do not. The motivation for this
+    distinction is to make it easier for walkers to match all classes which are
+    not user specified Attrs.
+    """
+    def __new__(cls, *args, **kwargs):
+        if cls is DataAttr:
+            raise TypeError("You should not directly instantiate DataAttr, only it's subclasses.")
+
+        return super().__new__(cls)
+
+
 class DummyAttr(Attr):
     """
     Empty attribute. Useful for building up queries. Returns other
@@ -237,7 +253,7 @@ class DummyAttr(Attr):
         return isinstance(other, DummyAttr)
 
 
-class SimpleAttr(Attr):
+class SimpleAttr(DataAttr):
     """
     An attribute that only has a single value.
 
@@ -261,7 +277,7 @@ class SimpleAttr(Attr):
             cname=self.__class__.__name__, val=self.value)
 
 
-class Range(Attr):
+class Range(DataAttr):
     """
     An attribute that represents a range of a value.
 
@@ -386,7 +402,7 @@ class AttrOr(Attr):
 # This appears to only be used as a base type for the Walker, i.e. a common
 # denominator for the walker to convert to whatever the output of the walker is
 # going to be.
-class ValueAttr(Attr):
+class ValueAttr(DataAttr):
     def __init__(self, attrs):
         super().__init__()
         self.attrs = attrs

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -1,10 +1,40 @@
 # -*- coding: utf-8 -*-
 
+"""
+'attrs' are parameters which can be composed together to specify searches to
+`Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`. They can be combined
+by using logical and (``&``) and logical or (``|``) operations to construct
+very complex queries.
+
+For example you could combine two instruments using or (``|``) with a time
+specification and a sample cadence using:
+
+.. code-block:: python
+
+    >>> import astropy.units as u
+    >>> from sunpy.net import Fido, attrs as a
+    >>> Fido.search(a.Time("2011/01/01", "2011/01/02") & (a.Instrument("AIA") | a.Instrument("HMI")) & a.Sample(1*u.day))  # doctest: +SKIP
+
+
+In addition to the core attrs defined here, clients also provide attrs specific
+to them, under:
+
+* `a.vso <sunpy.net.vso.attrs>`
+* `a.jsoc <sunpy.net.jsoc.attrs>`
+* `a.goes <sunpy.net.dataretriever.attrs.goes>`
+
+"""
 from .vso import attrs as vso
 from .jsoc import attrs as jsoc
 from .dataretriever.attrs import goes
 
-from .vso.attrs import Time, Instrument, Wavelength, Level, Sample, Detector, Resolution
+from ._attrs import Time, Instrument, Wavelength, Level, Sample, Detector, Resolution
+from .base_client import BaseClient
 
-__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'Sample', 'Detector', 'Resolution', 'vso',
-           'jsoc', 'goes']
+# Trick the docs into thinking these attrs are defined in here.
+for _a in (Time, Instrument, Wavelength, Level, Sample, Detector, Resolution):
+    _a.__module__ = __name__
+
+
+__all__ = ['Time', 'Instrument', 'Wavelength', 'Level', 'Sample', 'Detector', 'Resolution',
+           'vso', 'jsoc', 'goes']

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -16,8 +16,8 @@ specification and a sample cadence using:
     >>> Fido.search(a.Time("2011/01/01", "2011/01/02") & (a.Instrument("AIA") | a.Instrument("HMI")) & a.Sample(1*u.day))  # doctest: +SKIP
 
 
-In addition to the core attrs defined here, clients also provide attrs specific
-to them, under:
+In addition to the core attrs defined here, other sunpy clients also provide
+attrs specific to them, under:
 
 * `a.vso <sunpy.net.vso.attrs>`
 * `a.jsoc <sunpy.net.jsoc.attrs>`

--- a/sunpy/net/base_client.py
+++ b/sunpy/net/base_client.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 
 
+__all__ = ['BaseClient']
+
+
 class BaseClient(ABC):
     """
     This defines the Abstract Base Class for each download client.
@@ -9,11 +12,11 @@ class BaseClient(ABC):
     These are `search`, `fetch` and `_can_handle_query`.
     The last one ensures that each download client can be registered with Fido.
 
-    All download clients should subclass `~sunpy.net.dataretriever.GenericClient`.
+    Most download clients should subclass `~sunpy.net.dataretriever.GenericClient`.
     If the structure of `~sunpy.net.dataretriever.GenericClient`
     is not useful you should use `~sunpy.net.BaseClient`.
     `~sunpy.net.vso.VSOClient` and `~sunpy.net.jsoc.JSOCClient`
-    are examples of download clients that subclass `BaseClient`.
+    are examples of download clients that subclass ``BaseClient``.
     """
 
     _registry = dict()

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -14,7 +14,8 @@ import parfive
 import sunpy
 from sunpy import config
 from sunpy.net.base_client import BaseClient
-from sunpy.net.vso.attrs import Time, Wavelength, _Range
+from sunpy.net.attr import Range
+from sunpy.net.vso.attrs import Time, Wavelength
 from sunpy.time import TimeRange
 
 TIME_FORMAT = config.get("general", "time_format")
@@ -150,7 +151,7 @@ class GenericClient(BaseClient):
                 self.map_['TimeRange'] = TimeRange(elem.start, elem.end)
                 self.map_['Time_start'] = elem.start
                 self.map_['Time_end'] = elem.end
-            elif isinstance(elem, _Range):
+            elif isinstance(elem, Range):
                 a_min = elem.min
                 a_max = elem.max
                 if a_min == a_max:

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -15,7 +15,7 @@ import sunpy
 from sunpy import config
 from sunpy.net.base_client import BaseClient
 from sunpy.net.attr import Range
-from sunpy.net.vso.attrs import Time, Wavelength
+from sunpy.net._attrs import Time, Wavelength
 from sunpy.time import TimeRange
 
 TIME_FORMAT = config.get("general", "time_format")

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -294,7 +294,7 @@ class SUVIClient(GenericClient):
                     raise ValueError(f"Wavelength {kwargs.get('wavelength')} not supported.")
                 else:
                     wavelength = [kwargs.get("wavelength")]
-            else:  # _Range was provided
+            else:  # Range was provided
                 compress_index = [wavelength_input.wavemin <= this_wave <=
                                   wavelength_input.wavemax for this_wave in (supported_waves * u.Angstrom)]
                 if not any(compress_index):

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -3,7 +3,7 @@
 # Google Summer of Code 2014
 
 import os
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from itertools import compress
 from urllib.parse import urlsplit
 
@@ -11,11 +11,10 @@ import astropy.units as u
 from astropy.time import Time, TimeDelta
 
 from sunpy import config, log
-from sunpy.net import attrs as a
 from sunpy.time import TimeRange, parse_time
-from sunpy.util.scraper import Scraper
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
+from sunpy.util.scraper import Scraper
 
 from ..client import GenericClient
 
@@ -367,6 +366,8 @@ class SUVIClient(GenericClient):
         `bool`
             answer as to whether client can service the query.
         """
+        # Import here to prevent circular imports
+        from sunpy.net import attrs as a
 
         required = {a.Time, a.Instrument}
         optional = {a.Wavelength, a.Level, a.goes.SatelliteNumber}

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -2,14 +2,12 @@
 #  This Module was developed under funding provided by
 #  Google Summer of Code 2014
 
-
-from astropy.time import TimeDelta
 import astropy.units as u
+from astropy.time import TimeDelta
 
 from sunpy.time import TimeRange
 from sunpy.util.scraper import Scraper
 
-from sunpy.net import attrs as a
 from ..client import GenericClient
 
 __all__ = ['NoRHClient']
@@ -132,6 +130,9 @@ class NoRHClient(GenericClient):
         boolean
             answer as to whether client can service the query
         """
+        # Import here to prevent circular imports
+        from sunpy.net import attrs as a
+
         required = {a.Time, a.Instrument}
         optional = {a.Wavelength}
         all_attrs = {type(x) for x in query}

--- a/sunpy/net/dataretriever/tests/test_eve.py
+++ b/sunpy/net/dataretriever/tests/test_eve.py
@@ -1,15 +1,15 @@
 import pytest
 
-from sunpy.time import parse_time
-from sunpy.time.timerange import TimeRange
-from sunpy.net.vso import VSOClient
-from sunpy.net.vso.attrs import Time, Instrument, Source, Level
-from sunpy.net.dataretriever.client import QueryResponse
 import sunpy.net.dataretriever.sources.eve as eve
-from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net import Fido
 from sunpy.net import attrs as a
-
+from sunpy.net._attrs import Instrument, Level, Time
+from sunpy.net.vso.attrs import Source
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.net.fido_factory import UnifiedResponse
+from sunpy.net.vso import VSOClient
+from sunpy.time import parse_time
+from sunpy.time.timerange import TimeRange
 
 LCClient = eve.EVEClient()
 

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -5,7 +5,7 @@ from astropy.time import TimeDelta
 import astropy.units as u
 
 from sunpy.time.timerange import TimeRange
-from sunpy.net.vso.attrs import Time, Instrument
+from sunpy.net._attrs import Time, Instrument
 from sunpy.net.dataretriever.client import QueryResponse
 import sunpy.net.dataretriever.sources.goes as goes
 from sunpy.net.fido_factory import UnifiedResponse

--- a/sunpy/net/dataretriever/tests/test_lyra_ud.py
+++ b/sunpy/net/dataretriever/tests/test_lyra_ud.py
@@ -2,7 +2,7 @@ import pytest
 
 from sunpy.time.timerange import TimeRange
 from sunpy.time import parse_time
-from sunpy.net.vso.attrs import Time, Instrument
+from sunpy.net._attrs import Time, Instrument
 from sunpy.net.dataretriever.client import QueryResponse
 import sunpy.net.dataretriever.sources.lyra as lyra
 from sunpy.net.fido_factory import UnifiedResponse

--- a/sunpy/net/dataretriever/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/tests/test_noaa.py
@@ -5,9 +5,9 @@ import pytest
 
 from sunpy.net import Fido
 from sunpy.net import attrs as a
+from sunpy.net._attrs import Instrument, Time
 from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.sources import noaa
-from sunpy.net.vso.attrs import Instrument, Time
 from sunpy.time import parse_time
 from sunpy.time.timerange import TimeRange
 

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -273,7 +273,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         >>> unifresp = Fido.search(a.Time('2012/3/4', '2012/3/6'),
         ...                        a.Instrument('AIA'),
         ...                        a.Wavelength(304*u.angstrom, 304*u.angstrom),
-        ...                        a.vso.Sample(10*u.minute))  # doctest: +REMOTE_DATA
+        ...                        a.Sample(10*u.minute))  # doctest: +REMOTE_DATA
 
         Parameters
         ----------
@@ -339,7 +339,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
 
         Examples
         --------
-        >>> from sunpy.net.vso.attrs import Time, Instrument
+        >>> from sunpy.net.attrs import Time, Instrument
         >>> unifresp = Fido.search(Time('2012/3/4','2012/3/5'), Instrument('EIT'))  # doctest: +REMOTE_DATA
         >>> filepaths = Fido.fetch(unifresp)  # doctest: +SKIP
 

--- a/sunpy/net/hek/hek.py
+++ b/sunpy/net/hek/hek.py
@@ -20,6 +20,7 @@ from sunpy.net import attr
 from sunpy.util import dict_keys_same, unique
 from sunpy.net.hek import attrs
 from sunpy.net.vso import attrs as v_attrs
+import sunpy.net._attrs as core_attrs
 from sunpy.util.xml import xml_to_dict
 
 
@@ -130,7 +131,7 @@ class HEKRow(Row):
     """
     @property
     def vso_time(self):
-        return v_attrs.Time(
+        return core_attrs.Time(
             Time.strptime(self['event_starttime'], "%Y-%m-%dT%H:%M:%S"),
             Time.strptime(self['event_endtime'], "%Y-%m-%dT%H:%M:%S")
         )
@@ -139,7 +140,7 @@ class HEKRow(Row):
     def vso_instrument(self):
         if self['obs_instrument'] == 'HEK':
             raise ValueError("No instrument contained.")
-        return v_attrs.Instrument(self['obs_instrument'])
+        return core_attrs.Instrument(self['obs_instrument'])
 
     @property
     def vso_all(self):

--- a/sunpy/net/hek2vso/hek2vso.py
+++ b/sunpy/net/hek2vso/hek2vso.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 
 from sunpy.net import hek
 from sunpy.net import vso
+from sunpy.net import attrs as a
 
 __author__ = 'Michael Malocha'
 __version__ = 'Aug 10th, 2013'
@@ -92,12 +93,12 @@ def vso_attribute_parse(phrase):
     [<Time(<Time object: scale='utc' format='isot' value=2011-08-09T07:22:38.000>, <Time object: scale='utc' format='isot' value=2011-08-09T08:32:02.000>, None)>, <Source('SDO')>, <Instrument('AIA')>, <Wavelength(210.99999999999997, 210.99999999999997, 'Angstrom')>]
     """
     try:
-        query = [vso.attrs.Time(phrase['event_starttime'],
+        query = [a.Time(phrase['event_starttime'],
                                 phrase['event_endtime']),
-                 vso.attrs.Source(phrase['obs_observatory']),
-                 vso.attrs.Instrument(phrase['obs_instrument'])]
+                 a.vso.Source(phrase['obs_observatory']),
+                 a.Instrument(phrase['obs_instrument'])]
         avg_wave_len = phrase['obs_meanwavel'] * units.Unit(phrase['obs_wavelunit'])
-        query.append(vso.attrs.Wavelength(avg_wave_len, avg_wave_len))
+        query.append(a.Wavelength(avg_wave_len, avg_wave_len))
     except (KeyError, TypeError):
         raise TypeError("'{dtype!s}' is an improper data type".format(dtype=type(phrase)))
     return query

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from astropy.time import Time as astropyTime
 
-from sunpy.net.vso.attrs import _Range
 from sunpy.net.vso.attrs import Wavelength
 from sunpy.net.vso.attrs import Time as VSO_Time
 from sunpy.net.attr import AttrWalker, AttrAnd, AttrOr, Attr, SimpleAttr

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -14,14 +14,12 @@ class Series(SimpleAttr):
 
     This is the list of `Series <http://jsoc.stanford.edu/JsocSeries_DataProducts_map.html>`__.
     """
-    pass
 
 
 class Keys(SimpleAttr):
     """
     Keys choose which keywords to fetch while making a query request.
     """
-    pass
 
 
 class PrimeKey(DataAttr):
@@ -29,7 +27,7 @@ class PrimeKey(DataAttr):
     Prime Keys
     """
     def __init__(self, label, value):
-        super().__init()
+        super().__init__(label, value)
         self.label = label
         self.value = value
 
@@ -47,7 +45,7 @@ class Segment(SimpleAttr):
     one present for each record e.g. 'image'.
     """
     def __init__(self, value):
-        super().__init__()
+        super().__init__(value)
         self.value = value
 
     def __repr__(self):
@@ -64,14 +62,12 @@ class Protocol(SimpleAttr):
     ("FITS", "JPEG", "MPG", "MP4", or "as-is").
     Only FITS is supported, the others will require extra keywords.
     """
-    pass
 
 
 class Notify(SimpleAttr):
     """
     An email address to get a notification to when JSOC has staged your request.
     """
-
     def __init__(self, value):
         super().__init__(value)
         if value.find('@') == -1:

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from astropy.time import Time as astropyTime
 
-from sunpy.net.vso.attrs import Wavelength
-from sunpy.net.vso.attrs import Time as VSO_Time
+from sunpy.net._attrs import Wavelength, Time
 from sunpy.net.attr import AttrWalker, AttrAnd, AttrOr, Attr, SimpleAttr
 
 
@@ -84,7 +83,7 @@ class Notify(SimpleAttr):
 walker = AttrWalker()
 
 
-@walker.add_creator(AttrAnd, SimpleAttr, VSO_Time)
+@walker.add_creator(AttrAnd, SimpleAttr, Time)
 def _create(wlk, query):
 
     map_ = {}
@@ -125,7 +124,7 @@ def _apply1(wlk, query, imap):
         imap[key] = [query.value]
 
 
-@walker.add_applier(VSO_Time)
+@walker.add_applier(Time)
 def _apply2(wlk, query, imap):
     imap['start_time'] = query.start
     imap['end_time'] = query.end

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -2,7 +2,7 @@
 from astropy.time import Time as astropyTime
 
 from sunpy.net._attrs import Wavelength, Time
-from sunpy.net.attr import AttrWalker, AttrAnd, AttrOr, Attr, SimpleAttr
+from sunpy.net.attr import AttrWalker, AttrAnd, AttrOr, DataAttr, SimpleAttr
 
 
 __all__ = ['Series', 'Protocol', 'Notify', 'Segment', 'Keys', 'PrimeKey']
@@ -24,12 +24,12 @@ class Keys(SimpleAttr):
     pass
 
 
-class PrimeKey(Attr):
+class PrimeKey(DataAttr):
     """
     Prime Keys
     """
     def __init__(self, label, value):
-        Attr.__init__(self)
+        super().__init()
         self.label = label
         self.value = value
 
@@ -41,13 +41,13 @@ class PrimeKey(Attr):
         return False
 
 
-class Segment(Attr):
+class Segment(SimpleAttr):
     """
     Segments choose which files to download when there are more than
     one present for each record e.g. 'image'.
     """
     def __init__(self, value):
-        Attr.__init__(self)
+        super().__init__()
         self.value = value
 
     def __repr__(self):
@@ -83,7 +83,17 @@ class Notify(SimpleAttr):
 walker = AttrWalker()
 
 
-@walker.add_creator(AttrAnd, SimpleAttr, Time)
+@walker.add_creator(AttrOr)
+def _create1(wlk, query):
+
+    qblocks = []
+    for iattr in query.attrs:
+        qblocks.extend(wlk.create(iattr))
+
+    return qblocks
+
+
+@walker.add_creator(AttrAnd, DataAttr)
 def _create(wlk, query):
 
     map_ = {}
@@ -137,13 +147,3 @@ def _apply_wave(wlk, query, imap):
             "For JSOC queries Wavelength.min must equal Wavelength.max")
 
     imap[query.__class__.__name__.lower()] = query.min
-
-
-@walker.add_creator(AttrOr)
-def _create1(wlk, query):
-
-    qblocks = []
-    for iattr in query.attrs:
-        qblocks.extend(wlk.create(iattr))
-
-    return qblocks

--- a/sunpy/net/jsoc/tests/test_attr.py
+++ b/sunpy/net/jsoc/tests/test_attr.py
@@ -6,6 +6,7 @@ import astropy.units as u
 import sunpy.net.jsoc as jsoc
 import sunpy.net.jsoc.attrs as attrs
 import sunpy.net.vso.attrs as vso_attrs
+from sunpy.net import _attrs as core_attrs
 
 from sunpy.net.attr import AttrOr, AttrAnd
 
@@ -21,7 +22,7 @@ def test_and(attr1, attr2):
 
 def test_basicquery():
     a1 = attrs.Series('foo')
-    t1 = vso_attrs.Time('2012/01/01', '2013/1/2')
+    t1 = core_attrs.Time('2012/01/01', '2013/1/2')
     ans1 = jsoc.jsoc.and_(a1, t1)
     assert isinstance(ans1, AttrAnd)
     assert len(ans1.attrs) == 2
@@ -30,7 +31,7 @@ def test_basicquery():
 def test_mediumquery():
     a1 = attrs.Series('foo1')
     a2 = attrs.Series('foo2')
-    t1 = vso_attrs.Time('2012/01/01', '2013/1/2')
+    t1 = core_attrs.Time('2012/01/01', '2013/1/2')
     ans1 = jsoc.jsoc.and_(a1 | a2, t1)
     assert isinstance(ans1, AttrOr)
     assert isinstance(ans1.attrs[0], AttrAnd)
@@ -40,8 +41,8 @@ def test_mediumquery():
 def test_complexquery():
     a1 = attrs.Series('foo1')
     a2 = attrs.Series('foo2')
-    t1 = vso_attrs.Time('2012/01/01', '2013/1/2')
-    t2 = vso_attrs.Time('2012/01/01', '2013/1/3')
+    t1 = core_attrs.Time('2012/01/01', '2013/1/2')
+    t2 = core_attrs.Time('2012/01/01', '2013/1/3')
     ans1 = jsoc.jsoc.and_(a1 | a2, t1 | t2)
     assert isinstance(ans1.attrs[0], AttrOr)
     assert isinstance(ans1.attrs[0].attrs[0], AttrAnd)

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -9,8 +9,7 @@ import pytest
 from parfive import Results
 
 from sunpy.net.jsoc import JSOCClient, JSOCResponse
-import sunpy.net.jsoc.attrs as attrs
-import sunpy.net.vso.attrs as vso_attrs
+import sunpy.net.attrs as a
 
 client = JSOCClient()
 
@@ -44,8 +43,8 @@ def test_empty_jsoc_response():
 @pytest.mark.remote_data
 def test_query():
     Jresp = client.search(
-        vso_attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:01:30'),
-        attrs.Series('hmi.M_45s'), vso_attrs.Sample(90 * u.second))
+        a.Time('2012/1/1T00:00:00', '2012/1/1T00:01:30'),
+        a.jsoc.Series('hmi.M_45s'), a.Sample(90 * u.second))
     assert isinstance(Jresp, JSOCResponse)
     assert len(Jresp) == 2
 
@@ -53,8 +52,8 @@ def test_query():
 @pytest.mark.remote_data
 def test_post_pass():
     responses = client.search(
-        vso_attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'))
+        a.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
     aa = client.request_data(responses)
     tmpresp = aa._d
     assert tmpresp['protocol'] == 'fits'
@@ -64,9 +63,9 @@ def test_post_pass():
 @pytest.mark.remote_data
 def test_post_wavelength():
     responses = client.search(
-        vso_attrs.Time('2010/07/30T13:30:00', '2010/07/30T14:00:00'),
-        attrs.Series('aia.lev1_euv_12s'), attrs.Wavelength(193 * u.AA) |
-        attrs.Wavelength(335 * u.AA), attrs.Notify('jsoc@cadair.com'))
+        a.Time('2010/07/30T13:30:00', '2010/07/30T14:00:00'),
+        a.jsoc.Series('aia.lev1_euv_12s'), a.jsoc.Wavelength(193 * u.AA) |
+        a.jsoc.Wavelength(335 * u.AA), a.jsoc.Notify('jsoc@cadair.com'))
     aa = client.request_data(responses)
     [r.wait() for r in aa]
     tmpresp = aa[0]._d
@@ -82,8 +81,8 @@ def test_post_wavelength():
 @pytest.mark.remote_data
 def test_post_notify_fail():
     responses = client.search(
-        vso_attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
-        attrs.Series('hmi.M_45s'))
+        a.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
+        a.jsoc.Series('hmi.M_45s'))
     with pytest.raises(ValueError):
         client.request_data(responses)
 
@@ -92,16 +91,16 @@ def test_post_notify_fail():
 def test_post_wave_series():
     with pytest.raises(TypeError):
         client.search(
-            vso_attrs.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
-            attrs.Series('hmi.M_45s') | attrs.Series('aia.lev1_euv_12s'),
-            attrs.Wavelength(193 * u.AA) | attrs.Wavelength(335 * u.AA))
+            a.Time('2012/1/1T00:00:00', '2012/1/1T00:00:45'),
+            a.jsoc.Series('hmi.M_45s') | a.jsoc.Series('aia.lev1_euv_12s'),
+            a.jsoc.Wavelength(193 * u.AA) | a.jsoc.Wavelength(335 * u.AA))
 
 
 @pytest.mark.remote_data
 def test_wait_get():
     responses = client.search(
-        vso_attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'))
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
     path = tempfile.mkdtemp()
     res = client.fetch(responses, path=path)
     assert isinstance(res, Results)
@@ -111,8 +110,8 @@ def test_wait_get():
 @pytest.mark.remote_data
 def test_get_request():
     responses = client.search(
-        vso_attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'))
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
 
     bb = client.request_data(responses)
     path = tempfile.mkdtemp()
@@ -123,7 +122,7 @@ def test_get_request():
 @pytest.mark.remote_data
 def test_invalid_query():
     with pytest.raises(ValueError):
-        client.search(vso_attrs.Time('2012/1/1T01:00:00', '2012/1/1T01:00:45'))
+        client.search(a.Time('2012/1/1T01:00:00', '2012/1/1T01:00:45'))
 
 
 @pytest.mark.remote_data
@@ -239,8 +238,8 @@ def test_make_recordset():
 
 @pytest.mark.remote_data
 def test_search_metadata():
-    metadata = client.search_metadata(vso_attrs.Time('2014-01-01T00:00:00', '2014-01-01T00:02:00'),
-                                      attrs.Series('aia.lev1_euv_12s'), attrs.Wavelength(304*u.AA))
+    metadata = client.search_metadata(a.Time('2014-01-01T00:00:00', '2014-01-01T00:02:00'),
+                                      a.jsoc.Series('aia.lev1_euv_12s'), a.jsoc.Wavelength(304*u.AA))
     assert isinstance(metadata, pd.DataFrame)
     assert metadata.shape == (11, 176)
     for i in metadata.index.values:
@@ -250,9 +249,9 @@ def test_search_metadata():
 @pytest.mark.remote_data
 def test_request_data_error():
     responses = client.search(
-        vso_attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'),
-        attrs.Protocol('foo'))
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'),
+        a.jsoc.Protocol('foo'))
     with pytest.raises(TypeError):
         req = client.request_data(responses)
 
@@ -260,26 +259,26 @@ def test_request_data_error():
 @pytest.mark.remote_data
 def test_request_data_protocol():
     responses = client.search(
-        vso_attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'))
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
     req = client.request_data(responses)
     req.wait()
     assert req._d['method'] == 'url'
     assert req._d['protocol'] == 'fits'
 
     responses = client.search(
-        vso_attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'),
-        attrs.Protocol('fits'))
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'),
+        a.jsoc.Protocol('fits'))
     req = client.request_data(responses)
     req.wait()
     assert req._d['method'] == 'url'
     assert req._d['protocol'] == 'fits'
 
     responses = client.search(
-        vso_attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'),
-        attrs.Protocol('as-is'))
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'),
+        a.jsoc.Protocol('as-is'))
     req = client.request_data(responses)
     req.wait()
     assert req._d['method'] == 'url_quick'
@@ -289,8 +288,8 @@ def test_request_data_protocol():
 @pytest.mark.remote_data
 def test_check_request():
     responses = client.search(
-        vso_attrs.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'))
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
     req = client.request_data(responses)
     req.wait()
     assert req.status == 0
@@ -299,8 +298,8 @@ def test_check_request():
 @pytest.mark.remote_data
 def test_results_filenames():
     responses = client.search(
-        vso_attrs.Time('2014/1/1T1:00:36', '2014/1/1T01:01:38'),
-        attrs.Series('hmi.M_45s'), attrs.Notify('jsoc@cadair.com'))
+        a.Time('2014/1/1T1:00:36', '2014/1/1T01:01:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
     path = tempfile.mkdtemp()
     files = client.fetch(responses, path=path)
     assert isinstance(files, Results)

--- a/sunpy/net/tests/test_attr_walker.py
+++ b/sunpy/net/tests/test_attr_walker.py
@@ -1,0 +1,115 @@
+import pytest
+
+from sunpy.net import attr
+
+
+class SA1(attr.SimpleAttr):
+    pass
+
+
+class SA2(attr.SimpleAttr):
+    pass
+
+
+class SA3(SA2):
+    pass
+
+class RA1(attr.Range):
+    pass
+
+
+@pytest.fixture
+def walker():
+    return attr.AttrWalker()
+
+
+def test_creator(walker):
+    CALLED = False
+
+    @walker.add_creator(SA2)
+    def new_creator(wlk, tree):
+        nonlocal CALLED
+
+        assert wlk is walker
+        CALLED = True
+
+    walker.create(SA2("Hello"))
+
+    assert CALLED
+
+    # Test that dispatch also works with subclasses
+    CALLED = False
+
+    walker.create(SA3("Hello"))
+
+    assert CALLED
+
+
+def test_applier(walker):
+    CALLED = False
+
+    @walker.add_applier(SA2)
+    def new_applier(wlk, tree):
+        nonlocal CALLED
+
+        assert wlk is walker
+        CALLED = True
+
+    walker.apply(SA2("Hello"))
+
+    assert CALLED
+
+    CALLED = False
+
+    # Test that dispatch also works with subclasses
+    walker.apply(SA3("Hello"))
+
+    assert CALLED
+
+
+def test_creator_converter(walker):
+    CALLED = False
+
+    @walker.add_creator(SA1)
+    def new_creator(wlk, tree):
+        nonlocal CALLED
+
+        assert wlk is walker
+        CALLED = True
+
+    with pytest.raises(TypeError):
+        walker.create(RA1("Hello", "World"))
+
+    assert not CALLED
+
+    @walker.add_converter(RA1)
+    def new_converter(arange):
+        return SA1("CONVERTED")
+
+    walker.create(RA1("Hello", "World"))
+
+    assert CALLED
+
+
+def test_applier_converter(walker):
+    CALLED = False
+
+    @walker.add_applier(SA1)
+    def new_applier(wlk, tree):
+        nonlocal CALLED
+
+        assert wlk is walker
+        CALLED = True
+
+    with pytest.raises(TypeError):
+        walker.apply(RA1("Hello", "World"))
+
+    assert not CALLED
+
+    @walker.add_converter(RA1)
+    def new_converter(arange):
+        return SA1("CONVERTED")
+
+    walker.apply(RA1("Hello", "World"))
+
+    assert CALLED

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -157,7 +157,7 @@ def test_no_time_error():
 def test_no_match():
     with pytest.raises(DrmsQueryError):
         Fido.search(a.Time("2016/10/01", "2016/10/02"), a.jsoc.Series("bob"),
-                    a.vso.Sample(10*u.s))
+                    a.Sample(10*u.s))
 
 
 def test_call_error():

--- a/sunpy/net/tests/test_hek.py
+++ b/sunpy/net/tests/test_hek.py
@@ -2,7 +2,7 @@ import pytest
 
 from sunpy.time import parse_time
 from sunpy.net import hek
-from sunpy.net import attr, vso
+from sunpy.net import attr, vso, attrs
 
 
 @pytest.fixture
@@ -144,7 +144,7 @@ def test_get_voevent(hek_client_creator):
 def test_vso_time(hek_client_creator):
     hc = hek_client_creator
     ve = hc[0].vso_time
-    assert type(ve) == vso.attrs.Time
+    assert type(ve) == attrs.Time
 
 
 @pytest.mark.remote_data
@@ -152,7 +152,7 @@ def test_vso_instrument(hek_client_creator):
     hc = hek_client_creator
     try:
         vc = hc[1].vso_instrument
-        assert type(vc) == vso.attrs.Instrument
+        assert type(vc) == attrs.Instrument
     except ValueError:
         assert 1
 

--- a/sunpy/net/tests/test_vso.py
+++ b/sunpy/net/tests/test_vso.py
@@ -7,6 +7,7 @@ from parfive import Results
 
 import astropy.units as u
 
+from sunpy.net import _attrs as core_attrs
 from sunpy.net import attr, vso
 from sunpy.net.vso import QueryResponse
 from sunpy.net.vso import attrs as va
@@ -26,7 +27,7 @@ class MockQRRecord:
         self.size = size
         self.time = MockObject(start=start_time, end=end_time)
         self.source = va.Source(source)
-        self.instrument = va.Instrument(instrument)
+        self.instrument = core_attrs.Instrument(instrument)
         self.extent = MockObject(type=None if extent_type is None else extent_type.type)
 
 
@@ -56,7 +57,7 @@ def mock_response():
 
 @pytest.fixture
 def eit(request):
-    return va.Instrument('eit')
+    return core_attrs.Instrument('eit')
 
 
 @pytest.fixture
@@ -72,15 +73,15 @@ def test_simpleattr_apply():
 
 
 def test_Time_timerange():
-    t = va.Time(TimeRange('2012/1/1', '2012/1/2'))
-    assert isinstance(t, va.Time)
+    t = core_attrs.Time(TimeRange('2012/1/1', '2012/1/2'))
+    assert isinstance(t, core_attrs.Time)
     assert t.min == parse_time((2012, 1, 1))
     assert t.max == parse_time((2012, 1, 2))
 
 
 def test_input_error():
     with pytest.raises(ValueError):
-        va.Time('2012/1/1')
+        core_attrs.Time('2012/1/1')
 
 
 @pytest.mark.remote_data
@@ -90,22 +91,22 @@ def test_simpleattr_create(client):
 
 
 def test_simpleattr_and_duplicate():
-    attr = va.Instrument('foo')
-    pytest.raises(TypeError, lambda: attr & va.Instrument('bar'))
+    attr = core_attrs.Instrument('foo')
+    pytest.raises(TypeError, lambda: attr & core_attrs.Instrument('bar'))
     attr |= va.Source('foo')
-    pytest.raises(TypeError, lambda: attr & va.Instrument('bar'))
-    otherattr = va.Instrument('foo') | va.Source('foo')
+    pytest.raises(TypeError, lambda: attr & core_attrs.Instrument('bar'))
+    otherattr = core_attrs.Instrument('foo') | va.Source('foo')
     pytest.raises(TypeError, lambda: attr & otherattr)
-    pytest.raises(TypeError, lambda: (attr | otherattr) & va.Instrument('bar'))
-    tst = va.Instrument('foo') & va.Source('foo')
+    pytest.raises(TypeError, lambda: (attr | otherattr) & core_attrs.Instrument('bar'))
+    tst = core_attrs.Instrument('foo') & va.Source('foo')
     pytest.raises(TypeError, lambda: tst & tst)
 
 
 def test_simpleattr_or_eq():
-    attr = va.Instrument('eit')
+    attr = core_attrs.Instrument('eit')
 
     assert attr | attr == attr
-    assert attr | va.Instrument('eit') == attr
+    assert attr | core_attrs.Instrument('eit') == attr
 
 
 def test_complexattr_apply():
@@ -123,36 +124,36 @@ def test_complexattr_create(client):
 
 
 def test_complexattr_and_duplicate():
-    attr = va.Time((2011, 1, 1), (2011, 1, 1, 1))
+    attr = core_attrs.Time((2011, 1, 1), (2011, 1, 1, 1))
     pytest.raises(TypeError,
-                  lambda: attr & va.Time((2011, 2, 1), (2011, 2, 1, 1)))
+                  lambda: attr & core_attrs.Time((2011, 2, 1), (2011, 2, 1, 1)))
     attr |= va.Source('foo')
     pytest.raises(TypeError,
-                  lambda: attr & va.Time((2011, 2, 1), (2011, 2, 1, 1)))
+                  lambda: attr & core_attrs.Time((2011, 2, 1), (2011, 2, 1, 1)))
 
 
 def test_complexattr_or_eq():
-    attr = va.Time((2011, 1, 1), (2011, 1, 1, 1))
+    attr = core_attrs.Time((2011, 1, 1), (2011, 1, 1, 1))
 
     assert attr | attr == attr
-    assert attr | va.Time((2011, 1, 1), (2011, 1, 1, 1)) == attr
+    assert attr | core_attrs.Time((2011, 1, 1), (2011, 1, 1, 1)) == attr
 
 
 def test_attror_and():
-    attr = va.Instrument('foo') | va.Instrument('bar')
+    attr = core_attrs.Instrument('foo') | core_attrs.Instrument('bar')
     one = attr & va.Source('bar')
-    other = ((va.Instrument('foo') & va.Source('bar')) |
-             (va.Instrument('bar') & va.Source('bar')))
+    other = ((core_attrs.Instrument('foo') & va.Source('bar')) |
+             (core_attrs.Instrument('bar') & va.Source('bar')))
     assert one == other
 
 
 def test_wave_inputQuantity():
     wrong_type_mesage = "Wave inputs must be astropy Quantities"
     with pytest.raises(TypeError) as excinfo:
-        va.Wavelength(10, 23)
+        core_attrs.Wavelength(10, 23)
         assert excinfo.value.message == wrong_type_mesage
     with pytest.raises(TypeError) as excinfo:
-        va.Wavelength(10 * u.AA, 23)
+        core_attrs.Wavelength(10 * u.AA, 23)
         assert excinfo.value.message == wrong_type_mesage
 
 
@@ -169,57 +170,57 @@ def test_wave_toangstrom():
               (1e6, 1 * u.MeV)]
 
     for factor, unit in energy:
-        w = va.Wavelength((62 / factor) * unit, (62 / factor) * unit)
+        w = core_attrs.Wavelength((62 / factor) * unit, (62 / factor) * unit)
         assert int(w.min.to(u.AA, u.equivalencies.spectral()).value) == 199
 
-    w = va.Wavelength(62 * u.eV, 62 * u.eV)
+    w = core_attrs.Wavelength(62 * u.eV, 62 * u.eV)
     assert int(w.min.to(u.AA, u.equivalencies.spectral()).value) == 199
-    w = va.Wavelength(62e-3 * u.keV, 62e-3 * u.keV)
+    w = core_attrs.Wavelength(62e-3 * u.keV, 62e-3 * u.keV)
     assert int(w.min.to(u.AA, u.equivalencies.spectral()).value) == 199
 
     for factor, unit in frequency:
-        w = va.Wavelength((1.506e16 / factor) * unit, (1.506e16 / factor) * unit)
+        w = core_attrs.Wavelength((1.506e16 / factor) * unit, (1.506e16 / factor) * unit)
         assert int(w.min.to(u.AA, u.equivalencies.spectral()).value) == 199
 
-    w = va.Wavelength(1.506e16 * u.Hz, 1.506e16 * u.Hz)
+    w = core_attrs.Wavelength(1.506e16 * u.Hz, 1.506e16 * u.Hz)
     assert int(w.min.to(u.AA, u.equivalencies.spectral()).value) == 199
-    w = va.Wavelength(1.506e7 * u.GHz, 1.506e7 * u.GHz)
+    w = core_attrs.Wavelength(1.506e7 * u.GHz, 1.506e7 * u.GHz)
     assert int(w.min.to(u.AA, u.equivalencies.spectral()).value) == 199
 
     with pytest.raises(u.UnitsError) as excinfo:
-        va.Wavelength(10 * u.g, 23 * u.g)
+        core_attrs.Wavelength(10 * u.g, 23 * u.g)
     assert ('This unit is not convertable to any of [Unit("Angstrom"), Unit("kHz"), '
             'Unit("keV")]' in str(excinfo.value))
 
 
 def test_time_xor():
-    one = va.Time((2010, 1, 1), (2010, 1, 2))
-    a = one ^ va.Time((2010, 1, 1, 1), (2010, 1, 1, 2))
+    one = core_attrs.Time((2010, 1, 1), (2010, 1, 2))
+    a = one ^ core_attrs.Time((2010, 1, 1, 1), (2010, 1, 1, 2))
 
     assert a == attr.AttrOr(
-        [va.Time((2010, 1, 1), (2010, 1, 1, 1)),
-         va.Time((2010, 1, 1, 2), (2010, 1, 2))])
+        [core_attrs.Time((2010, 1, 1), (2010, 1, 1, 1)),
+         core_attrs.Time((2010, 1, 1, 2), (2010, 1, 2))])
 
-    a ^= va.Time((2010, 1, 1, 4), (2010, 1, 1, 5))
+    a ^= core_attrs.Time((2010, 1, 1, 4), (2010, 1, 1, 5))
     assert a == attr.AttrOr([
-        va.Time((2010, 1, 1), (2010, 1, 1, 1)),
-        va.Time((2010, 1, 1, 2), (2010, 1, 1, 4)),
-        va.Time((2010, 1, 1, 5), (2010, 1, 2))
+        core_attrs.Time((2010, 1, 1), (2010, 1, 1, 1)),
+        core_attrs.Time((2010, 1, 1, 2), (2010, 1, 1, 4)),
+        core_attrs.Time((2010, 1, 1, 5), (2010, 1, 2))
     ])
 
 
 def test_wave_xor():
-    one = va.Wavelength(0 * u.AA, 1000 * u.AA)
-    a = one ^ va.Wavelength(200 * u.AA, 400 * u.AA)
+    one = core_attrs.Wavelength(0 * u.AA, 1000 * u.AA)
+    a = one ^ core_attrs.Wavelength(200 * u.AA, 400 * u.AA)
 
-    assert a == attr.AttrOr([va.Wavelength(0 * u.AA, 200 * u.AA),
-                             va.Wavelength(400 * u.AA, 1000 * u.AA)])
+    assert a == attr.AttrOr([core_attrs.Wavelength(0 * u.AA, 200 * u.AA),
+                             core_attrs.Wavelength(400 * u.AA, 1000 * u.AA)])
 
-    a ^= va.Wavelength(600 * u.AA, 800 * u.AA)
+    a ^= core_attrs.Wavelength(600 * u.AA, 800 * u.AA)
 
     assert a == attr.AttrOr(
-        [va.Wavelength(0 * u.AA, 200 * u.AA), va.Wavelength(400 * u.AA, 600 * u.AA),
-         va.Wavelength(800 * u.AA, 1000 * u.AA)])
+        [core_attrs.Wavelength(0 * u.AA, 200 * u.AA), core_attrs.Wavelength(400 * u.AA, 600 * u.AA),
+         core_attrs.Wavelength(800 * u.AA, 1000 * u.AA)])
 
 
 def test_err_dummyattr_create():
@@ -234,8 +235,8 @@ def test_err_dummyattr_apply():
 
 def test_wave_repr():
     """Tests the __repr__ method of class vso.attrs.Wave"""
-    wav = vso.attrs.Wavelength(12 * u.AA, 16 * u.AA)
-    moarwav = vso.attrs.Wavelength(15 * u.AA, 12 * u.AA)
+    wav = core_attrs.Wavelength(12 * u.AA, 16 * u.AA)
+    moarwav = core_attrs.Wavelength(15 * u.AA, 12 * u.AA)
     assert repr(wav) == "<Wavelength(12.0, 16.0, 'Angstrom')>"
     assert repr(moarwav) == "<Wavelength(12.0, 15.0, 'Angstrom')>"
 
@@ -258,8 +259,8 @@ def test_path(client, tmpdir):
     it is not specified.
     """
     qr = client.search(
-        va.Time('2011-06-07 06:33', '2011-06-07 06:33:08'),
-        va.Instrument('aia'), va.Wavelength(171 * u.AA))
+        core_attrs.Time('2011-06-07 06:33', '2011-06-07 06:33:08'),
+        core_attrs.Instrument('aia'), core_attrs.Wavelength(171 * u.AA))
     tmp_dir = tmpdir / "{file}"
     files = client.fetch(qr, path=tmp_dir)
 
@@ -286,9 +287,9 @@ def test_no_download(client):
             download_called = True
 
     # this should fail
-    stereo = (va.Detector('STEREO_B') &
-              va.Instrument('EUVI') &
-              va.Time('1900-01-01', '1900-01-01T00:10:00'))
+    stereo = (core_attrs.Detector('STEREO_B') &
+              core_attrs.Instrument('EUVI') &
+              core_attrs.Time('1900-01-01', '1900-01-01T00:10:00'))
     qr = client.search(stereo)
     downloader = MockDownloader()
     res = client.fetch(qr, wait=False, downloader=downloader)
@@ -298,10 +299,10 @@ def test_no_download(client):
 
 def test_non_str_instrument():
     # Sanity Check
-    assert isinstance(va.Instrument("lyra"), va.Instrument)
+    assert isinstance(core_attrs.Instrument("lyra"), core_attrs.Instrument)
 
     with pytest.raises(ValueError):
-        va.Instrument(1234)
+        core_attrs.Instrument(1234)
 
 
 @pytest.mark.parametrize("waverange, as_dict", [
@@ -357,7 +358,7 @@ def test_QueryResponse_build_table_defaults():
 
     instrument_ = table['Instrument'].data
     assert len(instrument_) == 1
-    assert instrument_[0] == str(va.Instrument('aia'))
+    assert instrument_[0] == str(core_attrs.Instrument('aia'))
 
 
 def test_QueryResponse_build_table_with_extent_type():
@@ -422,8 +423,8 @@ def test_vso_hmi(client, tmpdir):
     """
     This is a regression test for https://github.com/sunpy/sunpy/issues/2284
     """
-    res = client.search(va.Time('2017-09-02 23:52:00', '2017-09-02 23:54:00'),
-                        va.Instrument('HMI') | va.Instrument('AIA'))
+    res = client.search(core_attrs.Time('2017-09-02 23:52:00', '2017-09-02 23:54:00'),
+                        core_attrs.Instrument('HMI') | core_attrs.Instrument('AIA'))
 
     dr = client.make_getdatarequest(res)
 
@@ -473,15 +474,15 @@ def test_vso_error(client):
     with pytest.warns(SunpyUserWarning,
         match="VSO-C500 :soap:Server.Transport : 404 Not Found"):
         client.search(
-            va.Time('2019/12/30', '2019/12/31'),
-            va.Instrument('ovsa'))
+            core_attrs.Time('2019/12/30', '2019/12/31'),
+            core_attrs.Instrument('ovsa'))
 
 
 @pytest.mark.remote_data
 def test_incorrect_content_disposition(client):
     results = client.search(
-        va.Time('2011/1/1 01:00', '2011/1/1 01:02'),
-        va.Instrument('mdi'))
+        core_attrs.Time('2011/1/1 01:00', '2011/1/1 01:02'),
+        core_attrs.Instrument('mdi'))
     files = client.fetch(results[0:1])
 
     assert len(files) == 1

--- a/sunpy/net/tests/test_vso.py
+++ b/sunpy/net/tests/test_vso.py
@@ -68,7 +68,7 @@ def client(request):
 def test_simpleattr_apply():
     a = attr.ValueAttr({('test', ): 1})
     dct = {}
-    va.walker.apply(a, None, dct)
+    va._walker.apply(a, None, dct)
     assert dct['test'] == 1
 
 
@@ -87,7 +87,7 @@ def test_input_error():
 @pytest.mark.remote_data
 def test_simpleattr_create(client):
     a = attr.ValueAttr({('instrument', ): 'eit'})
-    assert va.walker.create(a, client.api)[0].instrument == 'eit'
+    assert va._walker.create(a, client.api)[0].instrument == 'eit'
 
 
 def test_simpleattr_and_duplicate():
@@ -113,14 +113,14 @@ def test_complexattr_apply():
     tst = {('test', 'foo'): 'a', ('test', 'bar'): 'b'}
     a = attr.ValueAttr(tst)
     dct = {'test': {}}
-    va.walker.apply(a, None, dct)
+    va._walker.apply(a, None, dct)
     assert dct['test'] == {'foo': 'a', 'bar': 'b'}
 
 
 @pytest.mark.remote_data
 def test_complexattr_create(client):
     a = attr.ValueAttr({('time', 'start'): 'test'})
-    assert va.walker.create(a, client.api)[0].time['start'] == 'test'
+    assert va._walker.create(a, client.api)[0].time['start'] == 'test'
 
 
 def test_complexattr_and_duplicate():
@@ -225,12 +225,12 @@ def test_wave_xor():
 
 def test_err_dummyattr_create():
     with pytest.raises(TypeError):
-        va.walker.create(attr.DummyAttr(), None, {})
+        va._walker.create(attr.DummyAttr(), None, {})
 
 
 def test_err_dummyattr_apply():
     with pytest.raises(TypeError):
-        va.walker.apply(attr.DummyAttr(), None, {})
+        va._walker.apply(attr.DummyAttr(), None, {})
 
 
 def test_wave_repr():
@@ -382,7 +382,7 @@ def test_QueryResponse_build_table_with_no_start_time():
     """
     a_st = parse_time((2016, 2, 14, 8, 8, 12))
 
-    records = (MockQRRecord(end_time=a_st.strftime(va.TIMEFORMAT)),)
+    records = (MockQRRecord(end_time=a_st.strftime(va._TIMEFORMAT)),)
 
     qr = vso.QueryResponse(records)
     table = qr.build_table()
@@ -404,7 +404,7 @@ def test_QueryResponse_build_table_with_no_end_time():
     """
     a_st = parse_time((2016, 2, 14, 8, 8, 12))
 
-    records = (MockQRRecord(start_time=a_st.strftime(va.TIMEFORMAT)),)
+    records = (MockQRRecord(start_time=a_st.strftime(va._TIMEFORMAT)),)
 
     qr = vso.QueryResponse(records)
     table = qr.build_table()

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -43,7 +43,7 @@ class Field(_attr.ValueAttr):
         })
 
 
-class Extent(_attr.Attr):
+class Extent(_attr.DataAttr):
     """
     Specify the spatial field-of-view of the query. Due to a bug in the VSO,
     the Extent attribute is not used.

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -376,7 +376,8 @@ def _(attr, results):
 class _DeprecatedAttr:
     def __init__(self, *args, **kwargs):
         name = type(self).__name__
-        warnings.warn(f"sunpy.net.vso.attrs.{name} is deprecated, please use sunpy.net.attrs.{name}", SunpyDeprecationWarning)
+        warnings.warn(f"sunpy.net.vso.attrs.{name} is deprecated, please use sunpy.net.attrs.{name}",
+                      SunpyDeprecationWarning)
         super().__init__(*args, **kwargs)
 
 _deprecated_names = ['Time', 'Instrument', 'Wavelength', 'Level', 'Sample', 'Detector', 'Resolution']

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -7,27 +7,31 @@
 # pylint: disable=C0103,R0903
 
 """
-Attributes that can be used to construct VSO queries. Attributes are the
-fundamental building blocks of queries that, together with the two
-operations of AND and OR (and in some rare cases XOR) can be used to
+Attributes that can be used to construct VSO queries.
+"""
+
+"""
+Attributes are the fundamental building blocks of queries that, together with
+the two operations of AND and OR (and in some rare cases XOR) can be used to
 construct complex queries. Most attributes can only be used once in an
-AND-expression, if you still attempt to do so it is called a collision.
-For a quick example think about how the system should handle
-Instrument('aia') & Instrument('eit').
+AND-expression, if you still attempt to do so it is called a collision. For a
+quick example think about how the system should handle Instrument('aia') &
+Instrument('eit').
 """
 import collections
 
 import astropy.units as u
 
+from sunpy.net.attr import (Attr, AttrAnd, AttrOr, AttrWalker,
+                            DummyAttr, Range, SimpleAttr, ValueAttr)
 from sunpy.time import TimeRange as _TimeRange
-from sunpy.net.attr import (Attr, AttrWalker, AttrAnd,
-                            AttrOr, DummyAttr, ValueAttr, SimpleAttr, Range)
-from sunpy.util.multimethod import MultiMethod
 from sunpy.time import parse_time
+from sunpy.util.multimethod import MultiMethod
 
-__all__ = ['Wavelength', 'Time', 'Extent', 'Field', 'Provider', 'Source',
-           'Instrument', 'Physobs', 'Pixels', 'Level', 'Resolution',
-           'Detector', 'Filter', 'Sample', 'Quicklook', 'PScale']
+from .. import _attrs
+
+__all__ = ['Extent', 'Field', 'Provider', 'Source', 'Physobs', 'Pixels',
+           'Filter', 'Quicklook', 'PScale']
 
 TIMEFORMAT = '%Y%m%d%H%M%S'
 
@@ -41,124 +45,6 @@ class Field(ValueAttr):
         ValueAttr.__init__(self, {
             ('field', 'fielditem'): fielditem
         })
-
-
-class Wavelength(Range):
-    def __init__(self, wavemin, wavemax=None):
-        """
-        Specifies the wavelength or spectral energy range of the detector.
-
-        Parameters
-        ----------
-        wavemin : `~astropy.units.Quantity`
-            The lower bounds of the range.
-
-        wavemax : `~astropy.units.Quantity`
-            The upper bound of the range, if not specified it will default to
-            the lower bound.
-
-        Notes
-        -----
-        The VSO understands the 'wavelength' in one of three units, Angstroms,
-        kHz or keV. Therefore any unit which is directly convertible to these
-        units is valid input.
-        """
-
-        if wavemax is None:
-            wavemax = wavemin
-
-        if not all(isinstance(var, u.Quantity) for var in [wavemin, wavemax]):
-            raise TypeError("Wave inputs must be astropy Quantities")
-
-        if not all([wavemin.isscalar, wavemax.isscalar]):
-            raise ValueError("Both wavemin and wavemax must be scalar values")
-
-        # VSO just accept inputs as Angstroms, kHz or keV, the following
-        # converts to any of these units depending on the spectral inputs
-        # Note: the website asks for GHz, however it seems that using GHz
-        # produces weird responses on VSO.
-        supported_units = [u.AA, u.kHz, u.keV]
-        for unit in supported_units:
-            if wavemin.unit.is_equivalent(unit):
-                break
-            else:
-                unit = None
-        if unit is None:
-            raise u.UnitsError(f"This unit is not convertable to any of {supported_units}")
-
-        wavemin, wavemax = sorted([wavemin.to(unit), wavemax.to(unit)])
-        self.unit = unit
-
-        super().__init__(wavemin, wavemax)
-
-    def collides(self, other):
-        return isinstance(other, self.__class__)
-
-    def __repr__(self):
-        return "<Wavelength({!r}, {!r}, '{!s}')>".format(self.min.value,
-                                                            self.max.value,
-                                                            self.unit)
-
-
-class Time(Range):
-    """
-    Specify the time range of the query.
-
-    Parameters
-    ----------
-    start : SunPy time string or `~sunpy.time.TimeRange`.
-        The start time in a format parseable by `~sunpy.time.parse_time` or
-        a `sunpy.time.TimeRange` object.
-
-    end : SunPy Time String
-        The end time of the range.
-
-    near : SunPy Time String
-        Return a singular record closest in time to this value as possible,
-        inside the start and end window. Note: not all providers support this
-        functionality.
-
-    """
-    def __init__(self, start, end=None, near=None):
-        if end is None and not isinstance(start, _TimeRange):
-            raise ValueError("Specify start and end or start has to be a TimeRange")
-        if isinstance(start, _TimeRange):
-            self.start = start.start
-            self.end = start.end
-        else:
-            self.start = parse_time(start)
-            self.end = parse_time(end)
-
-        if self.start > self.end:
-            raise ValueError("End time must be after start time.")
-        self.near = None if near is None else parse_time(near)
-
-        super().__init__(self.start, self.end)
-
-    def __hash__(self):
-        if not (isinstance(self.start, collections.Hashable) and
-                isinstance(self.end, collections.Hashable)):
-            # The hash is the hash of the start and end time
-            return hash((self.start.jd1, self.start.jd2, self.start.scale,
-                         self.end.jd1, self.end.jd2, self.end.scale))
-        else:
-            return super().__hash__()
-
-    def collides(self, other):
-        return isinstance(other, self.__class__)
-
-    def __xor__(self, other):
-        if not isinstance(other, self.__class__):
-            raise TypeError
-        if self.near is not None or other.near is not None:
-            raise TypeError
-        return Range.__xor__(self, other)
-
-    def pad(self, timedelta):
-        return Time(self.start - timedelta, self.start + timedelta)
-
-    def __repr__(self):
-        return '<Time({s.start!r}, {s.end!r}, {s.near!r})>'.format(s=self)
 
 
 class Extent(Attr):
@@ -217,47 +103,6 @@ class Source(SimpleAttr):
     pass
 
 
-class Instrument(SimpleAttr):
-    """
-    Specifies the Instrument name for the search.
-
-    Parameters
-    ----------
-    value : str
-
-    Notes
-    -----
-    More information about each instrument supported by the VSO may be found
-    within the VSO Registry. For a list of instruments see
-    https://sdac.virtualsolar.org/cgi/show_details?keyword=INSTRUMENT.
-    """
-    def __init__(self, value):
-        if not isinstance(value, str):
-            raise ValueError("Instrument names must be strings")
-
-        super().__init__(value)
-
-
-class Detector(SimpleAttr):
-    """
-    The detector from which the data comes from.
-
-    Parameters
-    ----------
-    value : str
-
-    Notes
-    -----
-    For a list of values understood by the VSO see
-    https://sdac.virtualsolar.org/cgi/show_details?keyword=SOURCE.
-
-    References
-    ----------
-    Documentation in SSWIDL routine vso_search.pro.
-    """
-    pass
-
-
 class Physobs(SimpleAttr):
     """
     Specifies the physical observable the VSO can search for.
@@ -275,59 +120,11 @@ class Physobs(SimpleAttr):
     pass
 
 
-class Level(SimpleAttr):
-    """
-    Specifies the data processing level to search for.  The data processing
-    level is specified by the instrument PI.  May not work with all archives.
-
-    Parameters
-    ----------
-    value : float or str
-
-        The value can be entered in of three ways:
-
-        #. May be entered as a string or any numeric type for equality matching
-        #. May be a string of the format '(min) - (max)' for range matching
-        #. May be a string of the form '(operator) (number)' where operator is\
-        one of: lt gt le ge < > <= >=
-
-    """
-    pass
-
-
 class Pixels(SimpleAttr):
     """
     Pixels are (currently) limited to a single dimension (and only implemented
     for SDO data)  We hope to change this in the future to support TRACE,
     Hinode and other investigations where this changed between observations.
-
-    References
-    ----------
-    Documentation in SSWIDL routine vso_search.pro.
-    """
-    pass
-
-
-class Resolution(SimpleAttr):
-    """
-    Resolution level of the data.
-
-    Parameters
-    ----------
-    value : float or str
-
-        The value can be entered in of three ways:
-
-        #. May be entered as a string or any numeric type for equality matching
-        #. May be a string of the format '(min) - (max)' for range matching
-        #. May be a string of the form '(operator) (number)' where operator is\
-        one of: lt gt le ge < > <= >=
-
-        This attribute is currently implemented for SDO/AIA and HMI only.
-        The "resolution" is a function of the highest level of data available.
-        If the CCD is 2048x2048, but is binned to 512x512 before downlink,
-        the 512x512 product is designated as '1'.  If a 2048x2048 and 512x512
-        product are both available, the 512x512 product is designated '0.25'.
 
     References
     ----------
@@ -359,22 +156,6 @@ class PScale(SimpleAttr):
     Documentation in SSWIDL routine vso_search.pro.
     """
     pass
-
-
-class Sample(SimpleAttr):
-    """
-    Time interval for data sampling.
-
-    Parameters
-    ----------
-    value : `astropy.units.Quantity`
-        A sampling rate convertible to seconds.
-    """
-    @u.quantity_input
-    def __init__(self, value: u.s):
-        super().__init__(value)
-        self.value = value.to_value(u.s)
-
 
 class Quicklook(SimpleAttr):
     """
@@ -484,7 +265,7 @@ walker.add_converter(Extent)(
     )
 )
 
-walker.add_converter(Time)(
+walker.add_converter(_attrs.Time)(
     lambda x: ValueAttr({
             ('time', 'start'): x.start.strftime(TIMEFORMAT),
             ('time', 'end'): x.end.strftime(TIMEFORMAT),
@@ -497,7 +278,7 @@ walker.add_converter(SimpleAttr)(
     lambda x: ValueAttr({(x.__class__.__name__.lower(), ): x.value})
 )
 
-walker.add_converter(Wavelength)(
+walker.add_converter(_attrs.Wavelength)(
     lambda x: ValueAttr({
             ('wave', 'wavemin'): x.min.value,
             ('wave', 'wavemax'): x.max.value,
@@ -555,7 +336,7 @@ def _(attr, results):
     return set(results)
 
 
-@filter_results.add_dec(Wavelength)
+@filter_results.add_dec(_attrs.Wavelength)
 def _(attr, results):
     return {
         it for it in results
@@ -570,18 +351,18 @@ def _(attr, results):
     }
 
 
-@filter_results.add_dec(Time)
+@filter_results.add_dec(_attrs.Time)
 def _(attr, results):
     return {
         it for it in results
         if
         it.time.end is not None
         and
-        attr.min <= Time.strptime(it.time.end, TIMEFORMAT)
+        attr.min <= _attrs.Time.strptime(it.time.end, TIMEFORMAT)
         and
         it.time.start is not None
         and
-        attr.max >= Time.strptime(it.time.start, TIMEFORMAT)
+        attr.max >= _attrs.Time.strptime(it.time.start, TIMEFORMAT)
     }
 
 

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -27,7 +27,8 @@ from sunpy import config
 from sunpy.net.attr import and_
 from sunpy.net.base_client import BaseClient
 from sunpy.net.vso import attrs
-from sunpy.net.vso.attrs import TIMEFORMAT, walker
+from sunpy.net.vso.attrs import _TIMEFORMAT as TIMEFORMAT
+from sunpy.net.vso.attrs import _walker as walker
 from sunpy.time import TimeRange, parse_time
 from sunpy.util.decorators import deprecated
 from sunpy.util.exceptions import SunpyUserWarning

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -33,6 +33,7 @@ from sunpy.util.decorators import deprecated
 from sunpy.util.exceptions import SunpyUserWarning
 from sunpy.util.net import get_content_disposition, slugify
 
+from .. import _attrs as core_attrs
 from .zeep_plugins import SunPyLoggingZeepPlugin
 
 TIME_FORMAT = config.get("general", "time_format")
@@ -338,11 +339,11 @@ class VSOClient(BaseClient):
         2010-01-01T01:00.
 
         >>> from datetime import datetime
-        >>> from sunpy.net import vso
+        >>> from sunpy.net import vso, attrs as a
         >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
         >>> client.search(
-        ...    vso.attrs.Time(datetime(2010, 1, 1), datetime(2010, 1, 1, 1)),
-        ...    vso.attrs.Instrument('eit') | vso.attrs.Instrument('aia'))   # doctest:  +REMOTE_DATA
+        ...    a.Time(datetime(2010, 1, 1), datetime(2010, 1, 1, 1)),
+        ...    a.Instrument('eit') | a.Instrument('aia'))   # doctest:  +REMOTE_DATA
         <QTable length=5>
            Start Time [1]       End Time [1]    Source ...   Type   Wavelength [2]
                                                        ...             Angstrom
@@ -918,4 +919,4 @@ class VSOClient(BaseClient):
 
     @classmethod
     def _can_handle_query(cls, *query):
-        return all([x.__class__.__name__ in attrs.__all__ for x in query])
+        return all([x.__class__.__name__ in core_attrs.__all__ + attrs.__all__ for x in query])

--- a/sunpy/util/functools.py
+++ b/sunpy/util/functools.py
@@ -11,7 +11,6 @@ __all__ = ['seconddispatch']
 def seconddispatch(func):
     """
     A variant of `functools.singledispatch` which dispatches on type of the second argument.
-
     """
 
     dispatcher = functools.singledispatch(func)

--- a/sunpy/util/functools.py
+++ b/sunpy/util/functools.py
@@ -1,0 +1,32 @@
+"""
+This file defines wrappers and variants of things in the functools standard lib.
+"""
+
+import functools
+
+
+__all__ = ['seconddispatch']
+
+
+def seconddispatch(func):
+    """
+    A variant of `functools.singledispatch` which dispatches on type of the second argument.
+
+    """
+
+    dispatcher = functools.singledispatch(func)
+
+    def wrapper(*args, **kwargs):
+        return dispatcher.dispatch(args[1].__class__)(*args, **kwargs)
+
+    wrapper.dispatch = dispatcher.dispatch
+    wrapper.register = dispatcher.register
+    wrapper.registry = dispatcher.registry
+    wrapper._clear_cache = dispatcher._clear_cache
+    functools.update_wrapper(wrapper, func)
+
+    return wrapper
+
+
+# Extend the docstring with the original docs
+seconddispatch.__doc__ += functools.singledispatch.__doc__

--- a/sunpy/util/multimethod.py
+++ b/sunpy/util/multimethod.py
@@ -3,6 +3,8 @@ This module provides multimethod implementation in pure Python.
 """
 from warnings import warn
 
+from sunpy.util.exceptions import SunpyDeprecationWarning
+
 __all__ = ['TypeWarning', 'MultiMethod']
 
 SILENT = 0
@@ -29,6 +31,7 @@ class MultiMethod:
         The function which receives args and kwargs and returns a tuple of values to consider for dispatch.
     """
     def __init__(self, get):
+        warn("MultiMethod is deprecated and will be removed in sunpy 2.1", SunpyDeprecationWarning)
         self.get = get
 
         self.methods = []

--- a/sunpy/util/tests/test_functools.py
+++ b/sunpy/util/tests/test_functools.py
@@ -1,19 +1,22 @@
 """
 These tests are borrowed from CPython
 """
-import unittest
 import sys
-import decimal
+import unittest
 import collections
+
+import pytest
 
 from sunpy.util.functools import seconddispatch
 
 
 class TestSingleDispatch(unittest.TestCase):
     def test_simple_overloads(self):
+
         @seconddispatch
         def g(dummy, obj):
             return "base"
+
         def g_int(dummy, i):
             return "integer"
         g.register(int, g_int)
@@ -22,19 +25,26 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(g(None, [1,2,3]), "base")
 
     def test_mro(self):
+
         @seconddispatch
         def g(obj):
             return "base"
+
         class A:
             pass
+
         class C(A):
             pass
+
         class B(A):
             pass
+
         class D(C, B):
             pass
+
         def g_A(dummy, a):
             return "A"
+
         def g_B(dummy, b):
             return "B"
         g.register(A, g_A)
@@ -45,9 +55,11 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(g(None, D()), "B")
 
     def test_register_decorator(self):
+
         @seconddispatch
         def g(dummy, obj):
             return "base"
+
         @g.register(int)
         def g_int(dummy, i):
             return "int %s" % (i,)
@@ -67,13 +79,16 @@ class TestSingleDispatch(unittest.TestCase):
         if sys.flags.optimize < 2:
             self.assertEqual(g.__doc__, "Simple test")
 
+    @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
     def test_annotations(self):
         @seconddispatch
         def i(dummy, arg):
             return "base"
+
         @i.register
         def _(dummy, arg: collections.abc.Mapping):
             return "mapping"
+
         @i.register
         def _(dummy, arg: "collections.abc.Sequence"):
             return "sequence"

--- a/sunpy/util/tests/test_functools.py
+++ b/sunpy/util/tests/test_functools.py
@@ -1,0 +1,95 @@
+"""
+These tests are borrowed from CPython
+"""
+import unittest
+import sys
+import decimal
+import collections
+
+from sunpy.util.functools import seconddispatch
+
+
+class TestSingleDispatch(unittest.TestCase):
+    def test_simple_overloads(self):
+        @seconddispatch
+        def g(dummy, obj):
+            return "base"
+        def g_int(dummy, i):
+            return "integer"
+        g.register(int, g_int)
+        self.assertEqual(g(None, "str"), "base")
+        self.assertEqual(g(None, 1), "integer")
+        self.assertEqual(g(None, [1,2,3]), "base")
+
+    def test_mro(self):
+        @seconddispatch
+        def g(obj):
+            return "base"
+        class A:
+            pass
+        class C(A):
+            pass
+        class B(A):
+            pass
+        class D(C, B):
+            pass
+        def g_A(dummy, a):
+            return "A"
+        def g_B(dummy, b):
+            return "B"
+        g.register(A, g_A)
+        g.register(B, g_B)
+        self.assertEqual(g(None, A()), "A")
+        self.assertEqual(g(None, B()), "B")
+        self.assertEqual(g(None, C()), "A")
+        self.assertEqual(g(None, D()), "B")
+
+    def test_register_decorator(self):
+        @seconddispatch
+        def g(dummy, obj):
+            return "base"
+        @g.register(int)
+        def g_int(dummy, i):
+            return "int %s" % (i,)
+        self.assertEqual(g(None, ""), "base")
+        self.assertEqual(g(None, 12), "int 12")
+        self.assertIs(g.dispatch(int), g_int)
+        self.assertIs(g.dispatch(object), g.dispatch(str))
+        # Note: in the assert above this is not g.
+        # @singledispatch returns the wrapper.
+
+    def test_wrapping_attributes(self):
+        @seconddispatch
+        def g(dummy, obj):
+            "Simple test"
+            return "Test"
+        self.assertEqual(g.__name__, "g")
+        if sys.flags.optimize < 2:
+            self.assertEqual(g.__doc__, "Simple test")
+
+    def test_annotations(self):
+        @seconddispatch
+        def i(dummy, arg):
+            return "base"
+        @i.register
+        def _(dummy, arg: collections.abc.Mapping):
+            return "mapping"
+        @i.register
+        def _(dummy, arg: "collections.abc.Sequence"):
+            return "sequence"
+        self.assertEqual(i(None, None), "base")
+        self.assertEqual(i(None, {"a": 1}), "mapping")
+        self.assertEqual(i(None, [1, 2, 3]), "sequence")
+        self.assertEqual(i(None, (1, 2, 3)), "sequence")
+        self.assertEqual(i(None, "str"), "sequence")
+
+        # Registering classes as callables doesn't work with annotations,
+        # you need to pass the type explicitly.
+        @i.register(str)
+        class _:
+            def __init__(self, dummy, arg):
+                self.arg = arg
+
+            def __eq__(self, other):
+                return self.arg == other
+        self.assertEqual(i(None, "str"), "str")


### PR DESCRIPTION
The current state of `sunpy.net.attrs` is a bit of a mess as it has grown organically with the rest of net but never had a cleanup itself. The current state is that all the attrs are defined in `net/vso/attrs.py` and we import the ones which are generally applicable up into the `sunpy.net.attrs` namespace.

This PR makes the following changes:

### vso.attrs

All the classes defined in `vso.attrs` which are used outside of the VSO client have been moved into `net/_attrs.py`.

### `AttrWalker`

The `AttrWalker` class is designed to parse a query (collection of `Attr`s) and return a type specific to the client. This PR adds some limited inline documentation (I am planning a followup PR with narrative docs), as well as a basic set of API tests.

The `AttrWalker` was also the last place in sunpy still using `sunpy/util/multimethod` which I have refactored to use `functools.singledispatch` and a modified version thereof which dispatches on the second argument to the function and not the first.

I have now deprecated the use of `MultiMethod`.

### Generic cleanup

* `_Range` is no longer a mixin class but a subclass of `Attr` and should be used accordingly.
* I have endeavoured to cleanup the various `attrs.` namespaces to be free from all other variables so that your tab completion experience is as nice as possible.


## To Do:

Currently there is no deprecation of the classes that used to be in the `vso.attrs` namespace. Before I deprecate these we need to decide if the goal is to have the client specific attrs be only classes used exclusively by those clients (as it is now in this PR) or all the ones applicable to those clients (i.e. also including the generic ones) which would mean this PR isn't an API change for vso at all.