### PR TITLE
Ensure that SunpyDeprecationWarnings are raised as errors in the test suite

### DIFF
--- a/examples/computer_vision_techniques/loop_edge_enhance.py
+++ b/examples/computer_vision_techniques/loop_edge_enhance.py
@@ -21,7 +21,7 @@ from sunpy.data.sample import AIA_171_IMAGE
 aia = sunpy.map.Map(AIA_171_IMAGE)
 bottom_left = SkyCoord(750 * u.arcsec, -200 * u.arcsec, frame=aia.coordinate_frame)
 top_right = SkyCoord(1500 * u.arcsec, 550 * u.arcsec, frame=aia.coordinate_frame)
-aia_smap = aia.submap(bottom_left, top_right)
+aia_smap = aia.submap(bottom_left, top_right=top_right)
 
 ###############################################################################
 # Next we apply an edge enhance filter to the data in both x and y directions

--- a/examples/map/composite_map_AIA_HMI.py
+++ b/examples/map/composite_map_AIA_HMI.py
@@ -25,9 +25,9 @@ hmi_map = sunpy.map.Map(sunpy.data.sample.HMI_LOS_IMAGE)
 bottom_left = [0, 0] * u.arcsec
 top_right = [800, 800] * u.arcsec
 aia_smap = aia_map.submap(SkyCoord(*bottom_left, frame=aia_map.coordinate_frame),
-                          SkyCoord(*top_right, frame=aia_map.coordinate_frame))
+                          top_right=SkyCoord(*top_right, frame=aia_map.coordinate_frame))
 hmi_smap = hmi_map.submap(SkyCoord(*bottom_left, frame=hmi_map.coordinate_frame),
-                          SkyCoord(*top_right, frame=hmi_map.coordinate_frame))
+                          top_right=SkyCoord(*top_right, frame=hmi_map.coordinate_frame))
 
 
 ##############################################################################

--- a/examples/map/submaps_and_cropping.py
+++ b/examples/map/submaps_and_cropping.py
@@ -22,7 +22,7 @@ swap_map = sunpy.map.Map(sunpy.data.sample.SWAP_LEVEL1_IMAGE)
 # left as SkyCoord objects.
 top_right = SkyCoord(0 * u.arcsec, -200 * u.arcsec, frame=swap_map.coordinate_frame)
 bottom_left = SkyCoord(-900 * u.arcsec, -900 * u.arcsec, frame=swap_map.coordinate_frame)
-swap_submap = swap_map.submap(bottom_left, top_right)
+swap_submap = swap_map.submap(bottom_left, top_right=top_right)
 
 ###############################################################################
 # Let's plot the results

--- a/examples/plotting/finegrained_plot.py
+++ b/examples/plotting/finegrained_plot.py
@@ -21,7 +21,7 @@ aiamap = sunpy.map.Map(AIA_171_IMAGE)
 
 bottom_left = SkyCoord(-400*u.arcsec, -900*u.arcsec, frame=aiamap.coordinate_frame)
 top_right = SkyCoord(800*u.arcsec, 700*u.arcsec, frame=aiamap.coordinate_frame)
-aiamap_sub = aiamap.submap(bottom_left, top_right)
+aiamap_sub = aiamap.submap(bottom_left, top_right=top_right)
 
 title_obsdate = aiamap_sub.date.strftime('%Y-%b-%d %H:%M:%S')
 

--- a/examples/plotting/wcsaxes_map_example.py
+++ b/examples/plotting/wcsaxes_map_example.py
@@ -19,7 +19,7 @@ from sunpy.data.sample import AIA_171_IMAGE
 aia = sunpy.map.Map(AIA_171_IMAGE)
 top_right = SkyCoord(0 * u.arcsec, 1000 * u.arcsec, frame=aia.coordinate_frame)
 bottom_left = SkyCoord(-1000 * u.arcsec, 0 * u.arcsec, frame=aia.coordinate_frame)
-smap = aia.submap(bottom_left, top_right)
+smap = aia.submap(bottom_left, top_right=top_right)
 
 ###############################################################################
 # By setting the projection of the axis, a WCSAxes is created and this enables

