### PR TITLE
Fix map source test warnings

### DIFF
--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -6,19 +6,25 @@ This particular test file pertains to EUVIMap.
 import os
 import glob
 
+import pytest
+
 from sunpy.map.sources.stereo import EUVIMap
 from sunpy.map import Map
 from sunpy.coordinates import sun
 import sunpy.data.test
+from sunpy.util.exceptions import SunpyUserWarning
+
 
 path = sunpy.data.test.rootdir
 fitspath = glob.glob(os.path.join(path, "euvi_20090615_000900_n4euA_s.fts"))
 euvi = Map(fitspath)
 
+
 # EUVI Tests
 def test_fitstoEIT():
     """Tests the creation of EUVIMap using FITS."""
     assert isinstance(euvi, EUVIMap)
+
 
 def test_is_datasource_for():
     """Test the is_datasource_for method of EUVIMap.
@@ -26,23 +32,28 @@ def test_is_datasource_for():
     can be a MetaDict object."""
     assert euvi.is_datasource_for(euvi.data, euvi.meta)
 
+
 def test_measurement():
     """Tests the measurement property of the EUVIMap object."""
     assert euvi.measurement.value == 171
+
 
 def test_observatory():
     """Tests the observatory property of the EUVIMap object."""
     assert euvi.observatory == "STEREO A"
 
+
 def test_rsun_obs():
     """Tests the rsun_obs property"""
     assert euvi.rsun_obs.value == euvi.meta['rsun']
+
 
 def test_rsun_missing():
     """Tests output if 'rsun' is missing"""
     euvi_no_rsun = Map(fitspath)
     euvi_no_rsun.meta['rsun'] = None
-    assert euvi_no_rsun.rsun_obs.value == sun.angular_radius(euvi.date).to('arcsec').value
+    with pytest.warns(SunpyUserWarning, match='Missing metadata for solar radius'):
+        assert euvi_no_rsun.rsun_obs.value == sun.angular_radius(euvi.date).to('arcsec').value
 
 
 def test_norm_clip():

--- a/sunpy/map/sources/tests/test_iris_source.py
+++ b/sunpy/map/sources/tests/test_iris_source.py
@@ -6,29 +6,36 @@ This particular test file pertains to SJIMap.
 import os
 import glob
 
+import pytest
+
 from sunpy.map import Map
 from sunpy.map.sources.iris import SJIMap
 from sunpy.map.mapbase import GenericMap
 import sunpy.data.test
+from sunpy.util.exceptions import SunpyUserWarning
 
-path = sunpy.data.test.rootdir
-fitspath = glob.glob(os.path.join(path, "iris_l2_20130801_074720_4040000014_SJI_1400_t000.fits"))
-irismap = Map(fitspath, silence_errors=True)
+
+@pytest.fixture
+def irismap():
+    path = sunpy.data.test.rootdir
+    fitspath = glob.glob(os.path.join(path, "iris_l2_20130801_074720_4040000014_SJI_1400_t000.fits"))
+    with pytest.warns(SunpyUserWarning, match='This file contains more than 2 dimensions'):
+        return Map(fitspath, silence_errors=True)
 
 
 # IRIS Tests
-def test_fitstoIRIS():
+def test_fitstoIRIS(irismap):
     """Tests the creation of SJIMap using FITS."""
     assert (isinstance(irismap, SJIMap))
 
 
-def test_is_datasource_for():
+def test_is_datasource_for(irismap):
     """Test the is_datasource_for method of SJIMap.
     Note that header data to be provided as an argument
     can be a MetaDict object."""
     assert irismap.is_datasource_for(irismap.data, irismap.meta)
 
 
-def test_observatory():
+def test_observatory(irismap):
     """Tests the observatory property of SJIMap."""
     assert irismap.observatory == "IRIS"

--- a/sunpy/map/sources/tests/test_sot_source.py
+++ b/sunpy/map/sources/tests/test_sot_source.py
@@ -7,40 +7,51 @@ import os
 import glob
 
 import astropy.units as u
+import pytest
 
 from sunpy.map.sources.hinode import SOTMap
 from sunpy.map import Map
 import sunpy.data.test
+from sunpy.util.exceptions import SunpyUserWarning
 
