### PR TITLE
Enable interpreting HPC coordinates as on the inside of a spherical screen

### DIFF
--- a/changelog/4003.feature.rst
+++ b/changelog/4003.feature.rst
@@ -1,0 +1,1 @@
+Added a context manager (:meth:`~sunpy.coordinates.frames.Helioprojective.assume_spherical_screen`) to interpret `~sunpy.coordinates.frames.Helioprojective` coordinates as being on the inside of a spherical screen instead of on the surface of the Sun.

--- a/examples/map_transformations/reprojection_spherical_screen.py
+++ b/examples/map_transformations/reprojection_spherical_screen.py
@@ -1,0 +1,108 @@
+"""
+=====================================
+Reprojecting Using a Spherical Screen
+=====================================
+
+This example demonstrates how you can reproject an image as if it lies on the
+inside of a spherical screen and the observer is not at the center of the
+sphere.  This functionality is primarily for visualization purposes, since
+features in the image are unlikely to actually lie on this spherical screen.
+
+You will need `reproject <https://reproject.readthedocs.io/en/stable/>`__ v0.6
+or higher installed.
+"""
+# sphinx_gallery_thumbnail_number = 4
+
+import matplotlib.pyplot as plt
+from reproject import reproject_interp
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from astropy.wcs import WCS
+
+import sunpy.map
+from sunpy.coordinates import Helioprojective
+from sunpy.data.sample import AIA_171_IMAGE
+
+######################################################################
+# We will use one of the AIA images from the sample data.  We fix the
+# range of values for the Map's normalizer.
+
+aia_map = sunpy.map.Map(AIA_171_IMAGE)
+aia_map.plot_settings['norm'].vmin = 0
+aia_map.plot_settings['norm'].vmax = 10000
+
+plt.figure()
+plt.subplot(projection=aia_map)
+aia_map.plot()
+
+######################################################################
+# Let's define a new observer that is well separated from Earth.
+
+new_observer = SkyCoord(70*u.deg, 20*u.deg, 1*u.AU, obstime=aia_map.date,
+                        frame='heliographic_stonyhurst')
+
+######################################################################
+# Create a WCS header for this new observer using helioprojective
+# coordinates, and create the corresponding `~astropy.wcs.WCS` object.
+
+out_shape = aia_map.data.shape
+
+out_ref_coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime=new_observer.obstime,
+                         frame='helioprojective', observer=new_observer)
+out_header = sunpy.map.make_fitswcs_header(
+    out_shape,
+    out_ref_coord,
+    scale=u.Quantity(aia_map.scale),
+    rotation_matrix=aia_map.rotation_matrix,
+    instrument=aia_map.instrument,
+    wavelength=aia_map.wavelength
+)
+out_wcs = WCS(out_header)
+
+######################################################################
+# If you reproject the AIA Map to the perspective of the new observer,
+# the default assumption is that the image lies on the surface of the
+# Sun.  However, the parts of the image beyond the solar disk cannot
+# be mapped to the surface of the Sun, and thus do not show up in the
+# output.
+
+output, _ = reproject_interp(aia_map, out_wcs, out_shape)
+outmap_default = sunpy.map.Map((output, out_header))
+outmap_default.plot_settings = aia_map.plot_settings
+
+plt.figure()
+plt.subplot(projection=outmap_default)
+outmap_default.plot()
+
+######################################################################
+# You can use the different assumption that the image lies on the
+# surface of a spherical screen centered at AIA, with a radius equal
+# to the Sun-AIA distance.  The curvature of the spherical screen is
+# not obvious in this plot due to the relatively small field of view
+# of AIA (compared to, say, a coronagraph).
+
+with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate):
+    output, _ = reproject_interp(aia_map, out_wcs, out_shape)
+outmap_screen_all = sunpy.map.Map((output, out_header))
+outmap_screen_all.plot_settings = aia_map.plot_settings
+
+plt.figure()
+plt.subplot(projection=outmap_screen_all)
+outmap_screen_all.plot()
+
+######################################################################
+# Finally, you can specify that the spherical-screen assumption should
+# be used for only off-disk parts of the image, and continue to map
+# on-disk parts of the image to the surface of the Sun.
+
+with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate,
+                                             only_off_disk=True):
+    output, _ = reproject_interp(aia_map, out_wcs, out_shape)
+outmap_screen_off_disk = sunpy.map.Map((output, out_header))
+outmap_screen_off_disk.plot_settings = aia_map.plot_settings
+
+plt.figure()
+plt.subplot(projection=outmap_screen_off_disk)
+outmap_screen_off_disk.plot()
+plt.show()

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -512,6 +512,9 @@ class Helioprojective(SunPyBaseCoordinateFrame):
 
         Examples
         --------
