### PR TITLE
Fixed confusing printing of longitudes in Map repr

### DIFF
--- a/changelog/3959.bugfix.rst
+++ b/changelog/3959.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where the longitude value for the reference coordinate in the Map repr would be displayed with the unintended longitude wrapping.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -241,8 +241,8 @@ class GenericMap(NDData):
                                scale=u.Quantity(self.scale),
                                coord=self._coordinate_frame_name,
                                refpix=u.Quantity(self.reference_pixel),
-                               refcoord=u.Quantity((self.reference_coordinate.data.lon,
-                                                    self.reference_coordinate.data.lat)),
+                               refcoord=u.Quantity((self._reference_longitude,
+                                                    self._reference_latitude)),
                                tmf=TIME_FORMAT) + self.data.__repr__()
 
     @classmethod


### PR DESCRIPTION
When the longitude of the reference coordinate for a Map is negative, it can show up as a large value (e.g., just shy of 360 degrees) due to the way longitudes are handled:

```python
>>> sunpy.map.Map(sunpy.data.sample.HMI_LOS_IMAGE)
...
Reference Pixel:         [512.5 512.5] pix
Reference Coord:         [ 1.29599577e+06 -1.28524122e-01] arcsec
...
```

In the Map repr, the longitude of the reference coordinate is obtained via `self.reference_coordinate.data.lon`.  However, one should avoid using `.data`, but instead access the longitude component of `reference_coordinate` (e.g., `reference_coordinate.lon`) to preserve the intended wrapping.  However however, it's non-trivial to access the longitude component in general because the name of the component may be changed (e.g., `Tx` for helioprojective coordinates).  The straightforward solution is to avoid using `reference_coordinate` altogether, and instead go one step earlier and use the private property `_reference_longitude`.  Here's after this PR:

```python
>>> sunpy.map.Map(sunpy.data.sample.HMI_LOS_IMAGE)
...
Reference Pixel:         [512.5 512.5] pix
Reference Coord:         [-4.23431983 -0.12852412] arcsec
...
```