### PR TITLE
Move constants defined in "coordinates" sub-package to "sun"

### DIFF
--- a/changelog/4013.feature.rst
+++ b/changelog/4013.feature.rst
@@ -1,8 +1,8 @@
 Added extra constants to `sunpy.sun.constants`:
 
-- Longitude of the prime meridian (epoch J2000.0) : `sunpy.sun.constants.W_0`
+- Longitude of the prime meridian (epoch J2000.0) : ``sunpy.sun.constants.get('W_0')``
 - Sidereal rotation rate : `sunpy.sun.constants.sidereal_rotation_rate`
 - First Carrington rotation (JD TT) : `sunpy.sun.constants.first_carrington_rotation`
 - Mean synodic period : `sunpy.sun.constants.mean_synodic_period`
-- Right ascension (RA) of the north pole (epoch J2000.0) : `sunpy.sun.constants.alpha_0`
-- Declination of the north pole (epoch J2000.0) : `sunpy.sun.constants.delta_0`
+- Right ascension (RA) of the north pole (epoch J2000.0) : ``sunpy.sun.constants.get('alpha_0')``
+- Declination of the north pole (epoch J2000.0) : ``sunpy.sun.constants.get('delta_0')``

--- a/changelog/4013.feature.rst
+++ b/changelog/4013.feature.rst
@@ -1,9 +1,8 @@
 Added extra constants to `sunpy.sun.constants`:
 
-- True longitude of meridian : `sunpy.sun.constants.meridian_lon`
+- Longitude of the prime meridian (epoch J2000.0) : `sunpy.sun.constants.W_0`
 - Sidereal rotation rate : `sunpy.sun.constants.sidereal_rotation_rate`
-- First Carrington rotation : `sunpy.sun.constants.first_crot_jd`
-- First Carrington rotation (JD TT) : `sunpy.sun.constants.first_crot_jd_tt`
-- Mean synodic period : `sunpy.sun.constants.crot_period`
-- Right Ascension (RA) of the north pole at epoch J2000.0 : `sunpy.sun.constants.sun_north_pole_lon`
-- Declination of the North Pole at epoch J2000.0 : `sunpy.sun.constants.sun_north_pole_lat`
+- First Carrington rotation (JD TT) : `sunpy.sun.constants.first_carrington_rotation`
+- Mean synodic period : `sunpy.sun.constants.mean_synodic_period`
+- Right ascension (RA) of the north pole (epoch J2000.0) : `sunpy.sun.constants.alpha_0`
+- Declination of the north pole (epoch J2000.0) : `sunpy.sun.constants.delta_0`

--- a/changelog/4013.feature.rst
+++ b/changelog/4013.feature.rst
@@ -1,0 +1,9 @@
+Added extra constants to `sunpy.sun.constants`:
+
+- True longitude of meridian : `sunpy.sun.constants.meridian_lon`
+- Sidereal rotation rate : `sunpy.sun.constants.sidereal_rotation_rate`
+- First Carrington rotation : `sunpy.sun.constants.first_crot_jd`
+- First Carrington rotation (JD TT) : `sunpy.sun.constants.first_crot_jd_tt`
+- Mean synodic period : `sunpy.sun.constants.crot_period`
+- Right Ascension (RA) of the north pole at epoch J2000.0 : `sunpy.sun.constants.sun_north_pole_lon`
+- Declination of the North Pole at epoch J2000.0 : `sunpy.sun.constants.sun_north_pole_lat`

--- a/docs/guide/tour.rst
+++ b/docs/guide/tour.rst
@@ -169,10 +169,10 @@ keys.::
                'metallicity', 'sunspot cycle', 'average intensity',
                'effective temperature', 'mass conversion rate', 'center density',
                'center temperature', 'absolute magnitude', 'mean energy production',
