### PR TITLE
Pin pytest to <5.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ asdf = asdf
 dask = dask[array]
 tests =
   hypothesis
-  pytest
+  pytest<5.4
   pytest-doctestplus >= 0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
   pytest-astropy >= 0.8  # 0.8 is the first release to include filter-subpackage
   pytest-cov


### PR DESCRIPTION
This should be a stopgap fix for the pytest-xdist errors showing up on CI.