### PR TITLE
Implemented _get_time_for_url in GenericClient

### DIFF
--- a/changelog/3863.trivial.rst
+++ b/changelog/3863.trivial.rst
@@ -1,0 +1,1 @@
+Implemented `_get_time_for_url` function in ~sunpy.net.dataretriever.client.GenericClient` so as to avoid its implementation in every client.

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -48,9 +48,9 @@ variable set to the Fido search, in this case, result::
          Start Time           End Time      Source Instrument Wavelength
            str19               str19         str6     str4       str3
     ------------------- ------------------- ------ ---------- ----------
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
+    2012-03-04 00:00:00 2012-03-04 23:59:59 Proba2       lyra        nan
+    2012-03-05 00:00:00 2012-03-05 23:59:59 Proba2       lyra        nan
+    2012-03-06 00:00:00 2012-03-06 23:59:59 Proba2       lyra        nan
     <BLANKLINE>
     <BLANKLINE>
 
@@ -69,9 +69,9 @@ passbands can be searched for by supplying an `~astropy.units.Quantity` to the
          Start Time           End Time      Source Instrument   Wavelength
            str19               str19         str4     str4        str14
     ------------------- ------------------- ------ ---------- --------------
-    2012-03-04 00:00:00 2012-03-05 00:00:00   NAOJ       NORH 17000000.0 kHz
-    2012-03-05 00:00:00 2012-03-06 00:00:00   NAOJ       NORH 17000000.0 kHz
-    2012-03-06 00:00:00 2012-03-07 00:00:00   NAOJ       NORH 17000000.0 kHz
+    2012-03-04 00:00:00 2012-03-04 23:59:59   NAOJ       NORH 17000000.0 kHz
+    2012-03-05 00:00:00 2012-03-05 23:59:59   NAOJ       NORH 17000000.0 kHz
+    2012-03-06 00:00:00 2012-03-06 23:59:59   NAOJ       NORH 17000000.0 kHz
     <BLANKLINE>
     <BLANKLINE>
 
@@ -130,9 +130,9 @@ operator would::
          Start Time           End Time      Source Instrument Wavelength
            str19               str19         str6     str4       str3
     ------------------- ------------------- ------ ---------- ----------
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
+    2012-03-04 00:00:00 2012-03-04 23:59:59 Proba2       lyra        nan
+    2012-03-05 00:00:00 2012-03-05 23:59:59 Proba2       lyra        nan
+    2012-03-06 00:00:00 2012-03-06 23:59:59 Proba2       lyra        nan
     <BLANKLINE>
     3 Results from the RHESSIClient:
          Start Time           End Time      Source Instrument Wavelength
@@ -174,8 +174,8 @@ results returned by the `~sunpy.net.dataretriever.sources.LYRAClient`::
          Start Time           End Time      Source Instrument Wavelength
            str19               str19         str6     str4       str3
     ------------------- ------------------- ------ ---------- ----------
-    2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
-    2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
+    2012-01-01 00:00:00 2012-01-01 23:59:59 Proba2       lyra        nan
+    2012-01-02 00:00:00 2012-01-02 23:59:59 Proba2       lyra        nan
     <BLANKLINE>
     <BLANKLINE>
 
@@ -189,8 +189,8 @@ Or, equivalently::
          Start Time           End Time      Source Instrument Wavelength
            str19               str19         str6     str4       str3
     ------------------- ------------------- ------ ---------- ----------
-    2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
-    2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
+    2012-01-01 00:00:00 2012-01-01 23:59:59 Proba2       lyra        nan
+    2012-01-02 00:00:00 2012-01-02 23:59:59 Proba2       lyra        nan
     <BLANKLINE>
     <BLANKLINE>
 

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -580,7 +580,7 @@ def entries_from_fido_search_result(sr, default_waveunit=None):
     >>> entry.fileid # doctest: +REMOTE_DATA
     'http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits'
     >>> entry.observation_time_start, entry.observation_time_end # doctest: +REMOTE_DATA
-    (datetime.datetime(2012, 1, 1, 0, 0), datetime.datetime(2012, 1, 2, 0, 0))
+    (datetime.datetime(2012, 1, 1, 0, 0), datetime.datetime(2012, 1, 1, 23, 59, 59, 999000))
     >>> entry.instrument # doctest: +REMOTE_DATA
     'lyra'
 

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -122,7 +122,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         source='Proba2', provider='esa', physobs='irradiance',
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
-        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=np.nan, wavemax=np.nan,
         instrument='lyra')
     # 54 entries from EVE
@@ -164,7 +164,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid=("ftp://anonymous:data@sunpy.org@solar-pub.nao.ac.jp/"
                 "pub/nsro/norh/data/tcx/2012/01/tca120101"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
-        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=17634850.470588233, wavemax=17634850.470588233,
         instrument='NORH')
     # 1 entry from rhessi
@@ -182,7 +182,7 @@ def test_entries_from_fido_search_result(fido_search_result):
         fileid=("http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook"
                 "/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
-        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=np.nan, wavemax=np.nan,
         instrument='eve')
 
@@ -209,7 +209,7 @@ def test_from_fido_search_result_block(fido_search_result):
         source='Proba2', provider='esa', physobs='irradiance',
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
-        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=np.nan, wavemax=np.nan,
         instrument='lyra')
     assert entry == expected_entry

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -8,6 +8,7 @@ from parfive import Downloader
 
 import astropy.table
 import astropy.units as u
+from astropy.time import TimeDelta
 
 import parfive
 
@@ -132,6 +133,7 @@ class GenericClient(BaseClient):
 
     def __init__(self):
         self.map_ = {}
+        self.crawler = None
 
     def _makeargs(self, *args):
         """
@@ -259,7 +261,16 @@ class GenericClient(BaseClient):
 
         It should return a sunpy.time.TimeRange object per URL.
         """
-        return NotImplemented
+        if self.crawler is None:
+            return NotImplemented
+        else:
+            crawler = self.crawler
+            times = list()
+            for url in urls:
+                t0 = crawler._extractDateURL(url)
+                almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
+                times.append(TimeRange(t0, t0 + almost_day))
+            return times
 
     def search(self, *args, **kwargs):
         """

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -133,7 +133,7 @@ class GenericClient(BaseClient):
 
     def __init__(self):
         self.map_ = {}
-        self.crawler = None
+        self.scraper = None
 
     def _makeargs(self, *args):
         """
@@ -261,13 +261,13 @@ class GenericClient(BaseClient):
 
         It should return a sunpy.time.TimeRange object per URL.
         """
-        if self.crawler is None:
+        if self.scraper is None:
             return NotImplemented
         else:
-            crawler = self.crawler
+            scraper = self.scraper
             times = list()
             for url in urls:
-                t0 = crawler._extractDateURL(url)
+                t0 = scraper._extractDateURL(url)
                 almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
                 times.append(TimeRange(t0, t0 + almost_day))
             return times

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -265,11 +265,8 @@ class GenericClient(BaseClient):
             return NotImplemented
         else:
             scraper = self.scraper
-            times = list()
-            for url in urls:
-                t0 = scraper._extractDateURL(url)
-                almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
-                times.append(TimeRange(t0, t0 + almost_day))
+            almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
+            times = [TimeRange(t0, t0 + almost_day) for t0 in map(scraper._extractDateURL, urls)]
             return times
 
     def search(self, *args, **kwargs):

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -60,8 +60,8 @@ class EVEClient(GenericClient):
             list of URLs corresponding to the requested time range
 
         """
-        self.crawler = Scraper(BASEURL)
-        return self.crawler.filelist(timerange)
+        self.scraper = Scraper(BASEURL)
+        return self.scraper.filelist(timerange)
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -38,8 +38,8 @@ class EVEClient(GenericClient):
          Start Time           End Time      Source Instrument Wavelength
            str19               str19         str3     str3       str3
     ------------------- ------------------- ------ ---------- ----------
-    2016-01-01 00:00:00 2016-01-02 00:00:00    SDO        eve        nan
-    2016-01-02 00:00:00 2016-01-03 00:00:00    SDO        eve        nan
+    2016-01-01 00:00:00 2016-01-01 23:59:59    SDO        eve        nan
+    2016-01-02 00:00:00 2016-01-02 23:59:59    SDO        eve        nan
     <BLANKLINE>
     <BLANKLINE>
 
@@ -60,22 +60,8 @@ class EVEClient(GenericClient):
             list of URLs corresponding to the requested time range
 
         """
-        # If start of time range is before 00:00, converted to such, so
-        # files of the requested time ranger are included.
-        # This is done because the archive contains daily files.
-        if timerange.start.strftime('%M-%S') != '00-00':
-            timerange = TimeRange(timerange.start.strftime('%Y-%m-%d'), timerange.end)
-        eve = Scraper(BASEURL)
-        return eve.filelist(timerange)
-
-    def _get_time_for_url(self, urls):
-        eve = Scraper(BASEURL)
-        times = list()
-        for url in urls:
-            t0 = eve._extractDateURL(url)
-            # hard coded full day as that's the normal.
-            times.append(TimeRange(t0, t0 + TimeDelta(1*u.day)))
-        return times
+        self.crawler = Scraper(BASEURL)
+        return self.crawler.filelist(timerange)
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -77,8 +77,8 @@ class GBMClient(GenericClient):
 
         gbm_pattern = ('https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/'
                        '%Y/%m/%d/current/glg_{data_type}_{det}_%y%m%d_v00.pha')
-        self.crawler = Scraper(gbm_pattern, data_type=data_type, det=det)
-        urls = self.crawler.filelist(timerange)
+        self.scraper = Scraper(gbm_pattern, data_type=data_type, det=det)
+        urls = self.scraper.filelist(timerange)
 
         return urls
 

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -39,9 +39,9 @@ class GBMClient(GenericClient):
          Start Time           End Time      Source Instrument Wavelength
            str19               str19         str5     str3       str3
     ------------------- ------------------- ------ ---------- ----------
-    2015-06-21 00:00:00 2015-06-23 23:59:00  FERMI        GBM        nan
-    2015-06-21 00:00:00 2015-06-23 23:59:00  FERMI        GBM        nan
-    2015-06-21 00:00:00 2015-06-23 23:59:00  FERMI        GBM        nan
+    2015-06-21 00:00:00 2015-06-21 23:59:59  FERMI        GBM        nan
+    2015-06-22 00:00:00 2015-06-22 23:59:59  FERMI        GBM        nan
+    2015-06-23 00:00:00 2015-06-23 23:59:59  FERMI        GBM        nan
     <BLANKLINE>
     <BLANKLINE>
     <BLANKLINE>
@@ -77,8 +77,8 @@ class GBMClient(GenericClient):
 
         gbm_pattern = ('https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/'
                        '%Y/%m/%d/current/glg_{data_type}_{det}_%y%m%d_v00.pha')
-        gbm_files = Scraper(gbm_pattern, data_type=data_type, det=det)
-        urls = gbm_files.filelist(timerange)
+        self.crawler = Scraper(gbm_pattern, data_type=data_type, det=det)
+        urls = self.crawler.filelist(timerange)
 
         return urls
 

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -115,9 +115,9 @@ class XRSClient(GenericClient):
 
         goes_pattern = f"https://umbra.nascom.nasa.gov/goes/fits/{goes_file}"
         satellitenumber = kwargs.get("satellitenumber", self._get_goes_sat_num(timerange.start))
-        self.crawler = Scraper(goes_pattern, satellitenumber=satellitenumber)
+        self.scraper = Scraper(goes_pattern, satellitenumber=satellitenumber)
 
-        return self.crawler.filelist(timerange)
+        return self.scraper.filelist(timerange)
 
     def _get_overlap_urls(self, timerange):
         """
@@ -299,12 +299,12 @@ class SUVIClient(GenericClient):
                         'l{level}/suvi-l{level}-fe{wave:03}/%Y/%m/%d/OR_SUVI-L{level}-Fe{wave_minus1:03}_G{goes_number}_s%Y%j%H%M%S.*\.fits.gz'
 
             if search_pattern.count('wave_minus1'):
-                self.crawler = Scraper(search_pattern, level=level, wave=this_wave,
+                self.scraper = Scraper(search_pattern, level=level, wave=this_wave,
                                   goes_number=satellitenumber, wave_minus1=this_wave-1)
             else:
-                self.crawler = Scraper(search_pattern, level=level, wave=this_wave,
+                self.scraper = Scraper(search_pattern, level=level, wave=this_wave,
                                   goes_number=satellitenumber)
-            results.extend(self.crawler.filelist(timerange))
+            results.extend(self.scraper.filelist(timerange))
         return results
 
     def _makeimap(self):

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -28,8 +28,8 @@ class LYRAClient(GenericClient):
          Start Time           End Time      Source Instrument Wavelength
            str19               str19         str6     str4       str3
     ------------------- ------------------- ------ ---------- ----------
-    2016-01-01 00:00:00 2016-01-02 00:00:00 Proba2       lyra        nan
-    2016-01-01 00:00:00 2016-01-02 00:00:00 Proba2       lyra        nan
+    2016-01-01 00:00:00 2016-01-01 23:59:59 Proba2       lyra        nan
+    2016-01-02 00:00:00 2016-01-02 23:59:59 Proba2       lyra        nan
     <BLANKLINE>
     <BLANKLINE>
 
@@ -51,8 +51,8 @@ class LYRAClient(GenericClient):
         """
         lyra_pattern = ('http://proba2.oma.be/lyra/data/bsd/%Y/%m/%d/'
                         'lyra_%Y%m%d-000000_lev{level}_std.fits')
-        lyra_files = Scraper(lyra_pattern, level=kwargs.get('level', 2))
-        urls = lyra_files.filelist(timerange)
+        self.crawler = Scraper(lyra_pattern, level=kwargs.get('level', 2))
+        urls = self.crawler.filelist(timerange)
 
         return urls
 

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -51,8 +51,8 @@ class LYRAClient(GenericClient):
         """
         lyra_pattern = ('http://proba2.oma.be/lyra/data/bsd/%Y/%m/%d/'
                         'lyra_%Y%m%d-000000_lev{level}_std.fits')
-        self.crawler = Scraper(lyra_pattern, level=kwargs.get('level', 2))
-        urls = self.crawler.filelist(timerange)
+        self.scraper = Scraper(lyra_pattern, level=kwargs.get('level', 2))
+        urls = self.scraper.filelist(timerange)
 
         return urls
 

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -39,8 +39,8 @@ class NoRHClient(GenericClient):
          Start Time           End Time      Source Instrument   Wavelength
            str19               str19         str4     str4        str14
     ------------------- ------------------- ------ ---------- --------------
-    2016-01-01 00:00:00 2016-01-02 00:00:00   NAOJ       NORH 17000000.0 kHz
-    2016-01-02 00:00:00 2016-01-03 00:00:00   NAOJ       NORH 17000000.0 kHz
+    2016-01-01 00:00:00 2016-01-01 23:59:59   NAOJ       NORH 17000000.0 kHz
+    2016-01-02 00:00:00 2016-01-02 23:59:59   NAOJ       NORH 17000000.0 kHz
     <BLANKLINE>
     <BLANKLINE>
 
@@ -90,22 +90,12 @@ class NoRHClient(GenericClient):
             timerange = TimeRange(timerange.start.strftime('%Y-%m-%d'),
                                   timerange.end)
 
-        norh = Scraper(BASEURL, freq=freq)
+        self.crawler = Scraper(BASEURL, freq=freq)
         # TODO: warn user that some files may have not been listed, like for example:
         #       tca160504_224657 on ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/05/
         #       as it doesn't follow pattern.
 
-        return norh.filelist(timerange)
-
-    def _get_time_for_url(self, urls):
-        freq = urls[0].split('/')[-1][0:3]  # extract the frequency label
-        crawler = Scraper(BASEURL, freq=freq)
-        times = list()
-        for url in urls:
-            t0 = crawler._extractDateURL(url)
-            # hard coded full day as that's the normal.
-            times.append(TimeRange(t0, t0 + TimeDelta(1*u.day)))
-        return times
+        return self.crawler.filelist(timerange)
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -90,12 +90,12 @@ class NoRHClient(GenericClient):
             timerange = TimeRange(timerange.start.strftime('%Y-%m-%d'),
                                   timerange.end)
 
-        self.crawler = Scraper(BASEURL, freq=freq)
+        self.scraper = Scraper(BASEURL, freq=freq)
         # TODO: warn user that some files may have not been listed, like for example:
         #       tca160504_224657 on ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/05/
         #       as it doesn't follow pattern.
 
-        return self.crawler.filelist(timerange)
+        return self.scraper.filelist(timerange)
 
     def _makeimap(self):
         """

--- a/sunpy/net/dataretriever/tests/test_eve.py
+++ b/sunpy/net/dataretriever/tests/test_eve.py
@@ -1,5 +1,8 @@
 import pytest
 
+from astropy.time import TimeDelta
+import astropy.units as u
+
 import sunpy.net.dataretriever.sources.eve as eve
 from sunpy.net import Fido
 from sunpy.net import attrs as a
@@ -53,7 +56,9 @@ def test_query():
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 2
     assert qr1.time_range().start == parse_time('2012/08/09')
-    assert qr1.time_range().end == parse_time('2012/08/11')  # includes end.
+    almost_day = TimeDelta(1*u.day - 1*u.millisecond)
+    end = parse_time('2012/08/10') + almost_day
+    assert qr1.time_range().end == end
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/dataretriever/tests/test_fermi_gbm.py
+++ b/sunpy/net/dataretriever/tests/test_fermi_gbm.py
@@ -1,5 +1,8 @@
 import pytest
 
+from astropy.time import TimeDelta
+import astropy.units as u
+
 from sunpy.time import parse_time
 from sunpy.time.timerange import TimeRange
 from sunpy.net.dataretriever.client import QueryResponse
@@ -55,7 +58,8 @@ def test_query(time, instrument):
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 2
     assert qr1.time_range().start == time.start
-    assert qr1.time_range().end == time.end
+    almost_day = TimeDelta(1*u.day - 1*u.millisecond)
+    assert qr1.time_range().end == time.end + almost_day
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/dataretriever/tests/test_goes_suvi.py
+++ b/sunpy/net/dataretriever/tests/test_goes_suvi.py
@@ -106,8 +106,8 @@ def test_fetch_working(suvi_client):
     assert mock_qr.instrument == qr.instrument
     assert mock_qr.url == qr.url
 
-    assert qr1.time_range() == TimeRange("2019-05-25T00:52:00.000",
-                                         "2019-05-25T00:56:00.000")
+    assert qr1.time_range() == TimeRange("2019-05-25T00:52:00",
+                                         "2019-05-26T00:51:59.999")
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         download_list = suvi_client.fetch(qr1, path=tmpdirname)
@@ -200,5 +200,5 @@ def test_query(suvi_client, start, end, expected_num_files):
     qr1 = suvi_client.search(a.Time(start, end), a.Instrument('suvi'))
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == expected_num_files
-    assert qr1.time_range().start == parse_time('2019/05/25 00:52')
-    assert qr1.time_range().end == parse_time('2019/05/25 00:56')
+    assert qr1.time_range().start == parse_time('2019-05-25T00:52:00')
+    assert qr1.time_range().end == parse_time('2019-05-26T00:51:59.999')

--- a/sunpy/net/dataretriever/tests/test_lyra_ud.py
+++ b/sunpy/net/dataretriever/tests/test_lyra_ud.py
@@ -1,5 +1,8 @@
 import pytest
 
+import astropy.units as u
+from astropy.time import TimeDelta
+
 from sunpy.time.timerange import TimeRange
 from sunpy.time import parse_time
 from sunpy.net._attrs import Time, Instrument
@@ -54,7 +57,8 @@ def test_query(time):
     qr1 = LCClient.search(time, Instrument('lyra'))
     assert isinstance(qr1, QueryResponse)
     assert qr1.time_range().start == time.start
-    assert qr1.time_range().end == time.end
+    almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
+    assert qr1.time_range().end == time.end + almost_day
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/dataretriever/tests/test_norh.py
+++ b/sunpy/net/dataretriever/tests/test_norh.py
@@ -64,7 +64,8 @@ def test_query(time, wave):
         assert qr1.time_range().start.strftime('%Y-%m-%d') >= time.start.strftime('%Y-%m-%d')
         #  and the end time equal or smaller.
         # hypothesis can give same start-end, but the query will give you from start to end (so +1)
-        assert qr1.time_range().end <= time.end + TimeDelta(1*u.day)
+        almost_day = TimeDelta(1*u.day - 1*u.millisecond)
+        assert qr1.time_range().end <= time.end + almost_day
 
 
 # Don't use time_attr here for speed.

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -22,7 +22,7 @@ from sunpy.net.dataretriever.client import QueryResponse
 from sunpy.net.dataretriever.sources.goes import XRSClient
 from sunpy.net.fido_factory import UnifiedResponse
 from sunpy.net.tests.strategies import goes_time, offline_instruments, online_instruments, time_attr
-from sunpy.net.vso import QueryResponse as vsoQueryResponse, attrs as va
+from sunpy.net.vso import QueryResponse as vsoQueryResponse
 from sunpy.net.vso.vso import DownloadFailed
 from sunpy.time import TimeRange, parse_time
 from sunpy.util.datatype_factory_base import MultipleMatchError
@@ -265,8 +265,8 @@ def test_tables_all_types():
     assert isinstance(drtables[0], Table)
 
     # VSO response objects
-    vsoclient = Fido.search(va.Time('2011-06-07 06:33', '2011-06-07 06:33:08'),
-                            va.Instrument('aia'), va.Wavelength(171 * u.AA))
+    vsoclient = Fido.search(a.Time('2011-06-07 06:33', '2011-06-07 06:33:08'),
+                            a.Instrument('aia'), a.Wavelength(171 * u.AA))
     vsotables = vsoclient.tables
     assert isinstance(vsotables, list)
     assert isinstance(vsotables[0], Table)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3715 
After this PR, there is no need to implement `_get_time_for_url()` function in most of the many clients.
Currently I have implemented `_get_time_for_url()` in GenericClient so that it is not needed to be implemented separately in every client.
Made a new member `crawler` in `GenericClient` which is used to get dates.

It might not be the best way, so I need suggestions from maintainers.
