### PR TITLE
Using our coordinates with SpacePy

### DIFF
--- a/docs/code_ref/coordinates/index.rst
+++ b/docs/code_ref/coordinates/index.rst
@@ -334,6 +334,9 @@ Reference/API
 .. automodapi:: sunpy.coordinates.sun
     :headings: ^#
 
+.. automodapi:: sunpy.coordinates.utils
+    :headings: ^#
+
 
 Attribution
 -----------


### PR DESCRIPTION
I'm not sure that this is actually a good idea, so consider this a proof of concept for now.  Here's a function to create a SpacePy coordinate (`spacepy.coordinates.Coords`) from an Astropy/SunPy coordinate (`astropy.coordinates.SkyCoord` or any frame).

``` python
>>> from sunpy.coordinates import get_body_heliographic_stonyhurst
>>> from sunpy.coordinates.utils import to_spacepy

>>> moon = get_body_heliographic_stonyhurst('moon', '2001-01-01')
>>> print(moon)
<HeliographicStonyhurst Coordinate (obstime=2001-01-01T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
    (-0.14516747, -3.03860194, 1.46953232e+08)>

# The SpacePy coordinate will be in Geocentric Solar Ecliptic (GSE) with units of Re
>>> spc = to_spacepy(moon)
>>> print(c)
Coords( [[23.384501191304054, 58.08241518972043, -5.185584518570753]] , 'GSE', 'car')

# With SpacePy, we can convert to MAG, which is not currently available in our framework
>>>print(spc.convert('MAG', 'sph'))
Coords( [[62.82612761175875, -0.5467027372146447, -37.06608268134964]] , 'MAG', 'sph')
```

To-do/concerns:

- [ ] Verify accuracy!
  - All of the coordinate handling in SpacePy is actually IRBEM-LIB, which appears to be a combination of SOFA code and equations from Hapgood (1992).  Even if there is complete agreement on definitions, IRBEM-LIB's use of Hapgood (1992) will limit its accuracy.
  - [ ] What is IRBEM-LIB's definition of GSE (mean vs. true, primary axis, aberration, etc.)?
    - IRBEM-LIB treats [HEE as a rotation of HAE about the ecliptic north pole](https://github.com/spacepy/spacepy/blob/188ee310727e45ad76b2924e52d55ee54c167720/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/heliospheric_transformation.f#L262), so considers the ecliptic north pole to be the primary axis.  Contrarily, SunPy considers the Sun-Earth line to be the primary axis, because that's what SunSPICE does.
  - [ ] What is IRBEM-LIB's definition of R_earth? (SunPy's is equatorial radius: 6378.1 km)
    - IRBEM-LIB uses the average value of [6371.2 km](https://github.com/spacepy/spacepy/blob/188ee310727e45ad76b2924e52d55ee54c167720/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/init_nouveau.f#L1602) (for example, [here](https://github.com/spacepy/spacepy/blob/188ee310727e45ad76b2924e52d55ee54c167720/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/heliospheric_transformation.f#L418)).

  - [ ] Inject access to HAE/HEE/HEEQ, which are available in IRBEM-LIB, but not carried out to `spacepy.irbempy`?
- [ ] How to do CI testing? (e.g., install SpacePy?)
- [ ] Handle `obstime=None`? (should only be a possibility if starting with GSE)
- [ ] Check any license implications (SpacePy and the included IRBEM-LIB)
