### PR TITLE
Fix printing an Attr when registry is empty

### DIFF
--- a/changelog/4199.bugfix.rst
+++ b/changelog/4199.bugfix.rst
@@ -1,0 +1,1 @@
+Fix attr printing when the attr registry is empty for that attr

--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -75,7 +75,10 @@ def _print_attrs(attr, html=False):
     """
     class_name = f"{attr.__module__+'.' or ''}{attr.__name__}"
     attrs = attr._attr_registry[attr]
-    sorted_attrs = _ATTR_TUPLE(*zip(*sorted(zip(*attrs))))
+    sorted_attrs = make_tuple()
+    # Only sort the attrs if any have been registered
+    if attrs.name:
+        sorted_attrs = _ATTR_TUPLE(*zip(*sorted(zip(*attrs))))
     names = sorted_attrs.name
     clients = sorted_attrs.client
     names_long = sorted_attrs.name_long

--- a/sunpy/net/tests/test_attr.py
+++ b/sunpy/net/tests/test_attr.py
@@ -69,6 +69,13 @@ class SA3(attr.SimpleAttr):
     pass
 
 
+def test_empty():
+    class TestAttr(attr.Attr):
+        pass
+
+    assert repr(TestAttr)
+
+
 def test_attr_and():
     a1 = SA1(1)
     a2 = SA2(2)


### PR DESCRIPTION
If an attr has not entries in the values registry it should still print / repr