### PR TITLE
Document that Astropy 3.2 is now the minimum required version

### DIFF
--- a/changelog/3936.breaking.rst
+++ b/changelog/3936.breaking.rst
@@ -1,0 +1,1 @@
+Astropy 3.2 is now the minimum required version of that dependency.

--- a/docs/guide/installation/advanced.rst
+++ b/docs/guide/installation/advanced.rst
@@ -96,7 +96,7 @@ SunPy has the following strict requirements:
 
 - `SciPy <https://www.scipy.org/>`__ 1.0.0 or later.
 
-- `Astropy <https://www.astropy.org/>`__ 3.1.0 or later.
+- `Astropy <https://www.astropy.org/>`__ 3.2.0 or later.
 
 - `pandas <https://pandas.pydata.org/>`__ 0.10 or later.
 


### PR DESCRIPTION
#3919 bumped our Astropy dependency to 3.2 or later, but it wasn't clearly documented

Fixes #3935