### PR TITLE
Miscellanous cleanup in coordinates now that we depend on Astropy 3.2+

### DIFF
--- a/examples/saving_and_loading_data/coordinates_in_asdf.py
+++ b/examples/saving_and_loading_data/coordinates_in_asdf.py
@@ -14,7 +14,7 @@ storing complex Astropy and SunPy objects in a way that can be loaded back into
 the same form as they were saved.
 
 .. note::
-    This example requires Astropy 3.1 and asdf 2.3.0
+    This example requires Astropy 3.2 and asdf 2.3.0
 
 """
 
@@ -90,17 +90,12 @@ plt.show()
 # We can now save these loop points to an asdf file to use later. The advantage
 # of saving them to asdf is that all the metadata about the coordinates will be
 # preserved, and when we load the asdf, we will get back an identical
-# `~sunpy.coordinates.frames.HeliographicStonyhurst` object.
+# `~astropy.coordinates.SkyCoord` object.
 #
 # asdf files save a dictionary to a file, so to save the loop coordinates we
 # need to put them into a dictionary. This becomes what asdf calls a tree.
-#
-# The asdf file can not save the `~astropy.coordinates.SkyCoord` object in
-# versions of Astropy prior to 3.2, but it
-# can save the underlying frame. Therefore we construct a tree with the frame.
 
-
-tree = {'loop_points': loop_coords.frame}
+tree = {'loop_points': loop_coords}
 
 with asdf.AsdfFile(tree) as asdf_file:
     asdf_file.write_to("loop_coords.asdf")
@@ -111,8 +106,7 @@ with asdf.AsdfFile(tree) as asdf_file:
 # Astropy and SunPy installed. We can reload the file like so:
 
 with asdf.open("loop_coords.asdf") as input_asdf:
-    coords = input_asdf['loop_points']
-    new_coords = SkyCoord(coords)
+    new_coords = input_asdf['loop_points']
 
 print(new_coords.shape)
 # print the first and last coordinate point

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -13,17 +13,11 @@ import astropy.units as u
 from astropy.time import Time
 from astropy.coordinates import (SkyCoord, Angle, Longitude, Distance,
                                  ICRS, ITRS, AltAz,
-                                 get_body_barycentric)
+                                 get_body_barycentric,
+                                 HeliocentricEclipticIAU76)
 from astropy.coordinates.representation import CartesianRepresentation, SphericalRepresentation
 from astropy._erfa.core import ErfaWarning
 from astropy.constants import c as speed_of_light
-# Versions of Astropy that do not have HeliocentricMeanEcliptic have the same frame
-# with the misleading name HeliocentricTrueEcliptic
-try:
-    from astropy.coordinates import HeliocentricMeanEcliptic
-except ImportError:
-    from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
-from astropy.coordinates import HeliocentricEclipticIAU76
 
 from sunpy.time import parse_time
 from sunpy import log

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -10,14 +10,8 @@ import numpy as np
 
 import astropy.units as u
 from astropy.time import Time
-from astropy.coordinates import Angle, Latitude, Longitude, SkyCoord
-# Versions of Astropy that do not have *MeanEcliptic frames have the same frames
-# with the misleading names *TrueEcliptic
-try:
-    from astropy.coordinates import HeliocentricMeanEcliptic, GeocentricMeanEcliptic
-except ImportError:
-    from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
-    from astropy.coordinates import GeocentricTrueEcliptic as GeocentricMeanEcliptic
+from astropy.coordinates import (Angle, Latitude, Longitude, SkyCoord,
+                                 HeliocentricMeanEcliptic, GeocentricMeanEcliptic)
 from astropy import _erfa as erfa
 from astropy.coordinates.builtin_frames.utils import get_jd12
 

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -8,14 +8,8 @@ from astropy.constants import c as speed_of_light
 from astropy.coordinates import (SkyCoord, get_body_barycentric, Angle,
                                  ConvertError, Longitude, CartesianRepresentation,
                                  get_body_barycentric_posvel,
-                                 CartesianDifferential, SphericalDifferential)
-# Versions of Astropy that do not have HeliocentricMeanEcliptic have the same frame
-# with the misleading name HeliocentricTrueEcliptic
-try:
-    from astropy.coordinates import HeliocentricMeanEcliptic
-except ImportError:
-    from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
-
+                                 CartesianDifferential, SphericalDifferential,
+                                 HeliocentricMeanEcliptic)
 from astropy.time import Time
 
 from sunpy.coordinates import (Helioprojective, HeliographicStonyhurst,

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -24,8 +24,10 @@ import astropy.units as u
 from astropy._erfa import obl06
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (HCRS, ICRS, BaseCoordinateFrame, ConvertError,
-                                 get_body_barycentric, get_body_barycentric_posvel)
+                                 get_body_barycentric, get_body_barycentric_posvel,
+                                 HeliocentricMeanEcliptic)
 from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.builtin_frames import make_transform_graph_docs
 from astropy.coordinates.builtin_frames.utils import get_jd12
 from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose, rotation_matrix
 from astropy.coordinates.representation import (CartesianDifferential, CartesianRepresentation,
@@ -40,19 +42,6 @@ from sunpy.sun import constants
 from .frames import (_J2000, GeocentricEarthEquatorial, GeocentricSolarEcliptic,
                      Heliocentric, HeliocentricEarthEcliptic, HeliocentricInertial,
                      HeliographicCarrington, HeliographicStonyhurst, Helioprojective)
-
-# Versions of Astropy that do not have HeliocentricMeanEcliptic have the same frame
-# with the incorrect name HeliocentricTrueEcliptic
-try:
-    from astropy.coordinates import HeliocentricMeanEcliptic
-except ImportError:
-    from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
-
-try:
-    from astropy.coordinates.builtin_frames import _make_transform_graph_docs as make_transform_graph_docs
-except ImportError:
-    from astropy.coordinates import make_transform_graph_docs as _make_transform_graph_docs
-    make_transform_graph_docs = lambda: _make_transform_graph_docs(frame_transform_graph)
 
 
 RSUN_METERS = constants.get('radius').si.to(u.m)
@@ -958,10 +947,7 @@ def _make_sunpy_graph():
 
     _add_astropy_node(small_graph)
 
-    # Overwrite the main transform graph
-    frame_transform_graph = small_graph
-
-    docstr = make_transform_graph_docs()
+    docstr = make_transform_graph_docs(small_graph)
 
     # Restore the main transform graph
     frame_transform_graph = backup_graph

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -1,12 +1,6 @@
 """SDO Map subclass definitions"""
 
-from astropy.coordinates import CartesianRepresentation, SkyCoord
-# Versions of Astropy that do not have HeliocentricMeanEcliptic have the same frame
-# with the misleading name HeliocentricTrueEcliptic
-try:
-    from astropy.coordinates import HeliocentricMeanEcliptic
-except ImportError:
-    from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
+from astropy.coordinates import CartesianRepresentation, SkyCoord, HeliocentricMeanEcliptic
 import astropy.units as u
 from astropy.visualization.mpl_normalize import ImageNormalize
 from astropy.visualization import AsinhStretch

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -4,19 +4,12 @@ import numpy as np
 from matplotlib import colors
 
 import astropy.units as u
-from astropy.coordinates import CartesianRepresentation, SkyCoord
+from astropy.coordinates import CartesianRepresentation, SkyCoord, HeliocentricMeanEcliptic
 from astropy.visualization import PowerStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
 
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
-
-# Versions of Astropy that do not have HeliocentricMeanEcliptic have the same frame
-# with the misleading name HeliocentricTrueEcliptic
-try:
-    from astropy.coordinates import HeliocentricMeanEcliptic
-except ImportError:
-    from astropy.coordinates import HeliocentricTrueEcliptic as HeliocentricMeanEcliptic
 
 
 __all__ = ['EITMap', 'LASCOMap', 'MDIMap']


### PR DESCRIPTION
Now that the minimum required version of Astropy is 3.2, we can do some cleanup in `sunpy.coordinates`.

~Curiously, some of the functions are now returning different values (this is technically the first time I'm making use of Astropy's `GeocentricTrueEcliptic`).  I'm investigating, but it's possibly a bug in Astropy.~  Removed any use of `GeocentricTrueEcliptic` from this PR pending further thought.

Addresses part of #3154