### PR TITLE
Do not install any dependencies via pip under tox conda

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,7 @@ deps =
 conda_deps =
     astropy
     beautifulsoup4
+    conda
     dask
     drms
     glymur
@@ -130,4 +131,7 @@ conda_deps =
     zeep
     pillow < 7.1.0
 conda_channels = sunpy
-commands = {env:PYTEST_COMMAND} {posargs}
+install_command = pip install --no-deps {opts} {packages}
+commands =
+    conda list
+    {env:PYTEST_COMMAND} {posargs}


### PR DESCRIPTION
For the tox conda build:
- The pip command will no longer install dependencies
- List out all of the installed packages

Closes #4285