### PR TITLE
Fix astropy pinning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
   scipy>=1.0.0
   matplotlib>=2.1.2
   pandas>=0.23.0
-  astropy>=3.2,!=4.0.1
+  astropy>=3.2,!=4.0.1,!=4.0.1.post1
   parfive[ftp]>=1.0
   importlib_resources;python_version<"3.7"
 

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
 changedir = docs
 description = Invoke sphinx-build to build the HTML docs
 extras = dev
-deps = astropy!=4.0.1
+deps = astropy!=4.0.1,!=4.0.1.post1
 commands =
     sphinx-build --color -W --keep-going -b html -d _build/.doctrees . _build/html {posargs}
     python -c 'import pathlib; print("Documentation available under file://\{0\}".format(pathlib.Path(r"{toxinidir}") / "docs" / "_build" / "index.html"))'


### PR DESCRIPTION
astropy released a new version with a different version number but no actual other changes, so we have to pin against the new version too. Should fix the doc build... Does this need backporting?