### PR TITLE
Improve fits header helper doc

### DIFF
--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -52,7 +52,7 @@ def make_fitswcs_header(data, coordinate,
     data : `~numpy.ndarray` or `tuple`
         Array data of Map for which a header is required, or the shape of the
         data array (in numpy order, i.e. ``(y_size, x_size)``).
-    coordinates : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseFrame`
+    coordinate : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseFrame`
         The coordinate of the reference pixel.
     reference_pixel :`~astropy.units.Quantity` of size 2, optional
         Reference pixel along each axis. These are expected to be Cartestian ordered, i.e

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -53,7 +53,7 @@ def make_fitswcs_header(data, coordinate,
         Array data of Map for which a header is required, or the shape of the
         data array (in numpy order, i.e. ``(y_size, x_size)``).
     coordinates : `~astropy.coordinates.SkyCoord` or `~astropy.coordinates.BaseFrame`
-        Coordinate object to get meta information for map header.
+        The coordinate of the reference pixel.
     reference_pixel :`~astropy.units.Quantity` of size 2, optional
         Reference pixel along each axis. These are expected to be Cartestian ordered, i.e
         the first index is the x axis, second index is the y axis. Defaults to


### PR DESCRIPTION
It wasn't obvious to me that `coordinates` was the coord of the reference pixel. Hopefully this is clearer.