### PR TITLE
Fix primekey pop in JSOCClient._make_recordset

### DIFF
--- a/changelog/3825.bugfix.rst
+++ b/changelog/3825.bugfix.rst
@@ -1,1 +1,1 @@
-JSOCClient now works with non-time primekeys.
+Fix a bug in `sunpy.net.jsoc.JSOCClient` where requesting data for export would not work if a non-time primekey was used.

--- a/changelog/3825.bugfix.rst
+++ b/changelog/3825.bugfix.rst
@@ -1,1 +1,1 @@
-This patch fixes query_args in JSOCClient return object. For formating dataset query, .pop method was used for extracting primekeys from input arguments list and that led to invalidating shalow copy of iargs object. This patch forces deepcopy of object so that primekeys persists.
+JSOCClient now works with non-time primekeys.

--- a/changelog/3825.bugfix.rst
+++ b/changelog/3825.bugfix.rst
@@ -1,0 +1,1 @@
+This patch fixes query_args in JSOCClient return object. For formating dataset query, .pop method was used for extracting primekeys from input arguments list and that led to invalidating shalow copy of iargs object. This patch forces deepcopy of object so that primekeys persists.

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -3,6 +3,7 @@ import os
 import time
 import urllib
 import warnings
+import copy
 from collections.abc import Sequence
 
 import drms
@@ -331,7 +332,8 @@ class JSOCClient(BaseClient):
         for block in walker.create(query):
             iargs = kwargs.copy()
             iargs.update(block)
-            blocks.append(iargs)
+            # Update blocks with deep copy of iargs because in _make_recordset we use .pop() on element from iargs
+            blocks.append(copy.deepcopy(iargs))
             return_results.append(self._lookup_records(iargs))
 
         return_results.query_args = blocks

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -44,8 +44,7 @@ def test_empty_jsoc_response():
 def test_return_query_args():
     res = client.search(a.jsoc.PrimeKey('HARPNUM', 3604),
                         a.jsoc.Series('hmi.sharp_cea_720s'),
-                        a.jsoc.Segment('Bp') & a.jsoc.Segment('magnetogram'),
-                        a.jsoc.Notify('sunpy@sunpy.net'))
+                        a.jsoc.Segment('Bp') & a.jsoc.Segment('magnetogram'))
     #Because res.query_args is list that contains dict
     assert 'primekey' in res.query_args[0]
 

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -46,7 +46,7 @@ def test_return_query_args():
                         a.jsoc.Series('hmi.sharp_cea_720s'),
                         a.jsoc.Segment('Bp') & a.jsoc.Segment('magnetogram'),
                         a.jsoc.Notify('sunpy@sunpy.net'))
-    #Because res.query_args is list that containes set
+    #Because res.query_args is list that contains dict
     assert 'primekey' in res.query_args[0]
 
 @pytest.mark.remote_data

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -41,6 +41,15 @@ def test_empty_jsoc_response():
 
 
 @pytest.mark.remote_data
+def test_return_query_args():
+    res = client.search(a.jsoc.PrimeKey('HARPNUM', 3604),
+                        a.jsoc.Series('hmi.sharp_cea_720s'),
+                        a.jsoc.Segment('Bp') & a.jsoc.Segment('magnetogram'),
+                        a.jsoc.Notify('sunpy@sunpy.net'))
+    #Because res.query_args is list that containes set
+    assert 'primekey' in res.query_args[0]
+
+@pytest.mark.remote_data
 def test_query():
     Jresp = client.search(
         a.Time('2012/1/1T00:00:00', '2012/1/1T00:01:30'),


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This pull request fixes missing primekey from jsocresponse.query_args after request to jsoc is made and we get successful response. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3817 
