### PR TITLE
Transition doc build to RTD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run: *skip-check
       - run: *merge-check
       - run: *apt-install
-      - run: pip install --user -U tox codecov
+      - run: pip install --user -U tox codecov virtualenv!=20.0.24
       - run: tox
       - run: codecov
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,42 +27,6 @@ apt-run: &apt-install
     sudo apt install -y graphviz build-essential libopenjp2-7 python3-dev
 
 jobs:
-  html-docs:
-    docker:
-      - image: circleci/python:3.8.1-buster
-    environment:
-      SUNPY_SAMPLEDIR=/home/circleci/sunpy/data/sample_data/
-    steps:
-      - run: *no-backports
-      - checkout
-      - run: *skip-check
-      - restore_cache:
-          keys: sample-data-v13
-      - run: *merge-check
-      - run: *apt-install
-      - run: pip install --user -U tox tox-pypi-filter>=0.12
-      - run: tox -e build_docs
-      - save_cache:
-          key: sample-data-v13
-          paths:
-            - /home/circleci/sunpy/data/sample_data/
-      - run:
-          name: Prepare for upload
-          command: |
-            # If it's not a PR, don't upload
-            if [ -z "${CIRCLE_PULL_REQUEST}" ]; then
-              rm -r docs/_build/html/*
-            else
-              # If it is a PR, delete sources, because it's a lot of files
-              # which we don't really need to upload
-              rm -r docs/_build/html/_sources
-            fi
-      - store_artifacts:
-          path: docs/_build/html
-      - run:
-          name: "Built documentation is available at:"
-          command: DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/docs/_build/html/index.html"; echo $DOCS_URL
-
   figure:
     parameters:
       jobname:
@@ -130,10 +94,6 @@ workflows:
             branches:
               only:
                 - master
-
-  test-documentation:
-    jobs:
-      - html-docs
 
 notify:
   webhooks:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,6 +4,11 @@ version: 2
 conda:
   environment: rtd-environment.yml
 
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
 python:
    version: 3.8
    install:


### PR DESCRIPTION
Thanks to @pllim in astropy/astropy#10497 it turns out you can make RTD fail on warnings, so I don't think there is really any reason to keep the circleci build around at all.

I have kept the tox build there and still erroring on warnings, so people can use it to build locally. Obviously we can't be 100% sure that if tox passes the RTD build will pass now, but I think it's worth the tradeoff.