### PR TITLE
Warn when assuming CUNIT in map sources

### DIFF
--- a/changelog/4047.trivial.rst
+++ b/changelog/4047.trivial.rst
@@ -1,0 +1,1 @@
+Several map sources in `sunpy.map.sources` assume 'arcsec' units. If this assumption is raised a warning is now raised, instead of the assumption happening silently.

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -105,12 +105,11 @@ demonstrated by the following example.
 .. code-block:: python
 
     import sunpy.map
+
     class FutureMap(sunpy.map.GenericMap):
 
         def __init__(self, data, header, **kwargs):
-
-            super(FutureMap, self).__init__(data, header, **kwargs)
-
+            super().__init__(data, header, **kwargs)
             # Any Future Instrument specific keyword manipulation
 
        # Specify a classmethod that determines if the data-header pair matches

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -1,6 +1,9 @@
+import warnings
+
 import numpy as np
 
 from sunpy.map import GenericMap
+from sunpy.util.exceptions import SunpyUserWarning
 
 __all__ = ['SJIMap']
 
@@ -38,8 +41,14 @@ class SJIMap(GenericMap):
 
     def __init__(self, data, header, **kwargs):
         # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
+        if 'cunit1' not in header:
+            warnings.warn("Could not find CUNIT1 in header, assuming CUNIT1 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit1'] = header.get('cunit1', 'arcsec')
+        if 'cunit2' not in header:
+            warnings.warn("Could not find CUNIT2 in header, assuming CUNIT2 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit2'] = header.get('cunit2', 'arcsec')
         super().__init__(data, header, **kwargs)
 
         self.meta['detector'] = "SJI"

--- a/sunpy/map/sources/rhessi.py
+++ b/sunpy/map/sources/rhessi.py
@@ -1,12 +1,12 @@
 """RHESSI Map subclass definitions"""
 #pylint: disable=W0221,W0222,E1121
+import warnings
+
+from sunpy.map import GenericMap
+from sunpy.util.exceptions import SunpyUserWarning
 
 __author__ = "Steven Christe"
 __email__ = "steven.d.christe@nasa.gov"
-
-from sunpy.map import GenericMap
-
-
 __all__ = ['RHESSIMap']
 
 
@@ -37,8 +37,14 @@ class RHESSIMap(GenericMap):
 
     def __init__(self, data, header, **kwargs):
         # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
+        if 'cunit1' not in header:
+            warnings.warn("Could not find CUNIT1 in header, assuming CUNIT1 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit1'] = header.get('cunit1', 'arcsec')
+        if 'cunit2' not in header:
+            warnings.warn("Could not find CUNIT2 in header, assuming CUNIT2 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit2'] = header.get('cunit2', 'arcsec')
 
         super().__init__(data, header, **kwargs)
 

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -1,4 +1,5 @@
 """SOHO Map subclass definitions"""
+import warnings
 
 import numpy as np
 from matplotlib import colors
@@ -10,7 +11,7 @@ from astropy.visualization.mpl_normalize import ImageNormalize
 
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
-
+from sunpy.util.exceptions import SunpyUserWarning
 
 __all__ = ['EITMap', 'LASCOMap', 'MDIMap']
 
@@ -36,8 +37,14 @@ class EITMap(GenericMap):
 
     def __init__(self, data, header, **kwargs):
         # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
+        if 'cunit1' not in header:
+            warnings.warn("Could not find CUNIT1 in header, assuming CUNIT1 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit1'] = header.get('cunit1', 'arcsec')
+        if 'cunit2' not in header:
+            warnings.warn("Could not find CUNIT2 in header, assuming CUNIT2 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit2'] = header.get('cunit2', 'arcsec')
 
         super().__init__(data, header, **kwargs)
 
@@ -97,9 +104,15 @@ class LASCOMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
-        header['cunit1'] = header['cunit1'].lower()
-        header['cunit2'] = header['cunit2'].lower()
+        # Assume pixel units are arcesc if not given
+        if 'cunit1' not in header:
+            warnings.warn("Could not find CUNIT1 in header, assuming CUNIT1 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit1'] = header.get('cunit1', 'arcsec')
+        if 'cunit2' not in header:
+            warnings.warn("Could not find CUNIT2 in header, assuming CUNIT2 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit2'] = header.get('cunit2', 'arcsec')
 
         super().__init__(data, header, **kwargs)
 
@@ -164,8 +177,14 @@ class MDIMap(GenericMap):
 
     def __init__(self, data, header, **kwargs):
         # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
+        if 'cunit1' not in header:
+            warnings.warn("Could not find CUNIT1 in header, assuming CUNIT1 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit1'] = header.get('cunit1', 'arcsec')
+        if 'cunit2' not in header:
+            warnings.warn("Could not find CUNIT2 in header, assuming CUNIT2 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit2'] = header.get('cunit2', 'arcsec')
         super().__init__(data, header, **kwargs)
 
         # Fill in some missing or broken info

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -1,14 +1,16 @@
 """TRACE Map subclass definitions"""
 #pylint: disable=W0221,W0222,E1101,E1121
 
-__author__ = "Jack Ireland"
-__email__ = "jack.ireland@nasa.gov"
+import warnings
 
 from astropy.visualization import LogStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
+from sunpy.util.exceptions import SunpyUserWarning
 
+__author__ = "Jack Ireland"
+__email__ = "jack.ireland@nasa.gov"
 __all__ = ['TRACEMap']
 
 
@@ -47,8 +49,14 @@ class TRACEMap(GenericMap):
 
     def __init__(self, data, header, **kwargs):
         # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
+        if 'cunit1' not in header:
+            warnings.warn("Could not find CUNIT1 in header, assuming CUNIT1 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit1'] = header.get('cunit1', 'arcsec')
+        if 'cunit2' not in header:
+            warnings.warn("Could not find CUNIT2 in header, assuming CUNIT2 is 'arcsec'",
+                          SunpyUserWarning)
+            header['cunit2'] = header.get('cunit2', 'arcsec')
 
         GenericMap.__init__(self, data, header, **kwargs)
 


### PR DESCRIPTION
I was taking a look at map sources and to see examples of fixing metadata, and it struck me that there should probably be a warning if anything is being assumed that isn't being cross checked against other present header keys.