### PR TITLE
Show detailed hypothesis statistics in a dedicated CI build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,8 @@ jobs:
       - linux: codestyle
         name: python_codestyle
 
+      - linux: py38-hypothesis
+
       - linux: py36-conda
         name: py36_conda
         libraries: {}

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -112,7 +112,7 @@ def test_get_horizons_coord_array_time():
 
 @pytest.mark.remote_data
 @given(obstime=times())
-@settings(deadline=2000, max_examples=10)
+@settings(deadline=5000, max_examples=10)
 def test_consistency_with_horizons(astropy_ephemeris_de432s, obstime):
     # get_horizons_coord() depends on astroquery
     astroquery = pytest.importorskip("astroquery")

--- a/sunpy/net/dataretriever/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/tests/test_goes_ud.py
@@ -134,7 +134,7 @@ def test_fido(time, instrument):
     assert len(response) == qr._numfile
 
 
-@settings(deadline=50000)
+@settings(deadline=10000, max_examples=10)
 @pytest.mark.remote_data
 @given(goes_time())
 def test_time_for_url(LCClient, time):

--- a/sunpy/net/tests/strategies.py
+++ b/sunpy/net/tests/strategies.py
@@ -12,7 +12,7 @@ import astropy.time
 from astropy.time import Time
 
 from sunpy.net import attrs as a
-from sunpy.time import TimeRange
+from sunpy.time import TimeRange, parse_time
 
 TimesLeapsecond = sampled_from((Time('2015-06-30T23:59:60'),
                                 Time('2012-06-30T23:59:60')))
@@ -116,9 +116,8 @@ def goes_time(draw, time=Times(
 
 def range_time(min_date, max_date=Time.now()):
     time = Times(
-        min_value=datetime.datetime(1981, 1, 1, 0, 0),
-        max_value=datetime.datetime(datetime.datetime.utcnow().year, 1, 1, 0, 0),
+        min_value=parse_time(min_date).datetime,
+        max_value=parse_time(max_date).datetime
     )
-    time = time.filter(lambda x: min_date < x < max_date)
 
     return time_attr(time=time)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
-    py{36,37,38}{,-oldestdeps,-devdeps,-online}
+    py{36,37,38}{,-oldestdeps,-devdeps,-online,-hypothesis}
     build_docs
     figure
     figure_astropydev
     py36-conda
     codestyle
+    hypothesis
 isolated_build = true
 
 [testenv]
@@ -30,6 +31,8 @@ description =
     alldeps: with all optional dependencies
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
+    online: that require remote data
+    hypothesis: using hypothesis (both offline and online)
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
@@ -53,10 +56,11 @@ deps =
     oldestdeps: astropy<4.0
     oldestdeps: numpy<1.15.0
     oldestdeps: matplotlib<3.0
-    # These are specfici online extras we use to run the online tests.
+    # These are specific online extras we use to run the online tests.
     online: pytest-rerunfailures
     online: pytest-timeout
     online: astroquery
+    hypothesis: astroquery
 
     # The 32bit build needs numpy installed before trying to install sunpy due
     # to https://github.com/scikit-image/scikit-image/issues/4261
@@ -67,9 +71,10 @@ deps =
 extras =
     dev
 commands =
-    !online: {env:PYTEST_COMMAND} {posargs}
+    !online-!hypothesis: {env:PYTEST_COMMAND} {posargs}
     online: {env:PYTEST_COMMAND} --reruns 2 --timeout=180 --remote-data=any -m "remote_data" {posargs}
     devdeps: bash -ec "for f in {toxinidir}/examples/*/*.py; do [[ $f == *skip* ]] && continue; echo "$f" && python "$f"; done"
+    hypothesis: {env:PYTEST_COMMAND} --hypothesis-show-statistics --remote-data=any -m "hypothesis" {posargs}
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
Edit: Now in its own tox enviroment that is run as a separate CI build

I wanted to see how long particular `hypothesis` runs are taking on CI, but maybe it's generally useful enough to always be included.  The drawback is that the additional output is long, e.g.:
```
============================================================================== Hypothesis Statistics ===============================================================================
.tox/py38-32bit/lib/python3.8/site-packages/sunpy/coordinates/tests/test_metaframes.py::test_rotatedsun_transforms[HeliocentricInertial]:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 180-225 ms
  - Fraction of time spent in data generation: ~ 14%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/coordinates/tests/test_metaframes.py::test_rotatedsun_transforms[HeliographicStonyhurst]:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 426-570 ms
  - Fraction of time spent in data generation: ~ 6%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/coordinates/tests/test_offset_frame.py::test_transform:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 28-45 ms
  - Fraction of time spent in data generation: ~ 7%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/dataretriever/tests/test_lyra_ud.py::test_can_handle_query:

  - 100 passing examples, 0 failing examples, 58 invalid examples
  - Typical runtimes: 2-16 ms
  - Fraction of time spent in data generation: ~ 95%
  - Stopped because settings.max_examples=100
  - Events:
    *  55.70%, Retried draw from Times(max_value=datetime.datetime(2020, 1, 1, 0, 0), min_value=datetime.datetime(1981, 1, 1, 0, 0)).filter(lambda x: min_date < x < max_date) to satisfy filter
    *  22.78%, Aborted test because unable to satisfy Times(max_value=datetime.datetime(2020, 1, 1, 0, 0), min_value=datetime.datetime(1981, 1, 1, 0, 0)).filter(lambda x: min_date < x < max_date)

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/dataretriever/tests/test_norh.py::test_can_handle_query:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 2-11 ms
  - Fraction of time spent in data generation: ~ 81%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/tests/test_fido.py::test_offline_fido:

  - 100 passing examples, 0 failing examples, 1 invalid examples
  - Typical runtimes: 3-28 ms
  - Fraction of time spent in data generation: ~ 58%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/tests/test_fido.py::test_fido_indexing:

  - 100 passing examples, 0 failing examples, 89 invalid examples
  - Typical runtimes: 6-39 ms
  - Fraction of time spent in data generation: ~ 73%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/tests/test_fido.py::test_fido_iter:

  - 100 passing examples, 0 failing examples, 85 invalid examples
  - Typical runtimes: 6-33 ms
  - Fraction of time spent in data generation: ~ 79%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/dataretriever/tests/test_fermi_gbm.py::test_can_handle_query:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 2-12 ms
  - Fraction of time spent in data generation: ~ 82%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/dataretriever/tests/test_goes_suvi.py::test_can_handle_query:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 2-12 ms
  - Fraction of time spent in data generation: ~ 71%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/tests/test_fido.py::test_repr2:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 20-66 ms
  - Fraction of time spent in data generation: ~ 18%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/net/dataretriever/tests/test_goes_ud.py::test_can_handle_query:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 5-22 ms
  - Fraction of time spent in data generation: ~ 93%
  - Stopped because settings.max_examples=100

.tox/py38-32bit/lib/python3.8/site-packages/sunpy/coordinates/tests/test_metaframes.py::test_rotatedsun_transforms[HeliographicCarrington]:

  - 100 passing examples, 0 failing examples, 0 invalid examples
  - Typical runtimes: 1025-1316 ms
  - Fraction of time spent in data generation: ~ 3%
  - Stopped because settings.max_examples=100
```
Thoughts?