-               'ellipticity', 'GM', 'true longitude of meridian', 'sidereal rotation rate',
-               'first Carrington rotation', 'first Carrington rotation (JD TT)',
-               'mean synodic period', 'right ascension (RA) of the north pole at epoch J2000.0',
-               'declination of the north pole at epoch J2000.0'])
+               'ellipticity', 'GM', 'W_0', 'sidereal rotation rate',
+               'first Carrington rotation (JD TT)',
+               'mean synodic period', 'alpha_0',
+               'delta_0'])
 
 You can also use the function `sunpy.constants.print_all()` to print out a table of all of the values
 available. These constants are provided as a convenience so that everyone is using the same

--- a/docs/guide/tour.rst
+++ b/docs/guide/tour.rst
@@ -169,7 +169,10 @@ keys.::
                'metallicity', 'sunspot cycle', 'average intensity',
                'effective temperature', 'mass conversion rate', 'center density',
                'center temperature', 'absolute magnitude', 'mean energy production',
-               'ellipticity', 'GM'])
+               'ellipticity', 'GM', 'true longitude of meridian', 'sidereal rotation rate',
+               'first Carrington rotation', 'first Carrington rotation (JD TT)',
+               'mean synodic period', 'right ascension (RA) of the north pole at epoch J2000.0',
+               'declination of the north pole at epoch J2000.0'])
 
 You can also use the function `sunpy.constants.print_all()` to print out a table of all of the values
 available. These constants are provided as a convenience so that everyone is using the same

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -18,6 +18,7 @@ from sunpy.sun import constants
 from sunpy.time import parse_time
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
+from sunpy.sun.constants import sidereal_rotation_rate, meridian_lon
 
 from .ephemeris import get_earth
 from .frames import HeliographicStonyhurst
@@ -477,7 +478,7 @@ _NODE = SkyCoord(_SOLAR_NORTH_POLE_HCRS.lon + 90*u.deg, 0*u.deg, frame='hcrs')
 # The longitude in the de-tilted frame of the Sun's prime meridian.
 # The IAU (Seidelmann et al. 2007 and later) defines the true longitude of the meridian (i.e.,
 # without light travel time to Earth and aberration effects) as 84.176 degrees eastward at J2000.
