### PR TITLE
Add colormaps.color_tables to docs

### DIFF
--- a/changelog/4182.doc.rst
+++ b/changelog/4182.doc.rst
@@ -1,0 +1,1 @@
+Added `sunpy.visualization.colormaps.color_tables` to the docs.

--- a/docs/code_ref/visualization.rst
+++ b/docs/code_ref/visualization.rst
@@ -7,6 +7,8 @@ SunPy visualization
 
 .. automodapi:: sunpy.visualization.colormaps
 
+.. automodapi:: sunpy.visualization.colormaps.color_tables
+
 .. automodapi:: sunpy.visualization.animator
 
 .. automodapi:: sunpy.visualization.wcsaxes_compat

--- a/sunpy/visualization/colormaps/color_tables.py
+++ b/sunpy/visualization/colormaps/color_tables.py
@@ -91,8 +91,8 @@ def aia_color_table(wavelength: u.angstrom):
     Based on aia_lct.pro part of SDO/AIA on SSWIDL written by Karel
     Schrijver (2010/04/12).
 
-    Parmeters
-    ---------
+    Parameters
+    ----------
     wavelength : `~astropy.units.quantity`
         Wavelength for the desired AIA color table.
     """


### PR DESCRIPTION
I noticed this was missing from the docs. Once the docs build might need some fixes to the docstrings since they've not been built by sphinx before.