### PR TITLE
Fix Matplotlib deprecation warning in animator

### DIFF
--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -251,7 +251,9 @@ class BaseFuncAnimator:
         """
         Allow replacement of main axes by subclassing.
         """
-        return self.fig.add_subplot(111)
+        if not len(self.fig.axes):
+            self.fig.add_subplot(111)
+        return self.fig.axes[0]
 
     def _make_axes_grid(self):
         self.axes = self._get_main_axes()

--- a/sunpy/visualization/animator/mapsequenceanimator.py
+++ b/sunpy/visualization/animator/mapsequenceanimator.py
@@ -108,10 +108,15 @@ class MapSequenceAnimator(imageanimator.BaseFuncAnimator):
         """
         Create an axes which is a `~astropy.visualization.wcsaxes.WCSAxes`.
         """
-        if not _FORCE_NO_WCSAXES:
-            return self.fig.add_subplot(111, projection=self.mapsequence[0].wcs)
-        else:
+        # If axes already exist, just return them
+        if len(self.fig.axes):
+            return self.fig.axes[0]
+        elif _FORCE_NO_WCSAXES:
             return self.fig.add_subplot(111)
+        else:
+            return self.fig.add_subplot(111, projection=self.mapsequence[0].wcs)
+
+
 
     def plot_start_image(self, ax):
         im = self.mapsequence[0].plot(

--- a/sunpy/visualization/animator/mapsequenceanimator.py
+++ b/sunpy/visualization/animator/mapsequenceanimator.py
@@ -116,8 +116,6 @@ class MapSequenceAnimator(imageanimator.BaseFuncAnimator):
         else:
             return self.fig.add_subplot(111, projection=self.mapsequence[0].wcs)
 
-
-
     def plot_start_image(self, ax):
         im = self.mapsequence[0].plot(
             annotate=self.annotate, axes=ax, **self.imshow_kwargs)


### PR DESCRIPTION
I think this is the trivial fix, but I've put it in it's own PR just to get some scrutiny. Previously `fig.add_subplot(111)` would just return the axes if it already existed in the figure, but this will no longer be the case in a later version of Matplotlib. I think the fix is to check if there is a axes present, and if not create it.

I'm unsure what "Allow replacement of main axes by subclassing." means though...