### PR TITLE
Avoid use of .data in TimeSeries examples

### DIFF
--- a/examples/time_series/power_spectra_example.py
+++ b/examples/time_series/power_spectra_example.py
@@ -26,7 +26,7 @@ ts = sunpy.timeseries.TimeSeries(RHESSI_TIMESERIES)
 
 x_ray = ts.columns[0]
 # The suitable value for fs would be 0.25 Hz as the time step is 4 s.
-freq, spectra = signal.periodogram(ts.data[x_ray], fs=0.25)
+freq, spectra = signal.periodogram(ts.quantity(x_ray), fs=0.25)
 
 ###############################################################################
 # Let's plot the results

--- a/examples/time_series/timeseries_convolution_filter.py
+++ b/examples/time_series/timeseries_convolution_filter.py
@@ -23,15 +23,17 @@ ts_noaa_ind = TimeSeries(noaa_ind, source='NOAAIndices')
 # using it to make a new signal where each element is the average of w adjacent
 # elements. Here we will use AstroPy’s convolve function with a “boxcar” kernel
 # of width w = 10.
-ts_noaa_ind.data['sunspot SWO Smoothed'] = convolve(
-    ts_noaa_ind.data['sunspot SWO'].values, kernel=Box1DKernel(10))
+ts_noaa_ind = ts_noaa_ind.add_column(
+    'sunspot SWO Smoothed',
+    convolve(ts_noaa_ind.quantity('sunspot SWO'), kernel=Box1DKernel(10))
+)
 
 ###############################################################################
 # Plotting original and smoothed timeseries
 plt.ylabel('Sunspot Number')
 plt.xlabel('Time')
 plt.title('Smoothing of Time Series')
-plt.plot(ts_noaa_ind.data['sunspot SWO'])
-plt.plot(ts_noaa_ind.data['sunspot SWO Smoothed'])
+plt.plot(ts_noaa_ind.quantity('sunspot SWO'), label='original data')
+plt.plot(ts_noaa_ind.quantity('sunspot SWO Smoothed'), label='smoothed')
 plt.legend()
 plt.show()

--- a/examples/time_series/timeseries_example.py
+++ b/examples/time_series/timeseries_example.py
@@ -71,12 +71,12 @@ combined_goes_ts.plot()
 
 ##############################################################################
 # The TimeSeries object has 3 primary data storage components:
-# data (pandas.DataFrame): stores the data.
+#
+# data: to get the underlying data, use to_dataframe()
 # meta (OrderedDict): stores the metadata (like the Map)
 # units (OrderedDict): stores the units for each column, with keys that match
 # the name of each column.
-# These can be accessed like on the map:
-ts_lyra.data
+ts_lyra.to_dataframe()
 ts_lyra.meta
 ts_lyra.units
 # There are a couple of other useful properties you can quickly get:
@@ -97,12 +97,12 @@ combined_goes_ts.meta.get('telescop').values()
 # You can access a specific value within the TimeSeries data DataFrame using
 # all the normal Pandas methods.
 # For example, the row with the index of 2015-01-01 00:02:00.008000:
-ts_lyra.data.loc[parse_time('2011-06-07 00:02:00.010').datetime]
+ts_lyra.to_dataframe().loc[parse_time('2011-06-07 00:02:00.010').datetime]
 # Pandas will actually parse a string to a datetime automatically if it can:
-ts_lyra.data.loc['2011-06-07 00:02:00.010']
+ts_lyra.to_dataframe().loc['2011-06-07 00:02:00.010']
 # Pandas includes methods to find the indexes of the max/min values in a dataframe:
-lyra_ch1_max_index = ts_lyra.data['CHANNEL1'].idxmax()
-lyra_ch1_min_index = ts_lyra.data['CHANNEL1'].idxmin()
+lyra_ch1_max_index = ts_lyra.to_dataframe()['CHANNEL1'].idxmax()
+lyra_ch1_min_index = ts_lyra.to_dataframe()['CHANNEL1'].idxmin()
 
 ##############################################################################
 # The TimeSeriesMetaData can be summarised:
@@ -141,10 +141,10 @@ ts_goes_trunc.plot()
 
 ##############################################################################
 # You can use Pandas resample method, for example to downsample:
-df_downsampled = ts_goes_trunc.data.resample('10T').mean()
-# To get this into a similar TimeSeries we can copy the original:
-ts_downsampled = copy.deepcopy(ts_goes_trunc)
-ts_downsampled.data = df_downsampled
+df_downsampled = ts_goes_trunc.to_dataframe().resample('10T').mean()
+ts_downsampled = sunpy.timeseries.TimeSeries(df_downsampled,
+                                             ts_goes_trunc.meta,
+                                             ts_goes_trunc.units)
 fig, ax = plt.subplots()
 ts_downsampled.plot()
 # You can use 'mean', 'sum' and 'std' methods and any other methods in Pandas.
@@ -154,10 +154,11 @@ ts_downsampled.plot()
 
 ##############################################################################
 # Similarly, to upsample:
-df_upsampled = ts_downsampled.data.resample('1T').ffill()
+df_upsampled = ts_downsampled.to_dataframe().resample('1T').ffill()
 # And this can be made into a TimeSeries using:
-ts_upsampled = copy.deepcopy(ts_downsampled)
-ts_upsampled.data = df_upsampled
+ts_upsampled = sunpy.timeseries.TimeSeries(df_upsampled,
+                                           ts_downsampled.meta,
+                                           ts_downsampled.units)
 fig, ax = plt.subplots()
 ts_upsampled.plot()
 # Note: 'ffill', 'bfill' and 'pad' methods work, and as before others should also.

--- a/examples/time_series/timeseries_peak_finding.py
+++ b/examples/time_series/timeseries_peak_finding.py
@@ -97,7 +97,7 @@ def findpeaks(series, DELTA):
 # Now we take the column 'sunspot SWO' of this TimeSeries and try to find it's
 # extrema using the function findpeaks. We take the value of DELTA to be
 # approximately the length of smallest peak that we wish to detect.
-series = my_timeseries.data['sunspot SWO']
+series = my_timeseries.to_dataframe()['sunspot SWO']
 minpeaks, maxpeaks = findpeaks(series, DELTA=10.)
 # Plotting the figure and extremum points
 fig, ax = plt.subplots()

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -388,7 +388,7 @@ class GenericTimeSeries:
         # Concatenate the metadata and data
         kwargs['sort'] = kwargs.pop('sort', False)
         meta = self.meta.concatenate(otherts.meta)
-        data = pd.concat([self._data.copy(), otherts.data], **kwargs)
+        data = pd.concat([self._data.copy(), otherts.to_dataframe()], **kwargs)
 
         # Add all the new units to the dictionary.
         units = OrderedDict()
@@ -634,7 +634,7 @@ class GenericTimeSeries:
         """
         match = True
         if isinstance(other, type(self)):
-            if ((not self._data.equals(other.data)) or
+            if ((not self._data.equals(other.to_dataframe())) or
                     (self.meta != other.meta) or
                     (self.units != other.units)):
                 match = False


### PR DESCRIPTION
Since using `.data` now raises a warning, fix the examples so they use best practice methods etc. Marked as no changelog needed because I think it falls under the PR that made the original change.