### PR TITLE
 Fix/overhaul/test submap 

### DIFF
--- a/changelog/4134.bugfix.rst
+++ b/changelog/4134.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed inconsistencies in how `~sunpy.map.GenericMap.submap` behaves when passed corners in pixel and world coordinates.
+The behavior for submaps specified in pixel coordinates is now well-defined for pixels on the boundary of the rectangle 
+and is consistent for all boundaries. Previously pixels on the lower left boundary were included, but excluded on the 
+upper and right boundary. This means the shape of a submap may now be 1 pixel larger in each dimension.
+Added several more tests for `~sunpy.map.GenericMap.submap` for a range of cutout sizes in both pixel and world 
+coordinates.

--- a/changelog/4134.bugfix.rst
+++ b/changelog/4134.bugfix.rst
@@ -1,6 +1,6 @@
 Fixed inconsistencies in how `~sunpy.map.GenericMap.submap` behaves when passed corners in pixel and world coordinates.
-The behavior for submaps specified in pixel coordinates is now well-defined for pixels on the boundary of the rectangle 
-and is consistent for all boundaries. Previously pixels on the lower left boundary were included, but excluded on the 
+The behavior for submaps specified in pixel coordinates is now well-defined for pixels on the boundary of the rectangle
+and is consistent for all boundaries. Previously pixels on the lower left boundary were included, but excluded on the
 upper and right boundary. This means the shape of a submap may now be 1 pixel larger in each dimension.
-Added several more tests for `~sunpy.map.GenericMap.submap` for a range of cutout sizes in both pixel and world 
+Added several more tests for `~sunpy.map.GenericMap.submap` for a range of cutout sizes in both pixel and world
 coordinates.

--- a/examples/map/composite_map_AIA_HMI.py
+++ b/examples/map/composite_map_AIA_HMI.py
@@ -23,10 +23,12 @@ import sunpy.data.sample
 aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 hmi_map = sunpy.map.Map(sunpy.data.sample.HMI_LOS_IMAGE)
 
-bottom_left = SkyCoord(0 * u.arcsec, 0 * u.arcsec, frame=aia_map.coordinate_frame)
-top_right = SkyCoord(800 * u.arcsec, 800 * u.arcsec, frame=aia_map.coordinate_frame)
-aia_smap = aia_map.submap(bottom_left, top_right)
-hmi_smap = hmi_map.submap(bottom_left, top_right)
+bottom_left = [0, 0] * u.arcsec
+top_right = [800, 800] * u.arcsec
+aia_smap = aia_map.submap(SkyCoord(*bottom_left, frame=aia_map.coordinate_frame),
+                          SkyCoord(*top_right, frame=aia_map.coordinate_frame))
+hmi_smap = hmi_map.submap(SkyCoord(*bottom_left, frame=hmi_map.coordinate_frame),
+                          SkyCoord(*top_right, frame=hmi_map.coordinate_frame))
 
 
 ##############################################################################

--- a/examples/units_and_coordinates/SDO_to_STEREO_Coordinate_Conversion.py
+++ b/examples/units_and_coordinates/SDO_to_STEREO_Coordinate_Conversion.py
@@ -13,7 +13,6 @@ from astropy.coordinates import SkyCoord
 
 import sunpy.map
 import sunpy.coordinates
-import sunpy.coordinates.wcs_utils
 from sunpy.net import Fido, attrs as a
 
 
@@ -57,7 +56,8 @@ for i, m in enumerate(maps.values()):
 # We are now going to pick out a region around the south west corner:
 aia_width = 200 * u.arcsec
 aia_height = 250 * u.arcsec