+
+        .. minigallery:: sunpy.coordinates.Helioprojective.assume_spherical_screen
+
         >>> import astropy.units as u
         >>> from sunpy.coordinates import Helioprojective
         >>> h = Helioprojective(range(7)*u.arcsec*319, [0]*7*u.arcsec,
@@ -530,7 +533,6 @@ class Helioprojective(SunPyBaseCoordinateFrame):
              ( 638., 0., 1.00125872), ( 957., 0., 1.00125872),
              (1276., 0., 1.00125872), (1595., 0., 1.00125872),
              (1914., 0., 1.00125872)]>
-
 
         >>> with Helioprojective.assume_spherical_screen(h.observer, only_off_disk=True):
         ...     print(h.make_3d())

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -4,6 +4,8 @@ Common solar physics coordinate systems.
 This submodule implements various solar physics coordinate frames for use with
 the `astropy.coordinates` module.
 """
+from contextlib import contextmanager
+
 import numpy as np
 
 import astropy.units as u
@@ -463,16 +465,93 @@ class Helioprojective(SunPyBaseCoordinateFrame):
 
         rep = self.represent_as(UnitSphericalRepresentation)
         lat, lon = rep.lat, rep.lon
-        alpha = np.arccos(np.cos(lat) * np.cos(lon)).to(lat.unit)
+        cos_alpha = np.cos(lat) * np.cos(lon)
         c = self.observer.radius**2 - self.rsun**2
-        b = -2 * self.observer.radius * np.cos(alpha)
-        # Ingore sqrt of NaNs
+        b = -2 * self.observer.radius * cos_alpha
+        # Ignore sqrt of NaNs
         with np.errstate(invalid='ignore'):
-            d = ((-1*b) - np.sqrt(b**2 - 4*c)) / 2
+            d = ((-1*b) - np.sqrt(b**2 - 4*c)) / 2  # use the "near" solution
+
+        if self._spherical_screen:
+            sphere_center = self._spherical_screen['center'].transform_to(self).cartesian
+            c = sphere_center.norm()**2 - self._spherical_screen['radius']**2
+            b = -2 * sphere_center.dot(rep)
+            # Ignore sqrt of NaNs
+            with np.errstate(invalid='ignore'):
+                dd = ((-1*b) + np.sqrt(b**2 - 4*c)) / 2  # use the "far" solution
+
+            d = np.fmin(d, dd) if self._spherical_screen['only_off_disk'] else dd
 
         return self.realize_frame(SphericalRepresentation(lon=lon,
                                                           lat=lat,
                                                           distance=d))
+
+    _spherical_screen = None
+
+    @classmethod
+    @contextmanager
+    def assume_spherical_screen(cls, center, only_off_disk=False):
+        """
+        Context manager to interpret 2D coordinates as being on the inside of a spherical screen.
+
+        The radius of the screen is the distance between the specified `center` and Sun center.
+        This `center` does not have to be the same as the observer location for the coordinate
+        frame.  If they are the same, then this context manager is equivalent to assuming that the
+        helioprojective "zeta" component is zero.
+
+        This replaces the default assumption where 2D coordinates are mapped onto the surface of the
+        Sun.
+
+        Parameters
+        ----------
+        center : `~astropy.coordinates.SkyCoord`
+            The center of the spherical screen
+        only_off_disk : `bool`, optional
+            If `True`, apply this assumption only to off-disk coordinates, with on-disk coordinates
+            still mapped onto the surface of the Sun.  Defaults to `False`.
+
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> from sunpy.coordinates import Helioprojective
+        >>> h = Helioprojective(range(7)*u.arcsec*319, [0]*7*u.arcsec,
+        ...                     observer='earth', obstime='2020-04-08')
+        >>> print(h.make_3d())
+        <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+            [(   0., 0., 0.99660825), ( 319., 0., 0.99687244),
+             ( 638., 0., 0.99778472), ( 957., 0., 1.00103285),
+             (1276., 0.,        nan), (1595., 0.,        nan),
+             (1914., 0.,        nan)]>
+
+        >>> with Helioprojective.assume_spherical_screen(h.observer):
+        ...     print(h.make_3d())
+        <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+            [(   0., 0., 1.00125872), ( 319., 0., 1.00125872),
+             ( 638., 0., 1.00125872), ( 957., 0., 1.00125872),
+             (1276., 0., 1.00125872), (1595., 0., 1.00125872),
+             (1914., 0., 1.00125872)]>
+
+
+        >>> with Helioprojective.assume_spherical_screen(h.observer, only_off_disk=True):
+        ...     print(h.make_3d())
+        <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+            [(   0., 0., 0.99660825), ( 319., 0., 0.99687244),
+             ( 638., 0., 0.99778472), ( 957., 0., 1.00103285),
+             (1276., 0., 1.00125872), (1595., 0., 1.00125872),
+             (1914., 0., 1.00125872)]>
+        """
+        try:
+            old_spherical_screen = cls._spherical_screen  # nominally None
+
+            center_hgs = center.transform_to(HeliographicStonyhurst(obstime=center.obstime))
+            cls._spherical_screen = {
+                'center': center,
+                'radius': center_hgs.radius,
+                'only_off_disk': only_off_disk
+            }
+            yield
+        finally:
+            cls._spherical_screen = old_spherical_screen
 
 
 @add_common_docstring(**_frame_parameters())


### PR DESCRIPTION
We normally interpret Helioprojective (HPC) 2D coordinates as being on the surface of the Sun.
This PR adds a context manager to instead interpret HPC 2D coordinates as on the inside of a spherical screen.  The center of the spherical screen is user-supplied, and the radius of the screen is the distance between the supplied center and Sun center.  One can also optionally choose (using the keyword `only_off_disk`) to have this overriding assumption apply only to off-disk coordinates, with on-disk coordinates still being on the surface of the Sun.

Addresses #3997 

## Simple examples
```python
>>> import astropy.units as u
>>> from sunpy.coordinates import Helioprojective
>>> h = Helioprojective(range(7)*u.arcsec*319, [0]*7*u.arcsec, observer='earth', obstime='2020-04-08')
>>> print(h.make_3d())
<Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcse
c, arcsec, AU)
    [(   0., 0., 0.99660825), ( 319., 0., 0.99687244),
     ( 638., 0., 0.99778472), ( 957., 0., 1.00103285),
     (1276., 0.,        nan), (1595., 0.,        nan),
     (1914., 0.,        nan)]>

>>> with Helioprojective.assume_spherical_screen(h.observer):
...     print(h.make_3d())
<Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcse
c, arcsec, AU)
    [(   0., 0., 1.00125872), ( 319., 0., 1.00125872),
     ( 638., 0., 1.00125872), ( 957., 0., 1.00125872),
     (1276., 0., 1.00125872), (1595., 0., 1.00125872),
     (1914., 0., 1.00125872)]>

>>> with Helioprojective.assume_spherical_screen(h.observer, only_off_disk=True):
...     print(h.make_3d())
<Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcse
c, arcsec, AU)
    [(   0., 0., 0.99660825), ( 319., 0., 0.99687244),
     ( 638., 0., 0.99778472), ( 957., 0., 1.00103285),
     (1276., 0., 1.00125872), (1595., 0., 1.00125872),
     (1914., 0., 1.00125872)]>
```

## Examples using `reproject`
```python
aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
...
with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate):
    output, _ = reproject_interp(...)
```
or
```python
with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate, only_off_disk=True):
    output, _ = reproject_interp(...)
```

![screen](https://user-images.githubusercontent.com/991759/78792054-a20fb500-797e-11ea-8b28-a2a91eb6392e.png)