### PR TITLE
Fix reference pixel in header helper

### DIFF
--- a/changelog/4152.bugfix.rst
+++ b/changelog/4152.bugfix.rst
@@ -1,0 +1,2 @@
+Fix an off-by-one error in the reference pixel returned by
+`sunpy.map.make_fitswcs_header`.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -120,8 +120,8 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
     >>> for key, value in header.items():
     ...     print(f"{key}: {value}")
     wcsaxes: 2
-    crpix1: 5.0
-    crpix2: 5.0
+    crpix1: 6.0
+    crpix2: 6.0
     cdelt1: 2.0
     cdelt2: 2.0
     cunit1: arcsec

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -133,15 +133,16 @@ def make_fitswcs_header(data, coordinate,
     meta_wcs.update(meta_instrument)
 
     if reference_pixel is None:
-        reference_pixel = u.Quantity([(shape[1] + 1)/2.*u.pixel, (shape[0] + 1)/2.*u.pixel])
+        reference_pixel = u.Quantity([(shape[1] - 1)/2.*u.pixel, (shape[0] - 1)/2.*u.pixel])
     if scale is None:
         scale = [1., 1.] * (u.arcsec/u.pixel)
 
     meta_wcs['crval1'], meta_wcs['crval2'] = (coordinate.spherical.lon.to_value(meta_wcs['cunit1']),
                                               coordinate.spherical.lat.to_value(meta_wcs['cunit2']))
 
-    meta_wcs['crpix1'], meta_wcs['crpix2'] = (reference_pixel[0].to_value(u.pixel),
-                                              reference_pixel[1].to_value(u.pixel))
+    # Add 1 to go from input 0-based indexing to FITS 1-based indexing
+    meta_wcs['crpix1'], meta_wcs['crpix2'] = (reference_pixel[0].to_value(u.pixel) + 1,
+                                              reference_pixel[1].to_value(u.pixel) + 1)
 
     meta_wcs['cdelt1'], meta_wcs['cdelt2'] = (scale[0].to_value(meta_wcs['cunit1']/u.pixel),
                                               scale[1].to_value(meta_wcs['cunit2']/u.pixel))


### PR DESCRIPTION
Fixes #4120. Indexing from 0 as input is consistent with the current docstring, and other pixel inputs in the codebase.