### PR TITLE
Fixed missing transformation errors when `obstime` is `None`

### DIFF
--- a/changelog/4267.bugfix.rst
+++ b/changelog/4267.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where transformation errors were not getting raised in some situations when a coordinate frame had ``obstime`` set to the default value of ``None`` and `~astropy.coordinates.SkyCoord` was not being used.
+Users are recommended to use `~astropy.coordinates.SkyCoord` to manage coordinate transformations unless they have a specific reason not to.

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -57,8 +57,8 @@ Furthermore, you can use tab completion to auto-fill the attribute name, for exa
 So now you can do the following instead::
 
     Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument.norh, a.Wavelength(17*u.GHz))
-    
-    
+
+
 aiaprep is now deprecated
 =========================
 
@@ -89,7 +89,7 @@ Standardization of `~sunpy.map.GenericMap.submap` and `~sunpy.map.GenericMap.dra
 Both `~sunpy.map.GenericMap.submap` and `~sunpy.map.GenericMap.draw_rectangle` allow specification of "rectangles" in world (spherical) coordinates.
 In versions prior to 2.0 you passed the coordinates of the rectangle to ``draw_rectangle`` as a bottom left coordinate, and a height and width, but for submap you passed it as a bottom left and a top right.
 In 2.0 the way you call both methods has changed, to accept a bottom left and then either width and height or a top right coordinate.
-As part of this change, the ``top_right``, ``width``, and ``height`` arguments **must** always be keyword arguments, i.e. ``width=10*u.arcsec`` 
+As part of this change, the ``top_right``, ``width``, and ``height`` arguments **must** always be keyword arguments, i.e. ``width=10*u.arcsec``
 
 This change allows you to give the same rectangle specification to `~sunpy.map.GenericMap.submap` as to `~sunpy.map.GenericMap.draw_rectangle`.
 Which is especially useful when you wish to plot a cropped area of a map, along with it's context in the parent map::

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -771,15 +771,8 @@ def test_convert_error_with_no_obstime(frame_class):
         frame.transform_to(ICRS)
 
 
-_frameset1 = [HeliographicStonyhurst, HeliocentricInertial]
-_frameset2 = [HeliographicCarrington, Heliocentric, Helioprojective]
-
-
-@pytest.mark.parametrize("start_class", _frameset1 + _frameset2)
-@pytest.mark.parametrize("end_class", _frameset1)
-def test_no_obstime_on_target_end(start_class, end_class):
-    # We currently allow the target `obstime` to be `None` for the transformation subgraph
-    # below `HeliographicStonyhurst`, but this may change in the future
+# Convenience function to check whether a transformation succeeds if the target `obstime` is `None`
+def assert_no_obstime_on_target_end(start_class, end_class):
     start_obstime = Time("2001-01-01")
 
     if hasattr(start_class, 'observer'):
@@ -790,6 +783,29 @@ def test_no_obstime_on_target_end(start_class, end_class):
 
     result = coord.transform_to(end_class)
     assert result.obstime == start_obstime
+
+
+# We currently allow the target `obstime` to be `None` for the transformation subgraph
+# below `HeliographicStonyhurst`, but this may change in the future
+_frameset1 = [HeliographicStonyhurst, HeliocentricInertial]
+_frameset2 = [HeliographicCarrington, Heliocentric, Helioprojective]
+
+
+@pytest.mark.parametrize("start_class", _frameset1 + _frameset2)
+@pytest.mark.parametrize("end_class", _frameset1)
+def test_no_obstime_on_target_end_hgs_subgraph(start_class, end_class):
+    assert_no_obstime_on_target_end(start_class, end_class)
+
+
+# We currently allow the target `obstime` to be `None` for the transformation subgraph
+# below `HeliocentricEarthEcliptic`, but this may change in the future
+_frameset3 = [HeliocentricEarthEcliptic, GeocentricSolarEcliptic]
+
+
+@pytest.mark.parametrize("start_class", _frameset3)
+@pytest.mark.parametrize("end_class", _frameset3)
+def test_no_obstime_on_target_end_hee_subgraph(start_class, end_class):
+    assert_no_obstime_on_target_end(start_class, end_class)
 
 
 def test_transform_with_sun_center():

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -686,6 +686,10 @@ def hme_to_hee(hmecoord, heeframe):
     """
     Convert from Heliocentric Mean Ecliptic to Heliocentric Earth Ecliptic
     """
+    if heeframe.obstime is None:
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
+
     # Convert to the HME frame with mean equinox of date at the HEE obstime, through HCRS
     int_frame = HeliocentricMeanEcliptic(obstime=heeframe.obstime, equinox=heeframe.obstime)
     int_coord = hmecoord.transform_to(HCRS).transform_to(int_frame)
@@ -704,6 +708,10 @@ def hee_to_hme(heecoord, hmeframe):
     """
     Convert from Heliocentric Earth Ecliptic to Heliocentric Mean Ecliptic
     """
+    if heecoord.obstime is None:
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
+
     int_frame = HeliocentricMeanEcliptic(obstime=heecoord.obstime, equinox=heecoord.obstime)
 
     # Rotate the HEE coord to the intermediate frame
@@ -735,6 +743,10 @@ def hee_to_gse(heecoord, gseframe):
     """
     Convert from Heliocentric Earth Ecliptic to Geocentric Solar Ecliptic
     """
+    if heecoord.obstime is None:
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
+
     # Use an intermediate frame of HEE at the GSE observation time
     int_frame = HeliocentricEarthEcliptic(obstime=gseframe.obstime)
     int_coord = heecoord.transform_to(int_frame)
@@ -760,6 +772,10 @@ def gse_to_hee(gsecoord, heeframe):
     """
     Convert from Geocentric Solar Ecliptic to Heliocentric Earth Ecliptic
     """
+    if gsecoord.obstime is None:
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
+
     # Use an intermediate frame of HEE at the GSE observation time
     int_frame = HeliocentricEarthEcliptic(obstime=gsecoord.obstime)
 
@@ -822,6 +838,10 @@ def hgs_to_hci(hgscoord, hciframe):
     # First transform the HGS coord to the HCI obstime
     int_coord = _transform_obstime(hgscoord, hciframe.obstime)
 
+    if int_coord.obstime is None:
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
+
     # Rotate from HGS to HCI
     total_matrix = _rotation_matrix_hgs_to_hci(int_coord.obstime)
     newrepr = int_coord.cartesian.transform(total_matrix)
@@ -838,6 +858,10 @@ def hci_to_hgs(hcicoord, hgsframe):
     """
     # First transform the HCI coord to the HGS obstime
     int_coord = _transform_obstime(hcicoord, hgsframe.obstime)
+
+    if int_coord.obstime is None:
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
 
     # Rotate from HCI to HGS
     total_matrix = matrix_transpose(_rotation_matrix_hgs_to_hci(int_coord.obstime))
@@ -874,6 +898,10 @@ def hme_to_gei(hmecoord, geiframe):
     """
     Convert from Heliocentric Mean Ecliptic to Geocentric Earth Equatorial
     """
+    if geiframe.obstime is None:
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
+
     # Use an intermediate frame of HME at the GEI observation time, through HCRS
     int_frame = HeliocentricMeanEcliptic(obstime=geiframe.obstime, equinox=geiframe.equinox)
     int_coord = hmecoord.transform_to(HCRS).transform_to(int_frame)
@@ -899,6 +927,10 @@ def gei_to_hme(geicoord, hmeframe):
     """
     Convert from Geocentric Earth Equatorial to Heliocentric Mean Ecliptic
     """
+    if geicoord.obstime is None:
+        raise ConvertError("To perform this transformation, the coordinate"
+                           " frame needs a specified `obstime`.")
+
     # Use an intermediate frame of HME at the GEI observation time
     int_frame = HeliocentricMeanEcliptic(obstime=geicoord.obstime, equinox=geicoord.equinox)
 


### PR DESCRIPTION
The transformations to/from SunPy 1.0 frames are fairly permissive when they encounter `obstime=None` for a frame and try to transfer it from the other frame in the transformation, or even the `observer` attribute if it's an observer-based frame.  The behavior is no longer permissive if attempting to transform beyond that subgraph.  (The permissive behavior was primarily motivated by our `observer` frame attribute, but the specific bug there has been fixed by #4266, and the concept of under-defined `SkyCoord`-less transformations may be going away in the future.  This PR leaves this permissive behavior untouched.)

The transformations to/from SunPy 1.1 frames (HEE, GSE, GEI, HCI) don't fully handle all situations with `obstime=None`, and weren't raising transformation errors.  Some of the transformation output in edge cases could be outright wrong.

This PR adds a bunch of transformation errors.