### PR TITLE
Supporting Post search filtering again for VSO

### DIFF
--- a/changelog/4011.bugfix.rst
+++ b/changelog/4011.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed unhashable type `zeep.objects.QueryResponseBlock` error while post search filtering of 
+VSO results using `~sunpy.net.vso.vso.HashedResponse` class by implementing `__has__` method using fileid.

--- a/changelog/4011.bugfix.rst
+++ b/changelog/4011.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed unhashable type `zeep.objects.QueryResponseBlock` error while post search filtering of 
-VSO results using `~sunpy.net.vso.vso.HashedResponse` class by implementing `__has__` method using fileid.
+When sunpy moved to using Zeep for 1.0, we broke the ability to filter search results from the `sunpy.net.vso.VSOClient`.
+This feature has been restored by enabling the hashing of the the results from the `sunpy.net.vso.VSOClient` using the "fileid".

--- a/changelog/4011.bugfix.rst
+++ b/changelog/4011.bugfix.rst
@@ -1,2 +1,2 @@
-When sunpy moved to using Zeep for 1.0, we broke the ability to filter search results from the `sunpy.net.vso.VSOClient`.
-This feature has been restored by enabling the hashing of the the results from the `sunpy.net.vso.VSOClient` using the "fileid".
+The ability to to filter search results from the `~sunpy.net.vso.VSOClient` was broken.
+This has now been restored.

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -321,12 +321,12 @@ def _(attr, results):
         it.wave.wavemax is not None
         and
         attr.min <= u.Quantity(it.wave.wavemax, unit=it.wave.waveunit).to(
-                               u.angstrom, equivalencies=u.spectral())
+            u.angstrom, equivalencies=u.spectral())
         and
         it.wave.wavemin is not None
         and
         attr.max >= u.Quantity(it.wave.wavemin, unit=it.wave.waveunit).to(
-                               u.angstrom, equivalencies=u.spectral())
+            u.angstrom, equivalencies=u.spectral())
     }
 
 

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -320,11 +320,13 @@ def _(attr, results):
         if
         it.wave.wavemax is not None
         and
-        attr.min <= it.wave.wavemax.to(u.angstrom, equivalencies=u.spectral())
+        attr.min <= u.Quantity(it.wave.wavemax, unit=it.wave.waveunit).to(
+                               u.angstrom, equivalencies=u.spectral())
         and
         it.wave.wavemin is not None
         and
-        attr.max >= it.wave.wavemin.to(u.angstrom, equivalencies=u.spectral())
+        attr.max >= u.Quantity(it.wave.wavemin, unit=it.wave.waveunit).to(
+                               u.angstrom, equivalencies=u.spectral())
     }
 
 

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -12,7 +12,7 @@ from sunpy.net import attrs as a
 from sunpy.net import vso
 from sunpy.net.vso import QueryResponse
 from sunpy.net.vso import attrs as va
-from sunpy.net.vso.vso import VSOClient, build_client, get_online_vso_url
+from sunpy.net.vso.vso import VSOClient, build_client, get_online_vso_url, HashableResponse
 from sunpy.tests.mocks import MockObject
 from sunpy.time import TimeRange, parse_time
 
@@ -502,6 +502,19 @@ def test_build_client_params():
 
 
 @pytest.mark.remote_data
+def test_vso_post_search(client):
+    timerange = a.Time(('2020-01-01 00:01:05'), ('2020-01-01 00:01:10'))
+    results = client.search(timerange, a.Instrument('aia') | a.Instrument('hmi'))
+    trange_filter = a.Time(('2020-01-01 00:01:05'), ('2020-01-01 00:01:07'))
+    wave_filter = a.Wavelength(131 * u.Angstrom)
+    res_filtered = results.search(trange_filter & a.Instrument('aia') & wave_filter)
+    for rec in res_filtered:
+        assert parse_time(rec.time.start) <= parse_time(trange_filter.end)
+        assert rec.instrument.lower() == 'aia'
+        assert (float(rec.wave.wavemax) == 131.0 or float(rec.wave.wavemin) == 131.0)
+
+
+@pytest.mark.remote_data
 def test_incorrect_content_disposition(client):
     results = client.search(
         core_attrs.Time('2011/1/1 01:00', '2011/1/1 01:02'),
@@ -555,3 +568,19 @@ def test_response_block_properties(client):
                         a.Sample(10 * u.minute))
     properties = res.response_block_properties()
     assert len(properties) == 0
+
+
+def test_HashableResponse():
+    d0 = {'instrument': 'HMI', 'wave': {'wavemin': '6173', 'wavemax': '6174'}, 'fileid': 'fid1'}
+    d1 = {'instrument': 'AIA', 'wave': {'wavemin': '304', 'wavemax': '304'}, 'fileid': 'fid1'}
+    d2 = {'instrument': 'AIA', 'wave': {'wavemin': '131', 'wavemax': '131'}, 'fileid': 'fid2'}
+    dicts = [d0, d1, d2]
+    hashRecs = list()
+    for d in dicts:
+        hashRecs.append(HashableResponse(d))
+    assert d0['wave']['wavemax'] == hashRecs[0].wave.wavemax == '6174'
+    assert d2['fileid'] == hashRecs[2].fileid
+    assert hashRecs[0].__eq__(hashRecs[2]) is False
+    assert hashRecs[0] == hashRecs[1]
+    assert hashRecs[1].__hash__() != hashRecs[2].__hash__()
+    assert len(set(hashRecs)) == 2

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -12,7 +12,7 @@ from sunpy.net import attrs as a
 from sunpy.net import vso
 from sunpy.net.vso import QueryResponse
 from sunpy.net.vso import attrs as va
-from sunpy.net.vso.vso import VSOClient, build_client, get_online_vso_url, HashableResponse
+from sunpy.net.vso.vso import HashableResponse, VSOClient, build_client, get_online_vso_url
 from sunpy.tests.mocks import MockObject
 from sunpy.time import TimeRange, parse_time
 

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -11,7 +11,6 @@ import inspect
 import datetime
 import warnings
 import itertools
-import json
 from functools import partial
 from collections import defaultdict
 from urllib.error import URLError, HTTPError

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -81,6 +81,12 @@ class HashableResponse:
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()
 
+    def __str__(self):
+        return self.data.__str__()
+
+    def __repr__(self):
+        return self.data.__str__()
+
 
 class _Str(str):
 

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -85,7 +85,7 @@ class HashableResponse:
         return self.data.__str__()
 
     def __repr__(self):
-        return self.data.__str__()
+        return self.data.__repr__()
 
 
 class _Str(str):


### PR DESCRIPTION

Fixes #3833 
I converted all `zeep.objects.QueryResponseBlock` to a `hashedresponse` class which have `__hash__` function defined, so doesn't gives error while we make sets or compare them, used by `attrs` to filter out the required records.

Used codereference from this thread https://stackoverflow.com/questions/1305532/convert-nested-python-dict-to-object


