### PR TITLE
Add AttrWalker __repr__

### DIFF
--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -445,8 +445,8 @@ class AttrWalker:
 
     """
     def __repr__(self):
-        creators = [key for key in self.createmm.registry.keys()]
-        appliers = [key for key in self.applymm.registry.keys()]
+        creators = list(self.createmm.registry.keys())
+        appliers = list(self.applymm.registry.keys())
         return f"""{super().__repr__()}
 Registered creators: {creators}
 Registered appliers: {appliers}"""

--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -444,6 +444,13 @@ class AttrWalker:
       type and return a different one.
 
     """
+    def __repr__(self):
+        creators = [key for key in self.createmm.registry.keys()]
+        appliers = [key for key in self.applymm.registry.keys()]
+        return f"""{super().__repr__()}
+Registered creators: {creators}
+Registered appliers: {appliers}"""
+
     @staticmethod
     def _unknown_type(*args, **kwargs):
         raise TypeError(f"{args[1]} or any of its parents have not been registered with the AttrWalker")


### PR DESCRIPTION
Prints something like
```
<sunpy.net.attr.AttrWalker object at 0x1232f99d0>
Registered creators: [<class 'object'>, <class 'sunpy.net.attr.AttrOr'>, <class 'sunpy.net.attr.AttrAnd'>]
Registered appliers: [<class 'object'>, <class 'sunpy.net.attrs.Time'>, <class 'heliopy.data.cdaweb.attrs.Dataset'>]
```