### PR TITLE
Fixed typos of Heliocentric instead of Heliographic

### DIFF
--- a/docs/code_ref/coordinates/index.rst
+++ b/docs/code_ref/coordinates/index.rst
@@ -51,11 +51,11 @@ Supported Coordinate Systems
      - HGRTN
      - similar to `~sunpy.coordinates.frames.Heliocentric`
      - The axes are permuted, with HCC X, Y, Z equivalent respectively to HGRTN Y, Z, X
-   * - Heliocentric Carrington
+   * - Heliographic Carrington
      - HGC
      - `~sunpy.coordinates.frames.HeliographicCarrington`
      -
-   * - Heliocentric Stonyhurst
+   * - Heliographic Stonyhurst
      - HGS
      - `~sunpy.coordinates.frames.HeliographicStonyhurst`
      -


### PR DESCRIPTION
Typos spotted by @dpshelio (https://github.com/sunpy/sunpy/pull/3782#discussion_r391261951)