### PR TITLE
Fixes for linear upsampling

### DIFF
--- a/changelog/4164.bugfix.rst
+++ b/changelog/4164.bugfix.rst
@@ -1,0 +1,4 @@
+Previously `sunpy.map.GenericMap.resample` with ``method='linear'`` was
+using an incorrect and constant value to fill edges when upsampling a map. Values
+near the edges are now correct extrapolated using the ``fill_value=extrapolate``
+option to `scipy.interpolate.interp1d`.

--- a/changelog/4164.bugfix.rst
+++ b/changelog/4164.bugfix.rst
@@ -1,4 +1,4 @@
 Previously `sunpy.map.GenericMap.resample` with ``method='linear'`` was
 using an incorrect and constant value to fill edges when upsampling a map. Values
-near the edges are now correct extrapolated using the ``fill_value=extrapolate``
+near the edges are now correctly extrapolated using the ``fill_value=extrapolate``
 option to `scipy.interpolate.interp1d`.

--- a/sunpy/image/resample.py
+++ b/sunpy/image/resample.py
@@ -85,22 +85,21 @@ def _resample_nearest_linear(orig, dimensions, method, offset, m1):
 
     Parameters
     ----------
-    orig :
+    orig : array-like
         Original data.
-    dimensions :
-        Dimensions of resamled data.
-    offset :
+    dimensions : `tuple`
+        Dimensions of resampled data.
+    method : `str`
+        Interpolation method passed to `~scipy.interpolate.interp1d`
+    offset : `float`
         Either 0 or 0.5, depending on whether interpolation is at the edge or
         centers of bins.
-    m1 :
+    m1 : 0 or 1
         For ``orig.shape = (i,j)`` & new dimensions ``= (x,y)``, if set to `False`
         (default) ``orig`` is resampled by factors of ``(i/x) * (j/y)``,
         otherwise ``orig`` is resampled by ``(i-1)/(x-1) * (j-1)/(y-1)``.
         This prevents extrapolation one element beyond bounds of input array.
     """
-    dimlist = []
-
-    # Calculate old coords. Add 0.5 to get centers of pixels
     old_coords = [np.arange(i, dtype=np.float) + offset for i in orig.shape]
     scale = (orig.shape - m1) / (dimensions - m1)
     new_coords = [(np.arange(dimensions[i], dtype=np.float) + offset) * scale[i] for i in

--- a/sunpy/image/resample.py
+++ b/sunpy/image/resample.py
@@ -82,31 +82,43 @@ def resample(orig, dimensions, method='linear', center=False, minusone=False):
 def _resample_nearest_linear(orig, dimensions, method, offset, m1):
     """
     Resample Map using either linear or nearest interpolation.
