### PR TITLE
Reconfigure the figure test artifacts and Giles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
       - run: tox -e figure_astropydev
       - run: codecov
       - store_artifacts:
-          path: .tmp/figure/figure_test_images
+          path: .tmp/figure_astropydev/figure_test_images
       - run:
           name: "Image comparison page is available at: "
           command: FIGS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/.tmp/figure/figure_test_images/fig_comparison.html"; echo $FIGS_URL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,15 @@ build-backend = 'setuptools.build_meta'
     url = "html/index.html"
     message = "Click details to preview the HTML documentation."
 
-  [ tool.gilesbot.circleci_artifacts.figure_tests ]
-    url = "figure_test_images/fig_comparison.html"
-    message = "Click details to see the figure test comparisons."
+  [ tool.gilesbot.circleci_artifacts.figure_report ]
+    url = "figure/figure_test_images/fig_comparison.html"
+    message = "Click details to see the figure test comparisons, for figure."
+    report_on_fail = true
+
+  [ tool.gilesbot.circleci_artifacts.figure_astropydev_report ]
+    url = "figure_astropydev/figure_test_images/fig_comparison.html"
+    message = "Click details to see the figure test comparisons for figure_astropydev."
+    report_on_fail = true
 
   [ tool.gilesbot.pull_requests ]
     enabled = true


### PR DESCRIPTION
This should hopefully fix the figure test uploads and (after merge) fix Giles reporting for both, even if the build fails