### PR TITLE
Document variables (e.g. Map, Fido, TimeSeries...)

### DIFF
--- a/changelog/4098.docfix.rst
+++ b/changelog/4098.docfix.rst
@@ -1,0 +1,2 @@
+Added `sunpy.data.manager`, `sunpy.data.cache`, `sunpy.net.Fido`, `sunpy.map.Map`,
+and `sunpy.timeseries.TimeSeries` to the docs.

--- a/docs/code_ref/data.rst
+++ b/docs/code_ref/data.rst
@@ -5,6 +5,7 @@ The SunPy data module contains ways to access sample data and small test files
 for running the SunPy test suite.
 
 .. automodapi:: sunpy.data
+   :include-all-objects:
 
 .. automodapi:: sunpy.data.sample
 

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -81,7 +81,7 @@ which convert the specific metadata and other differences in each instruments
 data to the standard `~sunpy.map.GenericMap` interface.
 These 'sources' also define things like the colormap and default
 normalisation for each instrument.
-These subclasses also provide a method, which describes to the `Map <sunpy.map.map_factory.MapFactory>` factory
+These subclasses also provide a method, which describes to the `~sunpy.map.Map` factory
 which data and metadata pairs match its instrument.
 
 .. automodapi:: sunpy.map.sources
@@ -94,7 +94,7 @@ Writing a new Instrument Map Class
 
 Any subclass of `~sunpy.map.GenericMap` which defines a method named
 `~sunpy.map.GenericMap.is_datasource_for` will automatically be registered with
-the `Map <sunpy.map.map_factory.MapFactory>` factory. The ``is_datasource_for`` method describes the form of the
+the `~sunpy.map.Map` factory. The ``is_datasource_for`` method describes the form of the
 data and metadata for which the `~sunpy.map.GenericMap` subclass is valid. For
 example it might check the value of the ``INSTRUMENT`` key in the metadata
 dictionary.
@@ -122,7 +122,7 @@ demonstrated by the following example.
             return str(header.get('instrume', '')).startswith('FUTURESCOPE')
 
 
-This class will now be available through the `Map <sunpy.map.map_factory.MapFactory>` factory as long as this
+This class will now be available through the `~sunpy.map.Map` factory as long as this
 class has been defined, i.e. imported into the current session.
 
 If you do not want to create a method named ``is_datasource_for`` you can

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -70,6 +70,7 @@ All SunPy Maps are derived from `sunpy.map.GenericMap`, all the methods and attr
     :no-main-docstr:
     :no-heading:
     :inherited-members:
+    :include-all-objects:
 
 .. _map-sources:
 

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -19,7 +19,7 @@ spatially-aware data array, often an image. In order to make it easy to work
 with image data in SunPy, the Map object provides a number of methods for
 commonly performed operations.
 
-2D map objects are subclasses of `~sunpy.map.MapBase` and all Map objects are
+2D map objects are subclasses of `~sunpy.map.GenericMap` and these objects are
 created using the Map factory `~sunpy.map.Map`.
 
 A number of instrument are supported by subclassing this base object. See

--- a/docs/code_ref/net.rst
+++ b/docs/code_ref/net.rst
@@ -4,10 +4,10 @@ SunPy net
 
 SunPy's net submodule contains a lot of different code for accessing various
 solar physics related web services. This submodule contains many layers. Most
-users should use `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`, which
+users should use `~sunpy.net.Fido`, which
 is an interface to multiple sources including all the sources implemented in
 `~sunpy.net.dataretriever` as well as `~sunpy.net.vso` and `~sunpy.net.jsoc`.
-`Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` can be used like so::
+`~sunpy.net.Fido` can be used like so::
 
     >>> from sunpy.net import Fido, attrs as a
     >>> results = Fido.search(a.Time("2012/1/1", "2012/1/2"), a.Instrument('lyra'))  # doctest: +REMOTE_DATA
