### PR TITLE
[Backport 1.0] Fixed missing `sunpy.coordinates.utils` in docs

### DIFF
--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -289,6 +289,10 @@ which is equivalent to::
 .. automodapi:: sunpy.coordinates.wcs_utils
     :headings: ^#
 
+.. automodapi:: sunpy.coordinates.utils
+    :headings: ^#
+    :no-inheritance-diagram:
+
 
 Attribution
 -----------

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -1,7 +1,6 @@
-#
-# Calculates the co-ordinates along great arcs between two specified points
-# which are assumed to be on disk.
-#
+"""
+Miscellaneous utilities related to coordinates
+"""
 import numpy as np
 
 import astropy.units as u


### PR DESCRIPTION
Backport #3887.