### PR TITLE
Removes appending login from norh and scraper.

### DIFF
--- a/changelog/4020.trivial.rst
+++ b/changelog/4020.trivial.rst
@@ -1,0 +1,1 @@
+Removes appending login details for ftp urls from scraper.

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -89,7 +89,7 @@ class NoRHClient(GenericClient):
             timerange = TimeRange(timerange.start.strftime('%Y-%m-%d'),
                                   timerange.end)
 
-        norh = Scraper(BASEURL, freq=freq, append_login=False)
+        norh = Scraper(BASEURL, freq=freq)
         # TODO: warn user that some files may have not been listed, like for example:
         #       tca160504_224657 on ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/05/
         #       as it doesn't follow pattern.
@@ -98,7 +98,7 @@ class NoRHClient(GenericClient):
 
     def _get_time_for_url(self, urls):
         freq = urls[0].split('/')[-1][0:3]  # extract the frequency label
-        crawler = Scraper(BASEURL, freq=freq, append_login=False)
+        crawler = Scraper(BASEURL, freq=freq)
         times = list()
         for url in urls:
             t0 = crawler._extractDateURL(url)

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -75,10 +75,6 @@ class Scraper:
                 end=self.pattern[milliseconds.end():]
             ))
 
-        self.append_login = True
-        if 'append_login' in kwargs:
-            self.append_login = kwargs['append_login']
-
     def matches(self, filepath, date):
         return date.strftime(self.pattern) == filepath
 
@@ -268,10 +264,7 @@ class Scraper:
                                 datehref <= timerange.end):
                             filesurls.append(fullpath)
 
-        login = ''
-        if self.append_login:
-            login = "anonymous:data@sunpy.org@"
-        filesurls = [f'ftp://{login}' + "{0.netloc}{0.path}".format(urlsplit(url))
+        filesurls = [f'ftp://' + "{0.netloc}{0.path}".format(urlsplit(url))
                      for url in filesurls]
 
         return filesurls


### PR DESCRIPTION
With parfive 1.1 in place, we can safely remove the login appending for ftp urls from scraper.