### PR TITLE
Add deprecation warning to aiaprep

### DIFF
--- a/changelog/3960.removal.rst
+++ b/changelog/3960.removal.rst
@@ -1,0 +1,3 @@
+Deprecate `sunpy.instr.aia.aiaprep` in favor of the `register` function in the
+[aiapy](https://gitlab.com/LMSAL_HUB/aia_hub/aiapy) package.
+`sunpy.instr.aia.aiaprep` will be removed in version 2.1

--- a/sunpy/instr/aia.py
+++ b/sunpy/instr/aia.py
@@ -7,10 +7,13 @@ import numpy as np
 import astropy.units as u
 
 from sunpy.map.sources.sdo import AIAMap, HMIMap
+from sunpy.util.decorators import deprecated
 
 __all__ = ['aiaprep']
 
 
+@deprecated("2.0", alternative="`register` in aiapy (https://aiapy.readthedocs.io) for converting \
+AIA images to level 1.5")
 def aiaprep(aiamap):
     """
     Processes a level 1 `~sunpy.map.sources.sdo.AIAMap` into a level 1.5
@@ -18,7 +21,8 @@ def aiaprep(aiamap):
 
     Rotates, scales and translates the image so that solar North is aligned
     with the y axis, each pixel is 0.6 arcsec across, and the center of the
-    Sun is at the center of the image. The actual transformation is done by Map's `~sunpy.map.mapbase.GenericMap.rotate` method.
+    Sun is at the center of the image. The actual transformation is done by Map's
+    `~sunpy.map.mapbase.GenericMap.rotate` method.
 
     This function is similar in functionality to ``aia_prep`` in SSWIDL, but
     it does not use the same transformation to rotate the image and it handles


### PR DESCRIPTION
Fixes #3282. Now that aiapy has had its first release, we can recommend that users use the `register` function in that package 🎉 .

I've put `2.0` in deprecated since and the deprecation decorator appends "scheduled for removal in 3.1" which I think is right?

The message covers multiple lines (its more than 100 characters), but I'd like it to appear as only 1 line in the output to the user. I'm not sure if there is a better way to format that than with the `\`.