### PR TITLE
Make gridline plotting example prettier

### DIFF
--- a/examples/plotting/finegrained_plot.py
+++ b/examples/plotting/finegrained_plot.py
@@ -56,7 +56,7 @@ lon.coord_wrap = 180
 lon.set_major_formatter('dd')
 
 # Plot the Heliographic Stonyhurst grid
-overlay.grid(color='blue', linewidth=2, linestyle='dashed')
+overlay.grid(color='tab:blue', linewidth=2, linestyle='dashed')
 # Switch off the helioprojective grid
 ax.grid(False)
 


### PR DESCRIPTION
100% blue is a bit of an eyesore (IMO, see https://docs.sunpy.org/en/stable/_images/sphx_glr_finegrained_plot_001.png), so use the Matplotlib colour cycle blue.