### PR TITLE
Improve submap argument parsing

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1588,7 +1588,6 @@ class GenericMap(NDData):
         Should take any valid input to submap() and return bottom_left and
         top_right in pixel coordinates.
         """
-        pass
 
     @_parse_submap_input.register(u.Quantity)
     def _parse_submap_quantity_input(self, bottom_left, top_right, width, height):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1595,8 +1595,8 @@ class GenericMap(NDData):
         """
         pass
 
-    @_parse_submap_input.register
-    def _parse_submap_quantity_input(self, bottom_left: u.Quantity, top_right, width, height):
+    @_parse_submap_input.register(u.Quantity)
+    def _parse_submap_quantity_input(self, bottom_left, top_right, width, height):
         if bottom_left.shape != (2, ):
             raise ValueError('bottom_left must have shape (2, ) when specified as a Quantity')
         if top_right is not None:
@@ -1616,8 +1616,8 @@ class GenericMap(NDData):
             top_right = u.Quantity([bottom_left[0] + width, bottom_left[1] + height])
         return bottom_left, top_right
 
-    @_parse_submap_input.register
-    def _parse_submap_coord_input(self, bottom_left: SkyCoord, top_right, width, height):
+    @_parse_submap_input.register(SkyCoord)
+    def _parse_submap_coord_input(self, bottom_left, top_right, width, height):
         if top_right is not None:
             if not isinstance(top_right, SkyCoord):
                 raise TypeError("When bottom_left is a SkyCoord, top_right "

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -988,8 +988,8 @@ def test_deprecated_submap_inputs(generic_map2, coords):
         generic_map2.submap(bl_pix, width_pix, height_pix)
 
     with pytest.warns(SunpyDeprecationWarning):
-        with pytest.raises(TypeError,
-                           match="top_right must be of type SkyCoord or BaseCoordinateFrame."):
+        with pytest.raises(ValueError,
+                           match="either top_right alone or both width and height must be specified."):
             generic_map2.submap(bl_coord, width_deg, height=height_deg)
 
     with pytest.warns(SunpyDeprecationWarning):
@@ -999,12 +999,12 @@ def test_deprecated_submap_inputs(generic_map2, coords):
 
     with pytest.warns(SunpyDeprecationWarning):
         with pytest.raises(TypeError,
-                           match="top_right must be of type SkyCoord or BaseCoordinateFrame"):
-            generic_map2.submap(bl_coord, width_deg, height=height_deg)
+                           match="When bottom_left is a SkyCoord, top_right must also be a SkyCoord."):
+            generic_map2.submap(bl_coord, width_deg)
 
     with pytest.warns(SunpyDeprecationWarning):
         with pytest.raises(ValueError,
-                           match="either top_right alone or both width and height must be specified"):
+                               match="either top_right alone or both width and height must be specified"):
             generic_map2.submap(bl_pix, width_pix, height=height_pix)
 
 
@@ -1041,28 +1041,24 @@ def test_submap_kwarg_only_input_errors(generic_map2, coords):
         with pytest.raises(ValueError, match="top_right alone or both width and height must be specified."):
             generic_map2.submap(bl_pix, **kwargs)
 
-    with pytest.raises(TypeError, match="must be Quantity objects in units of pixels"):
+    with pytest.raises(TypeError, match="width and height must be a Quantity in units of pixels"):
         generic_map2.submap(bl_pix, width=width_deg, height=height_deg)
 
     with pytest.raises(TypeError,
-                       match="top_right, width or height .* Quantity objects in units of pixels."):
-        generic_map2.submap(10*u.deg, top_right=10*u.deg)
+                       match="top_right must be a Quantity in units of pixels."):
+        generic_map2.submap([10, 10]*u.deg, top_right=[10, 10]*u.deg)
 
-    with pytest.raises(TypeError,
-                       match="top_right, width or height .* Quantity objects in units of pixels."):
-        generic_map2.submap([10, 10, 10]*u.deg, top_right=[10, 10, 10]*u.deg)
-
-    with pytest.raises(ValueError, match=r"must have shape \(2\,\)"):
+    with pytest.raises(ValueError, match=r"must have shape \(2\, \)"):
         generic_map2.submap(10*u.pix, top_right=10*u.pix)
 
