### PR TITLE
[Backport 1.1] Fixed typos of Heliocentric instead of Heliographic

### DIFF
--- a/docs/code_ref/coordinates.rst
+++ b/docs/code_ref/coordinates.rst
@@ -51,11 +51,11 @@ Supported Coordinate Systems
      - HGRTN
      - similar to `~sunpy.coordinates.frames.Heliocentric`
      - The axes are permuted, with HCC X, Y, Z equivalent respectively to HGRTN Y, Z, X
-   * - Heliocentric Carrington
+   * - Heliographic Carrington
      - HGC
      - `~sunpy.coordinates.frames.HeliographicCarrington`
      -
-   * - Heliocentric Stonyhurst
+   * - Heliographic Stonyhurst
      - HGS
      - `~sunpy.coordinates.frames.HeliographicStonyhurst`
      -


### PR DESCRIPTION
Backport #3892 