@@ -73,7 +73,7 @@ Internal Classes and Functions
 ------------------------------
 
 These classes and functions are designed to be used to help develop new clients
-for `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`.
+for `sunpy.net.Fido`.
 
 .. automodapi:: sunpy.net.base_client
 

--- a/docs/code_ref/net.rst
+++ b/docs/code_ref/net.rst
@@ -1,3 +1,4 @@
+=========
 SunPy net
 =========
 
@@ -14,6 +15,7 @@ is an interface to multiple sources including all the sources implemented in
 
 .. automodapi:: sunpy.net
    :no-heading:
+   :include-all-objects:
 
 .. automodapi:: sunpy.net.attrs
 
@@ -24,10 +26,8 @@ VSO
 ---
 
 .. automodapi:: sunpy.net.vso
-   :headings: ^#
 
 .. automodapi:: sunpy.net.vso.attrs
-   :headings: #~
 
 
 Dataretriever
@@ -35,48 +35,38 @@ Dataretriever
 
 .. automodapi:: sunpy.net.dataretriever
    :allowed-package-names: sources
-   :headings: ^#
 
 .. automodapi:: sunpy.net.dataretriever.sources
-   :headings: #~
 
 .. automodapi:: sunpy.net.dataretriever.attrs.goes
-   :headings: #~
 
 JSOC
 ----
 
 .. automodapi:: sunpy.net.jsoc
-    :headings: ^#
 
 .. automodapi:: sunpy.net.jsoc.attrs
-    :headings: #~
 
 
 HEK
 ---
 
 .. automodapi:: sunpy.net.hek
-    :headings: ^#
 
 .. automodapi:: sunpy.net.hek2vso
-    :headings: ^#
 
 
 HELIO
 -----
 
 .. automodapi:: sunpy.net.helio
-    :headings: ^#
 
 .. automodapi:: sunpy.net.helio.hec
-    :headings: #~
 
 Helioviewer
 -----------
 
 .. automodapi:: sunpy.net.helioviewer
-    :headings: ^#
 
 
 Internal Classes and Functions
@@ -86,7 +76,5 @@ These classes and functions are designed to be used to help develop new clients
 for `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`.
 
 .. automodapi:: sunpy.net.base_client
-   :headings: ^#
 
 .. automodapi:: sunpy.net.attr
-   :headings: ^#

--- a/docs/code_ref/timeseries.rst
+++ b/docs/code_ref/timeseries.rst
@@ -37,5 +37,6 @@ instance. The following instrument classes are supported.
 
 .. automodapi:: sunpy.timeseries
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: sunpy.timeseries.sources

--- a/docs/dev_guide/documentation.rst
+++ b/docs/dev_guide/documentation.rst
@@ -34,28 +34,6 @@ SunPy-Specific Rules
 --------------------
 
 * For **all** RST files, we enforce a one sentence per line rule and ignore the line length.
-
-* Core datatypes are referenced as follows:
-
-.. code-block:: python
-
-    """
-    Parameters
-    ----------
-    smap : `~sunpy.map.GenericMap`
-        A SunPy map.
-    """
-
-* The Factory classes (``Map``, ``Timeseries``, ``Fido``) are referenced as follows:
-
-.. code-block:: python
-
-    """
-    `Map <sunpy.map.map_factory.MapFactory>`
-    `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`
-    `TimeSeries <sunpy.timeseries.timeseries_factory.TimeSeriesFactory>`
-    """
-
 * Standards on docstring length and style are enforced using `docformatter <https://pypi.org/project/docformatter/>`__:
 
 .. code-block:: bash

--- a/docs/dev_guide/documentation.rst
+++ b/docs/dev_guide/documentation.rst
@@ -92,6 +92,10 @@ You can open the "index.html" file to browse the final product.
 The gallery examples are located under "docs/_build/html/generated/gallery".
 Sphinx builds documentation iteratively, only adding things that have changed.
 