-_DLON_MERIDIAN = Longitude(_detilt_lon(_NODE) + 84.176*u.deg)
+_DLON_MERIDIAN = Longitude(_detilt_lon(_NODE) + meridian_lon)
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())
@@ -555,7 +556,7 @@ def L0(time='now',
     antetime = (obstime - distance / speed_of_light) if light_travel_time_correction else obstime
 
     # Calculate the de-tilt longitude of the meridian due to the Sun's sidereal rotation
-    dlon_meridian = Longitude(_DLON_MERIDIAN + (antetime - _J2000) * 14.1844*u.deg/u.day)
+    dlon_meridian = Longitude(_DLON_MERIDIAN + (antetime - _J2000) * sidereal_rotation_rate)
 
     return Longitude(dlon_earth - dlon_meridian)
 

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -72,12 +72,6 @@ def sky_position(t='now', equinox_of_date=True):
     return ra, dec
 
 
-# Time in Julian Days (TT) of the start of the first Carrington rotation
-_FIRST_CROT_JD = 2398167.4
-# Length of a Carrington rotation in days
-_CARRINGTON_ROTATION_PERIOD = 27.2753
-
-
 def carrington_rotation_time(crot):
     """
     Return the time of a given Carrington rotation.
@@ -94,7 +88,7 @@ def carrington_rotation_time(crot):
     -------
     astropy.time.Time
     """
-    estimate = (_CARRINGTON_ROTATION_PERIOD * (crot - 1)) + _FIRST_CROT_JD
+    estimate = (constants.crot_period.value * (crot - 1)) + constants.first_crot_jd.value
 
     # The above estimate is inaccurate (see comments below in carrington_rotation_number),
     # so put the estimate into carrington_rotation_number to determine a correction amount
@@ -102,7 +96,7 @@ def carrington_rotation_time(crot):
         crot_estimate = carrington_rotation_number(t=Time(estimate, scale='tt', format='jd'))
         dcrot = crot - crot_estimate
         # Correct the estimate using a linear fraction of the Carrington rotation period
-        return estimate + (dcrot * _CARRINGTON_ROTATION_PERIOD)
+        return estimate + (dcrot * constants.crot_period.value)
 
     # Perform two iterations of the correction to achieve sub-second accuracy
     estimate = refine(estimate)
@@ -127,7 +121,7 @@ def carrington_rotation_number(t='now'):
     # Estimate the Carrington rotation number by dividing the time that has elapsed since
     # JD 2398167.4 (late in the day on 1853 Nov 9), see Astronomical Algorithms (Meeus 1998, p.191),
     # by the mean synodic period (27.2753 days)
-    estimate = (time.tt.jd - _FIRST_CROT_JD) / _CARRINGTON_ROTATION_PERIOD + 1
+    estimate = (time.tt.jd - constants.first_crot_jd.value) / constants.crot_period.value + 1
     estimate_int, estimate_frac = divmod(estimate, 1)
 
     # The fractional rotation number from the above estimate is inaccurate, so calculate the actual

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -72,7 +72,8 @@ def test_angular_radius():
     # The Astronomical Almanac publishes values, but I don't know what physical radius they use
     assert_quantity_allclose(sun.angular_radius("2012/11/11"), 968.871*u.arcsec, atol=1e-3*u.arcsec)
     with pytest.warns(ErfaWarning):
-        assert_quantity_allclose(sun.angular_radius("2043/03/01"), 968.326*u.arcsec, atol=1e-3*u.arcsec)
+        assert_quantity_allclose(sun.angular_radius("2043/03/01"),
+                                 968.326*u.arcsec, atol=1e-3*u.arcsec)
     assert_quantity_allclose(sun.angular_radius("2001/07/21"), 944.039*u.arcsec, atol=1e-3*u.arcsec)
 
 
@@ -91,7 +92,8 @@ def test_true_rightascension():
     # Regression-only test
     assert_quantity_allclose(sun.true_rightascension("2012/11/11"), 226.548*u.deg, atol=1e-3*u.deg)
     with pytest.warns(ErfaWarning):
-        assert_quantity_allclose(sun.true_rightascension("2142/02/03"), 316.466*u.deg, atol=1e-3*u.deg)
+        assert_quantity_allclose(sun.true_rightascension(
+            "2142/02/03"), 316.466*u.deg, atol=1e-3*u.deg)
     assert_quantity_allclose(sun.true_rightascension("2013/12/11"), 258.150*u.deg, atol=1e-3*u.deg)
 
 
@@ -389,18 +391,18 @@ def test_P_array_time():
                         '2013-10-01',
                         '2013-11-01',
                         '2013-12-01'], scale='tt'))
