### PR TITLE
Cleanup Dependencies and Re-enable asdf schema tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,8 +82,6 @@ sunpy.tests = figure_hashes_py36.json
 [options.entry_points]
 asdf_extensions =
   sunpy = sunpy.io.special.asdf.extension:SunpyExtension
-#pytest11 =
-#  asdf = asdf.tests.schema_tester
 
 [tool:pytest]
 minversion = 3.0
@@ -92,6 +90,8 @@ norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info"
 doctest_plus = enabled
 doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
 addopts = -p no:warnings --doctest-rst -m "not figure"
+asdf_schema_tests_enabled = true
+asdf_schema_root = sunpy/io/special/asdf/schemas/
 markers =
     online: marks this test function as needing online connectivity.
     figure: marks this test function as using hash-based Matplotlib figure verification. This mark is not meant to be directly applied, but is instead automatically applied when a test function uses the @sunpy.tests.helpers.figure_test decorator.

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
   scipy>=1.0.0
   matplotlib>=2.1.2
   pandas>=0.23.0
-  astropy>=3.2,!=4.0.1,!=4.0.1.post1
+  astropy>=3.2
   parfive[ftp]>=1.0
   importlib_resources;python_version<"3.7"
 
@@ -56,10 +56,8 @@ net =
 asdf = asdf
 dask = dask[array]
 tests =
-  hypothesis
-  pytest-doctestplus >= 0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
   pytest-astropy >= 0.8  # 0.8 is the first release to include filter-subpackage
-  pytest-cov
+  pytest-doctestplus >= 0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
   pytest-mock
   tox
   tox-conda


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description

Cleanup pins in the setup.cfg file we don't need after reproject 0.7.

Also clean up things which are deps of pytest astropy and also re-enable asdf schema tests.