### PR TITLE
Fix submap for scaled u.pix units

### DIFF
--- a/changelog/4127.bugfix.rst
+++ b/changelog/4127.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed `sunpy.map.GenericMap.submap()` when scaled pixel units (e.g. ``u.mpix``)
+are used.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1473,17 +1473,17 @@ class GenericMap(NDData):
 
             # Round the pixel values, we use floor+1 so that we always have at
             # least one pixel width of data.
-            x_pixels = u.Quantity([np.min(pixel_corners.x), np.max(pixel_corners.x)]).value
+            x_pixels = u.Quantity([np.min(pixel_corners.x), np.max(pixel_corners.x)]).to_value(u.pix)
             x_pixels[0] = np.ceil(x_pixels[0])
             x_pixels[1] = np.floor(x_pixels[1] + 1)
-            y_pixels = u.Quantity([np.min(pixel_corners.y), np.max(pixel_corners.y)]).value
+            y_pixels = u.Quantity([np.min(pixel_corners.y), np.max(pixel_corners.y)]).to_value(u.pix)
             y_pixels[0] = np.ceil(y_pixels[0])
             y_pixels[1] = np.floor(y_pixels[1] + 1)
 
         elif (isinstance(bottom_left, u.Quantity) and bottom_left.unit.is_equivalent(u.pix) and
               isinstance(top_right, u.Quantity) and top_right.unit.is_equivalent(u.pix)):
-            x_pixels = u.Quantity([bottom_left[0], top_right[0]]).value
-            y_pixels = u.Quantity([top_right[1], bottom_left[1]]).value
+            x_pixels = u.Quantity([bottom_left[0], top_right[0]]).to_value(u.pix)
+            y_pixels = u.Quantity([top_right[1], bottom_left[1]]).to_value(u.pix)
 
         else:
             raise ValueError("Invalid input, bottom_left and top_right must either be SkyCoord or Quantity in pixels.")
@@ -1510,8 +1510,8 @@ class GenericMap(NDData):
 
         # Make a copy of the header with updated centering information
         new_meta = self.meta.copy()
-        new_meta['crpix1'] = self.reference_pixel.x.value - x_pixels[0]
-        new_meta['crpix2'] = self.reference_pixel.y.value - y_pixels[0]
+        new_meta['crpix1'] = self.reference_pixel.x.to_value(u.pix) - x_pixels[0]
+        new_meta['crpix2'] = self.reference_pixel.y.to_value(u.pix) - y_pixels[0]
         new_meta['naxis1'] = new_data.shape[1]
         new_meta['naxis2'] = new_data.shape[0]
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -416,13 +416,15 @@ def test_shift_history(generic_map):
     assert resultant_shift[1] == y_shift1 + y_shift2
 
 
-def test_submap(generic_map):
+# Check that submap works with units convertable to pix but that aren't pix
+@pytest.mark.parametrize('unit', [u.pix, u.mpix * 1e3])
+def test_submap(generic_map, unit):
     """Check data and header information for a submap"""
     width = generic_map.data.shape[1]
     height = generic_map.data.shape[0]
 
     # Create a submap of the top-right quadrant of the image
-    submap = generic_map.submap([width / 2., height / 2.] * u.pix, [width, height] * u.pix)
+    submap = generic_map.submap([width / 2., height / 2.] * unit, [width, height] * unit)
 
     # Check to see if submap properties were updated properly
     assert submap.reference_pixel.x.value == generic_map.meta['crpix1'] - width / 2.


### PR DESCRIPTION
Currently in `submap()` there are a couple of locations that use `.value` instead of `.to_value()`. This is quite dangerous, because you have no idea what the units are! This means if you passed in `u.mpix` (milli-pixels) to `submap()` it would go badly wrong.