### PR TITLE
Fixed a bug with `transform_with_sun_center()`

### DIFF
--- a/changelog/4015.bugfix.rst
+++ b/changelog/4015.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug with :func:`~sunpy.coordinates.transformations.transform_with_sun_center` where the global variable was sometimes restored incorrectly.
+This bug was most likely encountered if there was a nested use of this context manager.

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -782,7 +782,7 @@ def test_transform_with_sun_center():
 
 
 def test_transform_with_sun_center_reset():
-    # This test sequence ensures that the context manager does not change anything permanently
+    # This test sequence ensures that the context manager resets propoerly
 
     sun_center = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU,
                           frame=HeliographicStonyhurst(obstime="2001-01-01"))
@@ -800,6 +800,15 @@ def test_transform_with_sun_center_reset():
     assert_quantity_allclose(result2.lon, sun_center.lon)
     assert_quantity_allclose(result2.lat, sun_center.lat)
     assert_quantity_allclose(result2.distance, sun_center.radius)
+
+    # Exiting a nested context manager should not affect the outer context manager
+    with transform_with_sun_center():
+        with transform_with_sun_center():
+            pass
+        result2a = sun_center.transform_to(end_frame)
+    assert_quantity_allclose(result2a.lon, result2.lon)
+    assert_quantity_allclose(result2a.lat, result2.lat)
+    assert_quantity_allclose(result2a.distance, result2.distance)
 
     # After the context manager, the coordinate should have the same result as the first transform
     result3 = sun_center.transform_to(end_frame)

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -114,11 +114,13 @@ def transform_with_sun_center():
     try:
         global _ignore_sun_motion
 
+        old_ignore_sun_motion = _ignore_sun_motion  # nominally False
+
         log.debug("Ignore the motion of the center of the Sun for transformations")
         _ignore_sun_motion = True
         yield
     finally:
-        _ignore_sun_motion = False
+        _ignore_sun_motion = old_ignore_sun_motion
 
 
 # Global counter to keep track of the layer of transformation


### PR DESCRIPTION
The context manager `sun.coordinates.transform_with_sun_center()` uses a global variable to control the behavior of transformations, which is set to `False` at the beginning.  There's a bug where the context manager set the global variable to `False` after it exited, even if the global variable had been `True` when the context manager was called.  The natural way to encounter this bug is a nested call to `transform_with_sun_center()`.  This PR fixes the resetting to the prior value of the global variable.

Not to be backported