### PR TITLE
Allow manager.override_file to specify a local file path without file:// prefix

### DIFF
--- a/changelog/3970.bugfix.rst
+++ b/changelog/3970.bugfix.rst
@@ -1,0 +1,3 @@
+It is now possible to specify a local file path to
+`sunpy.data.data_manager.DataManager.override_file` without having to prefix it
+with ``file://``.

--- a/sunpy/data/data_manager/tests/test_manager.py
+++ b/sunpy/data/data_manager/tests/test_manager.py
@@ -88,6 +88,10 @@ def test_override_file(manager, storage, downloader, data_function, tmpdir):
         # Inside the file is replaced
         data_function(override_file_tester)
 
+    with manager.override_file('test_file', f'{folder}/another_file'):
+        # Inside the file is replaced
+        data_function(override_file_tester)
+
     # check the function works with hash provided
     with manager.override_file('test_file', f'file://{folder}/another_file', MOCK_HASH):
         data_function(override_file_tester)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->

This makes specifying `file://` optional when giving a local file path to override_file optional

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3969