### PR TITLE
Various fixes to affine-transform unit tests

### DIFF
--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -32,10 +32,19 @@ def compare_results(expect, result, allclose=True):
     t1 = abs(exp.mean() - res.mean()) <= RTOL*exp.mean()
 
     # Don't do the allclose test for scipy as the bicubic algorithm has edge effects
-    if allclose:
-        t2 = np.allclose(exp, res, rtol=RTOL)  # TODO: Develop a better way of testing this
+    # TODO: Develop a way of testing this for scipy
+    if not allclose:
+        return t1
     else:
-        t2 = True
+        notclose = ~np.isclose(exp, res, rtol=RTOL)
+        t2 = not np.any(notclose)
+
+        # Print out every mismatch
+        if not t2:
+            mismatches = np.stack([*notclose.nonzero(), exp[notclose], res[notclose]]).T
+            for row in mismatches:
+                print(f"i={int(row[0]+1)}, j={int(row[1]+1)}: expected={row[2]}, result={row[3]}, "
+                      f"adiff={row[2]-row[3]}, rdiff={(row[2]-row[3])/row[2]}")
 
     return t1 and t2
 

--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -98,7 +98,7 @@ def test_shift(original, dx, dy):
     shift = affine_transform(original, rmatrix=rmatrix, recenter=True, image_center=rcen)
     ymin, ymax = max([0, dy]), min([original.shape[1], original.shape[1]+dy])
     xmin, xmax = max([0, dx]), min([original.shape[0], original.shape[0]+dx])
-    compare_results(expected[ymin:ymax, xmin:xmax], shift[ymin:ymax, xmin:xmax])
+    assert compare_results(expected[ymin:ymax, xmin:xmax], shift[ymin:ymax, xmin:xmax])
 
     # Check shifted and unshifted shape against original image
     rcen = image_center - np.array([dx, dy])
@@ -106,7 +106,7 @@ def test_shift(original, dx, dy):
     # Need to ignore the portion of the image cut off by the first shift
     ymin, ymax = max([0, -dy]), min([original.shape[1], original.shape[1]-dy])
     xmin, xmax = max([0, -dx]), min([original.shape[0], original.shape[0]-dx])
-    compare_results(original[ymin:ymax, xmin:xmax], unshift[ymin:ymax, xmin:xmax])
+    assert compare_results(original[ymin:ymax, xmin:xmax], unshift[ymin:ymax, xmin:xmax])
 
 
 @pytest.mark.parametrize("scale_factor", [0.25, 0.5, 0.75, 1.0, 1.25, 1.5])
@@ -129,7 +129,7 @@ def test_scale(original, scale_factor):
         lower = int(w - new_c)
         expected[lower:upper, lower:upper] = newim
     scale = affine_transform(original, rmatrix=rmatrix, scale=scale_factor)
