### PR TITLE
Fixed error in logger message for get_body_heliographic_stonyhurst()

### DIFF
--- a/changelog/4112.bugfix.rst
+++ b/changelog/4112.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in :func:`~sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst` that resulted in a error when requesting an array of locations in conjuction with enabling the light-travel-time correction.

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -72,8 +72,11 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None):
             light_travel_time = distance / speed_of_light
             emitted_time = obstime - light_travel_time
 
-        log.info(f"Apparent body location accounts for {light_travel_time.to('s').value:.2f}"
-                 " seconds of light travel time")
+        if light_travel_time.isscalar:
+            ltt_string = f"{light_travel_time.to_value('s'):.2f}"
+        else:
+            ltt_string = f"{light_travel_time.to_value('s')}"
+        log.info(f"Apparent body location accounts for {ltt_string} seconds of light travel time")
 
     body_hgs = ICRS(body_icrs).transform_to(HeliographicStonyhurst(obstime=obstime))
 

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -38,7 +38,7 @@ def test_get_body_heliographic_stonyhurst():
 
 
 def test_get_body_heliographic_stonyhurst_light_travel_time():
-    # Tests whether the apparent position of the Sun accoutns for light travel time
+    # Tests whether the apparent position of the Sun accounts for light travel time
     t = Time('2012-06-05 22:34:48.350')  # An arbitrary test time
 
     # Use the implemented correction for light travel time
@@ -52,6 +52,23 @@ def test_get_body_heliographic_stonyhurst_light_travel_time():
 
     difference = (implementation_icrs - manual_icrs).norm()
     assert_quantity_allclose(difference, 0*u.m, atol=1*u.m)
+
+
+def test_get_body_heliographic_stonyhurst_light_travel_time_array():
+    # Tests whether requesting an array of locations returns the same answers as individually
+    t1 = Time('2001-02-03 04:05:06')
+    t2 = Time('2011-12-13 14:15:16')
+
+    venus1 = get_body_heliographic_stonyhurst('venus', t1, observer=get_earth(t1))
+    venus2 = get_body_heliographic_stonyhurst('venus', t2, observer=get_earth(t2))
+    both = get_body_heliographic_stonyhurst('venus', [t1, t2], observer=get_earth([t1, t2]))
+
+    assert_quantity_allclose(venus1.lon, both[0].lon)
+    assert_quantity_allclose(venus1.lat, both[0].lat)
+    assert_quantity_allclose(venus1.radius, both[0].radius)
+    assert_quantity_allclose(venus2.lon, both[1].lon)
+    assert_quantity_allclose(venus2.lat, both[1].lat)
+    assert_quantity_allclose(venus2.radius, both[1].radius)
 
 
 def test_get_earth():


### PR DESCRIPTION
`get_body_heliographic_stonyhurst()` would error out for the silliest reason when requesting light-travel-time correction for an array of times: the formatting in the logger message.  This PR preserves the behavior for scalars, and prints out a message without formatting for arrays.