### PR TITLE
Updated VSOClient's response_block_properties method

### DIFF
--- a/changelog/3993.bugfix.rst
+++ b/changelog/3993.bugfix.rst
@@ -1,0 +1,1 @@
+Updated VSOClient.response_block_properties to check if "None" is in the return.

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -26,6 +26,7 @@ class NoRHClient(GenericClient):
 
     Examples
     --------
+    >>> import astropy.units as u
     >>> from sunpy.net import Fido, attrs as a
     >>> results = Fido.search(a.Time("2016/1/1", "2016/1/2"),
     ...                       a.Instrument.norh, a.Wavelength(17*u.GHz))  #doctest: +REMOTE_DATA

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -538,3 +538,11 @@ def test_vso_repr(client):
     """
     output = str(client)
     assert output[:50] == 'sunpy.net.vso.vso.VSOClient\n\nAllows queries and do'
+
+
+@pytest.mark.remote_data
+def test_response_block_properties(client):
+    res = client.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument('aia'), a.Wavelength(171 * u.angstrom),
+                        a.vso.Sample(10 * u.minute))
+    properties = res.response_block_properties()
+    assert len(properties) == 0

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -303,9 +303,12 @@ class QueryResponse(BaseQueryResponse):
         """
         s = {a if not a.startswith('_') else None for a in dir(self[0])}
         for resp in self[1:]:
+            if len(s) == 0:
+                break
             s = s.intersection({a if not a.startswith('_') else None for a in dir(resp)})
 
-        s.remove(None)
+        if None in s:
+            s.remove(None)
         return s
 
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

implemented response_block_properties method of jsoc, optimised response_block_properties of vso and also fixed its bug.
<!-- Provide a general description of what your pull request does. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->