+If you want to build the documentation without building the gallery, i.e. to reduce build times while working on other sections of the documentation you can run::
+
+    $ tox -e build_docs -- -D plot_gallery=0
+
 If you'd like to start from scratch (i.e., remove the tox cache) then run::
 
     $ tox -e build_docs -- -aE

--- a/docs/dev_guide/new_objects.rst
+++ b/docs/dev_guide/new_objects.rst
@@ -12,9 +12,9 @@ All instrument Map classes are subclasses of the generic `~sunpy.map.GenericMap`
 The instrument subclass implements the instrument-specific code to parse the metadata, apply any necessary procedures on the data array, as well as defining other things such what color tables to use.
 
 In practice, the instrument subclass is not directly accessed by users.
-The `Map <sunpy.map.map_factory.MapFactory>` factory is the primary interface for creating Map objects.
-Any subclass of `~sunpy.map.GenericMap` which defines a method named `~sunpy.map.GenericMap.is_datasource_for` will automatically be registered with the `Map <sunpy.map.map_factory.MapFactory>` factory.
-The ``is_datasource_for`` method is used by the `Map <sunpy.map.map_factory.MapFactory>` factory to check if a file should use a particular instrument Map class.
+The `~sunpy.map.Map` factory is the primary interface for creating Map objects.
+Any subclass of `~sunpy.map.GenericMap` which defines a method named `~sunpy.map.GenericMap.is_datasource_for` will automatically be registered with the `~sunpy.map.Map` factory.
+The ``is_datasource_for`` method is used by the `~sunpy.map.Map` factory to check if a file should use a particular instrument Map class.
 This function can run any test it needs to determine this.
 For example, it might check the value of the ``INSTRUMENT`` key in the metadata dictionary.
 The following example shows how this works and includes a sample doc string that is compatible with the :ref:`Docs Guidelines for Data Sources`.

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -1,3 +1,5 @@
+.. _fido_guide:
+
 ---------------------------------------
 Finding and Downloading Data using Fido
 ---------------------------------------

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -4,7 +4,7 @@ Finding and Downloading Data using Fido
 
 This guide outlines how to search for and download data using SunPy's
 Federated Internet Data Obtainer...or more usually (and sanely) referred to as Fido.
-`Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` is a unified interface for searching
+`~sunpy.net.Fido` is a unified interface for searching
 and fetching solar physics data irrespective of the underlying
 client or webservice through which the data is obtained, e.g. VSO_,
 JSOC_, etc.  It therefore supplies a single, easy and consistent way to
@@ -13,7 +13,7 @@ obtain most forms of solar physics data.
 Import
 ------
 
-The `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` object is in
+The `~sunpy.net.Fido` object is in
 `sunpy.net`. It can be imported as follows::
 
     >>> from sunpy.net import Fido, attrs as a
@@ -54,7 +54,7 @@ variable set to the Fido search, in this case, result::
     <BLANKLINE>
 
 Queries can be made more flexible or specific by adding more attrs objects to
-the `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` search. Specific
+the `~sunpy.net.Fido` search. Specific
 passbands can be searched for by supplying an `~astropy.units.Quantity` to the
 `a.Wavelength <sunpy.net.attrs.Wavelength>` attribute::
 
@@ -79,7 +79,7 @@ search for data at a given cadence use the
 `a.Sample <sunpy.net.attrs.Sample>` is only supported by the
 `sunpy.net.vso.VSOClient` hence it has the ``a.vso`` prefix. Attributes
 like this which are client specific will result in
-`Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` only searching that
+`~sunpy.net.Fido` only searching that
 client for results, in this case VSO.::
 
     >>> Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument('aia'),

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -13,7 +13,7 @@ Creating maps
 To make things easy, SunPy can download several example files which are used
 throughout the docs. These files have names like
 `~sunpy.data.sample.AIA_171_IMAGE` and `~sunpy.data.sample.RHESSI_IMAGE`. To
