### PR TITLE
Migrated the examples from the RotatedSunFrame tutorial to the gallery

### DIFF
--- a/docs/code_ref/coordinates/rotatedsunframe.rst
+++ b/docs/code_ref/coordinates/rotatedsunframe.rst
@@ -10,22 +10,23 @@ Thus, a coordinate that points to a solar feature (e.g., the center of the Sun o
 
 To evolve a coordinate in time such that it accounts for the rotational motion of the Sun, one can use the `~sunpy.coordinates.metaframes.RotatedSunFrame` "metaframe" class as described below.
 This machinery will take into account the latitude-dependent rotation rate of the solar surface, also known as differential rotation.
+Multiple models for differential rotation are supported (see :func:`~sunpy.physics.differential_rotation.diff_rot` for details).
 
-In addition, one may want to account for the translational motion of the Sun as well, and that can be achieved by also using the context manager `~sunpy.coordinates.transform_with_sun_center` for desired coordinate transformations.
+In addition, one may want to account for the translational motion of the Sun as well, and that can be achieved by also using the context manager :func:`~sunpy.coordinates.transform_with_sun_center` for desired coordinate transformations.
 
 Basics of the RotatedSunFrame class
 -----------------------------------
 In a nutshell, the `~sunpy.coordinates.metaframes.RotatedSunFrame` class allows one to specify coordinates in a coordinate frame prior to an amount of solar (differential) rotation being applied.
 That is, the coordinate will point to a location in inertial space at some time, but will use a coordinate system at a *different* time to refer to that point, while accounting for the differential rotation between those two times.
 
-Technical note: ``RotatedSunFrame`` is not itself a coordinate frame, but is instead a "metaframe".
+Technical note: `~sunpy.coordinates.metaframes.RotatedSunFrame` is not itself a coordinate frame, but is instead a "metaframe".
 A new frame class is created on the fly corresponding to each base coordinate frame class.
 This tutorial will refer to these new classes as ``RotatedSun*`` frames.
 
 Creating coordinates
 ^^^^^^^^^^^^^^^^^^^^
 
-``RotatedSunFrame`` requires two inputs: the base coordinate frame and the duration of solar rotation.
+`~sunpy.coordinates.metaframes.RotatedSunFrame` requires two inputs: the base coordinate frame and the duration of solar rotation.
 The base coordinate frame needs to be fully specified, which means a defined ``obstime`` and, if relevant, a defined ``observer``.
 Note that the ``RotatedSun*`` frame that is created in this example is appropriately named ``RotatedSunHeliographicStonyhurst``::
 
@@ -68,7 +69,7 @@ If one converts the ``RotatedSun*`` coordinate to a "real" coordinate frame, eve
   <HeliographicCarrington Coordinate (obstime=2020-03-04T00:00:00.000, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (lon, lat, radius) in (deg, deg, km)
       (45.13354448, 20., 695700.)>
 
-The above examples used the default differential-rotation model, but any of the models available through `sunpy.physics.diff_rot` are selectable.
+The above examples used the default differential-rotation model, but any of the models available through :func:`sunpy.physics.differential_rotation.diff_rot` are selectable.
 For example, instead of the default ("howard"), one can specify "allen" using the keyword argument ``rotation_model``.
 Note the slight difference in the "real" longitude compared to the output above::
 
@@ -136,7 +137,7 @@ Note that equator rotates slightly faster than the Carrington rotation rate (its
 
 Be aware that transformations with a change in ``obstime`` will also contend with a translation of the center of the Sun.
 Note that the ``radius`` component above is no longer precisely on the surface of the Sun.
-For precise transformations of solar features, one should also use the context manager `~sunpy.coordinates.transformations.transform_with_sun_center` to account for the translational motion of the Sun.
+For precise transformations of solar features, one should also use the context manager :func:`~sunpy.coordinates.transformations.transform_with_sun_center` to account for the translational motion of the Sun.
 Using the context manager, the ``radius`` component stays as the solar radius as desired::
 
   >>> from sunpy.coordinates import transform_with_sun_center
@@ -190,7 +191,7 @@ Let's convert to the base coordinate frame to reveal the motion of the active re
        ( 656.65386199, 440.43943386, 0.98058459),
        ( 780.54121099, 430.77097352, 0.98141858)]>
 
-Be aware that these coordinates are represented in the ``Helioprojective`` coordinates as seen from Earth at the base time.
+Be aware that these coordinates are represented in the `~sunpy.coordinates.frames.Helioprojective` coordinates as seen from Earth at the base time.
 Since the Earth moves in its orbit around the Sun, one may be more interested in representing these coordinates as they would been seen by an Earth observer at each time step.
 Since the destination frame of the transformation will now have arrays for ``obstime`` and ``observer``, one actually has to construct the initial coordinate with an array for ``obstime`` (and ``observer``) due to a limitation in Astropy.
 Note that the active region moves slightly slower across the disk of the Sun because the Earth orbits in the same direction as the Sun rotates, thus reducing the apparent rotation of the Sun::
@@ -245,7 +246,7 @@ If we create a ``RotatedSun*`` frame for a different base time, we can represent
       (10., 20., 695700.)>
 
 There coordinates are stored in the ``RotatedSun*`` frame, but it can be useful to "pop off" this extra layer and retain only the coordinate representation in the base coordinate frame.
-There is a convenience method called `~sunpy.coordinates.metaframes.RotatedSunFrame.as_base()` to do exactly that.
+There is a convenience method called :meth:`~sunpy.coordinates.metaframes.RotatedSunFrame.as_base()` to do exactly that.
 Be aware the resulting coordinate does *not* point to the same location in inertial space, despite the superficial similarity.
 Essentially, the component values have been copied from one coordinate frame to a different coordinate frame, and thus this is not merely a transformation between coordinate frames::
 
@@ -253,143 +254,14 @@ Essentially, the component values have been copied from one coordinate frame to 
   <HeliographicCarrington Coordinate (obstime=2020-03-04T00:00:00.000, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (lon, lat, radius) in (deg, deg, km)
       (10., 20., 695700.)>
 
-Advanced uses of RotatedSunFrame
---------------------------------
+Example uses of RotatedSunFrame
+-------------------------------
 
-Here are advanced examples of how to use ``RotatedSunFrame``.
+Here are the examples in our gallery that use `~sunpy.coordinates.metaframes.RotatedSunFrame`:
 
-Plotting differentially rotated coordinates
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. include:: ../../generated/modules/sunpy.coordinates.RotatedSunFrame.examples
+    :start-line: 5
 
-Coordinates in a ``RotatedSun*`` frame can be plotted onto a map in the same manner as a normal coordinate.
-Here, we plot the differentially rotated locations of a solar feature from -5 days to +5 days.
+.. raw:: html
 
-.. plot::
-   :include-source:
-
-   from astropy.coordinates import SkyCoord
-   import astropy.units as u
-   import matplotlib.pyplot as plt
-
-   from sunpy.coordinates import RotatedSunFrame
-   from sunpy.data.sample import AIA_171_IMAGE
-   from sunpy.map import Map
-
-   m = Map(AIA_171_IMAGE)
-
-   fig = plt.figure()
-   ax = plt.subplot(projection=m)
-   m.plot(clip_interval=(1., 99.95)*u.percent)
-
-   durations = range(-5, 6, 1)*u.day
-   point = SkyCoord(187*u.arcsec, 283*u.arcsec, frame=m.coordinate_frame)
-   diffrot_point = RotatedSunFrame(base=point, duration=durations)
-
-   middle = len(durations) // 2
-   ax.plot_coord(diffrot_point[middle], 'ro', fillstyle='none')
-   ax.plot_coord(diffrot_point[:middle], 'bo', fillstyle='none')
-   ax.plot_coord(diffrot_point[middle+1:], 'bo', fillstyle='none')
-
-   plt.show()
-
-Grid overlay on a Map
-^^^^^^^^^^^^^^^^^^^^^
-
-We can use the ``RotatedSun*`` frame to straightforwardly plot grid overlays.
-Here, we plot normal ``HeliographicStonyhurst`` longitude lines in white and ``RotatedSunHeliographicStonyhurst`` longitude lines (with 27 days of differential rotation) in blue.
-
-.. plot::
-   :include-source:
-
-   import astropy.units as u
-   import matplotlib.pyplot as plt
-
-   from sunpy.coordinates import RotatedSunFrame, HeliographicStonyhurst
-   from sunpy.data.sample import AIA_171_IMAGE
-   from sunpy.map import Map
-
-   m = Map(AIA_171_IMAGE)
-
-   fig = plt.figure()
-   ax = plt.subplot(projection=m)
-   m.plot(clip_interval=(1., 99.95)*u.percent)
-
-   overlay = ax.get_coords_overlay('heliographic_stonyhurst')
-   overlay[0].set_ticks(spacing=15. * u.deg)
-   overlay[1].set_ticks(spacing=90. * u.deg)
-   overlay.grid(ls='-', color='white')
-
-   rs_hgs = RotatedSunFrame(base=HeliographicStonyhurst(obstime=m.date), duration=27*u.day)
-   overlay = ax.get_coords_overlay(rs_hgs)
-   overlay[0].set_ticks(spacing=15. * u.deg)
-   overlay[1].set_ticks(spacing=90. * u.deg)
-   overlay.grid(ls='-', color='blue')
-
-   plt.show()
-
-Be aware that the distorted ``RotatedSunHeliographicStonyhurst`` longitude lines are plotted on the original coordinate frame, and thus use the ``Helioprojective`` coordinate frame for the location of AIA at the original observation time (as opposed to 27 days later).
-
-Differentially rotating a Map
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note::
-   This example requires `reproject` 0.6 or later to be installed.
-
-Here is an example of reprojecting a map to another time with an observer at a different location.
-To achieve the reprojection, one needs to transform from the original frame to the ``RotatedSun*`` version of the output frame with ``rotated_time`` set to the time of the original frame.
-When reprojecting across a change in time, it is generally advisable to use the `~sunpy.coordinates.transform_with_sun_center` context manager.
-
-.. plot::
-   :include-source:
-
-   from astropy.coordinates import SkyCoord
-   import astropy.units as u
-   from astropy.wcs import WCS
-   import matplotlib.pyplot as plt
-   from reproject import reproject_interp
-
-   from sunpy.coordinates import Helioprojective, RotatedSunFrame, HeliographicStonyhurst, transform_with_sun_center
-   from sunpy.data.sample import AIA_171_IMAGE
-   from sunpy.map import Map, make_fitswcs_header
-
-   # Load the map and define the output time with +5 days of differential rotation
-   m = Map(AIA_171_IMAGE)
-   in_time = m.date
-   out_time = in_time + 5*u.day
-
-   # Define the output real frame with an associated new observer (at Earth)
-   out_frame = Helioprojective(observer='earth', obstime=out_time)
-
-   # Define the output RotatedSunFrame (its `duration` will be -5 days)
-   rot_frame = RotatedSunFrame(base=out_frame, rotated_time=in_time)
-
-   # Construct a WCS object for the output map with the output RotatedSunFrame specified
-   out_shape = m.data.shape
-   out_center = SkyCoord(0*u.arcsec, 0*u.arcsec, frame=out_frame)
-   header = make_fitswcs_header(out_shape, out_center, scale=u.Quantity(m.scale))
-   out_wcs = WCS(header)
-   out_wcs.coordinate_frame = rot_frame
-
-   # Reproject the map from the input frame to the output RotatedSunFrame while following Sun center
-   with transform_with_sun_center():
-       arr, _ = reproject_interp(m, out_wcs, out_shape)
-
-   # Create the output map and preserve the original map's plot settings
-   out_warp = Map(arr, out_wcs)
-   out_warp.plot_settings = m.plot_settings
-
-   # Plot the output map next to the original map
-   fig = plt.figure(figsize=(12, 4))
-
-   ax1 = fig.add_subplot(1, 2, 1, projection=m)
-   m.plot(vmin=0, vmax=20000, title='Original map')
-   plt.colorbar()
-
-   ax2 = fig.add_subplot(1, 2, 2, projection=out_warp)
-   out_warp.plot(vmin=0, vmax=20000,
-                 title=f"Reprojected to an Earth observer {(out_time - in_time).to('day')} later")
-   plt.colorbar()
-
-   plt.show()
-
-Instead of the steps to construct a custom WCS object, one can instead use the WCS from an actual ``Map`` object at the desired output time (e.g., the actual AIA observation at the later time).
+    <div class="sphx-glr-clear"></div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,6 +242,7 @@ if has_sphinx_gallery:
             '../examples/time_series',
             '../examples/units_and_coordinates',
             '../examples/plotting',
+            '../examples/differential_rotation',
             '../examples/saving_and_loading_data',
             '../examples/computer_vision_techniques',
         ]),
@@ -249,7 +250,8 @@ if has_sphinx_gallery:
         'gallery_dirs': path.joinpath('generated', 'gallery'),
         'default_thumb_file': path.joinpath('logo', 'sunpy_icon_128x128.png'),
         'abort_on_example_error': False,
-        'plot_gallery': True
+        'plot_gallery': True,
+        'doc_module': ('sunpy')
     }
 
 """

--- a/examples/differential_rotation/README.txt
+++ b/examples/differential_rotation/README.txt
@@ -1,0 +1,4 @@
+Differential Rotation of the Sun
+================================
+
+This section showcases how to use `~sunpy.coordinates.metaframes.RotatedSunFrame` to account for differential rotation (i.e., the latitude-dependent rotation rate of the Sun) in the coordinates framework.

--- a/examples/differential_rotation/differentially_rotated_coordinate.py
+++ b/examples/differential_rotation/differentially_rotated_coordinate.py
@@ -1,0 +1,60 @@
+"""
+====================================
+Differentially rotating a coordinate
+====================================
+
+How to differentially rotate a coordinate.
+
+The example uses the `~sunpy.coordinates.metaframes.RotatedSunFrame` coordinate
+metaframe in `sunpy.coordinates` to apply differential rotation to a
+coordinate.  See :ref:`sunpy-coordinates-rotatedsunframe` for more details on
+using `~sunpy.coordinates.metaframes.RotatedSunFrame`.
+"""
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+import matplotlib.pyplot as plt
+import numpy as np
+
+import sunpy.map
+from sunpy.coordinates import RotatedSunFrame
+from sunpy.data.sample import AIA_171_IMAGE
+
+##############################################################################
+# First, load an AIA observation and define a coordinate in its coordinate
+# frame (here, helioprojective Cartesian).  The appropriate rate of rotation
+# is determined from the heliographic latitude of the coordinate.
+
+aiamap = sunpy.map.Map(AIA_171_IMAGE)
+point = SkyCoord(187*u.arcsec, 283*u.arcsec, frame=aiamap.coordinate_frame)
+
+##############################################################################
+# We can differentially rotate this coordinate by using
+# `~sunpy.coordinates.metaframes.RotatedSunFrame` with an array of observation
+# times.  Let's define a daily cadence for +/- five days.
+
+durations = np.concatenate([range(-5, 0), range(1, 6)]) * u.day
+diffrot_point = RotatedSunFrame(base=point, duration=durations)
+
+##############################################################################
+# To see what this coordinate looks like in "real" helioprojective
+# Cartesian coordinates, we can transform it back to the original frame.
+# Since these coordinates are represented in the original frame, they will not
+# account for the changing position of the observer over this same time range.
+
+transformed_diffrot_point = diffrot_point.transform_to(aiamap.coordinate_frame)
+print(transformed_diffrot_point)
+
+##############################################################################
+# Let's plot the original coordinate and the differentially rotated
+# coordinates on top of the AIA observation.
+
+fig = plt.figure()
+ax = plt.subplot(projection=aiamap)
+aiamap.plot(clip_interval=(1., 99.95)*u.percent)
+
+ax.plot_coord(point, 'ro', fillstyle='none', label='Original')
+ax.plot_coord(transformed_diffrot_point, 'bo', fillstyle='none',
+              label='Rotated')
+plt.legend()
+
+plt.show()

--- a/examples/differential_rotation/differentially_rotated_gridlines.py
+++ b/examples/differential_rotation/differentially_rotated_gridlines.py
@@ -1,0 +1,50 @@
+"""
+===========================================
+Overlaying differentially rotated gridlines
+===========================================
+
+How to overlay differentially rotated gridlines on a Map.
+
+The example uses the `~sunpy.coordinates.metaframes.RotatedSunFrame` coordinate
+metaframe in `sunpy.coordinates` to overlay differentially rotated gridlines on
+a Map.  See :ref:`sunpy-coordinates-rotatedsunframe` for more details on using
+`~sunpy.coordinates.metaframes.RotatedSunFrame`.
+"""
+import astropy.units as u
+import matplotlib.pyplot as plt
+
+import sunpy.map
+from sunpy.coordinates import RotatedSunFrame, HeliographicStonyhurst
+from sunpy.data.sample import AIA_171_IMAGE
+
+##############################################################################
+# Let's use an AIA observation, and plot lines of constant longtiude in
+# heliographic Stonyhurst.  We'll plot the normal lines (prior to applying
+# differential rotation) in white and the differentially rotated lines in
+# blue.  Be aware that the differentially rotated lines are plotted in the
+# original coordinate frame, so it doesn't account for any motion of the
+# observer over 27 days.
+
+aiamap = sunpy.map.Map(AIA_171_IMAGE)
+
+fig = plt.figure()
+ax = plt.subplot(projection=aiamap)
+aiamap.plot(clip_interval=(1., 99.95)*u.percent)
+
+# Lines of constant longitude prior to differential rotation
+
+overlay1 = ax.get_coords_overlay('heliographic_stonyhurst')
+overlay1[0].set_ticks(spacing=15. * u.deg)
+overlay1[1].set_ticks(spacing=90. * u.deg)
+overlay1.grid(ls='-', color='white')
+
+# Differentially rotating the lines of constant longitude by 27 days
+
+rs_hgs = RotatedSunFrame(base=HeliographicStonyhurst(obstime=aiamap.date),
+                         duration=27*u.day)
+overlay2 = ax.get_coords_overlay(rs_hgs)
+overlay2[0].set_ticks(spacing=15. * u.deg)
+overlay2[1].set_ticks(spacing=90. * u.deg)
+overlay2.grid(ls='-', color='blue')
+
+plt.show()

--- a/examples/differential_rotation/reprojected_map.py
+++ b/examples/differential_rotation/reprojected_map.py
@@ -1,0 +1,99 @@
+"""
+==================
+Reprojecting a Map
+==================
+
+How to apply differential rotation to a Map.
+
+The example uses the `~sunpy.coordinates.metaframes.RotatedSunFrame` coordinate
+metaframe in `sunpy.coordinates` to apply differential rotation to a
+Map.  See :ref:`sunpy-coordinates-rotatedsunframe` for more details on
+using `~sunpy.coordinates.metaframes.RotatedSunFrame`.
+
+.. note::
+   This example requires `reproject` 0.6 or later to be installed.
+
+"""
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+from astropy.wcs import WCS
+import matplotlib.pyplot as plt
+import numpy as np
+from reproject import reproject_interp
+
+import sunpy.map
+from sunpy.coordinates import (Helioprojective, RotatedSunFrame,
+                               transform_with_sun_center)
+from sunpy.data.sample import AIA_171_IMAGE
+
+##############################################################################
+# First, load an AIA observation.
+
+aiamap = sunpy.map.Map(AIA_171_IMAGE)
+in_time = aiamap.date
+
+##############################################################################
+# Let's define the output frame to be five days in the future for an observer
+# at Earth (i.e., about five degrees offset in heliographic longitude compared
+# to the location of AIA in the original observation).
+
+out_time = in_time + 5*u.day
+out_frame = Helioprojective(observer='earth', obstime=out_time)
+
+##############################################################################
+# For the reprojection, the definition of the target frame can be
+# counter-intuitive.  We will be transforming from the original frame to the
+# `~sunpy.coordinates.metaframes.RotatedSunFrame` version of the output frame
+# with ``rotated_time`` set to the time of the original frame.
+
+rot_frame = RotatedSunFrame(base=out_frame, rotated_time=in_time)
+print(rot_frame)
+
+##############################################################################
+# Construct a WCS object for the output map with the target
+# ``RotatedSunHelioprojective`` frame specified instead of the regular
+# `~sunpy.coordinates.frames.Helioprojective` frame.
+# If one has an actual ``Map`` object at the desired output
+# time (e.g., the actual AIA observation at the output time), one can use the
+# WCS object from that ``Map`` object (e.g., ``mymap.wcs``) instead of
+# constructing a custom WCS.
+
+out_shape = aiamap.data.shape
+out_center = SkyCoord(0*u.arcsec, 0*u.arcsec, frame=out_frame)
+header = sunpy.map.make_fitswcs_header(out_shape,
+                                       out_center,
+                                       scale=u.Quantity(aiamap.scale))
+out_wcs = WCS(header)
+out_wcs.coordinate_frame = rot_frame
+
+##############################################################################
+# Reproject the map from the input frame to the output frame.  We use the
+# :func:`~sunpy.coordinates.transform_with_sun_center` context manager so that
+# the coordinates stay defined relative to Sun center as the Sun moves slowly
+# over time.
+
+with transform_with_sun_center():
+    arr, _ = reproject_interp(aiamap, out_wcs, out_shape)
+
+##############################################################################
+# Finally, we create the output map and preserve the original map's plot
+# settings.
+
+out_warp = sunpy.map.Map(arr, out_wcs)
+out_warp.plot_settings = aiamap.plot_settings
+
+##############################################################################
+# Let's plot the differentially rotated Map next to the original Map.
+
+fig = plt.figure(figsize=(12, 4))
+
+ax1 = fig.add_subplot(1, 2, 1, projection=aiamap)
+aiamap.plot(vmin=0, vmax=20000, title='Original map')
+plt.colorbar()
+
+ax2 = fig.add_subplot(1, 2, 2, projection=out_warp)
+out_warp.plot(vmin=0, vmax=20000,
+              title=f"Reprojected to an Earth observer {(out_time - in_time).to('day')} later")
+plt.colorbar()
+
+plt.show()

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -132,6 +132,8 @@ class RotatedSunFrame:
     coordinate frame) to point to a location at a different time that has been differentially
     rotated by the time difference (``duration``).
 
+    See :ref:`sunpy-coordinates-rotatedsunframe` for how to use this class.
+
     Parameters
     ----------
     representation : `~astropy.coordinates.BaseRepresentation` or ``None``


### PR DESCRIPTION
This PR migrates the examples from the RotatedSunFrame tutorial to the gallery.  The tutorial now links to the gallery examples and embeds the final plot of each example.

Closes #3766 