### PR TITLE
Reduced the tolerance of affine-transform tests to avoid numerical-precision issues

### DIFF
--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -7,7 +7,7 @@ from sunpy.image.transform import affine_transform
 from sunpy.util import SunpyUserWarning
 
 # Tolerance for tests
-RTOL = 1.0e-15
+RTOL = 1.0e-10
 
 
 @pytest.fixture


### PR DESCRIPTION
Follow-up to #4076

The affine-transform tests still have intermittent failures on OS X, and I no longer see indications of pixel shifts.  I suspect, without proof, that the lingering issue may be due to numerical precision at the limit of 64-bit floats (IEEE 754 standard).  The relative tolerance had been set to 1e-15, which is looser than the minimum precision possible in the standard (~1e-16), but not by terribly much.  I've learned that library math functions are not universally mandated to maintain accuracy to the full IEEE 754 precision – although OS X is allegedly better about this than other OSes – so such a stringent relative tolerance may be hitting some weirdness.

Accordingly, I've reduced the relative-tolerance value, and hopefully that will put the intermittent failures to bed.