-aia_bottom_left = SkyCoord([[-800, -300]] * u.arcsec,
+aia_bottom_left = SkyCoord(-800 * u.arcsec,
+                           -300 * u.arcsec,
                            frame=maps['AIA'].coordinate_frame)
 aia_top_right = SkyCoord(aia_bottom_left.Tx + aia_width,
                          aia_bottom_left.Ty + aia_height,

--- a/sunpy/instr/aia.py
+++ b/sunpy/instr/aia.py
@@ -65,7 +65,8 @@ def aiaprep(aiamap):
     center = np.floor(tempmap.meta['crpix1'])
     range_side = (center + np.array([-1, 1]) * aiamap.data.shape[0] / 2) * u.pix
     newmap = tempmap.submap(u.Quantity([range_side[0], range_side[0]]),
-                            u.Quantity([range_side[1], range_side[1]]))
+                            u.Quantity([range_side[1] - 1 * u.pix,
+                                        range_side[1] - 1 * u.pix]))
 
     newmap.meta['r_sun'] = newmap.meta['rsun_obs'] / newmap.meta['cdelt1']
     newmap.meta['lvl_num'] = 1.5

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1488,12 +1488,14 @@ class GenericMap(NDData):
         x_pixels.sort()
         y_pixels.sort()
 
-        # Round down the lower left pixel to the nearest integer
-        x_pixels[0] = np.round(x_pixels[0])
-        y_pixels[0] = np.round(y_pixels[0])
+        # Round the lower left pixel to the nearest integer
+        # We want 0.5 to be rounded up to 1, so use floor(x + 0.5)
+        x_pixels[0] = np.floor(x_pixels[0] + 0.5)
+        y_pixels[0] = np.floor(y_pixels[0] + 0.5)
         # Round the top right pixel to the nearest integer, then add 1 for array indexing
-        x_pixels[1] = np.round(x_pixels[1]) + 1
-        y_pixels[1] = np.round(y_pixels[1]) + 1
+        # We want e.g. 2.5 to be rounded down to 2, so use ceil(x - 0.5)
+        x_pixels[1] = np.ceil(x_pixels[1] - 0.5) + 1
+        y_pixels[1] = np.ceil(y_pixels[1] - 0.5) + 1
 
         x_pixels = np.array(x_pixels)
         y_pixels = np.array(y_pixels)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1492,8 +1492,8 @@ class GenericMap(NDData):
         x_pixels[0] = np.round(x_pixels[0])
         y_pixels[0] = np.round(y_pixels[0])
         # Round the top right pixel to the nearest integer, then add 1 for array indexing
-        x_pixels[1] = round(x_pixels[1]) + 1
-        y_pixels[1] = round(y_pixels[1]) + 1
+        x_pixels[1] = np.round(x_pixels[1]) + 1
+        y_pixels[1] = np.round(y_pixels[1]) + 1
 
         x_pixels = np.array(x_pixels)
         y_pixels = np.array(y_pixels)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1379,6 +1379,9 @@ class GenericMap(NDData):
         Returns a submap of the map defined by the rectangle given by the
         ``[bottom_left, top_right]`` coordinates.
 
+        Any pixels which have at least part of their area inside the rectangle
+        are returned.
+
         Parameters
         ----------
         bottom_left : `astropy.units.Quantity` or `~astropy.coordinates.SkyCoord`
@@ -1462,58 +1465,43 @@ class GenericMap(NDData):
             [-95.92475   ,   6.028058  ,  -4.9797    ,  -1.0483578 ,
                 -3.9313421 ]], dtype=float32)
         """
-
+        # Convert coordinates to pixels
         if isinstance(bottom_left, (astropy.coordinates.SkyCoord,
                                     astropy.coordinates.BaseCoordinateFrame)):
             if not top_right:
                 if bottom_left.shape[0] != 2:
                     raise ValueError("If top_right is not specified bottom_left must have length two.")
                 else:
-                    lon, lat = self._get_lon_lat(bottom_left)
-                    top_right = u.Quantity([lon[1], lat[1]])
-                    bottom_left = u.Quantity([lon[0], lat[0]])
-            else:
-                bottom_left = u.Quantity(self._get_lon_lat(bottom_left))
-                top_right = u.Quantity(self._get_lon_lat(top_right))
+                    top_right = bottom_left[1]
+                    bottom_left = bottom_left[0]
 
-            top_left = u.Quantity([bottom_left[0], top_right[1]])
-            bottom_right = u.Quantity([top_right[0], bottom_left[1]])
+            bottom_left = self.world_to_pixel(bottom_left)
+            top_right = self.world_to_pixel(top_right)
 
-            corners = u.Quantity([bottom_left, bottom_right, top_left, top_right])
-            coord = SkyCoord(corners, frame=self.coordinate_frame)
-            pixel_corners = self.world_to_pixel(coord)
-
-            # Round the pixel values, we use floor+1 so that we always have at
-            # least one pixel width of data.
-            x_pixels = u.Quantity([np.min(pixel_corners.x), np.max(pixel_corners.x)]).to_value(u.pix)
-            x_pixels[0] = np.ceil(x_pixels[0])
-            x_pixels[1] = np.floor(x_pixels[1] + 1)
-            y_pixels = u.Quantity([np.min(pixel_corners.y), np.max(pixel_corners.y)]).to_value(u.pix)
-            y_pixels[0] = np.ceil(y_pixels[0])
-            y_pixels[1] = np.floor(y_pixels[1] + 1)
-
-        elif (isinstance(bottom_left, u.Quantity) and bottom_left.unit.is_equivalent(u.pix) and
-              isinstance(top_right, u.Quantity) and top_right.unit.is_equivalent(u.pix)):
-            x_pixels = u.Quantity([bottom_left[0], top_right[0]]).to_value(u.pix)
-            y_pixels = u.Quantity([top_right[1], bottom_left[1]]).to_value(u.pix)
-
-        else:
+        elif not (isinstance(bottom_left, u.Quantity) and bottom_left.unit.is_equivalent(u.pix) and
+                  isinstance(top_right, u.Quantity) and top_right.unit.is_equivalent(u.pix)):
             raise ValueError("Invalid input, bottom_left and top_right must either be SkyCoord or Quantity in pixels.")
 
+        x_pixels = u.Quantity([bottom_left[0], top_right[0]]).to_value(u.pix)
+        y_pixels = u.Quantity([top_right[1], bottom_left[1]]).to_value(u.pix)
         # Sort the pixel values so we always slice in the correct direction
         x_pixels.sort()
         y_pixels.sort()
+
+        # Round down the lower left pixel to the nearest integer
+        x_pixels[0] = np.round(x_pixels[0])
+        y_pixels[0] = np.round(y_pixels[0])
+        # Round the top right pixel to the nearest integer, then add 1 for array indexing
+        x_pixels[1] = round(x_pixels[1]) + 1
+        y_pixels[1] = round(y_pixels[1]) + 1
 
         x_pixels = np.array(x_pixels)
         y_pixels = np.array(y_pixels)
 
         # Clip pixel values to max of array, prevents negative
         # indexing
-        x_pixels[np.less(x_pixels, 0)] = 0
-        x_pixels[np.greater(x_pixels, self.data.shape[1])] = self.data.shape[1]
-
-        y_pixels[np.less(y_pixels, 0)] = 0
-        y_pixels[np.greater(y_pixels, self.data.shape[0])] = self.data.shape[0]
+        x_pixels = np.clip(x_pixels, 0, self.data.shape[1])
+        y_pixels = np.clip(y_pixels, 0, self.data.shape[0])
 
         # Get ndarray representation of submap
         xslice = slice(int(x_pixels[0]), int(x_pixels[1]))

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -468,10 +468,12 @@ def test_submap(simple_map, rect, submap_out):
     # Check that coordinates behave the same way
     corner1 = simple_map.pixel_to_world(*rect[0])
     corner2 = simple_map.pixel_to_world(*rect[1])
+    corners = simple_map.pixel_to_world(u.Quantity([rect[0][0], rect[1][0]]),
+                                        u.Quantity([rect[0][1], rect[1][1]]))
     for r in [(corner1, corner2),
               (corner2, corner1),
-              (SkyCoord([corner1, corner2]), ),
-              (SkyCoord([corner2, corner1]), )]:
+              (corners, ),
+              ]:
         submap = simple_map.submap(*r)
         np.testing.assert_equal(submap.data, submap_out)
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -450,6 +450,8 @@ def test_dimensions(simple_map):
 @pytest.mark.parametrize('rect, submap_out',
                          [[([0, 0] * u.pix, [0, 0] * u.pix), np.array([[0]])],
                           [([-1, -1] * u.pix, [0, 0] * u.pix), np.array([[0]])],
+                          # 0.5, 0.5 is the edge of the first pixel, so make sure
+                          # we don't include any other pixels
                           [([0, 0] * u.pix, [0.5, 0.5] * u.pix), np.array([[0]])],
                           [([0, 0] * u.pix, [0, 0.51] * u.pix), np.array([[0],
                                                                           [2]])],

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -96,11 +96,11 @@ def generic_map():
 
 @pytest.fixture
 def simple_map():
-    # A 2x2 map, with it's center at (0, 0), and scaled differently in
+    # A 3x3 map, with it's center at (0, 0), and scaled differently in
     # each direction
-    data = np.arange(4).reshape((2, 2))
-    ref_coord = SkyCoord(0, 0, frame='helioprojective', obstime='now', unit='deg')
-    ref_pix = [0.5, 0.5] * u.pix
+    data = np.arange(9).reshape((3, 3))
+    ref_coord = SkyCoord(0.0, 0.0, frame='helioprojective', obstime='now', unit='deg')
+    ref_pix = [1, 1] * u.pix
     scale = [2, 1] * u.arcsec / u.pix
     header = sunpy.map.make_fitswcs_header(data, ref_coord, reference_pixel=ref_pix, scale=scale)
 
@@ -431,10 +431,10 @@ def test_shift_history(generic_map):
 
 def test_corners(simple_map):
     # These are the centers of the corner pixels
-    assert u.allclose(simple_map.top_right_coord.Tx, 1 * u.arcsec)
-    assert u.allclose(simple_map.top_right_coord.Ty, 0.5 * u.arcsec)
-    assert u.allclose(simple_map.bottom_left_coord.Tx, -1 * u.arcsec)
-    assert u.allclose(simple_map.bottom_left_coord.Ty, -0.5 * u.arcsec)
+    assert u.allclose(simple_map.top_right_coord.Tx, 2 * u.arcsec)
+    assert u.allclose(simple_map.top_right_coord.Ty, 1 * u.arcsec)
+    assert u.allclose(simple_map.bottom_left_coord.Tx, -2 * u.arcsec)
+    assert u.allclose(simple_map.bottom_left_coord.Ty, -1 * u.arcsec)
 
 
 def test_center(simple_map):
@@ -443,30 +443,42 @@ def test_center(simple_map):
 
 
 def test_dimensions(simple_map):
-    assert simple_map.dimensions[0] == 2 * u.pix
-    assert simple_map.dimensions[1] == 2 * u.pix
+    assert simple_map.dimensions[0] == 3 * u.pix
+    assert simple_map.dimensions[1] == 3 * u.pix
 
 
-@pytest.mark.parametrize('rect, submap_out',
-                         [[([0, 0] * u.pix, [0, 0] * u.pix), np.array([[0]])],
-                          [([-1, -1] * u.pix, [0, 0] * u.pix), np.array([[0]])],
-                          # 0.5, 0.5 is the edge of the first pixel, so make sure
-                          # we don't include any other pixels
-                          [([0, 0] * u.pix, [0.5, 0.5] * u.pix), np.array([[0]])],
-                          [([0, 0] * u.pix, [0, 0.51] * u.pix), np.array([[0],
-                                                                          [2]])],
-                          [([0, 0] * u.pix, [0.51, 0] * u.pix), np.array([[0, 1]])],
-                          [([0, 0] * u.pix, [0.51, 0.51] * u.pix), np.array([[0, 1],
-                                                                             [2, 3]])],
-                          [([0, 0] * u.pix, [20, 20] * u.pix), np.array([[0, 1],
-                                                                         [2, 3]])],
-                          ])
-def test_submap(simple_map, rect, submap_out):
+pixel_corners = [
+    [([0, 0] * u.pix, [0, 0] * u.pix), np.array([[0]])],
+    [([-1, -1] * u.pix, [0, 0] * u.pix), np.array([[0]])],
+    # 0.5, 0.5 is the edge of the first pixel, so make sure
+    # we don't include any other pixels
+    [([0, 0] * u.pix, [0.5, 0.5] * u.pix), np.array([[0]])],
+    [([0, 0] * u.pix, [0, 0.51] * u.pix), np.array([[0],
+                                                    [3]])],
+    [([0, 0] * u.pix, [0.51, 0] * u.pix), np.array([[0, 1]])],
+    [([0, 0] * u.pix, [0.51, 0.51] * u.pix), np.array([[0, 1],
+                                                       [3, 4]])],
+    [([0.1, 0.1] * u.pix, [1.6, 1.4] * u.pix), np.array([[0, 1, 2],
+                                                         [3, 4, 5]])],
+    [([0, 0] * u.pix, [20, 20] * u.pix), np.array([[0, 1, 2],
+                                                   [3, 4, 5],
+                                                   [6, 7, 8]])],
+]
+
+
+@pytest.mark.parametrize('rect, submap_out', pixel_corners)
+def test_submap_pixel(simple_map, rect, submap_out):
     # Check that result is the same specifying corners either way round
     for r in [(rect[0], rect[1]), (rect[1], rect[0])]:
         submap = simple_map.submap(*r)
         np.testing.assert_equal(submap.data, submap_out)
 
+
+# The (0.5, 0.5) case is skipped as boundary points cannot reliably tested when
+# converting to world coordinates due to round-off error when round-tripping
+# through pixel_to_world -> world_to_pixel
+@pytest.mark.parametrize('rect, submap_out', pixel_corners[:2] + pixel_corners[3:])
+def test_submap_world(simple_map, rect, submap_out):
     # Check that coordinates behave the same way
     corner1 = simple_map.pixel_to_world(*rect[0])
     corner2 = simple_map.pixel_to_world(*rect[1])
@@ -505,17 +517,17 @@ def test_submap_data_header(generic_map, unit):
 
 
 def test_reference_coordinate(simple_map):
-    assert simple_map.reference_pixel.x == 0.5 * u.pix
-    assert simple_map.reference_pixel.y == 0.5 * u.pix
+    assert simple_map.reference_pixel.x == 1 * u.pix
+    assert simple_map.reference_pixel.y == 1 * u.pix
 
 
 def test_resample(simple_map):
     # Test resampling a 2x2 map
     resampled = simple_map.resample([1, 1] * u.pix)
     # Should be the mean of [0, 1, 2, 3]
-    assert resampled.data == np.array([[1.5]])
-    assert resampled.scale.axis1 == 2 * simple_map.scale.axis1
-    assert resampled.scale.axis2 == 2 * simple_map.scale.axis2
+    assert resampled.data == np.array([[4]])
+    assert resampled.scale.axis1 == 3 * simple_map.scale.axis1
+    assert resampled.scale.axis2 == 3 * simple_map.scale.axis2
 
     # Check that the corner coordinates of the input and output are the same
     resampled_lower_left = resampled.pixel_to_world(-0.5 * u.pix, -0.5 * u.pix)
@@ -524,7 +536,7 @@ def test_resample(simple_map):
     assert resampled_lower_left.Ty == original_lower_left.Ty
 
     resampled_upper_left = resampled.pixel_to_world(0.5 * u.pix, 0.5 * u.pix)
-    original_upper_left = simple_map.pixel_to_world(1.5 * u.pix, 1.5 * u.pix)
+    original_upper_left = simple_map.pixel_to_world(2.5 * u.pix, 2.5 * u.pix)
     assert resampled_upper_left.Tx == original_upper_left.Tx
     assert resampled_upper_left.Ty == original_upper_left.Ty
 

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -75,21 +75,21 @@ def test_all_coordinates_from_map(sub_smap):
 def test_map_edges(all_off_disk_map):
     edges = map_edges(all_off_disk_map)
     assert type(edges) is tuple
-    assert len(edges[2]) == 11
+    assert len(edges[2]) == 12
     assert np.all(edges[2][0] == [0, 0] * u.pix)
-    assert np.all(edges[2][10] == [0, 10] * u.pix)
+    assert np.all(edges[2][11] == [0, 11] * u.pix)
 
-    assert len(edges[3]) == 11
-    assert np.all(edges[3][0] == [9, 0] * u.pix)
-    assert np.all(edges[3][10] == [9, 10] * u.pix)
+    assert len(edges[3]) == 12
+    assert np.all(edges[3][0] == [10, 0] * u.pix)
+    assert np.all(edges[3][11] == [10, 11] * u.pix)
 
-    assert len(edges[1]) == 10
+    assert len(edges[1]) == 11
     assert np.all(edges[1][0] == [0, 0] * u.pix)
-    assert np.all(edges[1][9] == [9, 0] * u.pix)
+    assert np.all(edges[1][10] == [10, 0] * u.pix)
 
-    assert len(edges[0]) == 10
-    assert np.all(edges[0][0] == [0, 10] * u.pix)
-    assert np.all(edges[0][9] == [9, 10] * u.pix)
+    assert len(edges[0]) == 11
+    assert np.all(edges[0][0] == [0, 11] * u.pix)
+    assert np.all(edges[0][10] == [10, 11] * u.pix)
 
 
 def test_solar_angular_radius(aia171_test_map):

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -360,7 +360,7 @@ def _get_bounding_coordinates(coords):
     rotated_y_max = _get_extreme_position(coords, "Ty", operator=np.nanmax)
     return SkyCoord([rotated_x_min, rotated_x_max] * u.arcsec,
                     [rotated_y_min, rotated_y_max] * u.arcsec,
-                    frame=Helioprojective, observer=coords[0].observer)
+                    frame=coords[0].frame)
 
 
 def _warp_sun_coordinates(xy, smap, new_observer, **diff_rot_kwargs):

--- a/sunpy/physics/tests/test_solar_rotation.py
+++ b/sunpy/physics/tests/test_solar_rotation.py
@@ -83,7 +83,7 @@ def test_mapsequence_solar_derotate(aia171_test_mapsequence, aia171_test_submap)
     assert(isinstance(tmc, sunpy.map.MapSequence))
 
     # Test that the shape of data is correct when clipped
-    clipped_shape = (25, 19)
+    clipped_shape = (26, 20)
     for m in tmc:
         assert(m.data.shape == clipped_shape)
 


### PR DESCRIPTION
Previously the behaviour of `submap()` wasn't very well documented, so I decided to work out what it actually does. Along the way I discovered a lack of tests, some *interesting* code, and a lack of consistency between what happened with pixel and coordinate inputs.

This PR somewhat overhauls `submap` to
- Have well defined behaviour for pixels on the boundary of the rectangle, that is consistent for all boundaries (previously pixels on the lower and left boundary were included, but on the upper and right boundary excluded). This means the shape of a submap is now often 1 pixel larger in each dimension.
- Extend the tests
- Refactor the internals to remove code duplication

Fixes #4128, and is built on top of #4127