### PR TITLE
Improve warning when date-obs keyword not present

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -452,7 +452,9 @@ class GenericMap(NDData):
         time = self.meta.get('date-obs', None)
         if time is None:
             if self._default_time is None:
-                warnings.warn("Missing metadata for observation time: setting observation time to current time.",
+                warnings.warn("Missing metadata for observation time, "
+                              "setting observation time to current time. "
+                              "Set the 'DATE-OBS' FITS keyword to prevent this warning.",
                               SunpyUserWarning)
                 self._default_time = parse_time('now')
             time = self._default_time


### PR DESCRIPTION
It took me a few guesses to work out that "DATE-OBS" was the right keyword to set to stop this warning, so I thought it would be good to supply that information in the warning.