### PR TITLE
Fix hypothesis warning in horizons test

### DIFF
--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -15,7 +15,7 @@ from sunpy.time import parse_time
 from .strategies import times
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='module')
 def astropy_ephemeris_de432s():
     # Temporarily set Astropy's ephemeris to DE432s
     old_ephemeris = solar_system_ephemeris.get()


### PR DESCRIPTION
Currently the horizons test raises the following warning:
> E       hypothesis.errors.HypothesisDeprecationWarning: sunpy/coordinates/tests/test_ephemeris.py::test_consistency_with_horizons uses the 'astropy_ephemeris_de432s' fixture, which is reset between function calls but not between test cases generated by `@given(...)`.  You can change it to a module- or session-scoped fixture if it is safe to reuse; if not we recommend using a context manager inside your test function.  See https://docs.pytest.org/en/latest/fixture.html#sharing-test-data for details on fixture scope.

I think changing this to module scoped should be fine and the right fix, but thought I'd pull it out of the general warnings PR to get someone else to check.