### PR TITLE
fixed doc for timeseries classes

### DIFF
--- a/docs/code_ref/timeseries.rst
+++ b/docs/code_ref/timeseries.rst
@@ -36,3 +36,5 @@ The `~sunpy.timeseries.TimeSeries` factory will load the file and create the tim
 instance. The following instrument classes are supported.
 
 .. automodapi:: sunpy.timeseries
+    :no-inheritance-diagram:
+.. automodapi:: sunpy.timeseries.sources

--- a/docs/code_ref/timeseries.rst
+++ b/docs/code_ref/timeseries.rst
@@ -37,4 +37,5 @@ instance. The following instrument classes are supported.
 
 .. automodapi:: sunpy.timeseries
     :no-inheritance-diagram:
+
 .. automodapi:: sunpy.timeseries.sources


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Pull Request to fix the documentation for v1.0+ for Timeseries classes where the inherited GenericTimeSeries classes were not visible in the inheritance diagram.
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

@nabobalis 

Fixes #3682 
