### PR TITLE
Document types of jsoc.attrs.PrimeKey

### DIFF
--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -25,6 +25,11 @@ class Keys(SimpleAttr):
 class PrimeKey(DataAttr):
     """
     Prime Keys
+
+    Parameters
+    ----------
+    label : str
+    value : str
     """
     def __init__(self, label, value):
         super().__init__()


### PR DESCRIPTION
I was trying to pass an `int` to a `PrimeKey`, which I don't think you're meant to do; according to https://docs.sunpy.org/en/stable/guide/acquiring_data/jsoc.html everything should be a string, so document this.