### PR TITLE
Check for unintended behavior on pixels instead of coords

### DIFF
--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -319,6 +319,11 @@ def get_rectangle_coordinates(bottom_left, *, top_right=None, width: u.deg = Non
     >>> height = 10 * u.arcsec
     >>> bottom_left, top_right = get_rectangle_coordinates(bottom_left, width=width, height=height)
 
+    Notes
+    -----
+    This function does not check whether ``top_right`` is above and to the right of ``bottom_left``
+    in coordinate space. Whether this condition holds when plotting a rectangle depends on the
+    orientation of the axes, and therefore needs a WCS for context.
     """
     if not (hasattr(bottom_left, 'transform_to') and
             hasattr(bottom_left, 'shape') and

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -268,7 +268,8 @@ class GreatArc:
                         frame=Heliocentric).transform_to(self.start_frame)
 
 
-def get_rectangle_coordinates(bottom_left, *, top_right=None, width: u.deg = None, height: u.deg = None):
+def get_rectangle_coordinates(bottom_left, *, top_right=None,
+                              width: u.deg = None, height: u.deg = None):
     """
     Specify a rectangular region of interest in longitude and latitude in a given coordinate frame.
 

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -1,7 +1,6 @@
 """
 Miscellaneous utilities related to coordinates
 """
-import warnings
 
 import numpy as np
 
@@ -9,7 +8,6 @@ import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 
 from sunpy.coordinates import Heliocentric
-from sunpy.util.exceptions import SunpyUserWarning
 
 __all__ = ['GreatArc', 'get_rectangle_coordinates']
 

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -275,12 +275,13 @@ def get_rectangle_coordinates(bottom_left, *, top_right=None, width: u.deg = Non
     Parameters
     ----------
     bottom_left : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
-        The bottom-left coordinate of the rectangle.
-        Supports passing both the bottom left and top right coordinates by passing with a shape of ``(2,)``.
+        The bottom-left coordinate of the rectangle. Supports passing both the
+        bottom left and top right coordinates by passing with a shape of ``(2,)``.
     top_right : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
         The top-right coordinate of the rectangle.
-        If in a different frame than ``bottom_left`` and all required metadata for frame conversion is present,
-        ``top_right`` will be transformed to ``bottom_left`` frame.
+        If in a different frame than ``bottom_left`` and all required metadata
+        for frame conversion is present, ``top_right`` will be transformed to
+        ``bottom_left`` frame.
     width : `~astropy.units.Quantity`
         The width of the rectangle.
         Must be omitted if the coordinates of both corners have been specified.
@@ -373,14 +374,5 @@ def get_rectangle_coordinates(bottom_left, *, top_right=None, width: u.deg = Non
 
         if isinstance(bottom_left, BaseCoordinateFrame):
             top_right = top_right.frame
-
-    if top_right.spherical.lon < bottom_left.spherical.lon:
-        warnings.warn("The rectangle is inverted in the left/right (longitude) direction, possibly "
-                      f"due to the longitude wrap angle ({bottom_left.spherical.lon.wrap_angle}), "
-                      "and may lead to unintended behavior.", SunpyUserWarning)
-
-    if top_right.spherical.lat < bottom_left.spherical.lat:
-        warnings.warn("The rectangle is inverted in the bottom/top (latitude) direction "
-                      "and may lead to unintended behavior.", SunpyUserWarning)
 
     return bottom_left, top_right

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -320,9 +320,13 @@ def get_rectangle_coordinates(bottom_left, *, top_right=None,
 
     Notes
     -----
-    This function does not check whether ``top_right`` is above and to the right of ``bottom_left``
-    in coordinate space. Whether this condition holds when plotting a rectangle depends on the
-    orientation of the axes, and therefore needs a WCS for context.
+    ``width`` is always treated as an increase in longitude, but ``bottom_left`` may have a higher
+    value of longitude than ``top_right`` due to the wrapping of the longitude angle.  Appropriate
+    care should be taken when using this function's output to define a range of longitudes.
+
+    ``height`` is always treated as an increase in latitude, but this function does not enforce
+    that ``bottom_left`` has a lower value of latitude than ``top_right``, in case that orientation
+    is valid for the intended use.
     """
     if not (hasattr(bottom_left, 'transform_to') and
             hasattr(bottom_left, 'shape') and

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1797,6 +1797,13 @@ class GenericMap(NDData):
         """
         Draw a rectangle defined in world coordinates on the plot.
 
+        This draws a rectangle that has corners at ``(bottom_left, top_right)``,
+        and has sides parallel to the x and y axes of the plot.
+
+        If ``width`` and ``height`` are specified, they are respectively added to the
+        longitude and latitude of the ``bottom_left`` coordinate to calculate a
+        ``top_right`` coordinate.
+
         Parameters
         ----------
         bottom_left : `~astropy.coordinates.SkyCoord`
@@ -1839,13 +1846,6 @@ class GenericMap(NDData):
 
         width = Longitude(top_right.spherical.lon - bottom_left.spherical.lon)
         height = Latitude(top_right.spherical.lat - bottom_left.spherical.lat)
-        if width < 0:
-            warnings.warn("The rectangle is inverted in the left/right (longitude) direction,  "
-                          "which may lead to unintended behavior.", SunpyUserWarning)
-
-        if height < 0:
-            warnings.warn("The rectangle is inverted in the bottom/top (latitude) direction, "
-                          "which may lead to unintended behavior.", SunpyUserWarning)
 
         if not axes:
             axes = plt.gca()

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1549,11 +1549,11 @@ class GenericMap(NDData):
         x_pixels = u.Quantity([bottom_left[0], top_right[0]]).to_value(u.pix)
         y_pixels = u.Quantity([top_right[1], bottom_left[1]]).to_value(u.pix)
         if x_pixels[0] > x_pixels[1]:
-            warnings.warn("The rectangle is inverted in the left/right (longitude) direction,  "
+            warnings.warn("The rectangle is inverted in the left/right direction,  "
                           "which may lead to unintended behavior.", SunpyUserWarning)
 
         if y_pixels[0] > y_pixels[1]:
-            warnings.warn("The rectangle is inverted in the bottom/top (latitude) direction, "
+            warnings.warn("The rectangle is inverted in the bottom/top direction, "
                           "which may lead to unintended behavior.", SunpyUserWarning)
         # Sort the pixel values so we always slice in the correct direction
         x_pixels.sort()

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1534,14 +1534,17 @@ class GenericMap(NDData):
             raise ValueError("If bottom_left is not a SkyCoord either top_right alone or "
                              "both width and height must be specified.")
 
-        elif (not all([arg is None or (isinstance(arg, u.Quantity) and arg.unit.is_equivalent(u.pix))
-                       for arg in (bottom_left, top_right, width, height)])):
+        elif (not all([arg is None or (isinstance(arg, u.Quantity) and
+              arg.unit.is_equivalent(u.pix))
+                for arg in (bottom_left, top_right, width, height)])):
             raise TypeError("When bottom_left is not a SkyCoord, any values of top_right, "
-                            "width or height specified must be Quantity objects in units of pixels.")
+                            "width or height specified must be Quantity objects in "
+                            "units of pixels.")
 
         elif bottom_left.shape != (2,) or (top_right is not None and top_right.shape != (2,)):
             raise ValueError(
-                "Both bottom_left and top_right when specified as Quantity objects must have shape (2,)")
+                "Both bottom_left and top_right when specified as Quantity objects "
+                "must have shape (2,)")
 
         elif height is not None and width is not None:
             top_right = u.Quantity([bottom_left[0] + width, bottom_left[1] + height])

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1548,6 +1548,13 @@ class GenericMap(NDData):
 
         x_pixels = u.Quantity([bottom_left[0], top_right[0]]).to_value(u.pix)
         y_pixels = u.Quantity([top_right[1], bottom_left[1]]).to_value(u.pix)
+        if x_pixels[0] > x_pixels[1]:
+            warnings.warn("The rectangle is inverted in the left/right (longitude) direction,  "
+                          "which may lead to unintended behavior.", SunpyUserWarning)
+
+        if y_pixels[0] > y_pixels[1]:
+            warnings.warn("The rectangle is inverted in the bottom/top (latitude) direction, "
+                          "which may lead to unintended behavior.", SunpyUserWarning)
         # Sort the pixel values so we always slice in the correct direction
         x_pixels.sort()
         y_pixels.sort()
@@ -1829,6 +1836,13 @@ class GenericMap(NDData):
 
         width = Longitude(top_right.spherical.lon - bottom_left.spherical.lon)
         height = Latitude(top_right.spherical.lat - bottom_left.spherical.lat)
+        if width < 0:
+            warnings.warn("The rectangle is inverted in the left/right (longitude) direction,  "
+                          "which may lead to unintended behavior.", SunpyUserWarning)
+
+        if height < 0:
+            warnings.warn("The rectangle is inverted in the bottom/top (latitude) direction, "
+                          "which may lead to unintended behavior.", SunpyUserWarning)
 
         if not axes:
             axes = plt.gca()

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1798,7 +1798,7 @@ class GenericMap(NDData):
         Draw a rectangle defined in world coordinates on the plot.
 
         This draws a rectangle that has corners at ``(bottom_left, top_right)``,
-        and has sides parallel to the x and y axes of the plot.
+        and has sides parallel to coordinate axes of the map.
 
         If ``width`` and ``height`` are specified, they are respectively added to the
         longitude and latitude of the ``bottom_left`` coordinate to calculate a


### PR DESCRIPTION
See  https://github.com/sunpy/sunpy/pull/3677#pullrequestreview-412087551 for discussion on this. It is better to perform the check on pixels, because `lon1 < lon2` does  not necessarily imply that `world2pix(lon1)` < `world2pix(lon2)` for all maps (in particular for heliographic maps).