### PR TITLE
reduced time for goes_suvi fetch test

### DIFF
--- a/sunpy/net/dataretriever/tests/test_goes_suvi.py
+++ b/sunpy/net/dataretriever/tests/test_goes_suvi.py
@@ -63,7 +63,7 @@ def test_get_url_for_timerange_errors(suvi_client):
         suvi_client._get_url_for_timerange(tr, satellitenumber=1)
 
 
-def mock_querry_object(suvi_client, start, end):
+def mock_querry_object(suvi_client, start, end, wave):
     """
     Creating a Query Response object and prefilling it with some information
     """
@@ -77,7 +77,8 @@ def mock_querry_object(suvi_client, start, end):
         'physobs': 'flux',
         'provider': 'NOAA'
     }
-    results = QueryResponse.create(obj, suvi_client._get_url_for_timerange(TimeRange(start, end)), client=suvi_client)
+    results = QueryResponse.create(obj, suvi_client._get_url_for_timerange(TimeRange(start, end),
+                                   wavelength=wave), client=suvi_client)
     return results
 
 
@@ -89,10 +90,11 @@ def test_fetch_working(suvi_client):
     """
     start = '2019/05/25 00:50'
     end = '2019/05/25 00:52'
-    qr1 = suvi_client.search(a.Time(start, end), a.Instrument('suvi'))
+    wave = 94 * u.Angstrom
+    qr1 = suvi_client.search(a.Time(start, end), a.Instrument('suvi'), a.Wavelength(wave))
 
     # Mock QueryResponse object
-    mock_qr = mock_querry_object(suvi_client, start, end)
+    mock_qr = mock_querry_object(suvi_client, start, end, wave)
 
     # Compare if two objects have the same attribute
 


### PR DESCRIPTION
<!--
We know that working on sunpy and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them: https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #4099 .
It reduces test time for `test_fetch_working` from 9 seconds to 2 seconds on my system.
Specified a wavelength so that scraper opens just one directry instead of 6.
More information here: https://github.com/sunpy/sunpy/issues/4099#issuecomment-626128885 .
