### PR TITLE
Removed xfail label in scraper test & enabled to scrap local files

### DIFF
--- a/changelog/3994.feature.rst
+++ b/changelog/3994.feature.rst
@@ -1,0 +1,1 @@
+Added `_localfilelist` method in `~sunpy.util.scraper.Scraper` to scrap local data archives.

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -222,6 +222,8 @@ class Scraper:
         filesurls = []
         if urlsplit(directories[0]).scheme == "ftp":
             return self._ftpfileslist(timerange)
+        if urlsplit(directories[0]).scheme == "file":
+            return self._localfilelist(timerange)
         for directory in directories:
             try:
                 opn = urlopen(directory)
@@ -264,6 +266,20 @@ class Scraper:
         filesurls = ['ftp://anonymous:data@sunpy.org@' + "{0.netloc}{0.path}".format(urlsplit(url))
                      for url in filesurls]
         return filesurls
+
+    def _localfilelist(self, timerange):
+        directories = self.range(timerange)
+        filepaths = list()
+        for directory in directories:
+            for file_i in os.listdir(directory.replace('file://','')):
+                fullpath = directory + file_i
+                if self._URL_followsPattern(fullpath):
+                    datehref = self._extractDateURL(fullpath)
+                    if (datehref >= timerange.start and datehref <= timerange.end):
+                        filepaths.append(fullpath)
+        filepaths = ['file://' + "{0.netloc}{0.path}".format(urlsplit(path))
+                     for path in filepaths]
+        return filepaths
 
     def _smallerPattern(self, directoryPattern):
         """

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -269,9 +269,9 @@ class Scraper:
 
     def _localfilelist(self, timerange):
         pattern = self.pattern
-        pattern_temp = pattern.replace('file://','')
+        pattern_temp = pattern.replace('file://', '')
         if os.name == 'nt':
-            pattern_temp = pattern_temp.replace('\\','/')
+            pattern_temp = pattern_temp.replace('\\', '/')
             prefix = 'file:///'
         else:
             prefix = 'file://'

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -271,7 +271,7 @@ class Scraper:
         directories = self.range(timerange)
         filepaths = list()
         for directory in directories:
-            for file_i in os.listdir(directory.replace('file://','')):
+            for file_i in os.listdir(directory.replace('file://', '')):
                 fullpath = directory + file_i
                 if self._URL_followsPattern(fullpath):
                     datehref = self._extractDateURL(fullpath)

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -268,17 +268,25 @@ class Scraper:
         return filesurls
 
     def _localfilelist(self, timerange):
+        pattern = self.pattern
+        pattern_temp = pattern.replace('file://','')
+        if os.name == 'nt':
+            pattern_temp = pattern_temp.replace('\\','/')
+            prefix = 'file:///'
+        else:
+            prefix = 'file://'
+        self.pattern = pattern_temp
         directories = self.range(timerange)
         filepaths = list()
         for directory in directories:
-            for file_i in os.listdir(directory.replace('file://', '')):
+            for file_i in os.listdir(directory):
                 fullpath = directory + file_i
                 if self._URL_followsPattern(fullpath):
                     datehref = self._extractDateURL(fullpath)
                     if (datehref >= timerange.start and datehref <= timerange.end):
                         filepaths.append(fullpath)
-        filepaths = ['file://' + "{0.netloc}{0.path}".format(urlsplit(path))
-                     for path in filepaths]
+        filepaths = [prefix + path for path in filepaths]
+        self.pattern = pattern
         return filepaths
 
     def _smallerPattern(self, directoryPattern):

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -160,11 +160,7 @@ def testURL_patternMillisecondsZeroPadded():
     assert s.now == 'fd_20190419_000000_004.fts'
 
 
-# TODO: Fix this
-@pytest.mark.xfail
 def testFilesRange_sameDirectory_local():
-    # Fails due to an IsADirectoryError, wrapped in a URLError, after `requests`
-    # tries to open a directory as a binary file.
     s = Scraper('/'.join(['file:/', rootdir,
                           'EIT', 'efz%Y%m%d.%H%M%S_s.fits']))
     startdate = parse_time((2004, 3, 1, 4, 0))


### PR DESCRIPTION
`test_scraper.py` earlier had a test labelled `@pytest.mark.xfail`, so removed it. And added a new method `_localfilelist` to scrap local data files.
The method is called for `file://` protocols.