### PR TITLE
added kwargs to peek() to maintain consistency

### DIFF
--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -75,7 +75,7 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
         Parameters
         ----------
         **kwargs : `dict`
-        Additional plot keyword arguments that are handed to `axes.plot` functions
+            Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -71,6 +71,11 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
             import sunpy.data.sample
             gbm = sunpy.timeseries.TimeSeries(sunpy.data.sample.GBM_TIMESERIES, source='GBMSummary')
             gbm.peek()
+
+        Parameters
+        ----------
+        **kwargs : `dict`
+        Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -61,7 +61,7 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
     _source = 'gbmsummary'
 
     @peek_show
-    def peek(self):
+    def peek(self, **kwargs):
         """
         Plots the GBM lightcurve TimeSeries. An example can be seen below:
 

--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -80,7 +80,7 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
         data_lab = self.data.columns.values
 
         for d in data_lab:
-            axes.plot(self.data.index, self.data[d], label=d)
+            axes.plot(self.data.index, self.data[d], label=d, **kwargs)
 
         axes.set_yscale("log")
         axes.set_title('Fermi GBM Summary data ' + str(self.meta.get(

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -70,6 +70,8 @@ class XRSTimeSeries(GenericTimeSeries):
         ----------
         title : `str`. optional
             The title of the plot. Defaults to "GOES Xray Flux".
+        **kwargs : `dict`
+            Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -54,7 +54,7 @@ class XRSTimeSeries(GenericTimeSeries):
     _source = 'xrs'
 
     @peek_show
-    def peek(self, title="GOES Xray Flux"):
+    def peek(self, title="GOES Xray Flux", **kwargs):
         """
         Plots GOES XRS light curve is the usual manner. An example is shown
         below:

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -80,9 +80,9 @@ class XRSTimeSeries(GenericTimeSeries):
         dates = matplotlib.dates.date2num(parse_time(self.data.index).datetime)
 
         axes.plot_date(dates, self.data['xrsa'], '-',
-                       label=r'0.5--4.0 $\AA$', color='blue', lw=2)
+                       label=r'0.5--4.0 $\AA$', color='blue', lw=2, **kwargs)
         axes.plot_date(dates, self.data['xrsb'], '-',
-                       label=r'1.0--8.0 $\AA$', color='red', lw=2)
+                       label=r'1.0--8.0 $\AA$', color='red', lw=2, **kwargs)
 
         axes.set_yscale("log")
         axes.set_ylim(1e-9, 1e-2)

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -67,6 +67,8 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         ----------
         type : {'sunspot SWO', 'sunspot RI', 'sunspot compare', 'radio', 'geo'}, optional
             The type of plot required. Defaults to "sunspot SWO".
+        **kwargs : `dict`
+            Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
@@ -207,7 +209,7 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         Parameters
         ----------
         **plot_args : `dict`
-            Unused.
+            Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -75,24 +75,24 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         axes = plt.gca()
 
         if type == 'sunspot SWO':
-            axes = self.data['sunspot SWO'].plot()
-            self.data['sunspot SWO smooth'].plot()
+            axes = self.data['sunspot SWO'].plot(**kwargs)
+            self.data['sunspot SWO smooth'].plot(**kwargs)
             axes.set_ylabel('Sunspot Number')
         elif type == 'sunspot RI':
-            axes = self.data['sunspot RI'].plot()
-            self.data['sunspot RI smooth'].plot()
+            axes = self.data['sunspot RI'].plot(**kwargs)
+            self.data['sunspot RI smooth'].plot(**kwargs)
             axes.set_ylabel('Sunspot Number')
         elif type == 'sunspot compare':
-            axes = self.data['sunspot RI'].plot()
-            self.data['sunspot SWO'].plot()
+            axes = self.data['sunspot RI'].plot(**kwargs)
+            self.data['sunspot SWO'].plot(**kwargs)
             axes.set_ylabel('Sunspot Number')
         elif type == 'radio':
-            axes = self.data['radio flux'].plot()
-            self.data['radio flux smooth'].plot()
+            axes = self.data['radio flux'].plot(**kwargs)
+            self.data['radio flux smooth'].plot(**kwargs)
             axes.set_ylabel('Radio Flux [sfu]')
         elif type == 'geo':
