### PR TITLE
Document that the unified file IO shouldn't be used for FITS

### DIFF
--- a/changelog/4208.doc.rst
+++ b/changelog/4208.doc.rst
@@ -1,0 +1,1 @@
+Add a warning to `sunpy.io` docs to recommend not using it for FITS

--- a/docs/code_ref/io.rst
+++ b/docs/code_ref/io.rst
@@ -5,21 +5,10 @@ This submodule contains two types of routines, the first reads (data, header)
 pairs from files in a way similar to FITS files. The other is special readers
 for files that are commonly used in solar physics.
 
-.. automodapi:: sunpy.io
+.. warning::
 
-.. automodapi:: sunpy.io.header
-
-Unified File Readers
-====================
-
-.. _iofits:
-.. automodapi:: sunpy.io.fits
-
-.. _iojp2:
-.. automodapi:: sunpy.io.jp2
-
-.. _ioana:
-.. automodapi:: sunpy.io.ana
+   When reading FITS files, it is strongly recommended that `astropy.io.fits` be used over the tools in `sunpy.io`.
+   The sunpy FITS reader is designed to meet the needs of map, and does not represent the structure of the FITS file well.
 
 Special File Readers
 ====================
@@ -85,3 +74,20 @@ file
           [-128.03072  , -128.03072  , -128.03072  , ..., -128.03072  ,
            -128.03072  , -128.03072  ]], dtype=float32)
    >>> input_asdf.close()  # doctest: +REMOTE_DATA
+
+
+Unified File Readers
+====================
+
+.. automodapi:: sunpy.io
+
+.. automodapi:: sunpy.io.header
+
+.. _iofits:
+.. automodapi:: sunpy.io.fits
+
+.. _iojp2:
+.. automodapi:: sunpy.io.jp2
+
+.. _ioana:
+.. automodapi:: sunpy.io.ana


### PR DESCRIPTION
Also prioritise the special readers, which are actually public API.

This is the most minimal change to avoid some of the recent misunderstanding with `sunpy.io.fits`.