### PR TITLE
Adds the possibility to input a regular expression to the scrapper call

### DIFF
--- a/changelog/4107.feature.rst
+++ b/changelog/4107.feature.rst
@@ -1,0 +1,1 @@
+Adds to `~sunpy.net.scraper.Scraper` the ability to include regular expressions in the URL passed.

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -4,11 +4,11 @@ This module provides a web scraper.
 import os
 import re
 import datetime
+import warnings
 from ftplib import FTP
 from urllib.error import HTTPError
 from urllib.parse import urlsplit
 from urllib.request import urlopen
-import warnings
 
 from bs4 import BeautifulSoup
 

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -15,6 +15,8 @@ from bs4 import BeautifulSoup
 import astropy.units as u
 from astropy.time import Time, TimeDelta
 
+from sunpy.util.exceptions import SunpyUserWarning
+
 __all__ = ['Scraper']
 
 # regular expressions to convert datetime format
@@ -72,7 +74,8 @@ class Scraper:
         if regex:
             self.pattern = pattern
             if kwargs:
-                warnings.warn('regexp being used, the extra arguments passed are being ignored')
+                warnings.warn('regexp being used, the extra arguments passed are being ignored',
+                              SunpyUserWarning)
         else:
             self.pattern = pattern.format(**kwargs)
         self.domain = "{0.scheme}://{0.netloc}/".format(urlsplit(self.pattern))

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -8,6 +8,7 @@ from ftplib import FTP
 from urllib.error import HTTPError
 from urllib.parse import urlsplit
 from urllib.request import urlopen
+import warnings
 
 from bs4 import BeautifulSoup
 
@@ -36,6 +37,12 @@ class Scraper:
         A string containing the url with the date encoded as datetime formats,
         and any other parameter as ``kwargs`` as a string format.
 
+    regex : `bool`
+        Set to `True` if parts of the pattern uses regexp symbols. Be careful that
+        periods `.` matches any character and therefore it's better to escape them.
+        If `regexp` is used, other ``kwargs`` are ignored and string replacement is
+        not possible. Default is `False`.
+
     Attributes
     ----------
     pattern : `str`
@@ -61,9 +68,13 @@ class Scraper:
     The ``now`` attribute does not return an existent file, but just how the
     pattern looks with the actual time.
     """
-
-    def __init__(self, pattern, **kwargs):
-        self.pattern = pattern.format(**kwargs)
+    def __init__(self, pattern, regex=False, **kwargs):
+        if regex:
+            self.pattern = pattern
+            if kwargs:
+                warnings.warn('regexp being used, the extra arguments passed are being ignored')
+        else:
+            self.pattern = pattern.format(**kwargs)
         self.domain = "{0.scheme}://{0.netloc}/".format(urlsplit(self.pattern))
         milliseconds = re.search(r'\%e', self.pattern)
         if not milliseconds:

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -230,9 +230,12 @@ def test_filelist_relative_hrefs():
     # this checks that `scraper.filelist` returns fileurls relative to the domain
     fileurls = s.filelist(timerange)
     assert fileurls[1] == s.domain + 'pub/archive/2016/05/18/bbso_halph_fr_20160518_160033.fts'
-@pytest.mark.parametrize('pattern, check_file', [(r'MyFile_%Y_%M_%e\.(\D){2}\.fits', 'MyFile_2020_55_234.aa.fits'),
-                                                 (r'(\d){5}_(\d){2}\.fts', '01122_25.fts'),
-                                                 ('_%Y%m%d__%ec(\d){5}_(\d){2}\s.fts', '_20201535__012c12345_33 .fts')])
+
+
+@pytest.mark.parametrize('pattern, check_file', [
+    (r'MyFile_%Y_%M_%e\.(\D){2}\.fits', 'MyFile_2020_55_234.aa.fits'),
+    (r'(\d){5}_(\d){2}\.fts', '01122_25.fts'),
+    (r'_%Y%m%d__%ec(\d){5}_(\d){2}\s.fts', '_20201535__012c12345_33 .fts')])
 def test_regex(pattern, check_file):
     s = Scraper(pattern, regex=True)
     assert s._URL_followsPattern(check_file)
@@ -243,6 +246,6 @@ def test_regex_data():
     prefix = r'https://gong2.nso.edu/oQR/zqs/'
     pattern = prefix + r'%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
     s = Scraper(pattern, regex=True)
-    timerange = TimeRange('2020-01-05','2020-01-06T16:00:00')
+    timerange = TimeRange('2020-01-05', '2020-01-06T16:00:00')
     assert s._URL_followsPattern(prefix + '202001/mrzqs200106/mrzqs200106t1514c2226_297.fits.gz')
     assert len(s.filelist(timerange)) == 37

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -230,3 +230,19 @@ def test_filelist_relative_hrefs():
     # this checks that `scraper.filelist` returns fileurls relative to the domain
     fileurls = s.filelist(timerange)
     assert fileurls[1] == s.domain + 'pub/archive/2016/05/18/bbso_halph_fr_20160518_160033.fts'
+@pytest.mark.parametrize('pattern, check_file', [(r'MyFile_%Y_%M_%e\.(\D){2}\.fits', 'MyFile_2020_55_234.aa.fits'),
+                                                 (r'(\d){5}_(\d){2}\.fts', '01122_25.fts'),
+                                                 ('_%Y%m%d__%ec(\d){5}_(\d){2}\s.fts', '_20201535__012c12345_33 .fts')])
+def test_regex(pattern, check_file):
+    s = Scraper(pattern, regex=True)
+    assert s._URL_followsPattern(check_file)
+
+
+@pytest.mark.remote_data
+def test_regex_data():
+    prefix = r'https://gong2.nso.edu/oQR/zqs/'
+    pattern = prefix + r'%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
+    s = Scraper(pattern, regex=True)
+    timerange = TimeRange('2020-01-05','2020-01-06T16:00:00')
+    assert s._URL_followsPattern(prefix + '202001/mrzqs200106/mrzqs200106t1514c2226_297.fits.gz')
+    assert len(s.filelist(timerange)) == 37


### PR DESCRIPTION
### Description
If the URL that you want to scrap has some characters that change but not follow to any particular datetime pattern, then now you can use regex on the url:

Inspired by the imagination of gong synoptic maps archive (#4055)

```python
from sunpy.util.scraper import Scraper 
from sunpy.time import TimeRange 
pattern = r'https://gong2.nso.edu/oQR/zqs/%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
scraper = Scraper(pattern, regex=True)
timerange = TimeRange('2020-01-05','2020-01-06T16:00:00')
scraper.filelist(timerange)
```