-            axes = self.data['geomagnetic ap'].plot()
-            self.data['geomagnetic ap smooth'].plot()
+            axes = self.data['geomagnetic ap'].plot(**kwargs)
+            self.data['geomagnetic ap smooth'].plot(**kwargs)
             axes.set_ylabel('Geomagnetic AP Index')
         else:
             raise ValueError(f'Got unknown plot type "{type}"')
@@ -215,9 +215,9 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         figure = plt.figure()
         axes = plt.gca()
 
-        axes = self.data['sunspot'].plot(color='b')
-        self.data['sunspot low'].plot(linestyle='--', color='b')
-        self.data['sunspot high'].plot(linestyle='--', color='b')
+        axes = self.data['sunspot'].plot(color='b', **plot_args)
+        self.data['sunspot low'].plot(linestyle='--', color='b', **plot_args)
+        self.data['sunspot high'].plot(linestyle='--', color='b', **plot_args)
 
         axes.set_ylim(0)
         axes.set_title('Solar Cycle Sunspot Number Prediction')

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -52,7 +52,7 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
     _source = 'noaaindices'
 
     @peek_show
-    def peek(self, type='sunspot SWO'):
+    def peek(self, type='sunspot SWO', **kwargs):
         """
         Plots NOAA Indices as a function of time. An example is shown below.
 

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -66,6 +66,11 @@ class NoRHTimeSeries(GenericTimeSeries):
             import sunpy.timeseries
             norh = sunpy.timeseries.TimeSeries(sunpy.data.sample.NORH_TIMESERIES, source='NoRH')
             norh.peek()
+
+        Parameters
+        ----------
+        **kwargs : `dict`
+        Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -56,7 +56,7 @@ class NoRHTimeSeries(GenericTimeSeries):
         super().__init__(data, header, units, **kwargs)
 
     @peek_show
-    def peek(self):
+    def peek(self, **kwargs):
         """
         Plot the NoRH lightcurve TimeSeries.
 
@@ -74,7 +74,7 @@ class NoRHTimeSeries(GenericTimeSeries):
         axes = plt.gca()
         data_lab = str(self.meta.get('OBS-FREQ').values()).replace('[', '').replace(
             ']', '').replace('\'', '')
-        axes.plot(self.data.index, self.data, label=data_lab)
+        axes.plot(self.data.index, self.data, label=data_lab, **kwargs)
         axes.set_yscale("log")
         axes.set_ylim(1e-4, 1)
         axes.set_title('Nobeyama Radioheliograph')

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -70,7 +70,7 @@ class NoRHTimeSeries(GenericTimeSeries):
         Parameters
         ----------
         **kwargs : `dict`
-        Additional plot keyword arguments that are handed to `axes.plot` functions
+            Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -78,7 +78,7 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
         title : `str`
             The title of the plot.
         **kwargs : `dict`
-        Additional plot keyword arguments that are handed to `axes.plot` functions
+            Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -62,7 +62,7 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
     _source = 'rhessi'
 
     @peek_show
-    def peek(self, title="RHESSI Observing Summary Count Rate"):
+    def peek(self, title="RHESSI Observing Summary Count Rate", **kwargs):
         """
         Plots RHESSI Count Rate light curve. An example is shown below:
 

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -87,7 +87,7 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
         lc_linecolors = rhessi.hsi_linecolors()
 
         for lc_color, (item, frame) in zip(lc_linecolors, self.data.items()):
-            axes.plot_date(self.data.index, frame.values, '-', label=item, lw=2, color=lc_color)
+            axes.plot_date(self.data.index, frame.values, '-', label=item, lw=2, color=lc_color, **kwargs)
 
         axes.set_yscale("log")
         axes.set_xlabel(datetime.datetime.isoformat(self.data.index[0])[0:10])

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -77,6 +77,8 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
         ----------
         title : `str`
             The title of the plot.
+        **kwargs : `dict`
+        Additional plot keyword arguments that are handed to `axes.plot` functions
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Added kwargs to `peek()` function of some of the TimeSeries sources to maintain consistency with other TimeSeries sources and all other Maps.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3486 