--- a/examples/units_and_coordinates/SDO_to_STEREO_Coordinate_Conversion.py
+++ b/examples/units_and_coordinates/SDO_to_STEREO_Coordinate_Conversion.py
@@ -54,13 +54,11 @@ for i, m in enumerate(maps.values()):
 
 ###############################################################################
 # We are now going to pick out a region around the south west corner:
-aia_width = 200 * u.arcsec
-aia_height = 250 * u.arcsec
 aia_bottom_left = SkyCoord(-800 * u.arcsec,
                            -300 * u.arcsec,
                            frame=maps['AIA'].coordinate_frame)
-aia_top_right = SkyCoord(aia_bottom_left.Tx + aia_width,
-                         aia_bottom_left.Ty + aia_height,
+aia_top_right = SkyCoord(-600 * u.arcsec,
+                         -50 * u.arcsec,
                          frame=maps['AIA'].coordinate_frame)
 
 ###############################################################################
@@ -69,12 +67,12 @@ m = maps['AIA']
 fig = plt.figure()
 ax = fig.add_subplot(111, projection=m)
 m.plot(axes=ax)
-m.draw_rectangle(aia_bottom_left, aia_width, aia_height)
+m.draw_rectangle(aia_bottom_left, top_right=aia_top_right)
 
 
 ###############################################################################
 # Create a submap of this area
-subaia = maps['AIA'].submap(aia_bottom_left, aia_top_right)
+subaia = maps['AIA'].submap(aia_bottom_left, top_right=aia_top_right)
 fig = plt.figure()
 subaia.plot()
 
@@ -84,8 +82,8 @@ subaia.plot()
 # this object, we use `Map.coordinate_frame` so that the location parameters of
 # SDO are correctly set.
 corners = ([aia_bottom_left.Tx, aia_bottom_left.Ty],
-           [aia_bottom_left.Tx + aia_width, aia_bottom_left.Ty],
-           [aia_bottom_left.Tx, aia_bottom_left.Ty + aia_height],
+           [aia_top_right.Tx, aia_bottom_left.Ty],
+           [aia_bottom_left.Tx, aia_top_right.Ty],
            [aia_top_right.Tx, aia_top_right.Ty])
 
 hpc_aia = SkyCoord(corners, frame=maps['AIA'].coordinate_frame)
@@ -108,14 +106,12 @@ for i, (m, coord) in enumerate(zip([maps['EUVI'], maps['AIA']],
     m.plot(axes=ax)
 
     # coord[3] is the top-right corner coord[0] is the bottom-left corner.
-    w = (coord[3].Tx - coord[0].Tx)
-    h = (coord[3].Ty - coord[0].Ty)
-    m.draw_rectangle(coord[0], w, h,
+    m.draw_rectangle(coord[0], top_right=coord[3],
                      transform=ax.get_transform('world'))
 
 ###############################################################################
 # We can now zoom in on the region in the EUVI image:
-subeuvi = maps['EUVI'].submap(hpc_B[0], hpc_B[3])
+subeuvi = maps['EUVI'].submap(hpc_B[0], top_right=hpc_B[3])
 fig = plt.figure()
 plt.subplot(projection=subeuvi)
 subeuvi.plot()

--- a/examples/units_and_coordinates/venus_transit.py
+++ b/examples/units_and_coordinates/venus_transit.py
@@ -39,10 +39,9 @@ venus_hpc = venus.transform_to(aiamap.coordinate_frame)
 
 ###############################################################################
 # Let's crop the image with Venus at its center.
-fov = 100 * u.arcsec
-top_right = SkyCoord(venus_hpc.Tx + fov, venus_hpc.Ty + fov, frame=aiamap.coordinate_frame)
-bottom_left = SkyCoord(venus_hpc.Tx - fov, venus_hpc.Ty - fov, frame=aiamap.coordinate_frame)
-smap = aiamap.submap(top_right, bottom_left)
+fov = 200 * u.arcsec
+bottom_left = SkyCoord(venus_hpc.Tx - fov/2, venus_hpc.Ty - fov/2, frame=aiamap.coordinate_frame)
+smap = aiamap.submap(bottom_left, width=fov, height=fov)
 
 ###############################################################################
 # Let's plot the results.

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,10 +79,10 @@ asdf_extensions =
 [tool:pytest]
 minversion = 3.0
 testpaths = "sunpy" "docs"
-norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "examples" "sunpy[/\]cm" ".jupyter" "joss_paper" ".history"
+norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "examples" "sunpy[/\]cm" ".jupyter" ".history" "tools"
 doctest_plus = enabled
 doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
-addopts = -p no:warnings --doctest-rst -m "not figure" --doctest-ignore-import-errors
+addopts = --doctest-rst -m "not figure" --doctest-ignore-import-errors
 asdf_schema_tests_enabled = true
 asdf_schema_root = sunpy/io/special/asdf/schemas/
 markers =
@@ -91,6 +91,9 @@ markers =
     flaky
     array_compare
 remote_data_strict = True
+filterwarnings =
+    ignore
+    error::sunpy.util.exceptions.SunpyDeprecationWarning
 
 [pycodestyle]
 max_line_length = 100

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -2,7 +2,6 @@ import os
 import json
 import pathlib
 import tempfile
-import warnings
 import importlib
 
 import pytest
@@ -13,7 +12,6 @@ import astropy.config.paths
 import sunpy.tests.helpers
 from sunpy.tests.hash import HASH_LIBRARY_NAME
 from sunpy.tests.helpers import generate_figure_webpage, new_hash_library
-from sunpy.util.exceptions import SunpyDeprecationWarning
 
 # Force MPL to use non-gui backends for testing.
 try:
@@ -158,7 +156,3 @@ def pytest_unconfigure(config):
 
         print('All images from image tests can be found in {}'.format(figure_base_dir.resolve()))
         print("The corresponding hash library is {}".format(hashfile.resolve()))
-
-
-def pytest_sessionstart(session):
-    warnings.simplefilter("error", SunpyDeprecationWarning)

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -252,7 +252,7 @@ def test_calculate_match_template_shift(aia171_test_mc,
     assert_allclose(test_displacements['y'], aia171_mc_arcsec_displacements['y'], rtol=5e-2, atol=0)
 
     # Test setting the template as GenericMap
-    submap = aia171_test_map.submap([nx / 4, ny / 4]*u.pix, [3 * nx / 4, 3 * ny / 4]*u.pix)
+    submap = aia171_test_map.submap([nx / 4, ny / 4]*u.pix, top_right=[3 * nx / 4, 3 * ny / 4]*u.pix)
     with pytest.warns(SunpyDeprecationWarning):
         test_displacements = calculate_match_template_shift(aia171_test_mc, template=submap)
     assert_allclose(test_displacements['x'], aia171_mc_arcsec_displacements['x'], rtol=5e-2, atol=0)

--- a/sunpy/instr/tests/test_aia.py
+++ b/sunpy/instr/tests/test_aia.py
@@ -8,6 +8,7 @@ from astropy.io.fits.verify import VerifyWarning
 import sunpy.data.test as test
 import sunpy.map
 from sunpy.instr.aia import aiaprep
+from sunpy.util.exceptions import SunpyDeprecationWarning
 
 
 # Define the original and prepped images first so they're available to all
@@ -21,7 +22,8 @@ def original(request):
 
 @pytest.fixture
 def prep_map(original):
-    return aiaprep(original)
+    with pytest.warns(SunpyDeprecationWarning):
+        return aiaprep(original)
 
 
 def test_aiaprep(original, prep_map):

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -34,22 +34,22 @@ def aia171_test_map():
 
 @pytest.fixture
 def all_off_disk_map(aia171_test_map):
-    return aia171_test_map.submap((1, 1)*u.pix, (11, 12)*u.pix)
+    return aia171_test_map.submap((1, 1)*u.pix, top_right=(11, 12)*u.pix)
 
 
 @pytest.fixture
 def all_on_disk_map(aia171_test_map):
-    return aia171_test_map.submap((30, 60)*u.pix, (50, 85)*u.pix)
+    return aia171_test_map.submap((30, 60)*u.pix, top_right=(50, 85)*u.pix)
 
 
 @pytest.fixture
 def straddles_limb_map(aia171_test_map):
-    return aia171_test_map.submap((64, 80)*u.pix, (120, 127)*u.pix)
+    return aia171_test_map.submap((64, 80)*u.pix, top_right=(120, 127)*u.pix)
 
 
 @pytest.fixture
 def sub_smap(aia171_test_map):
-    return aia171_test_map.submap((0, 0)*u.pix, (50, 60)*u.pix)
+    return aia171_test_map.submap((0, 0)*u.pix, top_right=(50, 60)*u.pix)
 
 
 @pytest.fixture

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -543,6 +543,6 @@ def test_vso_repr(client):
 @pytest.mark.remote_data
 def test_response_block_properties(client):
     res = client.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument('aia'), a.Wavelength(171 * u.angstrom),
-                        a.vso.Sample(10 * u.minute))
+                        a.Sample(10 * u.minute))
     properties = res.response_block_properties()
     assert len(properties) == 0

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -531,7 +531,7 @@ def differential_rotate(smap, observer=None, time=None, **diff_rot_kwargs):
 
             # Create a submap that excludes the off disk emission that does
             # not need to be rotated.
-            smap = smap.submap(bottom_left, top_right)
+            smap = smap.submap(bottom_left, top_right=top_right)
         bottom_left = smap.bottom_left_coord
         top_right = smap.top_right_coord
 
@@ -615,6 +615,6 @@ def differential_rotate(smap, observer=None, time=None, **diff_rot_kwargs):
             ((center_rotated.Tx - smap.center.Tx)/smap.scale.axis1).value
         out_meta['crpix2'] = 1 + smap.data.shape[0]/2.0 + \
             ((center_rotated.Ty - smap.center.Ty)/smap.scale.axis2).value
-        return smap._new_instance(out_data, out_meta).submap(rotated_bl, rotated_tr)
+        return smap._new_instance(out_data, out_meta).submap(rotated_bl, top_right=rotated_tr)
     else:
         return smap._new_instance(out_data, out_meta)

--- a/sunpy/physics/tests/test_differential_rotation.py
+++ b/sunpy/physics/tests/test_differential_rotation.py
@@ -60,17 +60,17 @@ def aia171_test_map():
 
 @pytest.fixture
 def all_off_disk_map(aia171_test_map):
-    return aia171_test_map.submap((1, 1)*u.pix, (11, 12)*u.pix)
+    return aia171_test_map.submap((1, 1)*u.pix, top_right=(11, 12)*u.pix)
 
 
 @pytest.fixture
 def all_on_disk_map(aia171_test_map):
-    return aia171_test_map.submap((30, 60)*u.pix, (50, 85)*u.pix)
+    return aia171_test_map.submap((30, 60)*u.pix, top_right=(50, 85)*u.pix)
 
 
 @pytest.fixture
 def straddles_limb_map(aia171_test_map):
-    return aia171_test_map.submap((64, 80)*u.pix, (120, 127)*u.pix)
+    return aia171_test_map.submap((64, 80)*u.pix, top_right=(120, 127)*u.pix)
 
 
 @pytest.fixture
@@ -85,7 +85,7 @@ def aia171_test_map_with_mask(aia171_test_map):
 def aia171_test_submap(aia171_test_map):
     bl = SkyCoord(-512 * u.arcsec, 100 * u.arcsec, frame=aia171_test_map.coordinate_frame)
     ur = SkyCoord(-100 * u.arcsec, 400 * u.arcsec, frame=aia171_test_map.coordinate_frame)
-    return aia171_test_map.submap(bl, ur)
+    return aia171_test_map.submap(bl, top_right=ur)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description

It seems that at some point in the past we stopped raising SunpyDeprecationWarnings as errors in the test suite. This is *bad* :sob: