### PR TITLE
Remove sphinx-gallery config comments from rendered examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -252,6 +252,7 @@ if has_sphinx_gallery:
         'default_thumb_file': path.joinpath('logo', 'sunpy_icon_128x128.png'),
         'abort_on_example_error': False,
         'plot_gallery': True,
+        'remove_config_comments': True,
         'doc_module': ('sunpy')
     }
 


### PR DESCRIPTION
This configuration option removes stuff like `# sphinx_gallery_thumbnail_number = ...` from the rendered gallery example.

See https://sphinx-gallery.github.io/stable/configuration.html#removing-config-comments