### PR TITLE
Used parse_time function to compare Time

### DIFF
--- a/changelog/3840.bugfix.rst
+++ b/changelog/3840.bugfix.rst
@@ -1,0 +1,1 @@
+Used the `parse_time` function to compare time in VSO post-search filtering code

--- a/changelog/3840.bugfix.rst
+++ b/changelog/3840.bugfix.rst
@@ -1,1 +1,1 @@
-Used the `parse_time` function to compare time in VSO post-search filtering code
+Updated the method used to filter time in the VSO post-search filtering function.

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -25,6 +25,8 @@ from functools import singledispatch as _singledispatch
 import astropy.units as u
 
 from sunpy.util.exceptions import SunpyDeprecationWarning
+from sunpy.time import parse_time
+
 from .. import _attrs
 from .. import attr as _attr
 
@@ -337,11 +339,11 @@ def _(attr, results):
         if
         it.time.end is not None
         and
-        attr.min <= _attrs.Time.strptime(it.time.end, _TIMEFORMAT)
+        attr.min <= parse_time(it.time.end)
         and
         it.time.start is not None
         and
-        attr.max >= _attrs.Time.strptime(it.time.start, _TIMEFORMAT)
+        attr.max >= parse_time(it.time.start)
     }
 
 

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -23,9 +23,9 @@ import warnings
 from functools import singledispatch as _singledispatch
 
 import astropy.units as u
+from astropy.time import Time as AstropyTime
 
 from sunpy.util.exceptions import SunpyDeprecationWarning
-from sunpy.time import parse_time
 
 from .. import _attrs
 from .. import attr as _attr
@@ -339,11 +339,11 @@ def _(attr, results):
         if
         it.time.end is not None
         and
-        attr.min <= parse_time(it.time.end)
+        attr.min <= AstropyTime.strptime(it.time.end, _TIMEFORMAT)
         and
         it.time.start is not None
         and
-        attr.max >= parse_time(it.time.start)
+        attr.max >= AstropyTime.strptime(it.time.start, _TIMEFORMAT)
     }
 
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Removed the old code for filtering Time attribute in `vso/attrs.py`. Converted the time string (`it.time.start` and `it.time.end`) to Time objects using `parse_time` helper function.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3839 
