### PR TITLE
Fixed bug where some transformation errors raised ValueError instead ConvertError

### DIFF
--- a/changelog/3894.breaking.rst
+++ b/changelog/3894.breaking.rst
@@ -1,0 +1,1 @@
+Fixed a bug where some of the coordinate transformations could raise `ValueError` instead of `~astropy.coordinates.ConvertError` when the transformation could not be performed.

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 import numpy as np
 
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, ConvertError
 import astropy.units as u
 
 from sunpy.coordinates import sun
@@ -283,7 +283,7 @@ def test_rectangle_mismatching_frames_missing_parameters(rectangle_args):
     bottom_left, top_right, width, height = rectangle_args
     top_right = SkyCoord(10 * u.arcsec, 10 * u.arcsec, frame='heliographic_carrington')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ConvertError):
         bottom_left, top_right = get_rectangle_coordinates(bottom_left, top_right=top_right)
 
 

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -244,8 +244,8 @@ def _rotation_matrix_hgs_to_hgc(obstime):
     Return the rotation matrix from HGS to HGC at the same observation time
     """
     if obstime is None:
-        raise ValueError("To perform this transformation the coordinate"
-                         " Frame needs an obstime Attribute")
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
 
     # Import here to avoid a circular import
     from .sun import L0
@@ -518,8 +518,8 @@ def hcrs_to_hgs(hcrscoord, hgsframe):
     vector.
     """
     if hgsframe.obstime is None:
-        raise ValueError("To perform this transformation the coordinate"
-                         " Frame needs an obstime Attribute")
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
 
     # Check whether differentials are involved on either end
     has_differentials = ((hcrscoord._data is not None and hcrscoord.data.differentials) or


### PR DESCRIPTION
Some of our transformations raise `ValueError` instead of `ConvertError` (from Astropy).  This PR fixes them to all raise `ConvertError`.