### PR TITLE
Use singledispatch in Map factory 

### DIFF
--- a/changelog/4037.trivial.rst
+++ b/changelog/4037.trivial.rst
@@ -1,0 +1,1 @@
+Re-factored the `sunpy.map.Map` factory to dispatch argument parsing based on type.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -200,11 +200,12 @@ class MapFactory(BasicRegistrationFactory):
             elif isinstance(arg, str) and _is_url(arg):
                 # Repalce URL string with a Request object to dispatch on later
                 args[i] = Request(arg)
+            elif _possibly_a_path(arg):
+                args[i] = pathlib.Path(arg)
             i += 1
 
         # For each of the arguments, handle each of the cases
         for arg in args:
-            # Data-header or data-WCS pair
             if isinstance(arg, tuple):
                 data, header = arg
                 if isinstance(header, WCS):
@@ -230,7 +231,7 @@ class MapFactory(BasicRegistrationFactory):
                 data_header_pairs += pairs
 
             # File system path (file or directory or glob)
-            elif _possibly_a_path(arg):
+            elif isinstance(arg, pathlib.Path):
                 path = pathlib.Path(arg).expanduser()
                 if _is_file(path):
                     pairs = self._read_file(path, **kwargs)

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -23,7 +23,7 @@ from sunpy.util import expand_list
 from sunpy.util import SunpyUserWarning
 from sunpy.util.metadata import MetaDict
 from sunpy.util.types import DatabaseEntryType
-from sunpy.util.functools import _singledispatchmethod
+from sunpy.util.functools import seconddispatch
 
 from sunpy.util.datatype_factory_base import BasicRegistrationFactory
 from sunpy.util.datatype_factory_base import NoMatchError
@@ -211,7 +211,8 @@ class MapFactory(BasicRegistrationFactory):
 
         return data_header_pairs
 
-    @_singledispatchmethod
+    # Note that post python 3.8 this can be @functools.singledispatchmethod
+    @seconddispatch
     def _parse_arg(self, arg, **kwargs):
         """
         Take a factory input and parse into (data, header) pairs.

--- a/sunpy/util/functools.py
+++ b/sunpy/util/functools.py
@@ -27,19 +27,5 @@ def seconddispatch(func):
     return wrapper
 
 
-def _singledispatchmethod(func):
-    """
-    A variant of `functools.singledispatch` that can be used on methods.
-    As of python 3.8, this can be replaced by the stdlib `functools.singledispatchmethod` decorator.
-    """
-    dispatcher = functools.singledispatch(func)
-
-    def wrapper(*args, **kw):
-        return dispatcher.dispatch(args[1].__class__)(*args, **kw)
-    wrapper.register = dispatcher.register
-    functools.update_wrapper(wrapper, func)
-    return wrapper
-
-
 # Extend the docstring with the original docs
 seconddispatch.__doc__ += functools.singledispatch.__doc__

--- a/sunpy/util/functools.py
+++ b/sunpy/util/functools.py
@@ -27,5 +27,19 @@ def seconddispatch(func):
     return wrapper
 
 
+def _singledispatchmethod(func):
+    """
+    A variant of `functools.singledispatch` that can be used on methods.
+    As of python 3.8, this can be replaced by the stdlib `functools.singledispatchmethod` decorator.
+    """
+    dispatcher = functools.singledispatch(func)
+
+    def wrapper(*args, **kw):
+        return dispatcher.dispatch(args[1].__class__)(*args, **kw)
+    wrapper.register = dispatcher.register
+    functools.update_wrapper(wrapper, func)
+    return wrapper
+
+
 # Extend the docstring with the original docs
 seconddispatch.__doc__ += functools.singledispatch.__doc__


### PR DESCRIPTION
Solves the map part of #2384, and builds on #3977. Some notes

- This converts url strings into `urllib.request.Request` objects, solely for the purpose of having a unique class to dispatch on. I think this is the right choice?
- I had to vendor a `singledispatch` version that works on methods, because `singledispatchmethod` was only added in python 3.8.
- Should I add a changelog?

Otherwise everything should work as before, but much neater code, and easier to add other dispatching options in the future.