### PR TITLE
Fix peek warning

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1665,6 +1665,14 @@ class GenericMap(NDData):
 
         im = self.plot(axes=axes, **matplot_args)
 
+        grid_spacing = None
+        # Handle case where draw_grid is actually the grid sapcing
+        if isinstance(draw_grid, u.Quantity):
+            grid_spacing = draw_grid
+            draw_grid = True
+        elif not isinstance(draw_grid, bool):
+            raise TypeError("draw_grid should be a bool or an astropy Quantity.")
+
         if colorbar:
             if draw_grid:
                 pad = 0.12  # Pad to compensate for ticks and axes labels
@@ -1675,13 +1683,11 @@ class GenericMap(NDData):
         if draw_limb:
             self.draw_limb(axes=axes)
 
-        if isinstance(draw_grid, bool):
-            if draw_grid:
+        if draw_grid:
+            if grid_spacing is None:
                 self.draw_grid(axes=axes)
-        elif isinstance(draw_grid, u.Quantity):
-            self.draw_grid(axes=axes, grid_spacing=draw_grid)
-        else:
-            raise TypeError("draw_grid should be a bool or an astropy Quantity.")
+            else:
+                self.draw_grid(axes=axes, grid_spacing=grid_spacing)
 
         return figure
 


### PR DESCRIPTION
This prevents an AstropyWarning when calling `if draw_grid:`, where `draw_grid` is a Quantity. Instead, force `draw_grid` to be a bool, and if it's started as a quantity just save the value in another variable.