### PR TITLE
Fixed title/label overlap in example gallery

### DIFF
--- a/changelog/3835.doc.rst
+++ b/changelog/3835.doc.rst
@@ -1,2 +1,1 @@
 Changed padding value of an example in the example gallery to fix the overlap of titles and x-label axes.
-

--- a/changelog/3835.doc.rst
+++ b/changelog/3835.doc.rst
@@ -1,0 +1,2 @@
+Changed padding value of an example in the example gallery to fix the overlap of titles and x-label axes.
+

--- a/examples/acquiring_data/2011_06_07_sampledata_overview.py
+++ b/examples/acquiring_data/2011_06_07_sampledata_overview.py
@@ -78,7 +78,7 @@ ax = fig.add_subplot(616, projection=aia_1600_map)
 aia_1600_map.plot(clip_interval=(0.5, 99.9)*u.percent)
 aia_1600_map.draw_grid()
 
-fig.tight_layout(pad=6.50)
+fig.tight_layout(pad=8.50)
 plt.show()
 
 ###############################################################################


### PR DESCRIPTION
Changed padding value to avoid title and labels from overlapping in the example gallery (link: https://docs.sunpy.org/en/latest/generated/gallery/acquiring_data/2011_06_07_sampledata_overview.html#sphx-glr-generated-gallery-acquiring-data-2011-06-07-sampledata-overview-py)

Currently, the plots look like this: 
![sphx_glr_2011_06_07_sampledata_overview_003](https://user-images.githubusercontent.com/17577971/75103697-513d3a80-5624-11ea-91d6-d75e05394c38.png)

With padding equal to 8.5, they look like this: 

![doc title fix 3](https://user-images.githubusercontent.com/17577971/75103706-6b771880-5624-11ea-8bb3-d20822183529.png)

Fixes #3093 
