### PR TITLE
Changed quoted sentence (that we suggest authors add to their research papers) in CITATION.rst

### DIFF
--- a/changelog/3896.doc.rst
+++ b/changelog/3896.doc.rst
@@ -1,0 +1,1 @@
+Changed quoted sentence (that we suggest authors add to their research papers) in CITATION.rst

--- a/sunpy/CITATION.rst
+++ b/sunpy/CITATION.rst
@@ -9,8 +9,8 @@ Citing SunPy in Publications
 
 Please add the following line within your methods, conclusion or acknowledgements sections:
 
-   *This research has made use of SunPy vX.Y (software citation), an open-source and free
-   community-developed solar data analysis Python package (project citation).*
+   *This research used version vX.Y.Z (software citation) of the SunPy open source
+   software package (project citation).*
 
 The project citation should be to the `SunPy paper`_, and the software citation should be the specific `Zenodo DOI`_ for the version used in your work.
 

--- a/sunpy/CITATION.rst
+++ b/sunpy/CITATION.rst
@@ -9,7 +9,7 @@ Citing SunPy in Publications
 
 Please add the following line within your methods, conclusion or acknowledgements sections:
 
-   *This research used version vX.Y.Z (software citation) of the SunPy open source
+   *This research used version X.Y.Z (software citation) of the SunPy open source
    software package (project citation).*
 
 The project citation should be to the `SunPy paper`_, and the software citation should be the specific `Zenodo DOI`_ for the version used in your work.


### PR DESCRIPTION
I changed the sentence we suggest authors add to their research papers. Previously, it was: 

> This research has made use of SunPy vX.Y (software citation), an open-source and free community-developed solar data analysis Python package (project citation).

I suggest the following:

> This research used version vX.Y.Z (software citation) of the SunPy open source software package (project citation).

Here are my reasons:

- It is easier to read (and eliminates the passive voice)
- I added vX.Y.Z instead of vX.Y because we archive each vX.Y.Z release in Zenodo, therefore a reference to vX.Y is ambiguous when referring to the software citation
- I think we chose not to put a dash between open and source in the SunPy v1.0 paper
- It is more likely someone will add a short sentence into the methods or conclusion section of a paper (whereas a longer sentence seems more likely to end up in the acknowledgements section of a paper, which gets less visibility).
