### PR TITLE
Fixes to the transformation test for NorthOffsetFrame

### DIFF
--- a/changelog/3775.trivial.rst
+++ b/changelog/3775.trivial.rst
@@ -1,0 +1,1 @@
+Fixed the transformation test for `~sunpy.coordinates.metaframes.NorthOffsetFrame`, which would intermittently fail.

--- a/sunpy/coordinates/tests/test_offset_frame.py
+++ b/sunpy/coordinates/tests/test_offset_frame.py
@@ -1,5 +1,5 @@
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 import numpy as np
 
 import astropy.units as u
@@ -22,6 +22,7 @@ def test_null():
 
 
 @given(lon=longitudes(), lat=latitudes())
+@settings(deadline=1000)
 def test_transform(lon, lat):
     """
     Test that the north pole in the new frame transforms back to the given
@@ -31,8 +32,8 @@ def test_transform(lon, lat):
     off = NorthOffsetFrame(north=north)
     t_north = SkyCoord(lon=0*u.deg, lat=90*u.deg, frame=off)
     t_north = t_north.transform_to('heliographic_stonyhurst')
-    assert_quantity_allclose(north.lon, t_north.lon, atol=1e6*u.deg)
-    assert_quantity_allclose(north.lat, t_north.lat, atol=1e6*u.deg)
+    assert_quantity_allclose(north.lon, t_north.lon, atol=1e-6*u.deg)
+    assert_quantity_allclose(north.lat, t_north.lat, atol=1e-6*u.deg)
 
 
 def test_south_pole():


### PR DESCRIPTION
- Fixed the specifications of the absolute tolerances
- Extended the `hypothesis` deadline to 1 second (from the default of 200 ms)

Context: The first call to `NorthOffsetFrame` takes longer than subsequent calls (using the same base frame) because it needs to create the class.  This was causing unreliable test timings, with a misleading error message that the first call was "falsified".