### PR TITLE
Maintain coherence between keys and keycomments in MetaDict

### DIFF
--- a/changelog/4129.feature.rst
+++ b/changelog/4129.feature.rst
@@ -1,0 +1,1 @@
+`~sunpy.util.metadata.MetaDict` now maintains coherence between its keys and their corresponding keycomments. Calling ``del`` on a ``MetaDict`` object key is now case-insensitive.

--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -76,6 +76,11 @@ def sea_locations():
 
 
 @pytest.fixture
+def seas_metadict(sea_locations):
+    return MetaDict(sea_locations)
+
+
+@pytest.fixture
 def atomic_weights():
     return [['hydrogen', 1],
             ['chromium', 24],
@@ -84,8 +89,55 @@ def atomic_weights():
 
 
 @pytest.fixture
-def seas_metadict(sea_locations):
-    return MetaDict(sea_locations)
+def atomic_weights_keycomments():
+    """
+    Atomic weights with keycomments (including extraneous keycomments).
+    """
+    return [['hydrogen', 1],
+            ['chromium', 24],
+            ['mercury', 80],
+            ['iridium', 77],
+            ['keycomments', {
+                'chromium': 'Cr',
+                'extra key 1': 'foo',
+                'MERCURY': 'Hg',
+                'extra key 2': 'bar'
+             }]]
+
+
+@pytest.fixture
+def atomic_weights_pruned_keycomments():
+    """
+    Expected result of atomic weights with extraneous keycomments removed.
+    """
+    return [['hydrogen', 1],
+            ['chromium', 24],
+            ['mercury', 80],
+            ['iridium', 77],
+            ['keycomments', {
+                'chromium': 'Cr',
+                'MERCURY': 'Hg'
+             }]]
+
+
+@pytest.fixture
+def atomic_weights_keycomments_after_removal():
+    """
+    Expected result after removing some atomic weights and their keycomments.
+    """
+    return [['chromium', 24],
+            ['iridium', 77],
+            ['keycomments', {
+                'chromium': 'Cr'
+             }]]
+
+
+@pytest.fixture
+def empty_keycomments():
+    """
+    Expected result after removing all keys.
+    """
+    return [['keycomments', {}]]
 
 
 # Test constructors `MetaDict.__init__(...)`
@@ -139,12 +191,34 @@ def test_init_with_metadict(atomic_weights):
     assert id(original) != id(new)
 
 
+def test_init_with_keycomments(atomic_weights_keycomments, atomic_weights_pruned_keycomments):
+    """
+    Initialise `MetaDict` with keycomments. Ensure caller's keycomments dict is not mutated.
+    """
+    orig_dict = pairs_to_dict(atomic_weights_keycomments)
+    orig_keycomments = orig_dict['keycomments'].copy()
+
+    md = MetaDict(orig_dict)
+    check_contents_and_insertion_order(md, atomic_weights_pruned_keycomments)
+
+    assert md['keycomments'] is not orig_dict['keycomments']
+    assert orig_dict['keycomments'] == orig_keycomments
+
+
 def test_init_with_illegal_arg():
     """
     Ensure attempt to initialise with a nonsensical data structure is rejected.
     """
     with pytest.raises(TypeError):
         MetaDict({'a', 'b', 'c', 'd'})
+
+
+def test_init_with_invalid_keycomments_type():
+    """
+    Ensure attempt to initialise with an invalid keycomments type is rejected.
+    """
+    with pytest.raises(TypeError):
+        MetaDict({'a': 1, 'b': 2, 'keycomments': 3})
 
 
 # Test individual methods
@@ -191,6 +265,50 @@ def test_setitem_new_entry(seas_metadict):
     assert len(seas_metadict) == len_before + 1
 
     assert seas_metadict['Irish'] == 'N.Europe'
+
+
+def test_delitem(seas_metadict):
+    """
+    Test `MetaDict.__delitem__(...)`.
+    """
+    len_before = len(seas_metadict)
+    del seas_metadict['NoRwEgIaN']
+    del seas_metadict['baltic']
+    assert len(seas_metadict) == len_before - 2
+
+    with pytest.raises(KeyError):
+        seas_metadict['baltic']
+
+    with pytest.raises(KeyError):
+        seas_metadict['NoRwEgIaN']
+
+
+def test_delitem_missing_key(seas_metadict):
+    """
+    Test `MetaDict.__delitem__(...)` raises error on missing key.
+    """
+    with pytest.raises(KeyError):
+        del seas_metadict['missing key']
+
+
+def test_delitem_with_keycomments(atomic_weights_keycomments,
+                                  atomic_weights_keycomments_after_removal):
+    """
+    Test `MetaDict.__delitem__(...)` removes corresponding keycomments.
+    """
+    len_before = len(atomic_weights_keycomments)
+    md = MetaDict(atomic_weights_keycomments)
+    del md['hydrogen']
+    del md['mercury']
+    assert len(md) == len_before - 2
+
+    with pytest.raises(KeyError):
+        md['hydrogen']
+
+    with pytest.raises(KeyError):
+        md['mercury']
+
+    check_contents_and_insertion_order(md, atomic_weights_keycomments_after_removal)
 
 
 def test_get(seas_metadict):
@@ -242,6 +360,32 @@ def test_pop(seas_metadict):
     assert seas_metadict.pop('baltic') == 'europe'
     assert len(seas_metadict) == len_before - 1
 
+
+def test_pop_with_keycomments(atomic_weights_keycomments,
+                              atomic_weights_keycomments_after_removal):
+    """
+    Test `MetaDict.pop(...)` removes corresponding keycomments.
+    """
+    len_before = len(atomic_weights_keycomments)
+    md = MetaDict(atomic_weights_keycomments)
+
+    assert md.pop('hydrogen') == 1
+    assert md.pop('mercury') == 80
+    assert len(md) == len_before - 2
+    check_contents_and_insertion_order(md, atomic_weights_keycomments_after_removal)
+
+
+def test_popitem_with_keycomments(atomic_weights_keycomments, empty_keycomments):
+    """
+    Test `MetaDict.popitem(...)` removes corresponding keycomments.
+    """
+    md = MetaDict(atomic_weights_keycomments)
+
+    assert md.popitem(last=False) == ('hydrogen', 1)
+    assert md.popitem(last=False) == ('chromium', 24)
+    assert md.popitem(last=False) == ('mercury', 80)
+    assert md.popitem(last=False) == ('iridium', 77)
+    check_contents_and_insertion_order(md, empty_keycomments)
 
 #  Test `MetaDict.update(...)`.
 

--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -102,7 +102,7 @@ def atomic_weights_keycomments():
                 'extra key 1': 'foo',
                 'MERCURY': 'Hg',
                 'extra key 2': 'bar'
-             }]]
+            }]]
 
 
 @pytest.fixture
@@ -117,7 +117,7 @@ def atomic_weights_pruned_keycomments():
             ['keycomments', {
                 'chromium': 'Cr',
                 'MERCURY': 'Hg'
-             }]]
+            }]]
 
 
 @pytest.fixture
@@ -129,7 +129,7 @@ def atomic_weights_keycomments_after_removal():
             ['iridium', 77],
             ['keycomments', {
                 'chromium': 'Cr'
-             }]]
+            }]]
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
We know that working on sunpy and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them: https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
`sunpy.util.metadata.MetaDict` now maintains coherence between its keys and their corresponding keycomments.

If the key ``'keycomments'`` exists, its value must be a dictionary mapping keys in the `MetaDict` to their comments. The casing of keys in the keycomments dictionary is not significant. If a key is removed from the `MetaDict`, it will also be removed from the keycomments dictionary. Additionally, any extraneous keycomments will be removed when the `MetaDict` is instantiated.

Calling `del` on a `MetaDict` object key is now case-insensitive.

Fixes #2750