### PR TITLE
Fixes to the STEREO/SECCHI COR2 starfield gallery example

### DIFF
--- a/changelog/4039.doc.rst
+++ b/changelog/4039.doc.rst
@@ -1,0 +1,1 @@
+Made improvements to the gallery example :ref:`sphx_glr_generated_gallery_units_and_coordinates_stereo_secchi_starfield.py`.


### PR DESCRIPTION
The [STEREO/SECCHI COR2 starfield gallery example](https://docs.sunpy.org/en/stable/generated/gallery/units_and_coordinates/STEREO_SECCHI_starfield.html) has a few minor issues:

- It repeats the notion of having to install `astroquery`.
- It uses a list of scalar coordinates instead of a single array coordinate.
- It sets the `obstime` for an ICRS `SkyCoord`, which is allowed, but could be potentially confusing.  The ICRS coordinate frame doesn't change over time.  The `obstime` for the transformation chain will be read from the destination frame (`cor2.coordinate_frame`).
- It sets the "very far away" distance as `1e12 * u.km`, which is actually only ~0.1 light-years, which looks silly as a distance to stars.
- There's a use of `frames.Helioprojective(observer=cor2.observer_coordinate)` instead of simply using `cor2.coordinate_frame`, which will have the `obstime` set too.