### PR TITLE
Add contour map method

### DIFF
--- a/changelog/3909.feature.rst
+++ b/changelog/3909.feature.rst
@@ -1,0 +1,1 @@
+Added a `sunpy.map.GenericMap.contour()` method to find the contours on a map.

--- a/examples/map/map_contouring.py
+++ b/examples/map/map_contouring.py
@@ -1,0 +1,30 @@
+# coding: utf-8
+"""
+=========================
+Finding contours of a map
+=========================
+
+This example shows how to find and plot contours on a map.
+"""
+
+import matplotlib.pyplot as plt
+
+import sunpy.map
+from sunpy.data.sample import AIA_193_IMAGE
+
+###############################################################################
+# Start by loading the sample data
+aiamap = sunpy.map.Map(AIA_193_IMAGE)
+
+###############################################################################
+# Now find the contours
+contours = aiamap.contour(50000)
+
+##############################################################################
+# Finally, plot the map and add the contours
+plt.figure()
+ax = plt.subplot(projection=aiamap)
+aiamap.plot()
+for contour in contours:
+    ax.plot_coord(contour)
+plt.show()

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2091,6 +2091,33 @@ class GenericMap(NDData):
 
         return ret
 
+    def contour(self, level, **kwargs):
+        """
+        Returns coordinates of the contours for a given level value.
+
+        For details of the contouring algorithm see `skimage.measure.find_contours`.
+
+        Parameters
+        ----------
+        level : float
+            Value along which to find contours in the array.
+        kwargs :
+            Additional keyword arguments are passed to `skimage.measure.find_contours`.
+
+        Returns
+        -------
+        contours: list of (n,2) `~astropy.coordinates.SkyCoord`
+            Coordinates of each contour.
+
+        See also
+        --------
+        `skimage.measure.find_contours`
+        """
+        from skimage import measure
+        contours = measure.find_contours(self.data, level=level, **kwargs)
+        contours = [self.wcs.array_index_to_world(c[:, 0], c[:, 1]) for c in contours]
+        return contours
+
 
 class InvalidHeaderInformation(ValueError):
     """Exception to raise when an invalid header tag value is encountered for a

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1076,3 +1076,17 @@ def test_submap_inputs(generic_map2, coords):
     for args, kwargs in inputs:
         smap = generic_map2.submap(*args, **kwargs)
         assert u.allclose(smap.dimensions, (3, 3) * u.pix)
+
+
+def test_contour(simple_map):
+    data = np.ones((3, 3))
+    data[1, 1] = 2
+    simple_map = sunpy.map.Map(data, simple_map.meta)
+    # 2 is the central pixel of the map, so contour half way between 1 and 2
+    contours = simple_map.contour(1.5)
+    assert len(contours) == 1
+    contour = contours[0]
+    assert contour.observer == simple_map.observer_coordinate.frame
+    assert contour.obstime == simple_map.date
+    assert u.allclose(contour.Tx, [0, -1, 0, 1, 0] * u.arcsec, atol=1e-10 * u.arcsec)
+    assert u.allclose(contour.Ty, [0.5, 0, -0.5, 0, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)


### PR DESCRIPTION
I'm doing some contouring at the moment, and thought a helper function might be helpful. My current use case is contouring AIA 193 maps to isolate coronal holes, and then plotting those contours on other maps.

Essentially this just uses `skimage.measure.contours`, but returns the result as `SkyCoord` objects. Here is what the example I have added to the gallery looks like:

![sphx_glr_map_contouring_001](https://user-images.githubusercontent.com/6197628/78123947-e04d2780-7406-11ea-8a88-6e40ec9af7cc.png)

Needs

- [x] A documentation example
- [x] What's new
- [ ] Tests

Test ideas:
Sample maps with:
- No contours
- One contour