### PR TITLE
Make _observers_are_equal compatible with 4.1

### DIFF
--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -175,7 +175,7 @@ def _transformation_debug(description):
 
 def _observers_are_equal(obs_1, obs_2):
     # Note that this also lets pass the situation where both observers are None
-    if obs_1 == obs_2:
+    if obs_1 is obs_2:
         return True
 
     # obs_1 != obs_2


### PR DESCRIPTION
https://github.com/astropy/astropy/pull/10154 has made coordinate equality checking more stringent, which has broken `_observers_are_equal` (e.g. see https://dev.azure.com/sunpy/sunpy/_build/results?buildId=7437&view=logs&jobId=d3468eda-fa0c-5333-fa0e-f689a94bf857&j=7f33e5bd-7764-5d8a-ba2e-506e078b9c3f).

This PR fixes it to make it compatible with astropy 4.1. According to the astropy changelog `==` used to be equivalent to `is`, so that's the change I've made.