### PR TITLE
Improve subclassing attrs.Time and JSOC _can_handle_query

### DIFF
--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -62,7 +62,10 @@ class Time(Range):
             return super().__hash__()
 
     def collides(self, other):
-        return isinstance(other, self.__class__)
+        # Use exact type checking here, because otherwise it collides with all
+        # subclasses of itself which can have completely different search
+        # meanings.
+        return type(other) is type(self)
 
     def __xor__(self, other):
         if not isinstance(other, self.__class__):
@@ -72,7 +75,7 @@ class Time(Range):
         return Range.__xor__(self, other)
 
     def pad(self, timedelta):
-        return Time(self.start - timedelta, self.start + timedelta)
+        return type(self)(self.start - timedelta, self.start + timedelta)
 
     def __repr__(self):
         return '<Time({s.start!r}, {s.end!r}, {s.near!r})>'.format(s=self)

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -860,10 +860,19 @@ class JSOCClient(BaseClient):
 
     @classmethod
     def _can_handle_query(cls, *query):
-        chkattr = ['Series', 'Protocol', 'Notify', 'Wavelength', 'Time',
-                   'Segment', 'Keys', 'PrimeKey', 'Sample']
+        # Import here to prevent circular imports
+        from sunpy.net import attrs as a
 
-        return all([x.__class__.__name__ in chkattr for x in query])
+        required = {a.jsoc.Series}
+        optional = {a.jsoc.Protocol, a.jsoc.Notify, a.Wavelength, a.Time,
+                    a.jsoc.Segment, a.jsoc.Keys, a.jsoc.PrimeKey, a.Sample}
+        query_attrs = {type(x) for x in query}
+        all_attrs = required.union(optional)
+
+        if not required.issubset(query_attrs) or not query_attrs.issubset(all_attrs):
+            return False
+
+        return True
 
     @classmethod
     def _attrs_module(cls):

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -340,3 +340,9 @@ def test_results_filenames_as_is(tmp_path):
     assert len(files) == len(responses)
     for hmiurl in files:
         assert os.path.isfile(hmiurl)
+
+
+def test_can_handle_query_no_series():
+    assert not JSOCClient._can_handle_query(a.Time("2020/01/02", "2020/01/03"))
+    assert not JSOCClient._can_handle_query(a.Wavelength(17.1*u.nm))
+    assert JSOCClient._can_handle_query(a.jsoc.Series("hmi.M_45s"))

--- a/sunpy/net/tests/test_attrs.py
+++ b/sunpy/net/tests/test_attrs.py
@@ -1,0 +1,9 @@
+from sunpy.net import attr
+from sunpy.net import attrs as a
+
+
+def test_time_subclass():
+    class NewTime(a.Time):
+        pass
+
+    assert isinstance(NewTime("2020/01/01", "2020/01/02") & a.Time("2020/02/02", "2020/02/03"), attr.AttrAnd)


### PR DESCRIPTION
This is a couple of small fixes from #3770 

The first change is motivated by the DKIST client in dkistdc/dkist#73 where I am subclassing `a.Time` for a different purpose. Changing our checks to be for type rather than instance means that you can combine two different subclasses of Time in one query without issue.

The other is to make sure that the JSOC client can only handle queries if `a.jsoc.Series` is provided, otherwise queries with just `a.Wavelength` or `a.Time` match the JSOC but then .search errors.