-    compare_results(expected, scale)
+    assert compare_results(expected, scale)
 
 
 @pytest.mark.parametrize("angle, dx, dy, scale_factor", [(90, -100, 50, 0.25),
@@ -178,7 +178,7 @@ def test_all(original, angle, dx, dy, scale_factor):
     else:
         lower = int(w-new_c)
         expected[lower:upper, lower:upper] = rotscaleshift
-    compare_results(expected, rotscaleshift)
+    assert compare_results(expected, rotscaleshift)
 
     # Check a rotated/shifted and restored image against original
     transformed = affine_transform(original, rmatrix=rmatrix, scale=1.0, recenter=True,
@@ -193,7 +193,7 @@ def test_all(original, angle, dx, dy, scale_factor):
     # (which isn't the portion you'd expect, because of the rotation)
     ymin, ymax = max([0, -dy]), min([original.shape[1], original.shape[1]-dy])
     xmin, xmax = max([0, -dx]), min([original.shape[0], original.shape[0]-dx])
-    compare_results(original[ymin:ymax, xmin:xmax], inverse[ymin:ymax, xmin:xmax])
+    assert compare_results(original[ymin:ymax, xmin:xmax], inverse[ymin:ymax, xmin:xmax])
 
 
 def test_flat(identity):

--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -103,14 +103,14 @@ def test_shift(original, dx, dy):
 
     # Check a shifted shape against expected outcome
     expected = np.roll(np.roll(original, dx, axis=1), dy, axis=0)
-    rcen = image_center + np.array([dx, dy])
+    rcen = image_center - np.array([dx, dy])
     shift = affine_transform(original, rmatrix=rmatrix, recenter=True, image_center=rcen)
     ymin, ymax = max([0, dy]), min([original.shape[1], original.shape[1]+dy])
     xmin, xmax = max([0, dx]), min([original.shape[0], original.shape[0]+dx])
     assert compare_results(expected[ymin:ymax, xmin:xmax], shift[ymin:ymax, xmin:xmax])
 
     # Check shifted and unshifted shape against original image
-    rcen = image_center - np.array([dx, dy])
+    rcen = image_center + np.array([dx, dy])
     unshift = affine_transform(shift, rmatrix=rmatrix, recenter=True, image_center=rcen)
     # Need to ignore the portion of the image cut off by the first shift
     ymin, ymax = max([0, -dy]), min([original.shape[1], original.shape[1]-dy])
@@ -137,13 +137,13 @@ def test_scale(original, scale_factor):
     else:
         lower = int(w - new_c)
         expected[lower:upper, lower:upper] = newim
-    scale = affine_transform(original, rmatrix=rmatrix, scale=scale_factor)
+    scale = affine_transform(original, rmatrix=rmatrix, scale=scale_factor, order=4)
     assert compare_results(expected, scale)
 
 
-@pytest.mark.parametrize("angle, dx, dy, scale_factor", [(90, -100, 50, 0.25),
-                                                         (-90, 50, -100, 0.75),
-                                                         (180, 100, 50, 1.5)])
+@pytest.mark.parametrize("angle, dx, dy, scale_factor", [(90, -100, 40, 0.25),
+                                                         (-90, 40, -80, 0.75),
+                                                         (180, 20, 50, 1.5)])
 def test_all(original, angle, dx, dy, scale_factor):
     """
     Tests to make sure that combinations of scaling, shifting and rotation
@@ -161,45 +161,33 @@ def test_all(original, angle, dx, dy, scale_factor):
                        mode='constant', multichannel=False, anti_aliasing=False) * original.max()
     new = np.zeros(original.shape)
 
+    disp = np.array([dx, dy])
+    dxs, dys = np.asarray(disp * scale_factor, dtype=int)
     # Old width and new center of image
     w = np.array(original.shape[0])/2.0 - 0.5
     new_c = (np.array(scale.shape[0])/2.0 - 0.5)
     upper = int(w+new_c+1)
     if scale_factor > 1:
         lower = int(new_c-w)
-        new = scale[lower:upper, lower:upper]
+        new = scale[lower-dys:upper-dys, lower-dxs:upper-dxs]
     else:
         lower = int(w-new_c)
-        new[lower:upper, lower:upper] = scale
-    disp = np.array([dx, dy])
-    rcen = image_center + disp
-    rot = np.rot90(new, k=k)
-    shift = np.roll(np.roll(rot, dx, axis=1), dy, axis=0)
-    expected = shift
-    rotscaleshift = affine_transform(original, rmatrix=rmatrix, scale=scale_factor,
+        new[lower+dys:upper+dys, lower+dxs:upper+dxs] = scale
+    rcen = image_center - disp
+    expected = np.rot90(new, k=k)
+
+    rotscaleshift = affine_transform(original, rmatrix=rmatrix, scale=scale_factor, order=4,
                                      recenter=True, image_center=rcen)
-    w = np.array(expected.shape[0])/2.0 - 0.5
-    new_c = (np.array(rotscaleshift.shape[0])/2.0 - 0.5)
-    upper = int(w+new_c+1)
-    if scale_factor > 1:
-        lower = int(new_c-w)
-        expected = rotscaleshift[lower:upper, lower:upper]
-    else:
-        lower = int(w-new_c)
-        expected[lower:upper, lower:upper] = rotscaleshift
     assert compare_results(expected, rotscaleshift)
 
     # Check a rotated/shifted and restored image against original
-    transformed = affine_transform(original, rmatrix=rmatrix, scale=1.0, recenter=True,
+    transformed = affine_transform(original, rmatrix=rmatrix, scale=1.0, order=4, recenter=True,
                                    image_center=rcen)
-    rcen = image_center - np.dot(rmatrix, np.array([dx, dy]))
-    dx, dy = np.asarray(np.dot(rmatrix, disp), dtype=int)
-    rmatrix = np.array([[c, s], [-s, c]])
-    inverse = affine_transform(transformed, rmatrix=rmatrix, scale=1.0, recenter=True,
-                               image_center=rcen)
+    inv_rcen = image_center + np.dot(rmatrix.T, np.array([dx, dy]))
+    inverse = affine_transform(transformed, rmatrix=rmatrix.T, scale=1.0, order=4, recenter=True,
+                               image_center=inv_rcen)
 
     # Need to ignore the portion of the image cut off by the first shift
-    # (which isn't the portion you'd expect, because of the rotation)
     ymin, ymax = max([0, -dy]), min([original.shape[1], original.shape[1]-dy])
     xmin, xmax = max([0, -dx]), min([original.shape[0], original.shape[0]-dx])
     assert compare_results(original[ymin:ymax, xmin:xmax], inverse[ymin:ymax, xmin:xmax])


### PR DESCRIPTION
While thinking of how to further diagnose the mysterious OS X build failures (see #4076 and #4226), I discovered that a fair number of the affine-transform unit tests weren't actually making assertions.  Once I fixed that, I uncovered a bunch of failing tests.  The affine-transform code itself is fine; it's the tests themselves that had bugs.

This PR fixes the unit tests.  It also dumps out any mismatches in gory detail to help track down the OS X build failure.