-create a `Map <sunpy.map.map_factory.MapFactory>` from the the sample AIA image
+create a `~sunpy.map.Map` from the the sample AIA image
 type the following into your Python shell::
 
     >>> import sunpy
@@ -39,17 +39,17 @@ Creating Custom Maps
 --------------------
 It is also possible to create maps using custom data (e.g. from a simulation or an observation
 from a data source that is not explicitly supported in SunPy.) To do this you need to provide
-`sunpy.map.Map <sunpy.map.map_factory.MapFactory>` with both the data array as well as appropriate
-meta information. The meta information is important as it informs the `sunpy.map.Map <sunpy.map.map_factory.MapFactory>`
+`sunpy.map.Map` with both the data array as well as appropriate
+meta information. The meta information is important as it informs the `sunpy.map.Map`
 of the correct coordinate information associated with the data array. The meta information should be provided to
-`sunpy.map.Map <sunpy.map.map_factory.MapFactory>` in the form of a header as a `dict` or `MetaDict <sunpy.util.MetaDict>`.
+`sunpy.map.Map` in the form of a header as a `dict` or `MetaDict <sunpy.util.MetaDict>`.
 
 The keys that are required for the header information follows the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`_. SunPy now provides a map header helper function to assist the user in creating a header that contains the correct meta information
-to generate a `sunpy.map.Map <sunpy.map.map_factory.MapFactory>`.
+to generate a `sunpy.map.Map`.
 
 The helper functionality includes a `meta_keywords <sunpy.map.header_helper.meta_keywords>` function
 that will return a `dict` of all the current meta keywords and their descriptions currently used by
-`sunpy.map.Map <sunpy.map.map_factory.MapFactory>` to make a map::
+`sunpy.map.Map` to make a map::
 
     >>> from sunpy.map import header_helper
 
@@ -633,8 +633,8 @@ See `this example <https://docs.sunpy.org/en/stable/generated/gallery/computer_v
 Composite Maps and Overlaying Maps
 ----------------------------------
 
-The `Map <sunpy.map.map_factory.MapFactory>` method described above can also handle a list of maps. If a series of maps
-are supplied as inputs, `Map <sunpy.map.map_factory.MapFactory>` will return a list of maps as the output.  However,
+The `~sunpy.map.Map` method described above can also handle a list of maps. If a series of maps
+are supplied as inputs, `~sunpy.map.Map` will return a list of maps as the output.  However,
 if the 'composite' keyword is set to True, then a `~sunpy.map.CompositeMap` object is
 returned.  This is useful if the maps are of a different type (e.g. different
 instruments).  For example, to create a simple composite map::

--- a/docs/guide/tour.rst
+++ b/docs/guide/tour.rst
@@ -23,10 +23,10 @@ There are maps for a 2D image, a time series of 2D images or temporally aligned
 SunPy supports many different data products from various sources 'out of the
 box'. We shall use SDO's AIA instrument as an example in this tutorial. The
 general way to create a Map from one of the supported data products is with the
-`Map <sunpy.map.map_factory.MapFactory>` function from the `sunpy.map` submodule.
+`~sunpy.map.Map` function from the `sunpy.map` submodule.
 `Map <sunpy.map.map_factory.MapFactory` takes either a filename, a list of
 filenames or a data array and header. We can test
-`Map <sunpy.map.map_factory.MapFactory>` with:
+`~sunpy.map.Map` with:
 
 
 .. plot::
@@ -104,7 +104,7 @@ labels.
 There is lot going on here, but we will walk you through the example. Briefly,
 the first line is importing SunPy, and the second importing the sample data
 files. On the third line we create a SunPy Map object which is a spatially-aware