+
+    Parameters
+    ----------
+    orig :
+        Original data.
+    dimensions :
+        Dimensions of resamled data.
+    offset :
+        Either 0 or 0.5, depending on whether interpolation is at the edge or
+        centers of bins.
+    m1 :
+        For ``orig.shape = (i,j)`` & new dimensions ``= (x,y)``, if set to `False`
+        (default) ``orig`` is resampled by factors of ``(i/x) * (j/y)``,
+        otherwise ``orig`` is resampled by ``(i-1)/(x-1) * (j-1)/(y-1)``.
+        This prevents extrapolation one element beyond bounds of input array.
     """
     dimlist = []
 
-    # calculate new dims
-    for i in range(orig.ndim):
-        base = np.arange(dimensions[i])
-        dimlist.append((orig.shape[i] - m1) / (dimensions[i] - m1) *
-                       (base + offset) - offset)
-
-    # specify old coordinates
-    old_coords = [np.arange(i, dtype=np.float) for i in orig.shape]
+    # Calculate old coords. Add 0.5 to get centers of pixels
+    old_coords = [np.arange(i, dtype=np.float) + offset for i in orig.shape]
+    scale = (orig.shape - m1) / (dimensions - m1)
+    new_coords = [(np.arange(dimensions[i], dtype=np.float) + offset) * scale[i] for i in range(len(dimensions))]
 
     # first interpolation - for ndims = any
     mint = scipy.interpolate.interp1d(old_coords[-1], orig, bounds_error=False,
-                                      fill_value=min(old_coords[-1]), kind=method)
+                                      fill_value='extrapolate', kind=method)
 
-    new_data = mint(dimlist[-1])
+    new_data = mint(new_coords[-1])
 
     trorder = [orig.ndim - 1] + list(range(orig.ndim - 1))
     for i in range(orig.ndim - 2, -1, -1):
         new_data = new_data.transpose(trorder)
-
         mint = scipy.interpolate.interp1d(old_coords[i], new_data,
-                                          bounds_error=False, fill_value=min(old_coords[i]), kind=method)
-        new_data = mint(dimlist[i])
+                                          bounds_error=False,
+                                          fill_value='extrapolate',
+                                          kind=method)
+        new_data = mint(new_coords[i])
 
     if orig.ndim > 1:
         # need one more transpose to return to original dimensions

--- a/sunpy/image/resample.py
+++ b/sunpy/image/resample.py
@@ -103,7 +103,8 @@ def _resample_nearest_linear(orig, dimensions, method, offset, m1):
     # Calculate old coords. Add 0.5 to get centers of pixels
     old_coords = [np.arange(i, dtype=np.float) + offset for i in orig.shape]
     scale = (orig.shape - m1) / (dimensions - m1)
-    new_coords = [(np.arange(dimensions[i], dtype=np.float) + offset) * scale[i] for i in range(len(dimensions))]
+    new_coords = [(np.arange(dimensions[i], dtype=np.float) + offset) * scale[i] for i in
+                  range(len(dimensions))]
 
     # first interpolation - for ndims = any
     mint = scipy.interpolate.interp1d(old_coords[-1], orig, bounds_error=False,

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -521,13 +521,17 @@ def test_reference_coordinate(simple_map):
     assert simple_map.reference_pixel.y == 1 * u.pix
 
 
-def test_resample(simple_map):
+@pytest.mark.parametrize('shape', [[1, 1], [6, 6]])
+def test_resample(simple_map, shape):
     # Test resampling a 2x2 map
-    resampled = simple_map.resample([1, 1] * u.pix)
+    resampled = simple_map.resample(shape * u.pix, method='linear')
+    print(resampled)
+    assert np.mean(resampled.data) == np.mean(simple_map.data)
     # Should be the mean of [0,1,2,3,4,5,6,7,8,9]
-    assert resampled.data == np.array([[4]])
-    assert resampled.scale.axis1 == 3 * simple_map.scale.axis1
-    assert resampled.scale.axis2 == 3 * simple_map.scale.axis2
+    if shape == [1, 1]:
+        assert resampled.data == np.array([[4]])
+    assert resampled.scale.axis1 == 3 / shape[0] * simple_map.scale.axis1
+    assert resampled.scale.axis2 == 3 / shape[1] * simple_map.scale.axis2
 
     # Check that the corner coordinates of the input and output are the same
     resampled_lower_left = resampled.pixel_to_world(-0.5 * u.pix, -0.5 * u.pix)
@@ -535,7 +539,8 @@ def test_resample(simple_map):
     assert resampled_lower_left.Tx == original_lower_left.Tx
     assert resampled_lower_left.Ty == original_lower_left.Ty
 
-    resampled_upper_left = resampled.pixel_to_world(0.5 * u.pix, 0.5 * u.pix)
+    resampled_upper_left = resampled.pixel_to_world((shape[0] - 0.5) * u.pix,
+                                                    (shape[1] - 0.5) * u.pix)
     original_upper_left = simple_map.pixel_to_world(2.5 * u.pix, 2.5 * u.pix)
     assert resampled_upper_left.Tx == original_upper_left.Tx
     assert resampled_upper_left.Ty == original_upper_left.Ty

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -525,7 +525,6 @@ def test_reference_coordinate(simple_map):
 def test_resample(simple_map, shape):
     # Test resampling a 2x2 map
     resampled = simple_map.resample(shape * u.pix, method='linear')
-    print(resampled)
     assert np.mean(resampled.data) == np.mean(simple_map.data)
     # Should be the mean of [0,1,2,3,4,5,6,7,8,9]
     if shape == [1, 1]:


### PR DESCRIPTION
- The code for calculating new/old interpolating coordinates baffled me, so I re-wrote it to make it clearer what is going on (especially with respect to applying offsets)
- The interpolation was using a fill value of `min(old_coords[-1])` to fill in any data around the edges. This is crazy because `old_coords` are coordinates and not data, and is just arbitrarily filling with a value. I've changed this to extrapolate beyond the data edges.

These changes now mean that `np.mean(resampled.data) == np.mean(simple_map.data)` for upsampling in a linear fashion, which seems like a sensible result to me.