### PR TITLE
Fixed very small inaccuracy with sun.angular_radius()

### DIFF
--- a/changelog/4239.bugfix.rst
+++ b/changelog/4239.bugfix.rst
@@ -1,0 +1,2 @@
+Improved the accuracy of :func:`~sunpy.coordinates.sun.angular_radius` by removing the use of the small-angle approximation.
+The inaccuracy had been less than 5 milliarcseconds.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -55,8 +55,8 @@ def angular_radius(t='now'):
     t : {parse_time_types}
         Time to use in a parse-time-compatible format
     """
-    solar_semidiameter_rad = constants.radius / earth_distance(t)
-    return Angle(solar_semidiameter_rad.to(u.arcsec, equivalencies=u.dimensionless_angles()))
+    solar_semidiameter_rad = np.arcsin(constants.radius / earth_distance(t))
+    return Angle(solar_semidiameter_rad.to(u.arcsec))
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -10,6 +10,7 @@ from astropy.time import Time
 from astropy.utils.exceptions import ErfaWarning
 
 from sunpy.coordinates import sun
+from sunpy.sun.constants import radius
 from .helpers import assert_longitude_allclose
 
 # Ignore warnings that astropy throws when trying and failing to update ephemeris
@@ -65,14 +66,19 @@ def test_apparent_latitude(t1, t2):
     assert_quantity_allclose(sun.apparent_latitude(t2), Angle('-0.42s'), atol=0.005*u.arcsec)
 
 
-def test_angular_radius():
+def test_angular_radius(t2):
+    # Validate against a published value from the Astronomical Almanac (2013, C13)
+    # The Astromomical Almanac uses a slightly different radius for the Sun (6.96e5 km)
+    assert_quantity_allclose(sun.angular_radius(t2),
+                             Angle('0d15m44.61s') / (6.96e5*u.km) * radius,  # scale to IAU radius
+                             atol=0.005*u.arcsec)
+
     # Regression-only test
-    # The Astronomical Almanac publishes values, but I don't know what physical radius they use
-    assert_quantity_allclose(sun.angular_radius("2012/11/11"), 968.871*u.arcsec, atol=1e-3*u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2012/11/11"), 968.875*u.arcsec, atol=1e-3*u.arcsec)
     with pytest.warns(ErfaWarning):
         assert_quantity_allclose(sun.angular_radius("2043/03/01"),
-                                 968.326*u.arcsec, atol=1e-3*u.arcsec)
-    assert_quantity_allclose(sun.angular_radius("2001/07/21"), 944.039*u.arcsec, atol=1e-3*u.arcsec)
+                                 968.330*u.arcsec, atol=1e-3*u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2001/07/21"), 944.042*u.arcsec, atol=1e-3*u.arcsec)
 
 
 def test_mean_obliquity_of_ecliptic(t1, t2):


### PR DESCRIPTION
`coordinates.sun.angular_radius()` calculated the angular radius using the small-angle approximation rather than arcsine.  We may as well use a proper arcsine to be more accurate, although the difference is basically negligible (at the few milliarcsecond level).

I also confirmed that *The Astronomical Almanac* is using a different value for the radius of Sun, so I updated the unit test to also test against a published value there.