### PR TITLE
Prevent imshow_kwargs being modified in-place by plot()

### DIFF
--- a/changelog/3867.bugfix.rst
+++ b/changelog/3867.bugfix.rst
@@ -1,0 +1,1 @@
+Prevented `GenericMap.plot` modifying in-place any items passed as ``imshow_kwargs``.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1764,7 +1764,10 @@ class GenericMap(NDData):
             x_range = list(u.Quantity([bl[0], tr[0]]).to(self.spatial_units[0]).value)
             y_range = list(u.Quantity([bl[1], tr[1]]).to(self.spatial_units[1]).value)
             imshow_args.update({'extent': x_range + y_range})
-        imshow_args.update(imshow_kwargs)
+
+        # Take a deep copy here so that a norm in imshow_kwargs doesn't get modified
+        # by setting it's vmin and vmax
+        imshow_args.update(copy.deepcopy(imshow_kwargs))
 
         if clip_interval is not None:
             if len(clip_interval) == 2:


### PR DESCRIPTION
Fixes #3864. Note that is puts how we treat `imshow_kwargs` on a par with `map.plot_settings`, which we deepcopy earlier in the method to avoid a norm changing in place.