### PR TITLE
🔧 Changed HELIO online tests to iterate over available servers

### DIFF
--- a/sunpy/net/helio/hec.py
+++ b/sunpy/net/helio/hec.py
@@ -3,8 +3,10 @@ Access the Helio Event Catalogue
 """
 import io
 
-import zeep
 from lxml import etree
+from requests import Session
+from zeep import Client
+from zeep.transports import Transport
 
 from astropy.io.votable.table import parse_single_table
 
@@ -67,8 +69,11 @@ class HECClient:
         if link is None:
             # The default wsdl file
             link = parser.wsdl_retriever()
-
-        self.hec_client = zeep.Client(link)
+        # Disable SSL check.
+        session = Session()
+        session.verify = False
+        transport = Transport(session=session)
+        self.hec_client = Client(link, transport=transport)
 
     def time_query(self, start_time, end_time, table=None, max_records=None):
         """

--- a/sunpy/net/helio/parser.py
+++ b/sunpy/net/helio/parser.py
@@ -88,14 +88,14 @@ def endpoint_parser(link):
     --------
     >>> from sunpy.net.helio import parser
     >>> parser.endpoint_parser('http://msslkz.mssl.ucl.ac.uk/helio-hec/HelioService')  # doctest: +REMOTE_DATA
-    ['http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioService?wsdl',
-    'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioService1_0?wsdl',
-    'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioService1_0b?wsdl',
-    'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioLongQueryService?wsdl',
-    'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioLongQueryService1_0?wsdl',
-    'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioLongQueryService1_1?wsdl',
-    'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioLongQueryService1_0b?wsdl',
-    'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioTavernaService?wsdl']
+    ['http://helio.mssl.ucl.ac.uk/helio-hec/HelioService?wsdl',
+    'http://helio.mssl.ucl.ac.uk/helio-hec/HelioService1_0?wsdl',
+    'http://helio.mssl.ucl.ac.uk/helio-hec/HelioService1_0b?wsdl',
+    'http://helio.mssl.ucl.ac.uk/helio-hec/HelioLongQueryService?wsdl',
+    'http://helio.mssl.ucl.ac.uk/helio-hec/HelioLongQueryService1_0?wsdl',
+    'http://helio.mssl.ucl.ac.uk/helio-hec/HelioLongQueryService1_1?wsdl',
+    'http://helio.mssl.ucl.ac.uk/helio-hec/HelioLongQueryService1_0b?wsdl',
+    'http://helio.mssl.ucl.ac.uk/helio-hec/HelioTavernaService?wsdl']
 
     """
     endpoint_page = link_test(link)
@@ -134,7 +134,7 @@ def taverna_parser(link):
     --------
     >>> from sunpy.net.helio import parser
     >>> parser.taverna_parser('http://msslkz.mssl.ucl.ac.uk/helio-hec/HelioService')  # doctest: +REMOTE_DATA
-    ['http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioTavernaService?wsdl']
+    ['http://helio.mssl.ucl.ac.uk/helio-hec/HelioTavernaService?wsdl']
 
     """
     endpoints = endpoint_parser(link)
@@ -205,7 +205,7 @@ def wsdl_retriever(service='HEC'):
     --------
     >>> from sunpy.net.helio import parser
     >>> parser.wsdl_retriever()  # doctest: +REMOTE_DATA
-    'http://helio.mssl.ucl.ac.uk:80/helio_hec/HelioTavernaService?wsdl'
+    'http://helio.mssl.ucl.ac.uk/helio_hec/HelioTavernaService?wsdl'
 
     Notes
     -----

--- a/sunpy/net/helio/tests/test_helio.py
+++ b/sunpy/net/helio/tests/test_helio.py
@@ -88,10 +88,10 @@ def wsdl_urls():
     """
     No `Taverna` links, just `WSDL`
     """
-    return ('http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioTavernaService?wsdl',
-            'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioLongQueryService?wsdl',
-            'http://helio.mssl.ucl.ac.uk:80/helio-hec/HelioLongQueryService1_1?wsdl',
-            'http://helio.ucl.ac.uk:80/helio-hec/HelioLongQueryService1_0b?wsdl')
+    return ('http://helio.mssl.ucl.ac.uk/helio-hec/HelioTavernaService?wsdl',
+            'http://helio.mssl.ucl.ac.uk/helio-hec/HelioLongQueryService?wsdl',
+            'http://helio.mssl.ucl.ac.uk/helio-hec/HelioLongQueryService1_1?wsdl',
+            'http://helio.ucl.ac.uk/helio-hec/HelioLongQueryService1_0b?wsdl')
 
 
 @mock.patch('sunpy.net.helio.parser.link_test', return_value=None)

--- a/sunpy/net/helio/tests/test_helio.py
+++ b/sunpy/net/helio/tests/test_helio.py
@@ -260,10 +260,11 @@ def test_link_test_on_urlerror(mock_link_test):
 
 
 @pytest.mark.remote_data
-@pytest.fixture
+@pytest.fixture(scope="session")
 def client():
-    link = 'http://helio.mssl.ucl.ac.uk:80/helio_hec/HelioTavernaService?wsdl'
-    return HECClient(link)
+    working_links = list(filter(link_test, webservice_parser()))
+    taverna_link = taverna_parser(working_links[0])[0]
+    return HECClient(taverna_link)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
This should find a working Taverna server and instantiate the client only once.

However, it may still fail on the SSL error I've seen today. I've asked to HELIO people whether they know why that happens. I can get that page with the browser but not with curl or pytyhon:

```bash
$ curl --verbose 'https://www.helio-vo.eu/services/xml/instruments.xsd'
*   Trying 128.40.71.43:443...
* Connected to www.helio-vo.eu (128.40.71.43) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: none
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS alert, unknown CA (560):
* SSL certificate problem: unable to get local issuer certificate
* Closing connection 0
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```