-    with pytest.raises(ValueError, match=r"must have shape \(2\,\)"):
+    with pytest.raises(ValueError, match=r"must have shape \(2\, \)"):
         generic_map2.submap([10, 10, 10]*u.pix, top_right=[10, 10, 10]*u.pix)
 
     with pytest.raises(u.UnitsError):
         generic_map2.submap([10, 10]*u.deg, width=10*u.km, height=10*u.J)
 
     with pytest.raises(ValueError,
-                       match="bottom_left and top_right or bottom_left and height and width should be provided."):
+                       match="either top_right alone or both width and height must be specified"):
         generic_map2.submap(SkyCoord([10, 10, 10]*u.deg, [10, 10, 10]*u.deg,
                                      frame=generic_map2.coordinate_frame))
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -989,22 +989,22 @@ def test_deprecated_submap_inputs(generic_map2, coords):
 
     with pytest.warns(SunpyDeprecationWarning):
         with pytest.raises(ValueError,
-                           match="either top_right alone or both width and height must be specified."):
+                           match="Either top_right alone or both width and height must be specified."):
             generic_map2.submap(bl_coord, width_deg, height=height_deg)
 
     with pytest.warns(SunpyDeprecationWarning):
         with pytest.raises(ValueError,
-                           match="either top_right alone or both width and height must be specified"):
+                           match="Either top_right alone or both width and height must be specified"):
             generic_map2.submap(bl_pix, width_pix, height=height_pix)
 
     with pytest.warns(SunpyDeprecationWarning):
         with pytest.raises(TypeError,
-                           match="When bottom_left is a SkyCoord, top_right must also be a SkyCoord."):
+                           match="Invalid input, top_right must be of type SkyCoord or BaseCoordinateFrame."):
             generic_map2.submap(bl_coord, width_deg)
 
     with pytest.warns(SunpyDeprecationWarning):
         with pytest.raises(ValueError,
-                               match="either top_right alone or both width and height must be specified"):
+                           match="Either top_right alone or both width and height must be specified"):
             generic_map2.submap(bl_pix, width_pix, height=height_pix)
 
 
@@ -1038,7 +1038,8 @@ def test_submap_kwarg_only_input_errors(generic_map2, coords):
         dict(),  # Only post deprecation
     )
     for kwargs in inputs:
-        with pytest.raises(ValueError, match="top_right alone or both width and height must be specified."):
+        with pytest.raises(ValueError, match="top_right alone or both width and height "
+                                             "must be specified"):
             generic_map2.submap(bl_pix, **kwargs)
 
     with pytest.raises(TypeError, match="width and height must be a Quantity in units of pixels"):
@@ -1058,7 +1059,7 @@ def test_submap_kwarg_only_input_errors(generic_map2, coords):
         generic_map2.submap([10, 10]*u.deg, width=10*u.km, height=10*u.J)
 
     with pytest.raises(ValueError,
-                       match="either top_right alone or both width and height must be specified"):
+                       match="either bottom_left and top_right or bottom_left and height and width should be provided"):
         generic_map2.submap(SkyCoord([10, 10, 10]*u.deg, [10, 10, 10]*u.deg,
                                      frame=generic_map2.coordinate_frame))
 


### PR DESCRIPTION
This builds on #4179 to improve the argument parsing of `submap()`. In particular:

- The allowed args/kwargs are different depending on whether `bottom_left` is a Quantity or SkyCoord, so dispatch on type to make the code clearer
- Add more specific error messages (e.g. instead of "any values of top_right, width or height specified must be Quantity", there are now separate checks and messages for top_right and width or height)
- Check for the right argument combination (e.g. top_right OR width and height) first
- If bottom_left is a SkyCoord, check that top_right is a SkyCoord
- If bottom_left is a SkyCoord, check that width and height are in degrees