### PR TITLE
Backport #3872 to 1.0.x

### DIFF
--- a/changelog/3872.bugfix.rst
+++ b/changelog/3872.bugfix.rst
@@ -1,0 +1,1 @@
+Changed the format of DATE-OBS in `GenericMap.wcs` from iso to isot (ie. with a "T" between the date and time) to conform with the FITS standard.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -274,7 +274,7 @@ class GenericMap(NDData):
         w2.wcs.ctype = self.coordinate_system
         w2.wcs.pc = self.rotation_matrix
         w2.wcs.cunit = self.spatial_units
-        w2.wcs.dateobs = self.date.iso
+        w2.wcs.dateobs = self.date.isot
         w2.rsun = self.rsun_meters
 
         # Astropy WCS does not understand the SOHO default of "solar-x" and

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -717,3 +717,8 @@ def test_missing_metadata_warnings():
 
 def test_fits_header(aia171_test_map):
     assert isinstance(aia171_test_map.fits_header, fits.Header)
+
+
+def test_wcs_isot(aia171_test_map):
+    # Check that a Map WCS returns the time as isot format
+    assert aia171_test_map.wcs.to_header()['DATE-OBS'] == '2011-02-15T00:00:00.340'


### PR DESCRIPTION
Use isot for setting dateobs in GenericMap.wcs. A manual backport of #3872