### PR TITLE
Fixed incorrect module name in test on 1.1

### DIFF
--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -43,11 +43,12 @@ def test_empty_jsoc_response():
 
 @pytest.mark.remote_data
 def test_return_query_args():
-    res = client.search(a.jsoc.PrimeKey('HARPNUM', 3604),
-                        a.jsoc.Series('hmi.sharp_cea_720s'),
-                        a.jsoc.Segment('Bp') & a.jsoc.Segment('magnetogram'))
+    res = client.search(attrs.PrimeKey('HARPNUM', 3604),
+                        attrs.Series('hmi.sharp_cea_720s'),
+                        attrs.Segment('Bp') & attrs.Segment('magnetogram'))
     #Because res.query_args is list that contains dict
     assert 'primekey' in res.query_args[0]
+
 
 @pytest.mark.remote_data
 def test_query():


### PR DESCRIPTION
This bug was introduced in a backport (#3858)

(an analogous bug was introduced to 1.0 in #3857)