### PR TITLE
Improve the accuracy of `get_horizons_coord()`

### DIFF
--- a/changelog/3919.bugfix.rst
+++ b/changelog/3919.bugfix.rst
@@ -1,0 +1,1 @@
+The accuracy of the output of :func:`sunpy.coordinates.ephemeris.get_horizons_coord` is significantly improved.

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
   scipy>=1.0.0
   matplotlib>=2.1.2
   pandas>=0.23.0
-  astropy>=3.1
+  astropy>=3.2
   parfive[ftp]
   importlib_resources;python_version<"3.7"
 

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -23,6 +23,7 @@ try:
     from astropy.coordinates import HeliocentricMeanEcliptic
 except ImportError:
     from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
+from astropy.coordinates import HeliocentricEclipticIAU76
 
 from sunpy.time import parse_time
 from sunpy import log
@@ -169,21 +170,21 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     >>> get_horizons_coord('Venus barycenter', '2001-02-03 04:05:06')  # doctest: +REMOTE_DATA
     INFO: Obtained JPL HORIZONS location for Venus Barycenter (2) [sunpy.coordinates.ephemeris]
     <SkyCoord (HeliographicStonyhurst: obstime=2001-02-03T04:05:06.000): (lon, lat, radius) in (deg, deg, AU)
-        (-33.93155883, -1.64998481, 0.71915147)>
+        (-33.93155836, -1.64998443, 0.71915147)>
 
     Query the location of the SDO spacecraft
 
     >>> get_horizons_coord('SDO', '2011-11-11 11:11:11')  # doctest: +REMOTE_DATA
     INFO: Obtained JPL HORIZONS location for Solar Dynamics Observatory (spac [sunpy.coordinates.ephemeris]
     <SkyCoord (HeliographicStonyhurst: obstime=2011-11-11T11:11:11.000): (lon, lat, radius) in (deg, deg, AU)
-        (0.01018888, 3.29640407, 0.99011042)>
+        (0.01019118, 3.29640728, 0.99011042)>
 
     Query the location of the SOHO spacecraft via its ID number (-21)
 
     >>> get_horizons_coord(-21, '2004-05-06 11:22:33', 'id')  # doctest: +REMOTE_DATA
     INFO: Obtained JPL HORIZONS location for SOHO (spacecraft) (-21) [sunpy.coordinates.ephemeris]
     <SkyCoord (HeliographicStonyhurst: obstime=2004-05-06T11:22:33.000): (lon, lat, radius) in (deg, deg, AU)
-        (0.2523461, -3.55863351, 0.99923086)>
+        (0.25234902, -3.55863633, 0.99923086)>
     """
     obstime = parse_time(time)
     array_time = np.reshape(obstime, (-1,))  # Convert to an array, even if scalar
@@ -211,7 +212,7 @@ def get_horizons_coord(body, time='now', id_type='majorbody'):
     result = result[unsorted_indices]
 
     vector = CartesianRepresentation(result['x'], result['y'], result['z'])
-    coord = SkyCoord(vector, frame=HeliocentricMeanEcliptic, obstime=obstime)
+    coord = SkyCoord(vector, frame=HeliocentricEclipticIAU76, obstime=obstime)
 
     return coord.transform_to(HGS).reshape(obstime.shape)
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
     devdeps: cython
     devdeps,figure_astropydev: git+https://github.com/astropy/astropy
     # Oldest deps we pin against.
-    oldestdeps: astropy<3.2
+    oldestdeps: astropy<4.0
     oldestdeps: numpy<1.15.0
     oldestdeps: matplotlib<3.0
     # These are specfici online extras we use to run the online tests.
@@ -84,7 +84,7 @@ description = Run all figure tests with pinned versions
 extras = dev
 conda_deps =
     python = 3.6.8
-    astropy = 3.1.2
+    astropy = 3.2.3
     numpy = 1.16.2
     freetype = 2.10
     matplotlib = 3.1.1


### PR DESCRIPTION
By bumping our Astropy dependency to v3.2, I can better match the coordinate frame that JPL Horizons uses for calculations, and hence more accurately create a SkyCoord from its output.  This PR significantly decreases small discrepancies between Astropy (using a JPL ephemeris rather than Astropy's built-in ephemeris) and JPL Horizons.

Miscellaneous notes:
- This PR sets Astropy to use a JPL ephemeris (DE432s), which means an additional ~10 MB download for the online test build.
- The Earth discrepancy improves from tens of kilometers to tens of meters.  I can't reproduce my earlier claim (https://github.com/sunpy/sunpy/issues/3154#issuecomment-502938102) that the discrepancy would be sub-meter, so my current assumption is that I made a calculation error last year.
- This PR adds some (light) `hypothesis` testing to hopefully avoid issues like https://github.com/sunpy/sunpy/pull/3221#issuecomment-502646325)