### PR TITLE
Clarify draw_rectangle behaviour

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1836,8 +1836,8 @@ class GenericMap(NDData):
                                                            top_right=top_right,
                                                            width=width,
                                                            height=height)
-        bottom_left = self.world_to_pixel(bottom_left)
-        top_right = self.world_to_pixel(top_right)
+        bottom_left = self.world_to_pixel(bottom_left).to_value(u.pix)
+        top_right = self.world_to_pixel(top_right).to_value(u.pix)
         width = top_right[0] - bottom_left[0]
         height = top_right[1] - bottom_left[1]
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1790,6 +1790,13 @@ class GenericMap(NDData):
         This draws a rectangle that has corners at ``(bottom_left, top_right)``,
         and that has sides parallel to the x and y axes of the plot.
 
+        If ``width`` and ``height`` are specified, they are respectively added to the
+        longitude and latitude of the ``bottom_left`` coordinate to calculate a
+        ``top_right`` coordinate. This means that ``width`` and ``height`` will only
+        correspond to the width and height of the draw rectangle if the longitude
+        and latitude coordiante axes are parallel with the x and y axes of the pixels
+        that comprise the map.
+
         Parameters
         ----------
         bottom_left : `~astropy.coordinates.SkyCoord`


### PR DESCRIPTION
The code in `draw_rectangle` was doing all kinds of acrobatics with long/lat and units, which is fine for a plot where longitude-latitude align with the x-y axes, but I have no idea what wild things would happen if they weren't. The code is much simpler with a call to `world_to_pixel`.

In addition, this means that the behavior for an arbitrary WCS is well defined, as now indicated in the docstring:
```
This draws a rectangle that has corners at ``(bottom_left, top_right)``,
and that has sides parallel to the x and y axes of the plot.
```