### PR TITLE
Explicitly import ESPTimeSeries

### DIFF
--- a/sunpy/timeseries/sources/__init__.py
+++ b/sunpy/timeseries/sources/__init__.py
@@ -6,7 +6,7 @@ Each mission should have its own file with one or more classes defined.
 Typically, these classes will be subclasses of the
 `sunpy.timeseries.TimeSeries`.
 """
-from sunpy.timeseries.sources.eve import EVESpWxTimeSeries
+from sunpy.timeseries.sources.eve import EVESpWxTimeSeries, ESPTimeSeries
 from sunpy.timeseries.sources.fermi_gbm import GBMSummaryTimeSeries
 from sunpy.timeseries.sources.goes import XRSTimeSeries
 from sunpy.timeseries.sources.lyra import LYRATimeSeries

--- a/sunpy/timeseries/sources/__init__.py
+++ b/sunpy/timeseries/sources/__init__.py
@@ -6,7 +6,7 @@ Each mission should have its own file with one or more classes defined.
 Typically, these classes will be subclasses of the
 `sunpy.timeseries.TimeSeries`.
 """
-from sunpy.timeseries.sources.eve import EVESpWxTimeSeries, ESPTimeSeries
+from sunpy.timeseries.sources.eve import ESPTimeSeries, EVESpWxTimeSeries
 from sunpy.timeseries.sources.fermi_gbm import GBMSummaryTimeSeries
 from sunpy.timeseries.sources.goes import XRSTimeSeries
 from sunpy.timeseries.sources.lyra import LYRATimeSeries


### PR DESCRIPTION
This adds an explicit import for the `ESPTimeSeries` class so that the docstring is included in the API documentation for `timeseries.sources`.