-image. On the last line we then plot the `Map <sunpy.map.map_factory.MapFactory>` object, using the built in 'quick plot'
+image. On the last line we then plot the `~sunpy.map.Map` object, using the built in 'quick plot'
 function `~sunpy.map.GenericMap.peek`.
 
 SunPy uses a matplotlib-like interface to it's plotting so more complex
@@ -291,7 +291,7 @@ Obtaining Data
 SunPy supports searching for and fetching data from a variety of sources,
 including the `VSO <https://virtualsolar.org/>`__ and the
 `JSOC <http://jsoc.stanford.edu/>`__. The majority of SunPy's clients can be
-queried using the `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` interface. An example of searching the VSO using this
+queried using the `sunpy.net.Fido` interface. An example of searching the VSO using this
 is below::
 
   >>> from sunpy.net import Fido, attrs as a

--- a/examples/acquiring_data/downloading_hmi.py
+++ b/examples/acquiring_data/downloading_hmi.py
@@ -12,7 +12,7 @@ from sunpy.net import Fido, attrs as a
 
 ###############################################################################
 # To download the required data, we use
-# `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`, a downloader client,
+# `sunpy.net.Fido`, a downloader client,
 # to query the Joint Science Operations Center, or JSOC, where HMI data are stored.
 # First define the search variables, a timerange,
 # a `data series <http://jsoc.stanford.edu/JsocSeries_DataProducts_map.html>`_,

--- a/examples/acquiring_data/downloading_lascoC3.py
+++ b/examples/acquiring_data/downloading_lascoC3.py
@@ -14,7 +14,7 @@ from sunpy.io.file_tools import read_file
 
 ###############################################################################
 # In order to download the required data, we use
-# `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`, a downloader client.
+# `sunpy.net.Fido`, a downloader client.
 # We define two search variables:
 # a timerange and the instrument.
 timerange = a.Time('2002/05/24 11:06', '2002/05/24 11:07')

--- a/examples/acquiring_data/searching_vso.py
+++ b/examples/acquiring_data/searching_vso.py
@@ -10,7 +10,7 @@ import astropy.units as u
 from sunpy.net import Fido, attrs as a
 
 ###############################################################################
-# `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` is the primary
+# `sunpy.net.Fido` is the primary
 # interface to search for and download data and
 # will search the VSO when appropriate. The following example searches for all
 # SOHO/EIT images between the times defined below by defining

--- a/examples/map/README.txt
+++ b/examples/map/README.txt
@@ -2,4 +2,4 @@ Map
 ===
 
 This section contains any examples which showcase how SunPy's
-`Map <sunpy.map.map_factory.MapFactory>` can be used with solar data.
+`~sunpy.map.Map` can be used with solar data.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -42,11 +42,42 @@ __all__ = ['Map', 'MapFactory']
 
 class MapFactory(BasicRegistrationFactory):
     """
-    Map(\\*args, \\*\\*kwargs)
+    A factory for generating coordinate aware 2D images.
 
-    Map factory class.  Used to create a variety of Map objects.  Valid map types
-    are specified by registering them with the factory.
+    This factory takes a variety of inputs, such as file paths, wildcard
+    patterns or (data, header) pairs.
 
+    Depending on the input different return types are possible.
+
+    Parameters
+    ----------
+    \*inputs
+        Inputs to parse for map objects. See the examples section for a
+        detailed list of accepted inputs.
+
+    sequence : `bool`, optional
+        Return a `sunpy.map.MapSequence` object comprised of all the parsed maps.
+
+    composite : `bool`, optional
+        Return a `sunpy.map.CompositeMap` object comprised of all the parsed maps.
+
+    Returns
+    -------
+    `sunpy.map.GenericMap`
+        If the input results in a singular map object, then that is returned.
+
+    `list` of `~sunpy.map.GenericMap`
+        If multiple inputs are given and ``sequence=False`` and ``composite=False``
+        (the default) then a list of `~sunpy.map.GenericMap` objects will be
+        returned.
+
+    `sunpy.map.MapSequence`
+        If the input corresponds to multiple maps and ``sequence=True`` is set,
+        then a `~sunpy.map.MapSequence` object is returned.
+
+    `sunpy.map.CompositeMap`
+        If the input corresponds to multiple maps and ``composite=True`` is set,
+        then a `~sunpy.map.CompositeMap` object is returned.
 
     Examples
     --------

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -2,7 +2,7 @@
 
 """
 'attrs' are parameters which can be composed together to specify searches to
