### PR TITLE
Fixed a minor error in the calculation of the Sun's position angle

### DIFF
--- a/changelog/3886.bugfix.rst
+++ b/changelog/3886.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a minor error (up to ~10 arcseconds) in the calculation of the Sun's position angle (:func:`sunpy.coordinates.sun.P`).

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -12,7 +12,7 @@ import numpy as np
 import astropy.units as u
 from astropy.time import Time
 from astropy.coordinates import (SkyCoord, Angle, Longitude,
-                                 ICRS, PrecessedGeocentric, AltAz,
+                                 ICRS, ITRS, AltAz,
                                  get_body_barycentric)
 from astropy.coordinates.representation import CartesianRepresentation, SphericalRepresentation
 from astropy._erfa.core import ErfaWarning
@@ -336,7 +336,7 @@ def _P(time='now'):
     obstime = parse_time(time)
 
     # Define the frame where its Z axis is aligned with geocentric north
-    geocentric = PrecessedGeocentric(equinox=obstime, obstime=obstime)
+    geocentric = ITRS(obstime=obstime)
 
     return _sun_north_angle_to_z(geocentric)
 

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -227,9 +227,30 @@ def test_P():
 
 def test_P_array_time():
     # Validate against published values from the Astronomical Almanac (2013)
-    sun_P = sun.P(Time(['2013-04-01', '2013-12-01'], scale='tt'))
-    assert_quantity_allclose(sun_P[0], -26.15*u.deg, atol=1e-2*u.deg)
-    assert_quantity_allclose(sun_P[1], 16.05*u.deg, atol=1e-2*u.deg)
+    sun_P = sun.P(Time(['2013-01-01',
+                        '2013-02-01',
+                        '2013-03-01',
+                        '2013-04-01',
+                        '2013-05-01',
+                        '2013-06-01',
+                        '2013-07-01',
+                        '2013-08-01',
+                        '2013-09-01',
+                        '2013-10-01',
+                        '2013-11-01',
+                        '2013-12-01'], scale='tt'))
+    assert_quantity_allclose(sun_P, [  1.98,
+                                     -12.23,
+                                     -21.55,
+                                     -26.15,
+                                     -24.11,
+                                     -15.39,
+                                      -2.64,
+                                      10.85,
+                                      21.08,
+                                      25.97,
+                                      24.47,
+                                      16.05]*u.deg, atol=5e-3*u.deg)
 
 
 def test_earth_distance():


### PR DESCRIPTION
There have been some slight discrepancies between our values for the Sun's position angle (using `coordinates.sun.P()`) and the printed values in the Astronomical Almanac (see #3198).  I realized that I should be using the coordinate frame `ITRS` instead of `PrecessedGeocentric`, since the latter doesn't take into account all of the corrections for the pointing of the Earth's North pole.

Fixes #3198