-path = sunpy.data.test.rootdir
-fitspath = glob.glob(os.path.join(path, "HinodeSOT.fits"))
-sot = Map(fitspath)
+
+@pytest.fixture
+def sot():
+    path = sunpy.data.test.rootdir
+    fitspath = glob.glob(os.path.join(path, "HinodeSOT.fits"))
+    with pytest.warns(SunpyUserWarning, match='This file contains more than 2 dimensions'):
+        return Map(fitspath)
+
 
 # SOT Tests
-def test_fitstoSOT():
+def test_fitstoSOT(sot):
     """Tests the creation of SOTMap using FITS."""
     assert isinstance(sot, SOTMap)
 
-def test_is_datasource_for():
+
+def test_is_datasource_for(sot):
     """Test the is_datasource_for method of SOTMap.
     Note that header data to be provided as an argument
     can be a MetaDict object."""
     assert sot.is_datasource_for(sot.data, sot.meta)
 
-def test_observatory():
+
+def test_observatory(sot):
     """Tests the observatory property of the SOTMap object."""
     assert sot.observatory == "Hinode"
 
-def test_measurement():
+def test_measurement(sot):
     """Tests the measurement property of the SOTMap object."""
     assert sot.measurement == 0 * u.one
 
-def test_instruments():
+
+def test_instruments(sot):
     """Tests the Instruments object of SOTMap."""
     assert (sot.Instruments == ['SOT/WB',
             'SOT/NB','SOT/SP','SOT/CT'])
 
-def test_waves():
+
+def test_waves(sot):
     """Tests the Waves object of SOTMap."""
     assert (sot.Waves == ['6302A', 'BFI no move',
             'CN bandhead 3883', 'Ca II H line',
@@ -49,7 +60,8 @@ def test_waves():
             'blue cont 4504', 'green cont 5550',
             'red cont 6684'])
 
-def test_obstype():
+
+def test_obstype(sot):
     """Tests the Observation_Type object of SOTMap."""
     assert (sot.Observation_Type == ['FG (simple)',
             'FG focus scan', 'FG shuttered I and V',

--- a/sunpy/map/sources/tests/test_xrt_source.py
+++ b/sunpy/map/sources/tests/test_xrt_source.py
@@ -7,44 +7,50 @@ import os
 import glob
 import numpy as np
 from matplotlib import colors
+import pytest
 
 import astropy.units as u
+from astropy.utils.exceptions import AstropyUserWarning
 
 from sunpy.map.sources.hinode import XRTMap
 from sunpy.map import Map
 import sunpy.data.test
 
-path = sunpy.data.test.rootdir
-fitspath = glob.glob(os.path.join(path, "HinodeXRT.fits"))
-xrt = Map(fitspath)
+
+@pytest.fixture
+def xrt():
+    path = sunpy.data.test.rootdir
+    fitspath = glob.glob(os.path.join(path, "HinodeXRT.fits"))
+    with pytest.warns(AstropyUserWarning, match='File may have been truncated'):
+        return Map(fitspath)
 
 
 # XRT Tests
-def test_fitstoXRT():
+def test_fitstoXRT(xrt):
     """Tests the creation of XRTMap using FITS."""
     assert isinstance(xrt, XRTMap)
 
 
-def test_is_datasource_for():
+def test_is_datasource_for(xrt):
     """Test the is_datasource_for method of XRTMap.
     Note that header data to be provided as an argument
     can be a MetaDict object."""
     assert xrt.is_datasource_for(xrt.data, xrt.meta)
 
 
-def test_observatory():
+def test_observatory(xrt):
     """Tests the observatory property of the XRTMap object."""
     assert xrt.observatory == "Hinode"
 
 
-def test_measurement():
+def test_measurement(xrt):
     """Tests the measurement property of the XRTMap object."""
     measurement = xrt.filter_wheel1_measurements[5].replace("_", " ")
     measurement += '-' + xrt.filter_wheel2_measurements[1].replace("_", " ")
     assert xrt.measurement == measurement
 
 
-def test_wheel_measurements():
+def test_wheel_measurements(xrt):
     """Tests the filter_wheel_measurements objects present
     in the XRTMap object."""
     assert (xrt.filter_wheel1_measurements ==


### PR DESCRIPTION
Catching warnings thrown when the test maps are loaded. Split out of #3648