### PR TITLE
Reduce import time for `image.transform`

### DIFF
--- a/changelog/3818.feature.rst
+++ b/changelog/3818.feature.rst
@@ -1,0 +1,1 @@
+Made skimage.transform import lazy to reduce import time by ~50%

--- a/changelog/3818.feature.rst
+++ b/changelog/3818.feature.rst
@@ -1,1 +1,1 @@
-Made skimage.transform import lazy to reduce import time by ~50%
+Made skimage.transform import lazy to reduce import time of `sunpy.image.transform` by ~50%

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -8,15 +8,6 @@ import scipy.ndimage.interpolation
 
 from sunpy.util.exceptions import SunpyUserWarning
 
-try:
-    import skimage.transform
-    scikit_image_not_found = False
-except ImportError:
-    warnings.warn("scikit-image could not be imported. Image rotation will use scipy",
-                  ImportWarning)
-    scikit_image_not_found = True
-
-
 __all__ = ['affine_transform']
 
 
@@ -84,7 +75,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
     algorithm to map the original to target pixel values.
     """
     rmatrix = rmatrix / scale
-    array_center = (np.array(image.shape)[::-1]-1)/2.0
+    array_center = (np.array(image.shape)[::-1] - 1) / 2.0
 
     # Make sure the image center is an array and is where it's supposed to be
     if image_center is not None:
@@ -100,14 +91,22 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
 
     displacement = np.dot(rmatrix, rot_center)
     shift = image_center - displacement
-
+    scikit_image_not_found = True
+    if not use_scipy:
+        try:
+            import skimage.transform
+            scikit_image_not_found = False
+        except ImportError:
+            warnings.warn("scikit-image could not be imported. Image rotation will use scipy",
+                          ImportWarning)
+            scikit_image_not_found = True
     if use_scipy or scikit_image_not_found:
         if np.any(np.isnan(image)):
             warnings.warn("Setting NaNs to 0 for SciPy rotation.", SunpyUserWarning)
         # Transform the image using the scipy affine transform
         rotated_image = scipy.ndimage.interpolation.affine_transform(
-                np.nan_to_num(image).T, rmatrix, offset=shift, order=order,
-                mode='constant', cval=missing).T
+            np.nan_to_num(image).T, rmatrix, offset=shift, order=order,
+            mode='constant', cval=missing).T
     else:
         # Make the rotation matrix 3x3 to include translation of the image
         skmatrix = np.zeros((3, 3))

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -91,16 +91,14 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
 
     displacement = np.dot(rmatrix, rot_center)
     shift = image_center - displacement
-    scikit_image_not_found = True
     if not use_scipy:
         try:
             import skimage.transform
-            scikit_image_not_found = False
         except ImportError:
             warnings.warn("scikit-image could not be imported. Image rotation will use scipy",
                           ImportWarning)
-            scikit_image_not_found = True
-    if use_scipy or scikit_image_not_found:
+            use_scipy = True
+    if use_scipy:
         if np.any(np.isnan(image)):
             warnings.warn("Setting NaNs to 0 for SciPy rotation.", SunpyUserWarning)
         # Transform the image using the scipy affine transform


### PR DESCRIPTION



<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3447 by lazy import skimage.transform

![Screenshot from 2020-02-19 12-49-41](https://user-images.githubusercontent.com/42688747/74813905-2305e500-531c-11ea-8bf5-3721c0a4eaa9.png)
![Screenshot from 2020-02-19 12-50-11](https://user-images.githubusercontent.com/42688747/74813919-28fbc600-531c-11ea-9761-4912c812f2d7.png)