-`Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>`. They can be combined
+`sunpy.net.Fido`. They can be combined
 by using logical and (``&``) and logical or (``|``) operations to construct
 very complex queries.
 

--- a/sunpy/net/dataretriever/__init__.py
+++ b/sunpy/net/dataretriever/__init__.py
@@ -4,7 +4,7 @@ from "simple" web sources such as HTTP or FTP servers. Although it could be
 used for more complex services as well. Following the example of `sunpy.map`
 and `sunpy.timeseries` this module provides a base class
 `~sunpy.net.dataretriever.GenericClient` from which specific services can
-subclass. All these subclasses are then registered with the `Fido <sunpy.net.fido_factory.UnifiedDownloaderFactory>` factory
+subclass. All these subclasses are then registered with the `sunpy.net.Fido` factory
 class, so do not need to be called individually.
 """
 

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -215,9 +215,14 @@ def _create_or(walker, query, factory):
 
 class UnifiedDownloaderFactory(BasicRegistrationFactory):
     """
-    sunpy.net.Fido(\\*args, \\*\\*kwargs)
+    Fido is a unified data search and retrieval tool.
 
-    Search and Download data from a variety of supported sources.
+    It provides simultaneous access to a variety of online data sources, some
+    cover multiple instruments and data products like the Virtual Solar
+    Observatory and some are specific to a single source.
+
+    For details of using `~sunpy.net.Fido` see :ref:`fido_guide`.
+
     """
 
     def search(self, *query):

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -35,18 +35,35 @@ __all__ = ['TimeSeries', 'TimeSeriesFactory', 'NoTimeSeriesFound',
 
 class TimeSeriesFactory(BasicRegistrationFactory):
     """
-    TimeSeries factory class, used to create a variety of `~sunpy.timeseries.TimeSeries` objects.
-    Valid timeseries types are specified by registering them with the factory.
+    A factory for generating solar timeseries objects.
+
+    This factory takes a variety of inputs to generate
+    `~sunpy.timeseries.GenericTimeSeries` objects.
 
     Parameters
     ----------
+    \*inputs
+        Inputs to parse for timeseries objects. See the example section for a
+        detailed list of possible inputs.
+
     source : `str`, optional
         A string to select the observational source of the data, currently
         necessary to define how files should be read for all instruments.
+
     concatenate : `bool`, optional
         Defaults to `False`.
         If set, combine any resulting list of TimeSeries objects into a single
         TimeSeries, using successive concatenate methods.
+
+    Returns
+    -------
+    `sunpy.timeseries.GenericTimeSeries`
+        If the input results in a single timeseries object that will be returned, or if ``concatenate=True``.
+
+    `list` of `~sunpy.timeseries.GenericTimeseries`
+        If multiple inputs are parsed, they will be returned in a list, unless
+        ``concatenate=True`` is set when they will be combined into a single
+        timeseries.
 
     Examples
     --------

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -35,8 +35,6 @@ __all__ = ['TimeSeries', 'TimeSeriesFactory', 'NoTimeSeriesFound',
 
 class TimeSeriesFactory(BasicRegistrationFactory):
     """
-    TimeSeries(*args, **kwargs)
-
     TimeSeries factory class, used to create a variety of `~sunpy.timeseries.TimeSeries` objects.
     Valid timeseries types are specified by registering them with the factory.
 


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/3865. Because `sunpy.data.{manager,cache}` are variables, they need an extra option to make `automodapi` document them.