-    assert_quantity_allclose(sun_P, [  1.98,
+    assert_quantity_allclose(sun_P, [1.98,
                                      -12.23,
                                      -21.55,
                                      -26.15,
                                      -24.11,
                                      -15.39,
-                                      -2.64,
-                                      10.85,
-                                      21.08,
-                                      25.97,
-                                      24.47,
-                                      16.05]*u.deg, atol=5e-3*u.deg)
+                                     -2.64,
+                                     10.85,
+                                     21.08,
+                                     25.97,
+                                     24.47,
+                                     16.05]*u.deg, atol=5e-3*u.deg)
 
 
 def test_earth_distance():

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -20,7 +20,7 @@ from sunpy.coordinates import (Helioprojective, HeliographicStonyhurst,
 from sunpy.coordinates import sun
 from sunpy.coordinates.frames import _J2000
 from sunpy.coordinates.transformations import transform_with_sun_center
-from sunpy.sun.constants import radius as _RSUN
+from sunpy.sun.constants import radius as _RSUN, sidereal_rotation_rate
 from sunpy.time import parse_time
 
 
@@ -352,10 +352,10 @@ def test_hgc_hgc_different_observers():
     sc_hgc_sun = sc_hgc_mars.transform_to(hgc_sun)
 
     ltt_earth = hgc_earth.observer.radius / speed_of_light
-    assert_quantity_allclose(sc_hgc_earth.lon - sc_hgc_sun.lon, ltt_earth * 14.1844*u.deg/u.day)
+    assert_quantity_allclose(sc_hgc_earth.lon - sc_hgc_sun.lon, ltt_earth * sidereal_rotation_rate)
 
     ltt_mars = hgc_mars.observer.radius / speed_of_light
-    assert_quantity_allclose(sc_hgc_mars.lon - sc_hgc_sun.lon, ltt_mars * 14.1844*u.deg/u.day)
+    assert_quantity_allclose(sc_hgc_mars.lon - sc_hgc_sun.lon, ltt_mars * sidereal_rotation_rate)
 
 
 def test_hcc_hcc():
@@ -455,7 +455,7 @@ def test_hgs_hgc_sunspice():
     new = old.transform_to(HeliographicCarrington(observer='earth'))
 
     # Calculate the difference in longitude due to light travel time from the Sun to the Earth
-    delta_lon = (14.1844*u.deg/u.day) * (sun.earth_distance(old.obstime) - _RSUN) / speed_of_light
+    delta_lon = sidereal_rotation_rate * (sun.earth_distance(old.obstime) - _RSUN) / speed_of_light
 
     assert_quantity_allclose(new.lon, 16.688242*u.deg + delta_lon, atol=1e-2*u.arcsec, rtol=0)
     assert_quantity_allclose(new.lat, old.lat)

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -499,8 +499,8 @@ def _sun_earth_icrf(time):
 # (See Archinal et al. 2011,
 #   "Report of the IAU Working Group on Cartographic Coordinates and Rotational Elements: 2009")
 # The orientation of the north pole in ICRS/HCRS is assumed to be constant in time
-_SOLAR_NORTH_POLE_HCRS = UnitSphericalRepresentation(lon=constants.sun_north_pole_lon,
-                                                     lat=constants.sun_north_pole_lat)
+_SOLAR_NORTH_POLE_HCRS = UnitSphericalRepresentation(lon=constants.get('alpha_0'),
+                                                     lat=constants.get('delta_0'))
 
 
 # Calculate the rotation matrix to de-tilt the Sun's rotation axis to be parallel to the Z axis

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -247,7 +247,7 @@ def _rotation_matrix_hgs_to_hgc(obstime, observer_distance_from_sun):
     delta_time = (observer_distance_from_sun - earth_distance(obstime)) / speed_of_light
 
     # Calculate the corresponding difference in apparent longitude
-    delta_lon = delta_time * 14.1844*u.deg/u.day
+    delta_lon = delta_time * constants.sidereal_rotation_rate
 
     # Rotation is only in longitude, so only around the Z axis
     return rotation_matrix(-(L0(obstime) + delta_lon), 'z')
@@ -499,7 +499,8 @@ def _sun_earth_icrf(time):
 # (See Archinal et al. 2011,
 #   "Report of the IAU Working Group on Cartographic Coordinates and Rotational Elements: 2009")
 # The orientation of the north pole in ICRS/HCRS is assumed to be constant in time
-_SOLAR_NORTH_POLE_HCRS = UnitSphericalRepresentation(lon=286.13*u.deg, lat=63.87*u.deg)
+_SOLAR_NORTH_POLE_HCRS = UnitSphericalRepresentation(lon=constants.sun_north_pole_lon,
+                                                     lat=constants.sun_north_pole_lat)
 
 
 # Calculate the rotation matrix to de-tilt the Sun's rotation axis to be parallel to the Z axis

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -840,7 +840,7 @@ def hci_to_hci(from_coo, to_frame):
         return to_frame.realize_frame(from_coo.data)
     else:
         return from_coo.transform_to(HeliographicStonyhurst(obstime=from_coo.obstime)).\
-               transform_to(to_frame)
+            transform_to(to_frame)
 
 
 def _rotation_matrix_obliquity(time):

--- a/sunpy/sun/_constants.py
+++ b/sunpy/sun/_constants.py
@@ -5,6 +5,7 @@ This module provies a non-comprehensive collection of solar physical constants.
 import astropy.constants.astropyconst20 as astrocon
 from astropy.constants import Constant
 from astropy.time import Time
+import astropy.units as u
 
 __all__ = ['physical_constants']
 
@@ -12,7 +13,6 @@ physical_constants = {}
 
 # references
 gsfc_fact = "https://nssdc.gsfc.nasa.gov/planetary/factsheet/sunfact.html"
-aa = "Astronomical Almanac (2013 edition)"
 allen = "Allen's Astrophysical Quantities 4th Ed."
 archinal = 'Archinal et al. 2018'
 asplund = "Asplund et al. 2006"
@@ -168,14 +168,16 @@ physical_constants['first Carrington rotation (JD TT)'] = Constant('',
                                                                    'first Carrington '
                                                                    'rotation (JD TT)',
                                                                    first_carrington_rotation.tt.jd,
-                                                                   'day', 0,
+                                                                   'day', 0.1,
                                                                    meeus, system='si')
 
 # length of the mean Carrington rotation as seen from Earth
+# the rotation rate of the Sun appears to be slower by the rate at which the Earth orbits the Sun
+period = 1 / (physical_constants['sidereal rotation rate'] / (360*u.deg) - 1 / u.yr)
 physical_constants['mean synodic period'] = Constant('',
                                                      'mean synodic period',
-                                                     27.2753, 'day', 0,
-                                                     aa, system='si')
+                                                     period.to_value('day'), 'day', 0,
+                                                     archinal, system='si')
 
 # Sun's north pole is oriented RA=286.13 deg, Dec=63.87 deg in ICRS and HCRS
 physical_constants['alpha_0'] \

