### PR TITLE
[Backport 1.1] Fixed missing `sunpy.coordinates.utils` in docs

### DIFF
--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -363,6 +363,9 @@ which is equivalent to::
 .. automodapi:: sunpy.coordinates.offset_frame
     :headings: ^#
 
+.. automodapi:: sunpy.coordinates.utils
+    :headings: ^#
+
 .. automodapi:: sunpy.coordinates.wcs_utils
     :headings: ^#
 

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -1,7 +1,6 @@
-#
-# Calculates the co-ordinates along great arcs between two specified points
-# which are assumed to be on disk.
-#
+"""
+Miscellaneous utilities related to coordinates
+"""
 import numpy as np
 
 import astropy.units as u


### PR DESCRIPTION
Backport #3887.