### PR TITLE
Propagate map coordinate frame properly in on_disk_bounding_coordinates

### DIFF
--- a/changelog/4141.bugfix.rst
+++ b/changelog/4141.bugfix.rst
@@ -1,0 +1,3 @@
+`sunpy.map.on_disk_bounding_coordinates` now fully propagates the coordinate
+frame of the input map to the output coordinates. Previously only the observer
+coordinate, and no other frame attributes, were propagated.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -318,4 +318,4 @@ def on_disk_bounding_coordinates(smap):
     ty = on_disk_coordinates.Ty.value
     return SkyCoord([np.nanmin(tx), np.nanmax(tx)] * u.arcsec,
                     [np.nanmin(ty), np.nanmax(ty)] * u.arcsec,
-                    frame=Helioprojective, observer=smap.observer_coordinate)
+                    frame=smap.coordinate_frame)


### PR DESCRIPTION
The previous version didn't propagate other frame attributes such as `dsun` and `obstime`. This should now propagate the whole frame.