### PR TITLE
Add setter for map.date

### DIFF
--- a/changelog/3911.feature.rst
+++ b/changelog/3911.feature.rst
@@ -1,0 +1,1 @@
+Added the ability to set the ``.date`` property of a `~sunpy.map.GenericMap`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -462,6 +462,13 @@ class GenericMap(NDData):
 
     @date.setter
     def date(self, val):
+        """
+        Set the image observation time.
+
+        Notes
+        -----
+        This sets the DATE-OBS fits keyword in the map metadata.
+        """
         val = parse_time(val)
         self.meta['date-obs'] = val.isot
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -460,6 +460,11 @@ class GenericMap(NDData):
             time = self._default_time
         return parse_time(time)
 
+    @date.setter
+    def date(self, val):
+        val = parse_time(val)
+        self.meta['date-obs'] = val.isot
+
     @property
     def detector(self):
         """Detector name."""

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -175,6 +175,12 @@ def test_date_aia(aia171_test_map):
     assert aia171_test_map.date == parse_time('2011-02-15T00:00:00.34')
 
 
+def test_date_setter(generic_map):
+    dtime_old = generic_map.date
+    generic_map.date = '2011-02-15T00:00:00.34'
+    assert generic_map.date == parse_time('2011-02-15T00:00:00.34') != dtime_old
+
+
 def test_detector(generic_map):
     assert generic_map.detector == 'bar'
 


### PR DESCRIPTION
I find myself wanting to change the date of a map fairly regularly at the minute, so it would be good to have a way to do this without having to go into the metadata. See also #1155.