### PR TITLE
Fix specification of STEREO B in an example

### DIFF
--- a/examples/units_and_coordinates/SDO_to_STEREO_Coordinate_Conversion.py
+++ b/examples/units_and_coordinates/SDO_to_STEREO_Coordinate_Conversion.py
@@ -20,7 +20,7 @@ from sunpy.net import attrs as a
 # The first step is to download some data, we are going to get an image from
 # early 2011 when the STEREO spacecraft were roughly 90 deg seperated from the
 # Earth.
-stereo = (a.vso.Source.stereo &
+stereo = (a.vso.Source('STEREO_B') &
           a.Instrument("EUVI") &
           a.Time('2011-01-01', '2011-01-01T00:10:00'))
 


### PR DESCRIPTION
This example was broken in #3637 because it was mistakenly switched to downloading from both STEREO spacecraft, when we actually want only STEREO B.  The example would non-deterministically error depending on which STEREO Map was actually used for the coordinate frame.