### PR TITLE
href fix in scraper

### DIFF
--- a/changelog/4132.bugfix.rst
+++ b/changelog/4132.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed bugs in `~sunpy.util.scraper.Scraper.filelist`
+that resulted in error when the HTML page of URL opened by the scraper contains some "a" tags without "href" attribute
+and resulted in incorrect file urls when any href stores filepath relative to the URL's domain instead of just a filename.

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -63,6 +63,7 @@ class Scraper:
     """
     def __init__(self, pattern, **kwargs):
         self.pattern = pattern.format(**kwargs)
+        self.domain = "{0.scheme}://{0.netloc}/".format(urlsplit(self.pattern))
         milliseconds = re.search(r'\%e', self.pattern)
         if not milliseconds:
             self.now = datetime.datetime.now().strftime(self.pattern)
@@ -231,8 +232,11 @@ class Scraper:
                     soup = BeautifulSoup(opn, "html.parser")
                     for link in soup.find_all("a"):
                         href = link.get("href")
-                        if href.endswith(self.pattern.split('.')[-1]):
-                            fullpath = directory + href
+                        if href is not None and href.endswith(self.pattern.split('.')[-1]):
+                            if href[0] == '/':
+                                fullpath = self.domain + href[1:]
+                            else:
+                                fullpath = directory + href
                             if self._URL_followsPattern(fullpath):
                                 datehref = self._extractDateURL(fullpath)
                                 if (datehref.to_datetime() >= timerange.start.to_datetime() and

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -218,13 +218,15 @@ def test_filelist_url_missing_directory():
     timerange = TimeRange('1960/01/01 00:00:00', '1960/01/02 00:00:00')
     assert len(s.filelist(timerange)) == 0
 
+
 @pytest.mark.remote_data
 def test_filelist_relative_hrefs():
     # the url opened by the scraper from below pattern contains some links which don't have hrefs
     pattern = 'http://www.bbso.njit.edu/pub/archive/%Y/%m/%d/bbso_halph_fr_%Y%m%d_%H%M%S.fts'
     s = Scraper(pattern)
-    timerange = TimeRange('2016/5/18 15:28:00','2016/5/18 16:30:00')
+    timerange = TimeRange('2016/5/18 15:28:00', '2016/5/18 16:30:00')
     assert s.domain == 'http://www.bbso.njit.edu/'
     # hrefs are relative to domain here, not to the directory they are present in
     # this checks that `scraper.filelist` returns fileurls relative to the domain
-    assert s.filelist(timerange)[1] == s.domain + 'pub/archive/2016/05/18/bbso_halph_fr_20160518_160033.fts'
+    fileurls = s.filelist(timerange)
+    assert fileurls[1] == s.domain + 'pub/archive/2016/05/18/bbso_halph_fr_20160518_160033.fts'

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -217,3 +217,14 @@ def test_filelist_url_missing_directory():
     s = Scraper(pattern)
     timerange = TimeRange('1960/01/01 00:00:00', '1960/01/02 00:00:00')
     assert len(s.filelist(timerange)) == 0
+
+@pytest.mark.remote_data
+def test_filelist_relative_hrefs():
+    # the url opened by the scraper from below pattern contains some links which don't have hrefs
+    pattern = 'http://www.bbso.njit.edu/pub/archive/%Y/%m/%d/bbso_halph_fr_%Y%m%d_%H%M%S.fts'
+    s = Scraper(pattern)
+    timerange = TimeRange('2016/5/18 15:28:00','2016/5/18 16:30:00')
+    assert s.domain == 'http://www.bbso.njit.edu/'
+    # hrefs are relative to domain here, not to the directory they are present in
+    # this checks that `scraper.filelist` returns fileurls relative to the domain
+    assert s.filelist(timerange)[1] == s.domain + 'pub/archive/2016/05/18/bbso_halph_fr_20160518_160033.fts'


### PR DESCRIPTION
<!--
We know that working on sunpy and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them: https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

More info here https://github.com/sunpy/sunpy/pull/3812#discussion_r422460309
In short, we didn't checked href can be None and may give error here https://github.com/sunpy/sunpy/blob/553d60538ecb6fb955fc28d428372c17f0501557/sunpy/util/scraper.py#L234 
By working on #3812 , I found the source website do have some href which are **None**.
Also, sometimes path to files maybe relative to just domain, not always to directory they are in, so checking that by verifying if href for files begin with `\` .


