### PR TITLE
Transforming a SunPy frame to a class now preserves shared frame attributes

### DIFF
--- a/changelog/4257.bugfix.rst
+++ b/changelog/4257.bugfix.rst
@@ -1,0 +1,1 @@
+Transforming any `sunpy.coordinates` frame to a frame class (as opposed to an instantiated frame) will now preserve the values for any shared frame attributes (e.g., ``obstime``).

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -4,6 +4,8 @@ Common solar physics coordinate systems.
 This submodule implements various solar physics coordinate frames for use with
 the `astropy.coordinates` module.
 """
+import inspect
+
 import numpy as np
 
 import astropy.units as u
@@ -131,6 +133,25 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
         property in `~astropy.coordinates.BaseCoordinateFrame`.
         """
         return self.data.size if self.has_data else 0
+
+    def transform_to(self, new_frame):
+        """
+
+        Notes
+        -----
+        If a class is specified, the new frame will be instantiated using the values
+        from this frame for any shared frame attributes (e.g., ``obstime``) that do
+        not have default values.  All other frame attributes will have default values.
+        """
+        # The docstring above will be prepended by the parent method's docstring
+
+        if inspect.isclass(new_frame):
+            nondefault = set(self.frame_attributes.keys()) - set(self._attr_names_with_defaults)
+            shared_attr = nondefault.intersection(new_frame.frame_attributes.keys())
+            new_frame = new_frame(**dict([(attr, getattr(self, attr)) for attr in shared_attr]))
+        return super().transform_to(new_frame)
+
+    transform_to.__doc__ = BaseCoordinateFrame.transform_to.__doc__ + transform_to.__doc__
 
     def __str__(self):
         """

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -753,13 +753,15 @@ def test_array_obstime():
     assert isinstance(t2.frame, Helioprojective)
 
 
-_frameset1 = [HeliographicStonyhurst, HeliocentricInertial]
-_frameset2 = [HeliographicCarrington, Heliocentric, Helioprojective]
+_frames_wo_observer = [HeliographicStonyhurst, HeliocentricInertial,
+                       HeliocentricEarthEcliptic, GeocentricSolarEcliptic,
+                       GeocentricEarthEquatorial]
+_frames_w_observer = [HeliographicCarrington, Heliocentric, Helioprojective]
 
 
-@pytest.mark.parametrize("start_class", _frameset1 + _frameset2)
-@pytest.mark.parametrize("end_class", _frameset1)
-def test_no_obstime_on_one_end(start_class, end_class):
+@pytest.mark.parametrize("start_class", _frames_wo_observer + _frames_w_observer)
+@pytest.mark.parametrize("end_class", _frames_wo_observer)
+def test_transform_to_class(start_class, end_class):
     start_obstime = Time("2001-01-01")
 
     if hasattr(start_class, 'observer'):


### PR DESCRIPTION
Fixes #4237

Transforming a SunPy coordinate frame to a class now instantiates the destination frame with the (non-default) values in the original frame for any shared frame attributes (e.g., `obstime`) instead of being all default values.  This is particularly important for us because `obstime` in our frames defaults to `None`.

Thus, this now works:
```python
>>> from sunpy.coordinates import HeliocentricEarthEcliptic, HeliographicStonyhurst
>>> hee = HeliocentricEarthEcliptic(45*u.deg, 35*u.deg, 17*u.km, obstime="2020-01-01") 
>>> hee.transform_to(HeliographicStonyhurst) 
<HeliographicStonyhurst Coordinate (obstime=2020-01-01T00:00:00.000): (lon, lat, radius) in (deg, deg, km)
    (46.71542196, 28.19372091, 17.)>
```

This also means that there will no longer be transformation issues when supplying a non-HGS coordinate as the `observer` frame attribute (as long as that non-HGS coordinate is in a SunPy frame).

I've already created an upstream PR for this (astropy/astropy#10453), so assuming that PR is accepted, this fix can eventually be removed.