### PR TITLE
Fix a doctest to work on multiple versions of Astropy

### DIFF
--- a/docs/guide/units-coordinates.rst
+++ b/docs/guide/units-coordinates.rst
@@ -101,9 +101,10 @@ an error will be raised stating that the units are incorrect or missing::
   astropy.units.core.UnitsError: Argument 'time' to function 'speed' must be in units convertible to 's'.
 
   >>> speed(1*u.m, 10)
+  ...
   Traceback (most recent call last):
   ...
-  TypeError: Argument 'time' to function 'speed' has no 'unit' attribute. You may want to pass in an astropy Quantity instead.
+  TypeError: Argument 'time' to function 'speed' has no 'unit' attribute. ... pass in an astropy Quantity instead.
 
 Note that the units of the inputs do not have to be exactly the same as those in the function definition, as long
 as they can be converted to those units. So for instance, passing in a time in minutes still works even though we


### PR DESCRIPTION
Because of astropy/astropy#10232, the traceback and error message has slightly changed when supplying something that not a `Quantity` when units are required.  This PR enables the doctest to pass both before and after this change.