### PR TITLE
Move oldtestdep astropy pin from 3.1 to 3.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
     devdeps: cython
     devdeps,figure_astropydev: git+https://github.com/astropy/astropy
     # Oldest deps we pin against.
-    oldestdeps: astropy<3.2
+    oldestdeps: astropy<4.0
     oldestdeps: numpy<1.15.0
     oldestdeps: matplotlib<3.0
     # These are specfici online extras we use to run the online tests.


### PR DESCRIPTION
#3925 was merged, bumping the astropy version we test against for figure test. Do the same here for the normal tests.