### PR TITLE
Improve multiple-match error in map factory

### DIFF
--- a/changelog/4052.trivial.rst
+++ b/changelog/4052.trivial.rst
@@ -1,0 +1,1 @@
+Improved the error message raised by the Map factory when a map matches multiple source map types.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -332,9 +332,10 @@ class MapFactory(BasicRegistrationFactory):
             else:
                 candidate_widget_types = [self.default_widget_type]
         elif n_matches > 1:
-            raise MultipleMatchError("Too many candidate types identified ({})."
-                                     "Specify enough keywords to guarantee unique type"
-                                     "identification.".format(n_matches))
+            raise MultipleMatchError("Too many candidate types identified "
+                                     f"({candidate_widget_types}). "
+                                     "Specify enough keywords to guarantee unique type "
+                                     "identification.")
 
         # Only one is found
         WidgetType = candidate_widget_types[0]


### PR DESCRIPTION
- Add a missing space
- Add the list of clashing sources to the error message