### PR TITLE
Update JSOC warning

### DIFF
--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -787,8 +787,11 @@ class JSOCClient(BaseClient):
 
         if not pkstr:
             # pkstr cannot be totally empty
-            error_message = "Atleast one PrimeKey must be passed."
-            raise ValueError(error_message)
+            #
+            # Note that whilst it is technically posisble to just search by series,
+            # this is not allowed here, because some of these would be very large
+            # searches that would make JSOC sad
+            raise ValueError("At least one PrimeKey, time, or wavelength must be passed.")
 
         dataset = '{series}{primekey}{segment}'.format(series=series,
                                                        primekey=pkstr,

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -791,7 +791,7 @@ class JSOCClient(BaseClient):
             # Note that whilst it is technically posisble to just search by series,
             # this is not allowed here, because some of these would be very large
             # searches that would make JSOC sad
-            raise ValueError("At least one PrimeKey, time, or wavelength must be passed.")
+            raise ValueError("Time, Wavelength or an explicit PrimeKey must be specified.")
 
         dataset = '{series}{primekey}{segment}'.format(series=series,
                                                        primekey=pkstr,


### PR DESCRIPTION
Replaces #4050

- "Atleast" > "At least"
- pkstr contains the time and wavelength too, so passing one of these is enough to fix the error. Mention this in the error message.
- Add a comment explaining why we don't allow searching only by series (see https://github.com/sunpy/sunpy/pull/4050#issuecomment-619166920)