--- a/sunpy/sun/_constants.py
+++ b/sunpy/sun/_constants.py
@@ -166,7 +166,7 @@ physical_constants['sidereal rotation rate'] = Constant('', 'sidereal rotation r
 physical_constants['first Carrington rotation'] = Constant('', 'first Carrington rotation',
                                                            2398167.4,
                                                            'day', 0, meeus, system='si')
-first_crot_jd_tt = Time('2398167.4', format='jd').tt
+first_crot_jd_tt = Time(2398167.4, format='jd').tt
 physical_constants['first Carrington rotation (JD TT)'] = Constant('',
                                                                    'first Carrington '
                                                                    'rotation (JD TT)',

--- a/sunpy/sun/_constants.py
+++ b/sunpy/sun/_constants.py
@@ -12,6 +12,7 @@ physical_constants = {}
 
 # references
 gsfc_fact = "https://nssdc.gsfc.nasa.gov/planetary/factsheet/sunfact.html"
+aa = "Astronomical Almanac (2013 edition)"
 allen = "Allen's Astrophysical Quantities 4th Ed."
 archinal = 'Archinal et al. 2018'
 asplund = "Asplund et al. 2006"
@@ -148,44 +149,40 @@ physical_constants['GM'] = Constant('mu', "standard gravitational parameter",
                                     132.712e6, 'km**3 s**-2', 0,
                                     gsfc_fact, system='si')
 
-# true longitude of the meridian (i.e., without light travel time to Earth
+# longitude of the prime meridian (without light travel time to Earth
 # and aberration effects) is 84.176 degrees eastward at J2000
-physical_constants['true longitude of meridian'] = Constant('',
-                                                            'true longitude of meridian',
-                                                            84.176, 'deg',
-                                                            0, archinal,
-                                                            system='si')
+physical_constants['W_0'] = Constant('W_0',
+                                     'longitude of the prime meridian (epoch J2000.0)',
+                                     84.176, 'deg',
+                                     0, archinal,
+                                     system='si')
 
-# conversion factor for calculating the de-tilt longitude of the meridian
-# due to the Sun's sidereal rotation
+# the definitional (fixed) rotation rate of the Sun relative to the stars (i.e., sidereal rotation rate)
 physical_constants['sidereal rotation rate'] = Constant('', 'sidereal rotation rate',
                                                         14.1844, 'deg day**-1', 0,
                                                         archinal, system='si')
 
 # time in Julian Days (TT) of the start of the first Carrington rotation
-physical_constants['first Carrington rotation'] = Constant('', 'first Carrington rotation',
-                                                           2398167.4,
-                                                           'day', 0, meeus, system='si')
-first_crot_jd_tt = Time(2398167.4, format='jd').tt
+first_carrington_rotation = Time(2398167.4, format='jd', scale='tt')
 physical_constants['first Carrington rotation (JD TT)'] = Constant('',
                                                                    'first Carrington '
                                                                    'rotation (JD TT)',
-                                                                   first_crot_jd_tt.value,
+                                                                   first_carrington_rotation.tt.jd,
                                                                    'day', 0,
                                                                    meeus, system='si')
 
-# length of a Carrington rotation in days
+# length of the mean Carrington rotation as seen from Earth
 physical_constants['mean synodic period'] = Constant('',
                                                      'mean synodic period',
                                                      27.2753, 'day', 0,
-                                                     allen, system='si')
+                                                     aa, system='si')
 
 # Sun's north pole is oriented RA=286.13 deg, Dec=63.87 deg in ICRS and HCRS
-physical_constants['right ascension (RA) of the north pole at epoch J2000.0'] \
+physical_constants['alpha_0'] \
     = Constant('alpha_0',
-               'right ascension (RA) of the north pole at epoch J2000.0',
+               'right ascension (RA) of the north pole (epoch J2000.0)',
                286.13, 'deg', 0, archinal, system='si')
-physical_constants['declination of the north pole at epoch J2000.0'] \
+physical_constants['delta_0'] \
     = Constant('delta_0',
-               'declination of the north pole at epoch J2000.0',
+               'declination of the north pole (epoch J2000.0)',
                63.87, 'deg', 0, archinal, system='si')

--- a/sunpy/sun/_constants.py
+++ b/sunpy/sun/_constants.py
@@ -4,6 +4,7 @@ This module provies a non-comprehensive collection of solar physical constants.
 # TODO: Need better sources for some constants as well as error values.
 import astropy.constants.astropyconst20 as astrocon
 from astropy.constants import Constant
+from astropy.time import Time
 
 __all__ = ['physical_constants']
 
@@ -12,8 +13,10 @@ physical_constants = {}
 # references
 gsfc_fact = "https://nssdc.gsfc.nasa.gov/planetary/factsheet/sunfact.html"
 allen = "Allen's Astrophysical Quantities 4th Ed."
+archinal = 'Archinal et al. 2018'
 asplund = "Asplund et al. 2006"
 fivian = "Fivian et al. 2008"
+meeus = "Meeus 1998 Astronomical Algorithms 2nd Ed."
 
 physical_constants['mass'] = astrocon.M_sun
 physical_constants['radius'] = astrocon.R_sun
@@ -144,3 +147,45 @@ physical_constants['ellipticity'] = Constant('', "ellipticity",
 physical_constants['GM'] = Constant('mu', "standard gravitational parameter",
                                     132.712e6, 'km**3 s**-2', 0,
                                     gsfc_fact, system='si')
+
+# true longitude of the meridian (i.e., without light travel time to Earth
+# and aberration effects) is 84.176 degrees eastward at J2000
+physical_constants['true longitude of meridian'] = Constant('',
+                                                            'true longitude of meridian',
+                                                            84.176, 'deg',
+                                                            0, archinal,
+                                                            system='si')
+
+# conversion factor for calculating the de-tilt longitude of the meridian
+# due to the Sun's sidereal rotation
+physical_constants['sidereal rotation rate'] = Constant('', 'sidereal rotation rate',
+                                                        14.1844, 'deg day**-1', 0,
+                                                        archinal, system='si')
+
+# time in Julian Days (TT) of the start of the first Carrington rotation
+physical_constants['first Carrington rotation'] = Constant('', 'first Carrington rotation',
+                                                           2398167.4,
+                                                           'day', 0, meeus, system='si')
+first_crot_jd_tt = Time('2398167.4', format='jd').tt
+physical_constants['first Carrington rotation (JD TT)'] = Constant('',
+                                                                   'first Carrington '
+                                                                   'rotation (JD TT)',
+                                                                   first_crot_jd_tt.value,
+                                                                   'day', 0,
+                                                                   meeus, system='si')
+
+# length of a Carrington rotation in days
+physical_constants['mean synodic period'] = Constant('',
+                                                     'mean synodic period',
+                                                     27.2753, 'day', 0,
+                                                     allen, system='si')
+
+# Sun's north pole is oriented RA=286.13 deg, Dec=63.87 deg in ICRS and HCRS
+physical_constants['right ascension (RA) of the north pole at epoch J2000.0'] \
+    = Constant('alpha_0',
+               'right ascension (RA) of the north pole at epoch J2000.0',
+               286.13, 'deg', 0, archinal, system='si')
+physical_constants['declination of the north pole at epoch J2000.0'] \
+    = Constant('delta_0',
+               'declination of the north pole at epoch J2000.0',
+               63.87, 'deg', 0, archinal, system='si')

--- a/sunpy/sun/constants.py
+++ b/sunpy/sun/constants.py
@@ -2,6 +2,7 @@
 This module provides fundamental solar physical constants.
 """
 from astropy.table import Table
+from astropy.time import Time
 
 from sunpy.sun import _constants as _con
 
@@ -9,8 +10,8 @@ __all__ = [
     'get', 'find', 'print_all', 'spectral_classification', 'au', 'mass', 'equatorial_radius',
     'volume', 'surface_area', 'average_density', 'equatorial_surface_gravity',
     'effective_temperature', 'luminosity', 'mass_conversion_rate', 'escape_velocity', 'sfu',
-    'average_angular_size', 'meridian_lon', 'sidereal_rotation_rate', 'first_crot_jd',
-    'first_crot_jd_tt', 'crot_period', 'sun_north_pole_lon', 'sun_north_pole_lat'
+    'average_angular_size', 'sidereal_rotation_rate', 'first_carrington_rotation',
+    'mean_synodic_period'
 ]
 
 constants = _con.physical_constants
@@ -122,10 +123,6 @@ escape_velocity = get('escape velocity')
 sfu = get('solar flux unit')
 # Observable parameters
 average_angular_size = get('average angular size')
-meridian_lon = get('true longitude of meridian')
 sidereal_rotation_rate = get('sidereal rotation rate')
-first_crot_jd = get('first Carrington rotation')
-first_crot_jd_tt = get('first Carrington rotation (JD TT)')
-crot_period = get('mean synodic period')
-sun_north_pole_lon = get('right ascension (RA) of the north pole at epoch J2000.0')
-sun_north_pole_lat = get('declination of the north pole at epoch J2000.0')
+first_carrington_rotation = Time(get('first Carrington rotation (JD TT)'), format='jd', scale='tt')
+mean_synodic_period = get('mean synodic period')

--- a/sunpy/sun/constants.py
+++ b/sunpy/sun/constants.py
@@ -93,12 +93,12 @@ def print_all():
 # Add a list of constants to the docs
 _lines = [
     'The following constants are available:\n',
-    '========================== ============== ================ =================================',
-    '           Name                Value            Unit                 Description',
-    '========================== ============== ================ =================================',
+    '======================================================= ============== ================ =======================================================',  # NOQA
+    '                          Name                              Value            Unit                                 Description                  ',  # NOQA
+    '======================================================= ============== ================ =======================================================',  # NOQA
 ]
 for key, const in constants.items():
-    _lines.append('{:^22} {:^14.9g} {:^16} {}'.format(
+    _lines.append('{:^55} {:^14.9g} {:^16} {:^55}'.format(
         key, const.value, const._unit_string, const.name))
 _lines.append(_lines[1])
 if __doc__ is not None:

--- a/sunpy/sun/constants.py
+++ b/sunpy/sun/constants.py
@@ -9,7 +9,8 @@ __all__ = [
     'get', 'find', 'print_all', 'spectral_classification', 'au', 'mass', 'equatorial_radius',
     'volume', 'surface_area', 'average_density', 'equatorial_surface_gravity',
     'effective_temperature', 'luminosity', 'mass_conversion_rate', 'escape_velocity', 'sfu',
-    'average_angular_size'
+    'average_angular_size', 'meridian_lon', 'sidereal_rotation_rate', 'first_crot_jd',
+    'first_crot_jd_tt', 'crot_period', 'sun_north_pole_lon', 'sun_north_pole_lat'
 ]
 
 constants = _con.physical_constants
@@ -92,9 +93,9 @@ def print_all():
 # Add a list of constants to the docs
 _lines = [
     'The following constants are available:\n',
-    '====================== ============== ================ =================================',
-    '         Name              Value            Unit                 Description',
-    '====================== ============== ================ =================================',
+    '========================== ============== ================ =================================',
+    '           Name                Value            Unit                 Description',
+    '========================== ============== ================ =================================',
 ]
 for key, const in constants.items():
     _lines.append('{:^22} {:^14.9g} {:^16} {}'.format(
@@ -121,3 +122,10 @@ escape_velocity = get('escape velocity')
 sfu = get('solar flux unit')
 # Observable parameters
 average_angular_size = get('average angular size')
+meridian_lon = get('true longitude of meridian')
+sidereal_rotation_rate = get('sidereal rotation rate')
+first_crot_jd = get('first Carrington rotation')
+first_crot_jd_tt = get('first Carrington rotation (JD TT)')
+crot_period = get('mean synodic period')
+sun_north_pole_lon = get('right ascension (RA) of the north pole at epoch J2000.0')
+sun_north_pole_lat = get('declination of the north pole at epoch J2000.0')

--- a/sunpy/sun/tests/test_constants.py
+++ b/sunpy/sun/tests/test_constants.py
@@ -8,13 +8,13 @@ from sunpy.sun import constants as con
 
 def test_find_all():
     assert isinstance(con.find(), list)
-    assert len(con.find()) == 28
+    assert len(con.find()) == 35
 
 
 def test_print_all():
     table = con.print_all()
     assert isinstance(table, Table)
-    assert len(table) == 28
+    assert len(table) == 35
 
 
 @pytest.mark.parametrize('this_constant', [value for key, value in con.constants.items()])

--- a/sunpy/sun/tests/test_constants.py
+++ b/sunpy/sun/tests/test_constants.py
@@ -8,13 +8,13 @@ from sunpy.sun import constants as con
 
 def test_find_all():
     assert isinstance(con.find(), list)
-    assert len(con.find()) == 35
+    assert len(con.find()) == 34
 
 
 def test_print_all():
     table = con.print_all()
     assert isinstance(table, Table)
-    assert len(table) == 35
+    assert len(table) == 34
 
 
 @pytest.mark.parametrize('this_constant', [value for key, value in con.constants.items()])


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Move some magic numbers from the `coordinates` sub-package to the `sun` sub-package as part of `sunpy.sun.constants`. This is to ensure that different parts of the `sunpy` package can access these constants, while providing a central location for auditing constants and updating them as required.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #3934
