### PR TITLE
Use astropy to create `sunpy.sun.constants` docstring RST table

### DIFF
--- a/sunpy/sun/constants.py
+++ b/sunpy/sun/constants.py
@@ -1,6 +1,8 @@
 """
 This module provides fundamental solar physical constants.
 """
+import io
+
 from astropy.table import Table
 from astropy.time import Time
 
@@ -91,19 +93,27 @@ def print_all():
     return t
 
 
-# Add a list of constants to the docs
-_lines = [
-    'The following constants are available:\n',
-    '======================================================= ============== ================ =======================================================',  # NOQA
-    '                          Name                              Value            Unit                                 Description                  ',  # NOQA
-    '======================================================= ============== ================ =======================================================',  # NOQA
-]
-for key, const in constants.items():
-    _lines.append('{:^55} {:^14.9g} {:^16} {:^55}'.format(
-        key, const.value, const._unit_string, const.name))
-_lines.append(_lines[1])
+def _build_docstring():
+    """Build docstring containing RST-formatted table of constants."""
+    lines = ['The following constants are available:\n']
+
+    rows = []
+    for key, const in constants.items():
+        rows.append([key, const.value, const._unit_string, const.name])
+
+    table = Table(rows=rows, names=('Name', 'Value', 'Unit', 'Description'))
+    table['Value'].info.format = '14.9g'
+
+    f = io.StringIO()
+    table.write(f, format='ascii.rst')
+    lines.append(f.getvalue())
+
+    return '\n'.join(lines)
+
+
+# Add a table of constants to the docs
 if __doc__ is not None:
-    __doc__ += '\n'.join(_lines)
+    __doc__ += _build_docstring()
 
 # Spectral class is not included in physical constants since it is not a number
 spectral_classification = 'G2V'

--- a/sunpy/sun/tests/test_constants.py
+++ b/sunpy/sun/tests/test_constants.py
@@ -55,3 +55,25 @@ def test_find_function3(test_input):
     Test that the find function fails as expected.
     """
     assert len(con.find(test_input)) == 0
+
+
+def test_docstring():
+    """
+    Test that the docstring RST table has the correct number of constants.
+    """
+    lines = con.__doc__.split('\n')
+    description = 'The following constants are available:'
+    assert description in lines
+
+    # After the description line, there are five lines before the actual table
+    # data begins (including a newline, RST headers, and column names). Count
+    # the number of rows in the table until the RST column footer is reached.
+    data_start_idx = lines.index(description) + 5
+    data_end_idx = data_start_idx
+    for idx, line in enumerate(lines[data_start_idx:], data_start_idx):
+        if line.startswith('='):
+            data_end_idx = idx
+            break
+
+    num_rows = data_end_idx - data_start_idx
+    assert num_rows == 34


### PR DESCRIPTION
<!--
We know that working on sunpy and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them: https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
The RST table in `sunpy.sun.constants` docstring is now built with an astropy `Table` object and the `ascii.rst` writer. The previous implementation manually built an RST table and could break if names changed to become longer than the fixed column widths.

Note: the new implementation uses right-aligned columns, while the previous implementation used centered columns.

Fixes #4041.

Previous docstring:

<img width="1031" alt="Screen Shot 2020-05-07 at 9 06 17 AM" src="https://user-images.githubusercontent.com/1847232/81331273-304a8a00-9056-11ea-9fd2-dd9eb876e806.png">

New docstring:

<img width="853" alt="Screen Shot 2020-05-07 at 10 54 24 AM" src="https://user-images.githubusercontent.com/1847232/81331307-3e000f80-9056-11ea-8436-cc7fa7e849f1.png">

### Questions

1. Is a changelog entry necessary for this PR?
2. Would you like me to add unit test(s) for this functionality? I checked that the docs build and render successfully.