### PR TITLE
Redesigning genericClient

### DIFF
--- a/changelog/4321.breaking.1.rst
+++ b/changelog/4321.breaking.1.rst
@@ -1,0 +1,1 @@
+Removed :meth:`~sunpy.net.dataretriever.QueryResponse.create`.

--- a/changelog/4321.breaking.rst
+++ b/changelog/4321.breaking.rst
@@ -1,0 +1,1 @@
+Removed `~sunpy.net.dataretriever.QueryResponseBlock` as `~sunpy.net.dataretriever.QueryResponse` now uses a `list` of `~collections.OrderedDict` for building the response table.

--- a/changelog/4321.feature.1.rst
+++ b/changelog/4321.feature.1.rst
@@ -1,0 +1,3 @@
+Additions in `~sunpy.util.scraper` to support the refactoring of `~sunpy.net.dataretriever.GenericClient`:
+- :meth:`~sunpy.util.scraper.Scraper.findDatewith_extractor` that parses the url using extractor to return its start time.
+- A ``matcher`` in :meth:`~sunpy.util.scraper.Scraper._extract_files_meta` which validates the extracted metadata by using the dictionary returned from :meth:`~sunpy.net.dataretriever.GenericClient._get_match_dict`.

--- a/changelog/4321.feature.3.rst
+++ b/changelog/4321.feature.3.rst
@@ -1,0 +1,1 @@
+Added methods :meth:`~sunpy.net.dataretriever.GenericClient.pre_search_hook` and :meth:`~sunpy.net.dataretriever.GenericClient.post_search_hook` which helps to translate the attrs for scraper before and after the search respectively.

--- a/changelog/4321.feature.4.rst
+++ b/changelog/4321.feature.4.rst
@@ -1,0 +1,4 @@
+New class attributes added to `~sunpy.net.dataretriever.GenericClient`:
+
+- ``baseurl`` and ``pattern`` which are required to define a new simple client.
+- ``optional`` and ``required`` which are a ``set`` of optional and required `~sunpy.net.attrs` respectively; which generalizes :meth:`~sunpy.net.dataretriever.GenericClient._can_handle_query`.

--- a/changelog/4321.feature.rst
+++ b/changelog/4321.feature.rst
@@ -1,0 +1,4 @@
+Refactoring of `~sunpy.net.dataretriever` which adds these capabilities to `~sunpy.net.dataretriever.QueryResponse`:
+
+- Any ``attr`` shall not be defaulted to a hard-coded value in all subclasses of `~sunpy.net.dataretriever.GenericClient`; thus records for all possible ``attrs`` shall be returned if it is not specified in the query.
+- `~sunpy.net.dataretriever.QueryResponse` can now show more columns; thus all metadata extractable from matching file URLs shall be shown and for a client, non-spported ``attrs`` shall not be shown in the response tables.

--- a/changelog/4321.removal.rst
+++ b/changelog/4321.removal.rst
@@ -1,0 +1,2 @@
+Removed `~sunpy.net.vso.attrs.Source` and `~sunpy.net.vso.attrs.Provider`. They are now `~sunpy.net.attrs.Source` and `~sunpy.net.attrs.Provider` respectively.
+Thus ``attrs``, ``Source`` and ``Provider`` are moved from VSO namespace to `~sunpy.net.attrs`.

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -62,19 +62,6 @@ Using ``Instrument`` as the first example, if you print the object::
 You get a full list of known values, a description and what "Clients" support those values (if you want to use a specific data source).
 This is supported for most attributes including the client specific ones.
 
-For VSO::
-
-    >>> print(a.vso.Provider)
-    sunpy.net.vso.attrs.Provider
-    <BLANKLINE>
-    Specifies the VSO data provider to search for data for.
-    <BLANKLINE>
-    Attribute Name Client Full Name                                   Description
-    -------------- ------ --------- --------------------------------------------------------------------------------
-    hao            VSO    HAO       High Altitude Observatory, NCAR
-    jsoc           VSO    JSOC      SDO Joint Science Operations Center
-    kis            VSO    KIS       Kiepenheuer-Institut für Sonnenphysik
-    ...
 
 For JSOC::
 
@@ -98,7 +85,7 @@ Searching for Data Using Fido
 
 For example::
 
-    >>> result = Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument.lyra) # doctest: +REMOTE_DATA
+    >>> result = Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Instrument.lyra, a.Level.two) # doctest: +REMOTE_DATA
 
 this returns an `~sunpy.net.fido_factory.UnifiedResponse` object containing
 information on the available online files which fit the criteria specified by
@@ -113,11 +100,11 @@ variable set to the Fido search, in this case, result::
     Results from 1 Provider:
     <BLANKLINE>
     3 Results from the LYRAClient:
-         Start Time           End Time      Source Instrument Wavelength
-    ------------------- ------------------- ------ ---------- ----------
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
-    2012-03-04 00:00:00 2012-03-06 00:00:00 Proba2       lyra        nan
+         Start Time           End Time      Instrument ... Source Provider Level
+    ------------------- ------------------- ---------- ... ------ -------- -----
+    2012-03-04 00:00:00 2012-03-04 23:59:59       LYRA ... PROBA2      ESA     2
+    2012-03-05 00:00:00 2012-03-05 23:59:59       LYRA ... PROBA2      ESA     2
+    2012-03-06 00:00:00 2012-03-06 23:59:59       LYRA ... PROBA2      ESA     2
     <BLANKLINE>
     <BLANKLINE>
 
@@ -133,11 +120,11 @@ passbands can be searched for by supplying an `~astropy.units.Quantity` to the
     Results from 1 Provider:
     <BLANKLINE>
     3 Results from the NoRHClient:
-         Start Time           End Time      Source Instrument   Wavelength
-    ------------------- ------------------- ------ ---------- --------------
-    2012-03-04 00:00:00 2012-03-05 00:00:00   NAOJ       NORH 17000000.0 kHz
-    2012-03-05 00:00:00 2012-03-06 00:00:00   NAOJ       NORH 17000000.0 kHz
-    2012-03-06 00:00:00 2012-03-07 00:00:00   NAOJ       NORH 17000000.0 kHz
+         Start Time           End Time      Instrument Source Provider Wavelength
+    ------------------- ------------------- ---------- ------ -------- ----------
+    2012-03-04 00:00:00 2012-03-04 23:59:59       NORH   NAOJ      NRO   17.0 GHz
+    2012-03-05 00:00:00 2012-03-05 23:59:59       NORH   NAOJ      NRO   17.0 GHz
+    2012-03-06 00:00:00 2012-03-06 23:59:59       NORH   NAOJ      NRO   17.0 GHz
     <BLANKLINE>
     <BLANKLINE>
 
@@ -193,10 +180,11 @@ operator would::
     <sunpy.net.fido_factory.UnifiedResponse object at ...>
     Results from 3 Providers:
     <BLANKLINE>
-    1 Results from the LYRAClient:
-         Start Time           End Time      Source Instrument Wavelength
-    ------------------- ------------------- ------ ---------- ----------
-    2012-03-04 00:00:00 2012-03-04 02:00:00 Proba2       lyra        nan
+    2 Results from the LYRAClient:
+         Start Time           End Time      Instrument ... Source Provider Level
+    ------------------- ------------------- ---------- ... ------ -------- -----
+    2012-03-04 00:00:00 2012-03-04 23:59:59       LYRA ... PROBA2      ESA     2
+    2012-03-04 00:00:00 2012-03-04 23:59:59       LYRA ... PROBA2      ESA     3
     <BLANKLINE>
     3 Results from the VSOClient:
        Start Time [1]       End Time [1]    Source ...     Type    Wavelength [2]
@@ -207,9 +195,9 @@ operator would::
     2012-03-04 01:45:40 2012-03-04 02:09:00 RHESSI ... PARTIAL_SUN 3.0 .. 17000.0
     <BLANKLINE>
     1 Results from the RHESSIClient:
-         Start Time           End Time      Source Instrument Wavelength
-    ------------------- ------------------- ------ ---------- ----------
-    2012-03-04 00:00:00 2012-03-04 23:59:59 rhessi     rhessi        nan
+         Start Time           End Time      Instrument ... Source Provider
+    ------------------- ------------------- ---------- ... ------ --------
+    2012-03-04 00:00:00 2012-03-04 23:59:59     RHESSI ... RHESSI     NASA
     <BLANKLINE>
     <BLANKLINE>
 
@@ -227,7 +215,7 @@ the `~sunpy.net.dataretriever.LYRAClient`, and EVE data from the
 `~sunpy.net.vso.VSOClient`::
 
     >>> from sunpy.net import Fido, attrs as a
-    >>> results = Fido.search(a.Time("2012/1/1", "2012/1/2"),
+    >>> results = Fido.search(a.Time("2012/1/1", "2012/1/2"), a.Level.two,
     ...                       a.Instrument.lyra | a.Instrument.eve)  # doctest: +REMOTE_DATA
 
 If you then wanted to inspect just the LYRA data for the whole time range
@@ -239,10 +227,10 @@ results returned by the `~sunpy.net.dataretriever.LYRAClient`::
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the LYRAClient:
-         Start Time           End Time      Source Instrument Wavelength
-    ------------------- ------------------- ------ ---------- ----------
-    2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
-    2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
+         Start Time           End Time      Instrument ... Source Provider Level
+    ------------------- ------------------- ---------- ... ------ -------- -----
+    2012-01-01 00:00:00 2012-01-01 23:59:59       LYRA ... PROBA2      ESA     2
+    2012-01-02 00:00:00 2012-02-02 23:59:59       LYRA ... PROBA2      ESA     2
     <BLANKLINE>
     <BLANKLINE>
 
@@ -253,10 +241,10 @@ Or, equivalently::
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the LYRAClient:
-         Start Time           End Time      Source Instrument Wavelength
-    ------------------- ------------------- ------ ---------- ----------
-    2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
-    2012-01-01 00:00:00 2012-01-02 00:00:00 Proba2       lyra        nan
+         Start Time           End Time      Instrument ... Source Provider Level
+    ------------------- ------------------- ---------- ... ------ -------- -----
+    2012-01-01 00:00:00 2012-01-01 23:59:59       LYRA ... PROBA2      ESA     2
+    2012-01-02 00:00:00 2012-02-02 23:59:59       LYRA ... PROBA2      ESA     2
     <BLANKLINE>
     <BLANKLINE>
 

--- a/examples/time_series/goes_hek_m25.py
+++ b/examples/time_series/goes_hek_m25.py
@@ -15,7 +15,7 @@ from sunpy.timeseries import TimeSeries
 
 ###############################################################################
 # Let's first grab GOES XRS data for a particular time of interest
-tr = TimeRange(['2011-06-07 04:00', '2011-06-07 12:00'])
+tr = TimeRange(['2011-06-07 00:00', '2011-06-07 12:00'])
 results = Fido.search(a.Time(tr), a.Instrument.xrs)
 
 ###############################################################################

--- a/examples/time_series/goes_hek_m25.py
+++ b/examples/time_series/goes_hek_m25.py
@@ -15,7 +15,7 @@ from sunpy.timeseries import TimeSeries
 
 ###############################################################################
 # Let's first grab GOES XRS data for a particular time of interest
-tr = TimeRange(['2011-06-07 00:00', '2011-06-07 12:00'])
+tr = TimeRange(['2011-06-07 04:00', '2011-06-07 12:00'])
 results = Fido.search(a.Time(tr), a.Instrument.xrs)
 
 ###############################################################################

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -384,6 +384,8 @@ class DatabaseEntry(DatabaseEntryType, Base):
         time_end = sr_block.time.end.datetime
 
         wavelengths = getattr(sr_block, 'wave', None)
+        if wavelengths is None:
+            wavelengths = getattr(sr_block, 'wavelength', np.nan)
         wavelength_temp = {}
         if isinstance(wavelength_temp, tuple):
             # Tuple of values
@@ -572,17 +574,17 @@ def entries_from_fido_search_result(sr, default_waveunit=None):
     >>> entries = entries_from_fido_search_result(sr) # doctest: +REMOTE_DATA
     >>> entry = next(entries) # doctest: +REMOTE_DATA
     >>> entry.source # doctest: +REMOTE_DATA
-    'Proba2'
+    'PROBA2'
     >>> entry.provider # doctest: +REMOTE_DATA
-    'esa'
+    'ESA'
     >>> entry.physobs # doctest: +REMOTE_DATA
     'irradiance'
     >>> entry.fileid # doctest: +REMOTE_DATA
     'http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits'
     >>> entry.observation_time_start, entry.observation_time_end # doctest: +REMOTE_DATA
-    (datetime.datetime(2012, 1, 1, 0, 0), datetime.datetime(2012, 1, 2, 0, 0))
+    (datetime.datetime(2012, 1, 1, 0, 0),  datetime.datetime(2012, 1, 1, 23, 59, 59, 999000))
     >>> entry.instrument # doctest: +REMOTE_DATA
-    'lyra'
+    'LYRA'
 
     """
     for entry in sr:

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -374,18 +374,16 @@ class DatabaseEntry(DatabaseEntryType, Base):
         """
         # All attributes of DatabaseEntry that are not in QueryResponseBlock
         # are set as None for now.
-        source = getattr(sr_block, 'source', None)
-        provider = getattr(sr_block, 'provider', None)
-        physobs = getattr(sr_block, 'physobs', None)
+        source = sr_block.get('Source', None)
+        provider = sr_block.get('Provider', None)
+        physobs = sr_block.get('Physobs', None)
         if physobs is not None:
             physobs = str(physobs)
-        instrument = getattr(sr_block, 'instrument', None)
-        time_start = sr_block.time.start.datetime
-        time_end = sr_block.time.end.datetime
+        instrument = sr_block.get('Instrument', None)
+        time_start = sr_block['Time'].start.datetime
+        time_end = sr_block['Time'].end.datetime
 
-        wavelengths = getattr(sr_block, 'wave', None)
-        if wavelengths is None:
-            wavelengths = getattr(sr_block, 'wavelength', np.nan)
+        wavelengths = sr_block.get('Wavelength', np.nan)
         wavelength_temp = {}
         if isinstance(wavelength_temp, tuple):
             # Tuple of values
@@ -411,8 +409,7 @@ class DatabaseEntry(DatabaseEntryType, Base):
         wavemin = final_values['wavemin']
         wavemax = final_values['wavemax']
 
-        # sr_block.url of a QueryResponseBlock attribute is stored in fileid
-        fileid = str(sr_block.url) if sr_block.url is not None else None
+        fileid = sr_block.get('url', None)
         size = None
         return cls(
             source=source, provider=provider, physobs=physobs, fileid=fileid,

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -74,12 +74,11 @@ def fido_search_result():
     # No JSOC query
     return Fido.search(
         net_attrs.Time("2012/1/1", "2012/1/2"),
-        net_attrs.Instrument('lyra') | net_attrs.Instrument('eve') |
+        net_attrs.Instrument('lyra') & net_attrs.Level.two | net_attrs.Instrument('eve') |
         net_attrs.Instrument('XRS') | net_attrs.Instrument('noaa-indices') |
         net_attrs.Instrument('noaa-predict') |
         (net_attrs.Instrument('norh') & net_attrs.Wavelength(17*units.GHz)) |
-        (net_attrs.Instrument('rhessi') & net_attrs.Physobs("summary_lightcurve")) |
-        (net_attrs.Instrument('EVE') & net_attrs.Level(0))
+        (net_attrs.Instrument('rhessi') & net_attrs.Physobs("summary_lightcurve"))
     )
 
 
@@ -1107,8 +1106,8 @@ def test_split_database(split_function_database, database):
         split_function_database, database, net_attrs.Instrument('EIA'))
 
     observed_source_entries = split_function_database.search(
-        vso.attrs.Provider('xyz'), sortby='id')
-    observed_destination_entries = database.search(vso.attrs.Provider('xyz'))
+        net_attrs.Provider('xyz'), sortby='id')
+    observed_destination_entries = database.search(net_attrs.Provider('xyz'))
 
     assert observed_source_entries == [
         DatabaseEntry(id=1, instrument='RHESSI', provider='xyz'),

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -55,12 +55,11 @@ def fido_search_result():
     # No JSOC query
     return Fido.search(
         net_attrs.Time("2012/1/1", "2012/1/2"),
-        net_attrs.Instrument('lyra') | net_attrs.Instrument('eve') |
+        net_attrs.Instrument('lyra') & net_attrs.Level.two | net_attrs.Instrument('eve') |
         net_attrs.Instrument('XRS') | net_attrs.Instrument('noaa-indices') |
         net_attrs.Instrument('noaa-predict') |
         (net_attrs.Instrument('norh') & net_attrs.Wavelength(17 * u.GHz)) |
-        (net_attrs.Instrument('rhessi') & net_attrs.Physobs("summary_lightcurve")) |
-        (net_attrs.Instrument('EVE') & net_attrs.Level(0))
+        (net_attrs.Instrument('rhessi') & net_attrs.Physobs("summary_lightcurve"))
     )
 
 
@@ -74,15 +73,15 @@ def query_result():
 def qr_with_none_waves():
     return vso.VSOClient().search(
         net_attrs.Time('20121224T120049.8', '20121224T120049.8'),
-        vso.attrs.Provider('SDAC'), net_attrs.Instrument('VIRGO'))
+        net_attrs.Provider('SDAC'), net_attrs.Instrument('VIRGO'))
 
 
 @pytest.fixture
 def qr_block_with_missing_physobs():
     return vso.VSOClient().search(
         net_attrs.Time('20130805T120000', '20130805T121000'),
-        net_attrs.Instrument('SWAVES'), vso.attrs.Source('STEREO_A'),
-        vso.attrs.Provider('SSC'), net_attrs.Wavelength(10 * u.kHz, 160 * u.kHz))[0]
+        net_attrs.Instrument('SWAVES'), net_attrs.Source('STEREO_A'),
+        net_attrs.Provider('SSC'), net_attrs.Wavelength(10 * u.kHz, 160 * u.kHz))[0]
 
 
 @pytest.fixture
@@ -127,14 +126,23 @@ def test_entries_from_fido_search_result(fido_search_result):
     assert len(entries) == 66
     # First 2 entries are from lyra
     assert entries[0] == DatabaseEntry(
-        source='Proba2', provider='esa', physobs='irradiance',
+        source='PROBA2', provider='ESA', physobs='irradiance',
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
-        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=np.nan, wavemax=np.nan,
-        instrument='lyra')
-    # 54 entries from EVE
+        instrument='LYRA')
+    # 2 entries from eve, level 0
     assert entries[2] == DatabaseEntry(
+        source='SDO', provider='LASP', physobs='irradiance',
+        fileid=("http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook"
+                "/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt"),
+        observation_time_start=datetime(2012, 1, 1, 0, 0),
+        observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
+        wavemin=np.nan, wavemax=np.nan,
+        instrument='EVE')
+    # 54 entries from EVE
+    assert entries[4] == DatabaseEntry(
         source='SDO', provider='LASP', physobs='irradiance',
         fileid='EVE_L1_esp_2012001_00',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
@@ -143,56 +151,47 @@ def test_entries_from_fido_search_result(fido_search_result):
         instrument='EVE',
         wavemin=0.1, wavemax=30.4)
     # 2 entries from goes
-    assert entries[56] == DatabaseEntry(
-        source='nasa', provider='sdac', physobs='irradiance',
+    assert entries[58] == DatabaseEntry(
+        source='NASA', provider='SDAC', physobs='irradiance',
         fileid='https://umbra.nascom.nasa.gov/goes/fits/2012/go1520120101.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=np.nan, wavemax=np.nan,
-        instrument='goes')
+        instrument='XRS')
     # 1 entry from noaa-indices
-    assert entries[58] == DatabaseEntry(
-        source='sdic', provider='swpc', physobs='sunspot number',
+    assert entries[60] == DatabaseEntry(
+        source='SIDC', provider='SWPC', physobs='sunspot number',
         fileid='https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         wavemin=np.nan, wavemax=np.nan,
-        instrument='noaa-indices')
+        instrument='NOAA-Indices')
     # 1 entry from noaa-predict
-    assert entries[59] == DatabaseEntry(
-        source='ises', provider='swpc', physobs='sunspot number',
+    assert entries[61] == DatabaseEntry(
+        source='ISES', provider='SWPC', physobs='sunspot number',
         fileid='https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 2, 0, 0),
         wavemin=np.nan, wavemax=np.nan,
-        instrument='noaa-predict')
+        instrument='NOAA-Predict')
     # 2 entries from norh
-    assert entries[60] == DatabaseEntry(
-        source='NAOJ', provider='NRO', physobs="",
+    assert entries[62] == DatabaseEntry(
+        source='NAOJ', provider='NRO', physobs=None,
         fileid=("ftp://solar-pub.nao.ac.jp/"
                 "pub/nsro/norh/data/tcx/2012/01/tca120101"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
-        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=17634850.470588233, wavemax=17634850.470588233,
         instrument='NORH')
     # 1 entry from rhessi
-    assert entries[62] == DatabaseEntry(
-        source="rhessi", provider='nasa', physobs='irradiance',
+    assert entries[64] == DatabaseEntry(
+        source="RHESSI", provider='NASA', physobs='summary_lightcurve',
         fileid=("https://hesperia.gsfc.nasa.gov/"
                 "hessidata/metadata/catalog/hsi_obssumm_20120101_032.fits"),
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=np.nan, wavemax=np.nan,
-        instrument='rhessi')
-    # 2 entries from eve, level 0
-    assert entries[64] == DatabaseEntry(
-        source='SDO', provider='LASP', physobs='irradiance',
-        fileid=("http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook"
-                "/L0CS/SpWx/2012/20120101_EVE_L0CS_DIODES_1m.txt"),
-        observation_time_start=datetime(2012, 1, 1, 0, 0),
-        observation_time_end=datetime(2012, 1, 2, 0, 0),
-        wavemin=np.nan, wavemax=np.nan,
-        instrument='eve')
+        instrument='RHESSI')
 
 
 @pytest.mark.remote_data
@@ -214,12 +213,12 @@ def test_from_fido_search_result_block(fido_search_result):
     entry = DatabaseEntry._from_fido_search_result_block(
         fido_search_result[0, 0][0].get_response(0).blocks[0])
     expected_entry = DatabaseEntry(
-        source='Proba2', provider='esa', physobs='irradiance',
+        source='PROBA2', provider='ESA', physobs='irradiance',
         fileid='http://proba2.oma.be/lyra/data/bsd/2012/01/01/lyra_20120101-000000_lev2_std.fits',
         observation_time_start=datetime(2012, 1, 1, 0, 0),
-        observation_time_end=datetime(2012, 1, 2, 0, 0),
+        observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=np.nan, wavemax=np.nan,
-        instrument='lyra')
+        instrument='LYRA')
     assert entry == expected_entry
 
 

--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -245,11 +245,35 @@ class Physobs(SimpleAttr):
     """
 
 
-class Source(SimpleAttr):
-    """
-    """
-
-
 class Provider(SimpleAttr):
     """
+    Specifies the data provider to search for data using Fido clients.
+
+    Parameters
+    ----------
+    value : str
+
+    Notes
+    -----
+    For VSO, More information about each provider may be found within in the VSO Registry.
+    For a list of VSO providers see
+    https://sdac.virtualsolar.org/cgi/show_details?keyword=PROVIDER.
+    """
+
+
+class Source(SimpleAttr):
+    """
+    Data sources that Fido clients can search on.
+
+    Parameters
+    ----------
+    value : str
+
+    Notes
+    -----
+    For VSO, More information about each source may be found within in the VSO Registry.
+    User Interface programmers should note that some names may be encoded as
+    UTF-8. Please note that 'Source' is used internally by VSO to represent
+    what the VSO Data Model refers to as 'Observatory'.  For a list of VSO sources
+    see https://sdac.virtualsolar.org/cgi/show_details?keyword=SOURCE.
     """

--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -14,7 +14,7 @@ from sunpy.util.decorators import add_common_docstring
 from .attr import Range, SimpleAttr
 
 __all__ = ['Physobs', 'Resolution', 'Detector', 'Sample',
-           'Level', 'Instrument', 'Wavelength', 'Time']
+           'Level', 'Instrument', 'Wavelength', 'Time', 'Source', 'Provider']
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())
@@ -242,4 +242,14 @@ class Physobs(SimpleAttr):
     More information about the values of physobs used by the VSO
     registry can be found at
     https://sdac.virtualsolar.org/cgi/show_details?keyword=PHYSOBS.
+    """
+
+
+class Source(SimpleAttr):
+    """
+    """
+
+
+class Provider(SimpleAttr):
+    """
     """

--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -247,33 +247,33 @@ class Physobs(SimpleAttr):
 
 class Provider(SimpleAttr):
     """
-    Specifies the data provider to search for data using Fido clients.
+    Specifies the data provider to search for data using Fido.
 
     Parameters
     ----------
     value : str
+        A keyword describing the Provider for the data.
 
     Notes
     -----
-    For VSO, More information about each provider may be found within in the VSO Registry.
-    For a list of VSO providers see
-    https://sdac.virtualsolar.org/cgi/show_details?keyword=PROVIDER.
+    For VSO, more information about each provider may be found within in the VSO Registry.
+    See `VSO providers <https://sdac.virtualsolar.org/cgi/show_details?keyword=PROVIDER>`__.
     """
 
 
 class Source(SimpleAttr):
     """
-    Data sources that Fido clients can search on.
+    Data sources that Fido can search with.
 
     Parameters
     ----------
     value : str
+        A keyword describing the Data Source.
 
     Notes
     -----
-    For VSO, More information about each source may be found within in the VSO Registry.
-    User Interface programmers should note that some names may be encoded as
-    UTF-8. Please note that 'Source' is used internally by VSO to represent
-    what the VSO Data Model refers to as 'Observatory'.  For a list of VSO sources
-    see https://sdac.virtualsolar.org/cgi/show_details?keyword=SOURCE.
+    For VSO, more information about each source may be found within in the VSO Registry.
+    See `VSO sources <https://sdac.virtualsolar.org/cgi/show_details?keyword=SOURCE>`__.
+    Please note that 'Source' is used internally by VSO to represent
+    what the VSO Data Model refers to as 'Observatory'.
     """

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -22,7 +22,18 @@ attrs specific to them, under:
 * `a.goes <sunpy.net.dataretriever.attrs.goes>`
 
 """
-from ._attrs import Detector, Instrument, Level, Physobs, Resolution, Sample, Time, Wavelength, Source, Provider
+from ._attrs import (
+    Detector,
+    Instrument,
+    Level,
+    Physobs,
+    Provider,
+    Resolution,
+    Sample,
+    Source,
+    Time,
+    Wavelength,
+)
 
 # Trick the docs into thinking these attrs are defined in here.
 for _a in (Time, Instrument, Wavelength, Level, Sample, Detector, Resolution, Physobs, Source, Provider):

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -22,11 +22,11 @@ attrs specific to them, under:
 * `a.goes <sunpy.net.dataretriever.attrs.goes>`
 
 """
-from ._attrs import Detector, Instrument, Level, Physobs, Resolution, Sample, Time, Wavelength
+from ._attrs import Detector, Instrument, Level, Physobs, Resolution, Sample, Time, Wavelength, Source, Provider
 
 # Trick the docs into thinking these attrs are defined in here.
-for _a in (Time, Instrument, Wavelength, Level, Sample, Detector, Resolution, Physobs):
+for _a in (Time, Instrument, Wavelength, Level, Sample, Detector, Resolution, Physobs, Source, Provider):
     _a.__module__ = __name__
 
 __all__ = ['Time', 'Instrument', 'Wavelength', 'Level',
-           'Sample', 'Detector', 'Resolution', 'Physobs']
+           'Sample', 'Detector', 'Resolution', 'Physobs', 'Source', 'Provider']

--- a/sunpy/net/dataretriever/__init__.py
+++ b/sunpy/net/dataretriever/__init__.py
@@ -17,6 +17,6 @@ from .sources.noaa import NOAAIndicesClient, NOAAPredictClient, SRSClient
 from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 
-__all__ = ['QueryResponse', 'GenericClient',
-           'EVEClient', 'XRSClient', 'SUVIClient', 'LYRAClient', 'NOAAIndicesClient',
-           'NOAAPredictClient', 'NoRHClient', 'RHESSIClient', 'SRSClient', 'GBMClient']
+__all__ = ['QueryResponse', 'GenericClient', 'EVEClient', 'GBMClient',
+           'XRSClient', 'SUVI_Client', 'LYRAClient', 'NOAAIndicesClient',
+           'NOAAPredictClient', 'NoRHClient', 'RHESSIClient', 'SRSClient', ]

--- a/sunpy/net/dataretriever/__init__.py
+++ b/sunpy/net/dataretriever/__init__.py
@@ -18,5 +18,5 @@ from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 
 __all__ = ['QueryResponse', 'GenericClient', 'EVEClient', 'GBMClient',
-           'XRSClient', 'SUVI_Client', 'LYRAClient', 'NOAAIndicesClient',
+           'XRSClient', 'SUVIClient', 'LYRAClient', 'NOAAIndicesClient',
            'NOAAPredictClient', 'NoRHClient', 'RHESSIClient', 'SRSClient', ]

--- a/sunpy/net/dataretriever/__init__.py
+++ b/sunpy/net/dataretriever/__init__.py
@@ -8,7 +8,7 @@ subclass. All these subclasses are then registered with the `sunpy.net.Fido` fac
 class, so do not need to be called individually.
 """
 
-from .client import GenericClient, QueryResponse, QueryResponseBlock
+from .client import GenericClient, QueryResponse
 from .sources.eve import EVEClient
 from .sources.fermi_gbm import GBMClient
 from .sources.goes import SUVIClient, XRSClient
@@ -17,6 +17,6 @@ from .sources.noaa import NOAAIndicesClient, NOAAPredictClient, SRSClient
 from .sources.norh import NoRHClient
 from .sources.rhessi import RHESSIClient
 
-__all__ = ['QueryResponseBlock', 'QueryResponse', 'GenericClient',
+__all__ = ['QueryResponse', 'GenericClient',
            'EVEClient', 'XRSClient', 'SUVIClient', 'LYRAClient', 'NOAAIndicesClient',
            'NOAAPredictClient', 'NoRHClient', 'RHESSIClient', 'SRSClient', 'GBMClient']

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -7,7 +7,7 @@ from astropy.time import TimeDelta
 
 import sunpy
 from sunpy import config
-from sunpy.net._attrs import Time
+from sunpy.net._attrs import Time, Wavelength
 from sunpy.net.base_client import BaseClient, BaseQueryResponse
 from sunpy.time import TimeRange, parse_time
 from sunpy.util.parfive_helpers import Downloader
@@ -107,6 +107,8 @@ class GenericClient(BaseClient):
                 d['Time'] = timerange
             elif hasattr(elem, 'value'):
                 d[elem.__class__.__name__] = [str(elem.value)]
+            elif isinstance(elem, Wavelength):
+                d['Wavelength'] = elem
             else:
                 raise ValueError("GenericClient can not add {} to the map_ dictionary to pass to the Client.".format(elem.__class__.__name__))
         for k in kwargs:

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -128,7 +128,7 @@ class GenericClient(BaseClient):
                 timerange = TimeRange(elem.start, elem.end)
                 matchdict['Time'] = timerange
             elif hasattr(elem, 'value'):
-                matchdict[elem.__class__.__name__] = [str(elem.value)]
+                matchdict[elem.__class__.__name__] = [str(elem.value).lower()]
             elif isinstance(elem, Wavelength):
                 matchdict['Wavelength'] = elem
             else:
@@ -200,11 +200,11 @@ class GenericClient(BaseClient):
         map_['Time'] = TimeRange(start, end)
         map_['Start Time'] = start.strftime(TIME_FORMAT)
         map_['End Time'] = end.strftime(TIME_FORMAT)
-        map_['Instrument'] = matchdict['Instrument'][0]
+        map_['Instrument'] = matchdict['Instrument'][0].upper()
         if 'Physobs' in matchdict:
             map_['Phsyobs'] = matchdict['Physobs'][0]
-        map_['Source'] = matchdict['Source'][0]
-        map_['Provider'] = matchdict['Provider'][0]
+        map_['Source'] = matchdict['Source'][0].upper()
+        map_['Provider'] = matchdict['Provider'][0].upper()
         for k in exdict:
             if k not in ['year', 'month', 'day']:
                 map_[k] = exdict[k]

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -128,8 +128,9 @@ class GenericClient(BaseClient):
             optional = cls.optional
         if not cls.check_attr_types_in_query(query, required, optional):
             return False
+        all_instr = [i[0].lower() for i in adict[a.Instrument]]
         for x in query:
-            if isinstance(x, a.Instrument) and x.value.lower() == adict[a.Instrument][0][0].lower():
+            if isinstance(x, a.Instrument) and x.value.lower() in all_instr:
                 return True
         return False
 
@@ -137,8 +138,13 @@ class GenericClient(BaseClient):
         """
         """
         map_ = OrderedDict()
-        start = parse_time("{}/{}/{}".format(exdict['year'], exdict['month'], exdict['day']))
-        end = start + TimeDelta(1 * u.day - 1 * u.millisecond)
+        almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
+        if 'month' in exdict and 'day' in exdict:
+            start = parse_time("{}/{}/{}".format(exdict['year'], exdict['month'], exdict['day']))
+            end = start + almost_day
+        else:
+            start = parse_time("{}/{}/{}".format(exdict['year'], 1, 1))
+            end = parse_time("{}/{}/{}".format(exdict['year'], 12, 31)) + almost_day
         map_['Start Time'] = start.strftime(TIME_FORMAT)
         map_['End Time'] = end.strftime(TIME_FORMAT)
         map_['Instrument'] = matchdict['Instrument'][0]

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -165,10 +165,6 @@ class GenericClient(BaseClient):
                 raise ValueError(
                     "GenericClient can not add {} to the rowdict dictionary to"
                     "pass to the Client.".format(elem.__class__.__name__))
-        for k in kwargs:
-            matchdict[k] = [kwargs[k]]
-            if isinstance(kwargs[k], str):
-                matchdict[k] = [kwargs[k].lower()]
         return matchdict
 
     @classmethod
@@ -230,11 +226,9 @@ class GenericClient(BaseClient):
         rowdict['Time'] = TimeRange(start, end)
         rowdict['Start Time'] = start.strftime(TIME_FORMAT)
         rowdict['End Time'] = end.strftime(TIME_FORMAT)
-        rowdict['Instrument'] = matchdict['Instrument'][0].upper()
-        if 'Physobs' in matchdict:
-            rowdict['Physobs'] = matchdict['Physobs'][0]
-        rowdict['Source'] = matchdict['Source'][0].upper()
-        rowdict['Provider'] = matchdict['Provider'][0].upper()
+        for k in matchdict:
+            if k != 'Time' and k != 'Wavelength':
+                rowdict[k] = matchdict[k][0].upper()
         for k in exdict:
             if k not in ['year', 'month', 'day']:
                 rowdict[k] = exdict[k]

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -2,17 +2,9 @@
 # This module was developed under funding by
 # Google Summer of Code 2014
 
-import astropy.units as u
-from astropy.time import TimeDelta
-
 from sunpy.net.dataretriever import GenericClient
-from sunpy.time import TimeRange
-from sunpy.util.scraper import Scraper
 
 __all__ = ['EVEClient']
-
-BASEURL = ('http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
-           'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
 
 
 class EVEClient(GenericClient):
@@ -33,46 +25,17 @@ class EVEClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the EVEClient:
-         Start Time           End Time      Source Instrument Wavelength
-    ------------------- ------------------- ------ ---------- ----------
-    2016-01-01 00:00:00 2016-01-02 00:00:00    SDO        eve        nan
-    2016-01-02 00:00:00 2016-01-03 00:00:00    SDO        eve        nan
+         Start Time           End Time      Instrument ... Source Provider Level
+    ------------------- ------------------- ---------- ... ------ -------- -----
+    2016-01-01 00:00:00 2016-01-01 23:59:59        EVE ...    SDO     LASP     0
+    2016-01-02 00:00:00 2016-01-02 23:59:59        EVE ...    SDO     LASP     0
     <BLANKLINE>
     <BLANKLINE>
 
     """
-
-    def _get_url_for_timerange(self, timerange, **kwargs):
-        """
-        Return list of URLS corresponding to value of input timerange.
-
-        Parameters
-        ----------
-        timerange: `sunpy.time.TimeRange`
-            time range for which data is to be downloaded.
-
-        Returns
-        -------
-        urls : list
-            list of URLs corresponding to the requested time range
-
-        """
-        # If start of time range is before 00:00, converted to such, so
-        # files of the requested time ranger are included.
-        # This is done because the archive contains daily files.
-        if timerange.start.strftime('%M-%S') != '00-00':
-            timerange = TimeRange(timerange.start.strftime('%Y-%m-%d'), timerange.end)
-        eve = Scraper(BASEURL)
-        return eve.filelist(timerange)
-
-    def _get_time_for_url(self, urls):
-        eve = Scraper(BASEURL)
-        times = list()
-        for url in urls:
-            t0 = eve._extractDateURL(url)
-            # hard coded full day as that's the normal.
-            times.append(TimeRange(t0, t0 + TimeDelta(1*u.day)))
-        return times
+    baseurl = (r'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
+               r'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
+    pattern = '{}/SpWx/{:4d}/{year:4d}{month:2d}{day:2d}_EVE_L{Level:1d}{}'
 
     def _makeimap(self):
         """
@@ -84,54 +47,11 @@ class EVEClient(GenericClient):
         self.map_['physobs'] = 'irradiance'
 
     @classmethod
-    def _can_handle_query(cls, *query):
-        """
-        Answers whether client can service the query.
-
-        Parameters
-        ----------
-        query : list of query objects
-
-        Returns
-        -------
-        boolean
-            answer as to whether client can service the query
-        """
-        from sunpy.net import attrs as a
-
-        required = {a.Time, a.Instrument, a.Level}
-        # Level should really be in here, but VSO doesn't correctly provide
-        # Level information currently.
-        optional = {}
-        if not cls.check_attr_types_in_query(query, required, optional):
-            return False
-
-        matches = True
-        for x in query:
-            if isinstance(x, a.Instrument) and x.value.lower() != 'eve':
-                matches = False
-            if isinstance(x, a.Level):
-                # Level can be basically anything, this function should never
-                # really error. If level is a string we try and convert it to
-                # an int, if it's the string "0CS" we match it. Otherwise we
-                # check it's equal to 0
-                value = x.value
-                if isinstance(value, str):
-                    if value.lower() == '0cs':
-                        value = 0
-                    else:
-                        try:
-                            value = int(value)
-                        except ValueError:
-                            matches = False
-                if value != 0:
-                    matches = False
-
-        return matches
-
-    @classmethod
     def register_values(cls):
         from sunpy.net import attrs
         adict = {attrs.Instrument: [('EVE', 'Extreme ultraviolet Variability Experiment, which is part of the NASA Solar Dynamics Observatory mission.')],
-                 attrs.Level: [('0', 'EVE: The specific EVE client can only return Level 0C data. Any other number will use the VSO Client.')]}
+                 attrs.Level: [('0', 'EVE: The specific EVE client can only return Level 0C data. Any other number will use the VSO Client.')],
+                 attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area')],
+                 attrs.Source: [('SDO', 'The Solar Dynamics Observatory')],
+                 attrs.Provider: [('LASP', 'The Laboratory for Atmospheric and Space Physics')]}
         return adict

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -37,21 +37,12 @@ class EVEClient(GenericClient):
                r'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
     pattern = '{}/SpWx/{:4d}/{year:4d}{month:2d}{day:2d}_EVE_L{Level:1d}{}'
 
-    def _makeimap(self):
-        """
-        Helper Function: used to hold information about source.
-        """
-        self.map_['source'] = 'SDO'
-        self.map_['provider'] = 'LASP'
-        self.map_['instrument'] = 'eve'
-        self.map_['physobs'] = 'irradiance'
-
     @classmethod
     def register_values(cls):
         from sunpy.net import attrs
         adict = {attrs.Instrument: [('EVE', 'Extreme ultraviolet Variability Experiment, which is part of the NASA Solar Dynamics Observatory mission.')],
                  attrs.Level: [('0', 'EVE: The specific EVE client can only return Level 0C data. Any other number will use the VSO Client.')],
-                 attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area')],
-                 attrs.Source: [('SDO', 'The Solar Dynamics Observatory')],
-                 attrs.Provider: [('LASP', 'The Laboratory for Atmospheric and Space Physics')]}
+                 attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area.')],
+                 attrs.Source: [('SDO', 'The Solar Dynamics Observatory.')],
+                 attrs.Provider: [('LASP', 'The Laboratory for Atmospheric and Space Physics.')]}
         return adict

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -41,8 +41,8 @@ class EVEClient(GenericClient):
     def register_values(cls):
         from sunpy.net import attrs
         adict = {attrs.Instrument: [('EVE', 'Extreme ultraviolet Variability Experiment, which is part of the NASA Solar Dynamics Observatory mission.')],
-                 attrs.Level: [('0', 'EVE: The specific EVE client can only return Level 0C data. Any other number will use the VSO Client.')],
                  attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area.')],
                  attrs.Source: [('SDO', 'The Solar Dynamics Observatory.')],
-                 attrs.Provider: [('LASP', 'The Laboratory for Atmospheric and Space Physics.')]}
+                 attrs.Provider: [('LASP', 'The Laboratory for Atmospheric and Space Physics.')],
+                 attrs.Level: [('0', 'EVE: The specific EVE client can only return Level 0C data. Any other number will use the VSO Client.')]}
         return adict

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -57,7 +57,5 @@ class GBMClient(GenericClient):
                  attrs.Resolution: [
             ("cspec", "CSPEC 128 channel spectra every 4.096 seconds."),
             ("ctime", "CTIME provides 8 channel spectra every 0.256 seconds.")],
-                 attrs.Detector: [
-            (f"n{x}", f"GBM Detector short name for the detector NAI_{x:02}") for x in range(12)],
-        }
+            attrs.Detector: [(f"n{x}", f"GBM Detector short name for the detector NAI_{x:02}") for x in range(12)]}
         return adict

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -54,10 +54,10 @@ class GBMClient(GenericClient):
                  attrs.Physobs: [('flux', 'a measure of the amount of radiation received by an object from a given source.')],
                  attrs.Source: [('FERMI', 'The Fermi Gamma-ray Space Telescope.')],
                  attrs.Provider: [('NASA', 'The National Aeronautics and Space Administration.')],
+                 attrs.Resolution: [
+            ("cspec", "CSPEC 128 channel spectra every 4.096 seconds."),
+            ("ctime", "CTIME provides 8 channel spectra every 0.256 seconds.")],
                  attrs.Detector: [
             (f"n{x}", f"GBM Detector short name for the detector NAI_{x:02}") for x in range(12)],
-            attrs.Resolution: [
-            ("cspec", "CSPEC 128 channel spectra every 4.096 seconds."),
-            ("ctime", "CTIME provides 8 channel spectra every 0.256 seconds.")]
         }
         return adict

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -36,53 +36,28 @@ class GBMClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     3 Results from the GBMClient:
-         Start Time           End Time      Source Instrument Wavelength
-    ------------------- ------------------- ------ ---------- ----------
-    2015-06-21 00:00:00 2015-06-23 23:59:00  FERMI        GBM        nan
-    2015-06-21 00:00:00 2015-06-23 23:59:00  FERMI        GBM        nan
-    2015-06-21 00:00:00 2015-06-23 23:59:00  FERMI        GBM        nan
+         Start Time           End Time      Instrument ... Resolution Detector
+    ------------------- ------------------- ---------- ... ---------- --------
+    2015-06-21 00:00:00 2015-06-21 23:59:59        GBM ...      ctime       n3
+    2015-06-22 00:00:00 2015-06-22 23:59:59        GBM ...      ctime       n3
+    2015-06-23 00:00:00 2015-06-23 23:59:59        GBM ...      ctime       n3
     <BLANKLINE>
     <BLANKLINE>
     """
-
-    fixed = {'Source': 'FERMI', 'Phsyobs': 'flux', 'Provider': 'NASA'}
-    required = {'Time': [], 'Instrument': 'GBM'}
-    optional = {'Detector': ['n'+str(i) for i in range(12)], 'Resolution': ['cspec', 'ctime']}
     baseurl = r'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/%Y/%m/%d/current/glg_(\w){5}_(\w){2}_%y%m%d_v00.pha'
     pattern = '{}/daily/{year:4d}/{month:2d}/{day:2d}/current/glg_{Resolution:5}_{Detector:2}_{:6d}{}'
-
-    @classmethod
-    def _can_handle_query(cls, *query):
-        """
-        Answers whether a client can service the query.
-
-        Parameters
-        ----------
-        query : `list`
-            A list of of query objects.
-
-        Returns
-        -------
-        `bool`
-            `True` if this client can service the query, otherwise `False`.
-        """
-        chkattr = ['Time', 'Instrument', 'Detector', 'Resolution']
-        chklist = [x.__class__.__name__ in chkattr for x in query]
-        for x in query:
-            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'gbm':
-                return all(chklist)
-        return False
 
     @classmethod
     def register_values(cls):
         from sunpy.net import attrs
         adict = {attrs.Instrument: [('GBM', 'Gamma-Ray Burst Monitor on board the Fermi satellite.')],
-                 attrs.Physobs: [('CSPEC', 'counts accumulated every 4.096 seconds in 128 energy channels for each detector.'),
-                                 ('CTIME', 'counts accumulated every 0.256 seconds in 8 energy channels')],
+                 attrs.Physobs: [('flux', 'a measure of the amount of radiation received by an object from a given source')],
+                 attrs.Source: [('FERMI', 'The Fermi Gamma-ray Space Telescope')],
+                 attrs.Provider: [('NASA', 'The National Aeronautics and Space Administration')],
                  attrs.Detector: [
             (f"n{x}", f"GBM Detector short name for the detector NAI_{x:02}") for x in range(12)],
             attrs.Resolution: [
-            ("CSPEC", "CSPEC 128 channel spectra every 4.096 seconds."),
-            ("CTIME", "CTIME provides 8 channel spectra every 0.256 seconds")]
+            ("cspec", "CSPEC 128 channel spectra every 4.096 seconds."),
+            ("ctime", "CTIME provides 8 channel spectra every 0.256 seconds")]
         }
         return adict

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -51,13 +51,13 @@ class GBMClient(GenericClient):
     def register_values(cls):
         from sunpy.net import attrs
         adict = {attrs.Instrument: [('GBM', 'Gamma-Ray Burst Monitor on board the Fermi satellite.')],
-                 attrs.Physobs: [('flux', 'a measure of the amount of radiation received by an object from a given source')],
-                 attrs.Source: [('FERMI', 'The Fermi Gamma-ray Space Telescope')],
-                 attrs.Provider: [('NASA', 'The National Aeronautics and Space Administration')],
+                 attrs.Physobs: [('flux', 'a measure of the amount of radiation received by an object from a given source.')],
+                 attrs.Source: [('FERMI', 'The Fermi Gamma-ray Space Telescope.')],
+                 attrs.Provider: [('NASA', 'The National Aeronautics and Space Administration.')],
                  attrs.Detector: [
             (f"n{x}", f"GBM Detector short name for the detector NAI_{x:02}") for x in range(12)],
             attrs.Resolution: [
             ("cspec", "CSPEC 128 channel spectra every 4.096 seconds."),
-            ("ctime", "CTIME provides 8 channel spectra every 0.256 seconds")]
+            ("ctime", "CTIME provides 8 channel spectra every 0.256 seconds.")]
         }
         return adict

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -117,10 +117,6 @@ class SUVIClient(GenericClient):
                 '{eyear:4d}{emonth:2d}{eday:2d}T{ehour:2d}{eminute:2d}{esecond:2d}Z_{}')
     optional = {a.Wavelength, a.Source, a.Provider, a.Level, a.Physobs, a.goes.SatelliteNumber}
 
-    def pre_search_hook(cls, *args, **kwargs):
-        matchdict = cls._get_match_dict(*args, **kwargs)
-        return cls.baseurl1b, cls.pattern1b, cls.baseurl2, cls.pattern2, matchdict
-
     def post_search_hook(self, i, matchdict):
 
         # extracting start times and end times
@@ -145,7 +141,7 @@ class SUVIClient(GenericClient):
     def search(self, *args, **kwargs):
         supported_waves = [94, 131, 171, 195, 284, 304]*u.Angstrom
         all_waves = []
-        baseurl1b, pattern1b, baseurl2, pattern2, matchdict = self.pre_search_hook(*args, **kwargs)
+        matchdict = self._get_match_dict(*args, **kwargs)
         req_wave = matchdict.get('Wavelength', None)
         if req_wave is not None:
             wmin = req_wave.min.to(u.Angstrom, equivalencies=u.spectral())
@@ -169,11 +165,11 @@ class SUVIClient(GenericClient):
                         formdict['elem'] = 'fe'
                         if wave == 304:
                             formdict['elem'] = 'he'
-                        baseurl = baseurl1b
-                        pattern = pattern1b
+                        baseurl = self.baseurl1b
+                        pattern = self.pattern1b
                     elif str(level) == '2':
-                        baseurl = baseurl2
-                        pattern = pattern2
+                        baseurl = self.baseurl2
+                        pattern = self.pattern2
                     else:
                         raise ValueError(f"Level {level} is not supported.")
                     # formatting baseurl using Level, SatelliteNumber and Wavelength

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -102,9 +102,12 @@ class SUVIClient(GenericClient):
         return cls.baseurl1b, cls.pattern1b, cls.baseurl2, cls.pattern2, matchdict
 
     def post_search_hook(self, i, matchdict):
+
+        # extracting start times and end times
         start = datetime(i['year'], i['month'], i['day'], i['hour'], i['minute'], i['second'])
         end = datetime(i['year'], i['month'], i['day'], i['ehour'], i['eminute'], i['esecond'])
         timerange = TimeRange(start, end)
+
         map_ = OrderedDict()
         map_['Time'] = timerange
         map_['Start Time'] = start.strftime(TIME_FORMAT)
@@ -135,6 +138,8 @@ class SUVIClient(GenericClient):
         all_satnos = matchdict.get('SatelliteNumber')
         all_levels = matchdict.get('Level')
         metalist = []
+
+        # iterating over all possible Attr values through loops
         for satno in all_satnos:
             for level in all_levels:
                 for wave in all_waves:
@@ -150,12 +155,15 @@ class SUVIClient(GenericClient):
                         pattern = pattern2
                     else:
                         raise ValueError(f"Level {level} is not supported.")
+                    # formatting baseurl using Level, SatelliteNumber and Wavelength
                     urlpattern = baseurl.format(**formdict)
+
                     scraper = Scraper(urlpattern)
                     filesmeta = scraper._extract_files_meta(matchdict['Time'], extractor=pattern)
                     for i in filesmeta:
                         map_ = self.post_search_hook(i, matchdict)
                         metalist.append(map_)
+
         return QueryResponse(metalist, client=self)
 
     @classmethod

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -96,7 +96,7 @@ class SUVIClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     3 Results from the SUVIClient:
-         Start Time           End Time      Instrument ... Level   Wavelength  
+         Start Time           End Time      Instrument ... Level   Wavelength
     ------------------- ------------------- ---------- ... ----- --------------
     2020-07-10 00:00:00 2020-07-10 00:04:00       SUVI ...     2 304.0 Angstrom
     2020-07-10 00:04:00 2020-07-10 00:08:00       SUVI ...     2 304.0 Angstrom
@@ -133,12 +133,13 @@ class SUVIClient(GenericClient):
         map_['Start Time'] = start.strftime(TIME_FORMAT)
         map_['End Time'] = end.strftime(TIME_FORMAT)
         map_['Instrument'] = matchdict['Instrument'][0].upper()
-        map_['Phsyobs'] = matchdict['Physobs'][0]
+        map_['Physobs'] = matchdict['Physobs'][0]
         map_['Source'] = matchdict['Source'][0]
         map_['Provider'] = matchdict['Provider'][0]
         map_['SatelliteNumber'] = i['SatelliteNumber']
         map_['Level'] = i['Level']
         map_['Wavelength'] = i['Wavelength']*u.Angstrom
+        map_['url'] = i['url']
         return map_
 
     def search(self, *args, **kwargs):

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -58,10 +58,10 @@ class XRSClient(GenericClient):
         adict = {attrs.Instrument: [
             ("GOES", "The Geostationary Operational Environmental Satellite Program."),
             ("XRS", "GOES X-ray Flux")],
-            attrs.goes.SatelliteNumber: [(str(x), f"GOES Satellite Number {x}") for x in goes_number],
-            attrs.Source: [('NASA', 'The National Aeronautics and Space Administration.')],
             attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area.')],
-            attrs.Provider: [('SDAC', 'The Solar Data Analysis Center.')]}
+            attrs.Source: [('NASA', 'The National Aeronautics and Space Administration.')],
+            attrs.Provider: [('SDAC', 'The Solar Data Analysis Center.')],
+            attrs.goes.SatelliteNumber: [(str(x), f"GOES Satellite Number {x}") for x in goes_number]}
         return adict
 
 

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -123,19 +123,19 @@ class SUVIClient(GenericClient):
         end = datetime(i['year'], i['month'], i['day'], i['ehour'], i['eminute'], i['esecond'])
         timerange = TimeRange(start, end)
 
-        map_ = OrderedDict()
-        map_['Time'] = timerange
-        map_['Start Time'] = start.strftime(TIME_FORMAT)
-        map_['End Time'] = end.strftime(TIME_FORMAT)
-        map_['Instrument'] = matchdict['Instrument'][0].upper()
-        map_['Physobs'] = matchdict['Physobs'][0]
-        map_['Source'] = matchdict['Source'][0]
-        map_['Provider'] = matchdict['Provider'][0]
-        map_['SatelliteNumber'] = i['SatelliteNumber']
-        map_['Level'] = i['Level']
-        map_['Wavelength'] = i['Wavelength']*u.Angstrom
-        map_['url'] = i['url']
-        return map_
+        rowdict = OrderedDict()
+        rowdict['Time'] = timerange
+        rowdict['Start Time'] = start.strftime(TIME_FORMAT)
+        rowdict['End Time'] = end.strftime(TIME_FORMAT)
+        rowdict['Instrument'] = matchdict['Instrument'][0].upper()
+        rowdict['Physobs'] = matchdict['Physobs'][0]
+        rowdict['Source'] = matchdict['Source'][0]
+        rowdict['Provider'] = matchdict['Provider'][0]
+        rowdict['SatelliteNumber'] = i['SatelliteNumber']
+        rowdict['Level'] = i['Level']
+        rowdict['Wavelength'] = i['Wavelength']*u.Angstrom
+        rowdict['url'] = i['url']
+        return rowdict
 
     def search(self, *args, **kwargs):
         supported_waves = [94, 131, 171, 195, 284, 304]*u.Angstrom
@@ -177,8 +177,8 @@ class SUVIClient(GenericClient):
                     scraper = Scraper(urlpattern)
                     filesmeta = scraper._extract_files_meta(matchdict['Time'], extractor=pattern)
                     for i in filesmeta:
-                        map_ = self.post_search_hook(i, matchdict)
-                        metalist.append(map_)
+                        rowdict = self.post_search_hook(i, matchdict)
+                        metalist.append(rowdict)
 
         return QueryResponse(metalist, client=self)
 

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -84,6 +84,26 @@ class SUVIClient(GenericClient):
     GOES-16 began providing regular level-1b data on 2018-06-01.  At the time
     of writing, SUVI on GOES-17 is operational but currently does not provide
     Level-2 data.
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido, attrs as a
+    >>> import astropy.units as u
+    >>> results = Fido.search(a.Time("2020/7/10", "2020/7/10 00:10"), a.Instrument('suvi'),a.Level.two,
+    ...                       a.goes.SatelliteNumber(16), a.Wavelength(304*u.Angstrom))  #doctest: +REMOTE_DATA
+    >>> results  #doctest: +REMOTE_DATA
+    <sunpy.net.fido_factory.UnifiedResponse object at ...>
+    Results from 1 Provider:
+    <BLANKLINE>
+    3 Results from the SUVIClient:
+         Start Time           End Time      Instrument ... Level   Wavelength  
+    ------------------- ------------------- ---------- ... ----- --------------
+    2020-07-10 00:00:00 2020-07-10 00:04:00       SUVI ...     2 304.0 Angstrom
+    2020-07-10 00:04:00 2020-07-10 00:08:00       SUVI ...     2 304.0 Angstrom
+    2020-07-10 00:08:00 2020-07-10 00:12:00       SUVI ...     2 304.0 Angstrom
+    <BLANKLINE>
+    <BLANKLINE>
+
     """
     baseurl1b = (r'https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/goes'
                  r'{SatelliteNumber}/l1b/suvi-l1b-{elem:2}{wave:03}/%Y/%m/%d/OR_SUVI-L1b.*\.fits.gz')
@@ -95,7 +115,7 @@ class SUVIClient(GenericClient):
     pattern2 = ('{}/goes/goes{SatelliteNumber:2d}/{}/dr_suvi-l{Level}-ci{Wavelength:03d}_g{SatelliteNumber:2d}_s'
                 '{year:4d}{month:2d}{day:2d}T{hour:2d}{minute:2d}{second:2d}Z_e'
                 '{eyear:4d}{emonth:2d}{eday:2d}T{ehour:2d}{eminute:2d}{esecond:2d}Z_{}')
-    optional = {a.Wavelength, a.Source, a.Provider, a.Level, a.Physobs}
+    optional = {a.Wavelength, a.Source, a.Provider, a.Level, a.Physobs, a.goes.SatelliteNumber}
 
     def pre_search_hook(cls, *args, **kwargs):
         matchdict = cls._get_match_dict(*args, **kwargs)
@@ -112,7 +132,7 @@ class SUVIClient(GenericClient):
         map_['Time'] = timerange
         map_['Start Time'] = start.strftime(TIME_FORMAT)
         map_['End Time'] = end.strftime(TIME_FORMAT)
-        map_['Instrument'] = matchdict['Instrument'][0]
+        map_['Instrument'] = matchdict['Instrument'][0].upper()
         map_['Phsyobs'] = matchdict['Physobs'][0]
         map_['Source'] = matchdict['Source'][0]
         map_['Provider'] = matchdict['Provider'][0]

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -115,7 +115,6 @@ class SUVIClient(GenericClient):
     pattern2 = ('{}/goes/goes{SatelliteNumber:2d}/{}/dr_suvi-l{Level}-ci{Wavelength:03d}_g{SatelliteNumber:2d}_s'
                 '{year:4d}{month:2d}{day:2d}T{hour:2d}{minute:2d}{second:2d}Z_e'
                 '{eyear:4d}{emonth:2d}{eday:2d}T{ehour:2d}{eminute:2d}{esecond:2d}Z_{}')
-    optional = {a.Wavelength, a.Source, a.Provider, a.Level, a.Physobs, a.goes.SatelliteNumber}
 
     def post_search_hook(self, i, matchdict):
 
@@ -198,5 +197,6 @@ class SUVIClient(GenericClient):
             attrs.Physobs: [('flux', 'a measure of the amount of radiation received by an object from a given source.')],
             attrs.Provider: [('NOAA', 'The National Oceanic and Atmospheric Administration.')],
             attrs.Level: [('1b', 'Solar images at six wavelengths with image exposures 10 msec or 1 sec.'),
-                          ('2', 'Weighted average of level-1b product files of SUVI.')]}
+                          ('2', 'Weighted average of level-1b product files of SUVI.')],
+            attrs.Wavelength: [('*', 'Wavelength')]}
         return adict

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -45,7 +45,7 @@ class LYRAClient(GenericClient):
                  attrs.Level: [('1', 'LYRA: Metadata and uncalibrated data daily fits.'),
                                ('2', 'LYRA: Calibrated data, provided as daily fits.'),
                                ('3', 'LYRA: Same as level 2 but the calibrated data is averaged over 1 min.')],
-                 attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area')],
+                 attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area.')],
                  attrs.Source: [('Proba2', 'The PROBA-2 Satellite')],
-                 attrs.Provider: [('esa', 'The European Space Agency')]}
+                 attrs.Provider: [('esa', 'The European Space Agency.')]}
         return adict

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -3,7 +3,6 @@
 # Google Summer of Code 2014
 
 from sunpy.net.dataretriever.client import GenericClient
-from sunpy.util.scraper import Scraper
 
 __all__ = ['LYRAClient']
 
@@ -23,66 +22,20 @@ class LYRAClient(GenericClient):
     <sunpy.net.fido_factory.UnifiedResponse object at ...>
     Results from 1 Provider:
     <BLANKLINE>
-    2 Results from the LYRAClient:
-         Start Time           End Time      Source Instrument Wavelength
-    ------------------- ------------------- ------ ---------- ----------
-    2016-01-01 00:00:00 2016-01-02 00:00:00 Proba2       lyra        nan
-    2016-01-01 00:00:00 2016-01-02 00:00:00 Proba2       lyra        nan
+    4 Results from the LYRAClient:
+         Start Time           End Time      Instrument ... Source Provider Level
+    ------------------- ------------------- ---------- ... ------ -------- -----
+    2016-01-01 00:00:00 2016-01-01 23:59:59       LYRA ... Proba2      esa     2
+    2016-01-01 00:00:00 2016-01-01 23:59:59       LYRA ... Proba2      esa     3
+    2016-01-02 00:00:00 2016-01-02 23:59:59       LYRA ... Proba2      esa     2
+    2016-01-02 00:00:00 2016-01-02 23:59:59       LYRA ... Proba2      esa     3
     <BLANKLINE>
     <BLANKLINE>
 
     """
-
-    def _get_url_for_timerange(self, timerange, **kwargs):
-        """
-        Return URL(s) for corresponding timerange.
-
-        Parameters
-        ----------
-        timerange : `~sunpy.time.TimeRange`
-            The time range you want the files for.
-
-        Returns
-        -------
-        `list`
-            The URL(s) for the corresponding timerange.
-        """
-        lyra_pattern = ('http://proba2.oma.be/lyra/data/bsd/%Y/%m/%d/'
-                        'lyra_%Y%m%d-000000_lev{level}_std.fits')
-        lyra_files = Scraper(lyra_pattern, level=kwargs.get('level', 2))
-        urls = lyra_files.filelist(timerange)
-
-        return urls
-
-    def _makeimap(self):
-        """
-        Helper Function:used to hold information about source.
-        """
-        self.map_['source'] = 'Proba2'
-        self.map_['instrument'] = 'lyra'
-        self.map_['physobs'] = 'irradiance'
-        self.map_['provider'] = 'esa'
-
-    @classmethod
-    def _can_handle_query(cls, *query):
-        """
-        Answers whether client can service the query.
-
-        Parameters
-        ----------
-        query : list of query objects
-
-        Returns
-        -------
-        boolean
-            answer as to whether client can service the query
-        """
-        chkattr = ['Time', 'Instrument', 'Level']
-        chklist = [x.__class__.__name__ in chkattr for x in query]
-        for x in query:
-            if x.__class__.__name__ == 'Instrument' and x.value.lower() == 'lyra':
-                return all(chklist)
-        return False
+    baseurl = (r'http://proba2.oma.be/lyra/data/bsd/%Y/%m/%d/'
+               r'lyra_(\d){8}-000000_lev(\d){1}_std.fits')
+    pattern = '{}/bsd/{year:4d}/{month:2d}/{day:2d}/{}_lev{Level:1d}_std.fits'
 
     @classmethod
     def register_values(cls):
@@ -91,5 +44,8 @@ class LYRAClient(GenericClient):
                                      'Lyman Alpha Radiometer is the solar UV radiometer on board Proba-2.')],
                  attrs.Level: [('1', 'LYRA: Metadata and uncalibrated data daily fits.'),
                                ('2', 'LYRA: Calibrated data, provided as daily fits.'),
-                               ('3', 'LYRA: Same as level 2 but the calibrated data is averaged over 1 min.')]}
+                               ('3', 'LYRA: Same as level 2 but the calibrated data is averaged over 1 min.')],
+                 attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area')],
+                 attrs.Source: [('Proba2', 'The PROBA-2 Satellite')],
+                 attrs.Provider: [('esa', 'The European Space Agency')]}
         return adict

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -42,10 +42,10 @@ class LYRAClient(GenericClient):
         from sunpy.net import attrs
         adict = {attrs.Instrument: [('LYRA',
                                      'Lyman Alpha Radiometer is the solar UV radiometer on board Proba-2.')],
-                 attrs.Level: [('1', 'LYRA: Metadata and uncalibrated data daily fits.'),
-                               ('2', 'LYRA: Calibrated data, provided as daily fits.'),
-                               ('3', 'LYRA: Same as level 2 but the calibrated data is averaged over 1 min.')],
                  attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area.')],
                  attrs.Source: [('PROBA2', 'The PROBA-2 Satellite')],
-                 attrs.Provider: [('ESA', 'The European Space Agency.')]}
+                 attrs.Provider: [('ESA', 'The European Space Agency.')],
+                 attrs.Level: [('1', 'LYRA: Metadata and uncalibrated data daily fits.'),
+                               ('2', 'LYRA: Calibrated data, provided as daily fits.'),
+                               ('3', 'LYRA: Same as level 2 but the calibrated data is averaged over 1 min.')]}
         return adict

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -25,10 +25,10 @@ class LYRAClient(GenericClient):
     4 Results from the LYRAClient:
          Start Time           End Time      Instrument ... Source Provider Level
     ------------------- ------------------- ---------- ... ------ -------- -----
-    2016-01-01 00:00:00 2016-01-01 23:59:59       LYRA ... Proba2      esa     2
-    2016-01-01 00:00:00 2016-01-01 23:59:59       LYRA ... Proba2      esa     3
-    2016-01-02 00:00:00 2016-01-02 23:59:59       LYRA ... Proba2      esa     2
-    2016-01-02 00:00:00 2016-01-02 23:59:59       LYRA ... Proba2      esa     3
+    2016-01-01 00:00:00 2016-01-01 23:59:59       LYRA ... PROBA2      ESA     2
+    2016-01-01 00:00:00 2016-01-01 23:59:59       LYRA ... PROBA2      ESA     3
+    2016-01-02 00:00:00 2016-01-02 23:59:59       LYRA ... PROBA2      ESA     2
+    2016-01-02 00:00:00 2016-01-02 23:59:59       LYRA ... PROBA2      ESA     3
     <BLANKLINE>
     <BLANKLINE>
 
@@ -46,6 +46,6 @@ class LYRAClient(GenericClient):
                                ('2', 'LYRA: Calibrated data, provided as daily fits.'),
                                ('3', 'LYRA: Same as level 2 but the calibrated data is averaged over 1 min.')],
                  attrs.Physobs: [('irradiance', 'the flux of radiant energy per unit area.')],
-                 attrs.Source: [('Proba2', 'The PROBA-2 Satellite')],
-                 attrs.Provider: [('esa', 'The European Space Agency.')]}
+                 attrs.Source: [('PROBA2', 'The PROBA-2 Satellite')],
+                 attrs.Provider: [('ESA', 'The European Space Agency.')]}
         return adict

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -44,15 +44,15 @@ class NOAAIndicesClient(GenericClient):
     required = {a.Instrument}
 
     def search(self, *args, **kwargs):
-        map_ = self._get_match_dict(*args, **kwargs)
-        for key in map_:
-            if isinstance(map_[key], list):
+        rowdict = self._get_match_dict(*args, **kwargs)
+        for key in rowdict:
+            if isinstance(rowdict[key], list):
                 # uses first value among the list of possible values corresponding to an Attr
                 # returned by `get_match_dict()` to be shown in query response table.
-                map_[key] = map_[key][0]
-        map_['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json'
-        map_['Instrument'] = 'NOAA-Indices'
-        return QueryResponse([map_], client=self)
+                rowdict[key] = rowdict[key][0]
+        rowdict['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json'
+        rowdict['Instrument'] = 'NOAA-Indices'
+        return QueryResponse([rowdict], client=self)
 
     @classmethod
     def register_values(cls):
@@ -94,15 +94,15 @@ class NOAAPredictClient(GenericClient):
     required = {a.Instrument}
 
     def search(self, *args, **kwargs):
-        map_ = self._get_match_dict(*args, **kwargs)
-        for key in map_:
-            if isinstance(map_[key], list):
+        rowdict = self._get_match_dict(*args, **kwargs)
+        for key in rowdict:
+            if isinstance(rowdict[key], list):
                 # uses first value among the list of possible values corresponding to an Attr
                 # returned by `get_match_dict()` to be shown in query response table.
-                map_[key] = map_[key][0]
-        map_['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json'
-        map_['Instrument'] = 'NOAA-Predict'
-        return QueryResponse([map_], client=self)
+                rowdict[key] = rowdict[key][0]
+        rowdict['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json'
+        rowdict['Instrument'] = 'NOAA-Predict'
+        return QueryResponse([rowdict], client=self)
 
     @classmethod
     def register_values(cls):
@@ -172,9 +172,9 @@ class SRSClient(GenericClient):
             exdict1 = parse(extractor1, url)
             exdict2 = parse(extractor2, url)
             exdict = (exdict2 if exdict1 is None else exdict1).named
-            map_ = self.post_search_hook(exdict, matchdict)
-            map_['url'] = url
-            metalist.append(map_)
+            exdict['url'] = url
+            rowdict = self.post_search_hook(exdict, matchdict)
+            metalist.append(rowdict)
         return QueryResponse(metalist, client=self)
 
     def fetch(self, qres, path=None, error_callback=None, **kwargs):

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -128,7 +128,7 @@ class SRSClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the SRSClient:
-         Start Time           End Time      Instrument Phsyobs Source Provider
+         Start Time           End Time      Instrument Physobs Source Provider
     ------------------- ------------------- ---------- ------- ------ --------
     2016-01-01 00:00:00 2016-12-31 23:59:59       SOON     SRS   SWPC     NOAA
     2016-01-01 00:00:00 2016-12-31 23:59:59       SOON     SRS   SWPC     NOAA
@@ -169,6 +169,7 @@ class SRSClient(GenericClient):
             exdict2 = parse(extractor2, url)
             exdict = (exdict2 if exdict1 is None else exdict1).named
             map_ = super().post_search_hook(exdict, matchdict)
+            map_['url'] = url
             metalist.append(map_)
         return QueryResponse(metalist, client=self)
 
@@ -186,7 +187,7 @@ class SRSClient(GenericClient):
         Results Object
         """
 
-        urls = [qrblock.url for qrblock in qres]
+        urls = [qrblock['url'] for qrblock in qres]
 
         filenames = []
         local_filenames = []
@@ -195,7 +196,7 @@ class SRSClient(GenericClient):
             name = url.split('/')[-1]
 
             # temporary fix !!! coz All QRBs have same start_time values
-            day = Time(qre.time.start.strftime('%Y-%m-%d')) + TimeDelta(i*u.day)
+            day = Time(qre['Time'].start.strftime('%Y-%m-%d')) + TimeDelta(i*u.day)
 
             if name not in filenames:
                 filenames.append(name)

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -136,6 +136,10 @@ class SRSClient(GenericClient):
     """
 
     def _get_url_for_timerange(self, timerange):
+        """
+        Returns a list of urls corresponding to a
+        given time-range.
+        """
         result = list()
         base_url = 'ftp://ftp.swpc.noaa.gov/pub/warehouse/'
         total_days = int(timerange.days.value) + 1

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -48,6 +48,8 @@ class NOAAIndicesClient(GenericClient):
         map_ = self._get_match_dict(*args, **kwargs)
         for key in map_:
             if isinstance(map_[key], list):
+                # uses first value among the list of possible values corresponding to an Attr
+                # returned by `get_match_dict()` to be shown in query response table.
                 map_[key] = map_[key][0]
         map_['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json'
         map_['Instrument'] = 'NOAA-Indices'
@@ -96,6 +98,8 @@ class NOAAPredictClient(GenericClient):
         map_ = self._get_match_dict(*args, **kwargs)
         for key in map_:
             if isinstance(map_[key], list):
+                # uses first value among the list of possible values corresponding to an Attr
+                # returned by `get_match_dict()` to be shown in query response table.
                 map_[key] = map_[key][0]
         map_['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json'
         map_['Instrument'] = 'NOAA-Predict'
@@ -168,7 +172,7 @@ class SRSClient(GenericClient):
             exdict1 = parse(extractor1, url)
             exdict2 = parse(extractor2, url)
             exdict = (exdict2 if exdict1 is None else exdict1).named
-            map_ = super().post_search_hook(exdict, matchdict)
+            map_ = self.post_search_hook(exdict, matchdict)
             map_['url'] = url
             metalist.append(map_)
         return QueryResponse(metalist, client=self)

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -11,7 +11,6 @@ from astropy.time import Time, TimeDelta
 from sunpy.extern.parse import parse
 from sunpy.net import attrs as a
 from sunpy.net.dataretriever import GenericClient, QueryResponse
-from sunpy.time import TimeRange
 from sunpy.util.parfive_helpers import Downloader
 
 __all__ = ['NOAAIndicesClient', 'NOAAPredictClient', 'SRSClient']

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -42,7 +42,6 @@ class NOAAIndicesClient(GenericClient):
 
     """
     required = {a.Instrument}
-    optional = {a.Time, a.Source, a.Physobs, a.Provider}
 
     def search(self, *args, **kwargs):
         map_ = self._get_match_dict(*args, **kwargs)
@@ -62,7 +61,8 @@ class NOAAIndicesClient(GenericClient):
             ('NOAA-Indices', 'Recent Solar Indices of Observed Monthly Mean Values')],
             attrs.Physobs: [('sunspot number', 'Sunspot Number.')],
             attrs.Source: [('SIDC', 'The Solar Influence Data Analysis Center')],
-            attrs.Provider: [('SWPC', 'The Space Weather Prediction Center.')]}
+            attrs.Provider: [('SWPC', 'The Space Weather Prediction Center.')],
+            attrs.Time: [('*', 'Time')]}
         return adict
 
 
@@ -92,7 +92,6 @@ class NOAAPredictClient(GenericClient):
 
     """
     required = {a.Instrument}
-    optional = {a.Time, a.Source, a.Physobs, a.Provider}
 
     def search(self, *args, **kwargs):
         map_ = self._get_match_dict(*args, **kwargs)
@@ -112,7 +111,8 @@ class NOAAPredictClient(GenericClient):
             ('NOAA-Predict', 'Predicted Sunspot Number And Radio Flux Values With Expected Ranges.')],
             attrs.Physobs: [('sunspot number', 'Sunspot Number.')],
             attrs.Source: [('ISES', 'The International Space Environmental Services.')],
-            attrs.Provider: [('SWPC', 'The Space Weather Prediction Center.')]}
+            attrs.Provider: [('SWPC', 'The Space Weather Prediction Center.')],
+            attrs.Time: [('*', 'Time')]}
         return adict
 
 

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -50,6 +50,7 @@ class NOAAIndicesClient(GenericClient):
             if isinstance(map_[key], list):
                 map_[key] = map_[key][0]
         map_['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json'
+        map_['Instrument'] = 'NOAA-Indices'
         return QueryResponse([map_], client=self)
 
     @classmethod
@@ -97,6 +98,7 @@ class NOAAPredictClient(GenericClient):
             if isinstance(map_[key], list):
                 map_[key] = map_[key][0]
         map_['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json'
+        map_['Instrument'] = 'NOAA-Predict'
         return QueryResponse([map_], client=self)
 
     @classmethod

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -66,12 +66,12 @@ class NoRHClient(GenericClient):
         This method converts 'tca' and 'tcz' in the url's metadata
         to a frequency of '17 GHz' and '34 GHz' respectively.
         """
-        map_ = super().post_search_hook(exdict, matchdict)
-        if map_['Wavelength'] == 'tca':
-            map_['Wavelength'] = 17*u.GHz
-        elif map_['Wavelength'] == 'tcz':
-            map_['Wavelength'] = 34*u.GHz
-        return map_
+        rowdict = super().post_search_hook(exdict, matchdict)
+        if rowdict['Wavelength'] == 'tca':
+            rowdict['Wavelength'] = 17*u.GHz
+        elif rowdict['Wavelength'] == 'tcz':
+            rowdict['Wavelength'] = 34*u.GHz
+        return rowdict
 
     @classmethod
     def register_values(cls):

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -47,7 +47,7 @@ class NoRHClient(GenericClient):
     optional = {a.Wavelength, a.Source, a.Provider}
 
     @classmethod
-    def pre_hook(cls, *args, **kwargs):
+    def pre_search_hook(cls, *args, **kwargs):
         d = {'Source': ['NAOJ'], 'Instrument': ['NORH'], 'Provider': ['NRO']}
         d['Wavelength'] = []
         waverange = a.Wavelength(34*u.GHz, 17*u.GHz)
@@ -57,7 +57,7 @@ class NoRHClient(GenericClient):
                 req_wave = elem
             elif isinstance(elem, a.Time):
                 timerange = TimeRange(elem.start, elem.end)
-                d['timerange'] = timerange
+                d['Time'] = timerange
         if hasattr(kwargs, 'Wavelength'):
             req_wave = kwargs['Wavelength']
         wmin = req_wave.min.to(u.GHz, equivalencies=u.spectral())
@@ -69,8 +69,8 @@ class NoRHClient(GenericClient):
             d['Wavelength'].append('tca')
         return cls.baseurl, cls.pattern, d
 
-    def post_hook(self, exdict, matchdict):
-        map_ = super().post_hook(exdict, matchdict)
+    def post_search_hook(self, exdict, matchdict):
+        map_ = super().post_search_hook(exdict, matchdict)
         if map_['Wavelength'] == 'tcz':
             map_['Wavelength'] = 17*u.GHz
         elif map_['Wavelength'] == 'tca':

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -9,8 +9,6 @@ from sunpy.net.dataretriever import GenericClient
 
 __all__ = ['NoRHClient']
 
-BASEURL = 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/{freq}%y%m%d'
-
 
 class NoRHClient(GenericClient):
     """

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -41,7 +41,6 @@ class NoRHClient(GenericClient):
     """
     baseurl = r'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/(\w){3}%y%m%d'
     pattern = '{}/tcx/{year:4d}/{month:2d}/{Wavelength:3l}{:4d}{day:2d}'
-    optional = {a.Wavelength, a.Source, a.Provider}
 
     @classmethod
     def pre_search_hook(cls, *args, **kwargs):
@@ -81,5 +80,6 @@ class NoRHClient(GenericClient):
                                      ('Nobeyama Radio Heliograph is an imaging radio telescope at 17 '
                                       'or 34GHz located at the Nobeyama Solar Radio Observatory.'))],
                  attrs.Source: [('NAOJ', 'The National Astronomical Observatory of Japan')],
-                 attrs.Provider: [('NRO', 'Nobeyama Radio Observatory')]}
+                 attrs.Provider: [('NRO', 'Nobeyama Radio Observatory')],
+                 attrs.Wavelength: [('*', 'Wavelength')]}
         return adict

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -10,7 +10,6 @@ from dateutil.rrule import MONTHLY, rrule
 
 from sunpy.extern.parse import parse
 from sunpy.instr import rhessi
-from sunpy.net import attrs as a
 from sunpy.net.dataretriever import GenericClient, QueryResponse
 from sunpy.time import TimeRange, parse_time
 

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -62,6 +62,7 @@ class RHESSIClient(GenericClient):
     <BLANKLINE>
 
     """
+    pattern = '{}/catalog/hsi_obssumm_{year:4d}{month:2d}{day:2d}_{}'
 
     def get_observing_summary_filename(self, time_range):
         """
@@ -152,15 +153,12 @@ class RHESSIClient(GenericClient):
         return urlretrieve(url)
 
     def search(self, *args, **kwargs):
-        pattern = '{}/catalog/hsi_obssumm_{year:4d}{month:2d}{day:2d}_{}'
-        matchdict = {'Instrument': ['RHESSI'], 'Source': ['RHESSI'], 'Provider': ['NASA'], 'Physobs': ['summary_lightcurve']}
+        baseurl, pattern, matchdict = self.pre_search_hook(*args, **kwargs)
+        timerange = matchdict['Time']
         metalist = []
-        for elem in args:
-            if isinstance(elem, a.Time):
-                timerange = TimeRange(elem.start, elem.end)
         for url in self.get_observing_summary_filename(timerange):
             exdict = parse(pattern, url).named
-            map_ = super().post_hook(exdict, matchdict)
+            map_ = super().post_search_hook(exdict, matchdict)
             metalist.append(map_)
         return QueryResponse(metalist, client=self)
 

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -158,6 +158,7 @@ class RHESSIClient(GenericClient):
         for url in self.get_observing_summary_filename(timerange):
             exdict = parse(pattern, url).named
             map_ = super().post_search_hook(exdict, matchdict)
+            map_['url'] = url
             metalist.append(map_)
         return QueryResponse(metalist, client=self)
 

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -157,9 +157,9 @@ class RHESSIClient(GenericClient):
         metalist = []
         for url in self.get_observing_summary_filename(timerange):
             exdict = parse(pattern, url).named
-            map_ = super().post_search_hook(exdict, matchdict)
-            map_['url'] = url
-            metalist.append(map_)
+            exdict['url'] = url
+            rowdict = super().post_search_hook(exdict, matchdict)
+            metalist.append(rowdict)
         return QueryResponse(metalist, client=self)
 
     @classmethod

--- a/sunpy/net/dataretriever/sources/tests/test_eve.py
+++ b/sunpy/net/dataretriever/sources/tests/test_eve.py
@@ -64,8 +64,8 @@ def test_query(LCClient):
     qr1 = LCClient.search(Time('2012/8/9', '2012/8/10'), Instrument('eve'))
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 2
-    assert qr1.time_range().start == parse_time('2012/08/09')
-    assert qr1.time_range().end == parse_time('2012/08/10 23:59:59.999')  # includes end.
+    assert qr1.time_range().start == parse_time('2012/08/09').to_datetime()
+    assert qr1.time_range().end == parse_time('2012/08/10 23:59:59.999').to_datetime()
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/dataretriever/sources/tests/test_fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/tests/test_fermi_gbm.py
@@ -27,7 +27,7 @@ def LCClient():
                            'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/2011/06/09/'
                            'current/glg_cspec_n5_110609_v00.pha')])
 def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
-    qresponse = LCClient.search(timerange, Detector='n5', Resolution='cspec')
+    qresponse = LCClient.search(timerange, a.Detector.n5, a.Resolution.cspec)
     urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert urls[0] == url_start

--- a/sunpy/net/dataretriever/sources/tests/test_fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/tests/test_fermi_gbm.py
@@ -1,6 +1,9 @@
 import pytest
 from hypothesis import given
 
+import astropy.units as u
+from astropy.time import TimeDelta
+
 import sunpy.net.dataretriever.sources.fermi_gbm as fermi_gbm
 from sunpy.net import Fido
 from sunpy.net import attrs as a
@@ -18,13 +21,14 @@ def LCClient():
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize("timerange,url_start,url_end",
-                         [(TimeRange('2011/06/07', '2011/06/09'),
+                         [(a.Time('2011/06/07', '2011/06/09'),
                            'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/2011/06/07/'
                            'current/glg_cspec_n5_110607_v00.pha',
                            'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/2011/06/09/'
                            'current/glg_cspec_n5_110609_v00.pha')])
 def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
-    urls = LCClient._get_url_for_timerange(timerange, detector='n5', resolution='cspec')
+    qresponse = LCClient.search(timerange, Detector='n5', Resolution='cspec')
+    urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
@@ -50,11 +54,12 @@ def test_can_handle_query(time):
     (a.Time('2012/8/9', '2012/8/9'), a.Instrument.gbm),
 ])
 def test_query(LCClient, time, instrument):
-    qr1 = LCClient.search(time, instrument)
+    qr1 = LCClient.search(time, instrument, a.Detector.n5, a.Resolution.ctime)
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 1
+    almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
     assert qr1.time_range().start == time.start
-    assert qr1.time_range().end == time.end
+    assert qr1.time_range().end == time.end + almost_day
 
 
 @pytest.mark.remote_data
@@ -62,7 +67,7 @@ def test_query(LCClient, time, instrument):
     (a.Time('2012/11/27', '2012/11/27'), a.Instrument.gbm),
 ])
 def test_get(LCClient, time, instrument):
-    qr1 = LCClient.search(time, instrument)
+    qr1 = LCClient.search(time, instrument, a.Detector.n5, a.Resolution.ctime)
     download_list = LCClient.fetch(qr1)
     assert len(download_list) == len(qr1)
 
@@ -98,21 +103,21 @@ def mock_query_object(LCClient):
     """
     # Creating a Query Response Object
     start = '2016/1/1'
-    end = '2016/1/2'
+    end = '2016/1/1 23:59:59'
     obj = {
-        'TimeRange': TimeRange(parse_time(start), parse_time(end)),
-        'Time_start': parse_time(start),
-        'Time_end': parse_time(end),
-        'source': 'FERMI',
-        'instrument': 'GBM',
-        'physobs': 'flux',
-        'provider': 'NASA'
+        'Time': TimeRange(parse_time(start), parse_time(end)),
+        'Start Time': parse_time(start),
+        'End Time': parse_time(end),
+        'Instrument': 'GBM',
+        'Physobs': 'flux',
+        'Source': 'FERMI',
+        'Provider': 'NASA',
+        'Resolution': 'cspec',
+        'Detector': 'n5',
+        'url': ('https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/'
+                '2016/01/01/current/glg_cspec_n5_160101_v00.pha')
     }
-    urls = ['https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/'
-            '2016/01/01/current/glg_cspec_n5_160101_v00.pha',
-            'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/'
-            '2016/01/02/current/glg_cspec_n5_160102_v00.pha']
-    results = QueryResponse.create(obj, urls, client=LCClient)
+    results = QueryResponse([obj], client=LCClient)
     return results
 
 
@@ -120,7 +125,8 @@ def test_show(LCClient):
     mock_qr = mock_query_object(LCClient)
     qrshow0 = mock_qr.show()
     qrshow1 = mock_qr.show('Start Time', 'Instrument')
-    allcols = ['Start Time', 'End Time', 'Source', 'Instrument', 'Wavelength']
+    allcols = ['Start Time', 'End Time', 'Instrument', 'Physobs', 'Source',
+               'Provider', 'Resolution', 'Detector']
     assert qrshow0.colnames == allcols
     assert qrshow1.colnames == ['Start Time', 'Instrument']
     assert qrshow0['Instrument'][0] == 'GBM'

--- a/sunpy/net/dataretriever/sources/tests/test_fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/tests/test_fermi_gbm.py
@@ -58,8 +58,8 @@ def test_query(LCClient, time, instrument):
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == 1
     almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
-    assert qr1.time_range().start == time.start
-    assert qr1.time_range().end == time.end + almost_day
+    assert qr1.time_range().start == time.start.to_datetime()
+    assert qr1.time_range().end == (time.end + almost_day).to_datetime()
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/dataretriever/sources/tests/test_goes_suvi.py
+++ b/sunpy/net/dataretriever/sources/tests/test_goes_suvi.py
@@ -40,31 +40,6 @@ def test_can_handle_query(time):
     assert ans6 is True
 
 
-def test_get_goes_sat_num(suvi_client):
-    date = parse_time('2019/06/11 00:00')
-    min_satellite_number = 16  # when SUVI was first included
-    assert suvi_client._get_goes_sat_num(date) >= min_satellite_number
-    assert type(suvi_client._get_goes_sat_num(date)) is int
-
-
-@pytest.mark.filterwarnings('ignore:ERFA function')
-def test_get_goes_sat_num_error(suvi_client):
-    date = parse_time('1800/06/11 00:00')
-    with pytest.raises(ValueError):
-        suvi_client._get_goes_sat_num(date)
-
-
-def test_get_url_for_timerange_errors(suvi_client):
-    """Check that unsupported values raise errors."""
-    tr = TimeRange('2019/06/11 00:00', '2019/06/11 00:10')
-    with pytest.raises(ValueError):
-        suvi_client._get_url_for_timerange(tr, level=0)
-    with pytest.raises(ValueError):
-        suvi_client._get_url_for_timerange(tr, wavelength=100 * u.Angstrom)
-    with pytest.raises(ValueError):
-        suvi_client._get_url_for_timerange(tr, satellitenumber=1)
-
-
 def mock_query_object(suvi_client):
     """
     Creating a Query Response object and prefilling it with some information
@@ -74,19 +49,20 @@ def mock_query_object(suvi_client):
     end = '2019/05/25 00:52'
     wave = 94 * u.Angstrom
     obj = {
-        'TimeRange': TimeRange(parse_time(start), parse_time(end)),
-        'Time_start': parse_time(start),
-        'Time_end': parse_time(end),
-        'source': 'GOES',
-        'instrument': 'SUVI',
-        'physobs': 'flux',
-        'provider': 'NOAA',
-        'wavelength': wave
+        'Time': TimeRange(parse_time(start), parse_time(end)),
+        'Start Time': parse_time(start),
+        'End Time': parse_time(end),
+        'Instrument': 'SUVI',
+        'Physobs': 'flux',
+        'Source': 'GOES',
+        'Provider': 'NOAA',
+        'Level': '2',
+        'Wavelength': wave,
+        'url': ('https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites'
+                '/goes/goes16/l2/data/suvi-l2-ci094/2019/05/25/'
+                'dr_suvi-l2-ci094_g16_s20190525T005200Z_e20190525T005600Z_v1-0-0.fits')
     }
-    urls = ['https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites'
-            '/goes/goes16/l2/data/suvi-l2-ci094/2019/05/25/'
-            'dr_suvi-l2-ci094_g16_s20190525T005200Z_e20190525T005600Z_v1-0-0.fits']
-    results = QueryResponse.create(obj, urls, client=suvi_client)
+    results = QueryResponse([obj], client=suvi_client)
     return results
 
 
@@ -104,7 +80,9 @@ def test_fetch_working(suvi_client):
     start = '2019/05/25 00:50'
     end = '2019/05/25 00:52'
     wave = 94 * u.Angstrom
-    qr1 = suvi_client.search(a.Time(start, end), a.Instrument.suvi, a.Wavelength(wave))
+    goes_sat = a.goes.SatelliteNumber.sixteen
+    tr = a.Time(start, end)
+    qr1 = suvi_client.search(tr, a.Instrument.suvi, a.Wavelength(wave), goes_sat, a.Level(2))
 
     # Mock QueryResponse object
     mock_qr = mock_query_object(suvi_client)
@@ -114,11 +92,11 @@ def test_fetch_working(suvi_client):
     mock_qr = mock_qr.blocks[0]
     qr = qr1.blocks[0]
 
-    assert mock_qr.source == qr.source
-    assert mock_qr.provider == qr.provider
-    assert mock_qr.physobs == qr.physobs
-    assert mock_qr.instrument == qr.instrument
-    assert mock_qr.url == qr.url
+    assert mock_qr['Source'] == qr['Source']
+    assert mock_qr['Provider'] == qr['Provider']
+    assert mock_qr['Physobs'] == qr['Physobs']
+    assert mock_qr['Instrument'] == qr['Instrument']
+    assert mock_qr['url'] == qr['url']
 
     assert qr1.time_range() == TimeRange("2019-05-25T00:52:00.000",
                                          "2019-05-25T00:56:00.000")
@@ -138,9 +116,9 @@ def test_fetch_working(suvi_client):
                           ('2019/05/25 00:50', '2019/05/25 00:52', 304, 1)]
                          )
 def test_get_url_for_time_range_level2(suvi_client, start, end, wave, expected_num_files):
-    urls = suvi_client._get_url_for_timerange(TimeRange(start, end),
-                                              wavelength=wave * u.Angstrom,
-                                              level=2)
+    goes_sat = a.goes.SatelliteNumber.sixteen
+    qresponse = suvi_client.search(a.Time(start, end), a.Wavelength(wave * u.Angstrom), goes_sat, Level=2)
+    urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert len(urls) == expected_num_files
 
@@ -151,7 +129,9 @@ def test_get_url_for_time_range_level2(suvi_client, start, end, wave, expected_n
                          )
 def test_get_url_for_time_range_level2_allwave(suvi_client, start, end, expected_num_files):
     """check that we get all wavelengths if no wavelength is given"""
-    urls = suvi_client._get_url_for_timerange(TimeRange(start, end), level=2)
+    goes_sat = a.goes.SatelliteNumber.sixteen
+    qresponse = suvi_client.search(a.Time(start, end), goes_sat, Level=2)
+    urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert len(urls) == expected_num_files
 
@@ -167,9 +147,9 @@ def test_get_url_for_time_range_level2_allwave(suvi_client, start, end, expected
                          )
 def test_get_url_for_time_range_level1b(suvi_client, start, end, wave, expected_num_files):
     """check that we get all wavelengths if no wavelength is given"""
-    urls = suvi_client._get_url_for_timerange(TimeRange(start, end),
-                                              wavelength=wave * u.Angstrom,
-                                              level='1b')
+    goes_sat = a.goes.SatelliteNumber.sixteen
+    qresponse = suvi_client.search(a.Time(start, end), a.Wavelength(wave * u.Angstrom), goes_sat, Level='1b')
+    urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert len(urls) == expected_num_files
 
@@ -184,7 +164,8 @@ def test_get_url_for_time_range_level1b(suvi_client, start, end, wave, expected_
                           ('2019/05/25 00:50', '2019/05/25 00:54', 304, 4)]
                          )
 def test_fido_onewave_level1b(start, end, wave, expected_num_files):
-    result = Fido.search(a.Time(start, end), a.Instrument.suvi,
+    goes_sat = a.goes.SatelliteNumber.sixteen
+    result = Fido.search(a.Time(start, end), a.Instrument.suvi, goes_sat,
                          a.Wavelength(wave * u.Angstrom), a.Level('1b'))
     assert result.file_num == expected_num_files
 
@@ -200,7 +181,8 @@ def test_fido_onewave_level1b(start, end, wave, expected_num_files):
                          )
 def test_fido_waverange_level1b(start, end, wave1, wave2, expected_num_files):
     """check that we get all wavelengths if no wavelength is given"""
-    result = Fido.search(a.Time(start, end), a.Instrument.suvi,
+    goes_sat = a.goes.SatelliteNumber.sixteen
+    result = Fido.search(a.Time(start, end), a.Instrument.suvi, goes_sat,
                          a.Wavelength(wave1 * u.Angstrom, wave2 * u.Angstrom),
                          a.Level('1b'))
     assert result.file_num == expected_num_files
@@ -211,7 +193,8 @@ def test_fido_waverange_level1b(start, end, wave1, wave2, expected_num_files):
                          [('2019/05/25 00:50', '2019/05/25 00:52', 6)]
                          )
 def test_query(suvi_client, start, end, expected_num_files):
-    qr1 = suvi_client.search(a.Time(start, end), a.Instrument.suvi)
+    goes_sat = a.goes.SatelliteNumber.sixteen
+    qr1 = suvi_client.search(a.Time(start, end), a.Instrument.suvi, goes_sat, a.Level.two)
     assert isinstance(qr1, QueryResponse)
     assert len(qr1) == expected_num_files
     assert qr1.time_range().start == parse_time('2019/05/25 00:52')
@@ -222,7 +205,8 @@ def test_show(suvi_client):
     mock_qr = mock_query_object(suvi_client)
     qrshow0 = mock_qr.show()
     qrshow1 = mock_qr.show('Start Time', 'Instrument')
-    allcols = ['Start Time', 'End Time', 'Source', 'Instrument', 'Wavelength']
+    allcols = ['Start Time', 'End Time', 'Instrument', 'Physobs', 'Source',
+               'Provider', 'Level', 'Wavelength']
     assert qrshow0.colnames == allcols
     assert qrshow1.colnames == ['Start Time', 'Instrument']
     assert qrshow0['Instrument'][0] == 'SUVI'

--- a/sunpy/net/dataretriever/sources/tests/test_goes_suvi.py
+++ b/sunpy/net/dataretriever/sources/tests/test_goes_suvi.py
@@ -117,7 +117,7 @@ def test_fetch_working(suvi_client):
                          )
 def test_get_url_for_time_range_level2(suvi_client, start, end, wave, expected_num_files):
     goes_sat = a.goes.SatelliteNumber.sixteen
-    qresponse = suvi_client.search(a.Time(start, end), a.Wavelength(wave * u.Angstrom), goes_sat, Level=2)
+    qresponse = suvi_client.search(a.Time(start, end), a.Wavelength(wave * u.Angstrom), goes_sat, a.Level(2))
     urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert len(urls) == expected_num_files
@@ -130,7 +130,7 @@ def test_get_url_for_time_range_level2(suvi_client, start, end, wave, expected_n
 def test_get_url_for_time_range_level2_allwave(suvi_client, start, end, expected_num_files):
     """check that we get all wavelengths if no wavelength is given"""
     goes_sat = a.goes.SatelliteNumber.sixteen
-    qresponse = suvi_client.search(a.Time(start, end), goes_sat, Level=2)
+    qresponse = suvi_client.search(a.Time(start, end), goes_sat, a.Level(2))
     urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert len(urls) == expected_num_files
@@ -148,7 +148,7 @@ def test_get_url_for_time_range_level2_allwave(suvi_client, start, end, expected
 def test_get_url_for_time_range_level1b(suvi_client, start, end, wave, expected_num_files):
     """check that we get all wavelengths if no wavelength is given"""
     goes_sat = a.goes.SatelliteNumber.sixteen
-    qresponse = suvi_client.search(a.Time(start, end), a.Wavelength(wave * u.Angstrom), goes_sat, Level='1b')
+    qresponse = suvi_client.search(a.Time(start, end), a.Wavelength(wave * u.Angstrom), goes_sat, a.Level('1b'))
     urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert len(urls) == expected_num_files

--- a/sunpy/net/dataretriever/sources/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/sources/tests/test_goes_ud.py
@@ -121,13 +121,15 @@ def test_new_logic(LCClient):
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize(
-    "time, instrument",
-    [(a.Time("2012/10/4", "2012/10/5"), a.Instrument.goes)])
-def test_fido(time, instrument):
-    qr = Fido.search(time, Instrument('XRS'))
+    "time, instrument, expected_num_files",
+    [(a.Time("2012/10/4", "2012/10/5"), a.Instrument.goes, 4),
+     (a.Time('2013-10-28 01:00', '2013-10-28 03:00'), a.Instrument('XRS'), 1)])
+def test_fido(time, instrument, expected_num_files):
+    qr = Fido.search(time, instrument)
     assert isinstance(qr, UnifiedResponse)
     response = Fido.fetch(qr)
     assert len(response) == qr._numfile
+    assert len(response) == expected_num_files
 
 
 def test_attr_reg():

--- a/sunpy/net/dataretriever/sources/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/sources/tests/test_goes_ud.py
@@ -23,10 +23,10 @@ def LCClient():
 @pytest.mark.remote_data
 @pytest.mark.parametrize(
     "timerange,url_start,url_end",
-    [(Time('1995/06/03', '1995/06/05'),
+    [(Time('1995/06/03 1:00', '1995/06/05'),
       'https://umbra.nascom.nasa.gov/goes/fits/1995/go07950603.fits',
       'https://umbra.nascom.nasa.gov/goes/fits/1995/go07950605.fits'),
-     (Time('2008/06/02', '2008/06/04'),
+     (Time('2008/06/02 12:00', '2008/06/04'),
       'https://umbra.nascom.nasa.gov/goes/fits/2008/go1020080602.fits',
       'https://umbra.nascom.nasa.gov/goes/fits/2008/go1020080604.fits')])
 def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
@@ -39,7 +39,7 @@ def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize("timerange, url_start, url_end",
-                         [(a.Time('1999/01/10', '1999/01/20'),
+                         [(a.Time('1999/01/10 00:10', '1999/01/20'),
                            'https://umbra.nascom.nasa.gov/goes/fits/1999/go10990110.fits',
                            'https://umbra.nascom.nasa.gov/goes/fits/1999/go1019990120.fits')])
 def test_get_overlap_urls(LCClient, timerange, url_start, url_end):
@@ -63,14 +63,14 @@ def test_can_handle_query(time):
 @pytest.mark.filterwarnings('ignore:ERFA function.*dubious year')
 @pytest.mark.remote_data
 def test_fixed_satellite(LCClient):
-    ans1 = LCClient.search(a.Time("2017/01/01", "2017/01/02"),
+    ans1 = LCClient.search(a.Time("2017/01/01 2:00", "2017/01/02 2:10"),
                            a.Instrument.xrs,
                            a.goes.SatelliteNumber.fifteen)
 
     for resp in ans1:
         assert "go15" in resp['url']
 
-    ans1 = LCClient.search(a.Time("2017/01/01", "2017/01/02"),
+    ans1 = LCClient.search(a.Time("2017/01/01", "2017/01/02 23:00"),
                            a.Instrument.xrs,
                            a.goes.SatelliteNumber(13))
 
@@ -86,7 +86,7 @@ def test_fixed_satellite(LCClient):
 
 
 @pytest.mark.parametrize("time", [
-    Time('2005/4/27', '2005/4/27'),
+    Time('2005/4/27', '2005/4/27 12:00'),
     Time('2016/2/4', '2016/2/10')])
 @pytest.mark.remote_data
 def test_query(LCClient, time):
@@ -114,7 +114,7 @@ def test_get(LCClient, time, instrument):
 
 @pytest.mark.remote_data
 def test_new_logic(LCClient):
-    qr = LCClient.search(Time('2012/10/4', '2012/10/6'), Instrument('XRS'))
+    qr = LCClient.search(Time('2012/10/4 20:20', '2012/10/6'), Instrument('XRS'))
     download_list = LCClient.fetch(qr)
     assert len(download_list) == len(qr)
 

--- a/sunpy/net/dataretriever/sources/tests/test_lyra_ud.py
+++ b/sunpy/net/dataretriever/sources/tests/test_lyra_ud.py
@@ -1,6 +1,9 @@
 import pytest
 from hypothesis import given
 
+import astropy.units as u
+from astropy.time import TimeDelta
+
 import sunpy.net.dataretriever.sources.lyra as lyra
 from sunpy.net import Fido
 from sunpy.net import attrs as a
@@ -19,21 +22,22 @@ def LCClient():
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize("timerange,url_start,url_end", [
-    (TimeRange('2012/1/7', '2012/1/7'),
+    (Time('2012/1/7', '2012/1/7'),
      'http://proba2.oma.be/lyra/data/bsd/2012/01/07/lyra_20120107-000000_lev2_std.fits',
      'http://proba2.oma.be/lyra/data/bsd/2012/01/07/lyra_20120107-000000_lev2_std.fits'
      ),
-    (TimeRange('2012/12/1', '2012/12/2'),
+    (Time('2012/12/1', '2012/12/2'),
      'http://proba2.oma.be/lyra/data/bsd/2012/12/01/lyra_20121201-000000_lev2_std.fits',
      'http://proba2.oma.be/lyra/data/bsd/2012/12/02/lyra_20121202-000000_lev2_std.fits'
      ),
-    (TimeRange('2012/4/7', '2012/4/14'),
+    (Time('2012/4/7', '2012/4/14'),
      'http://proba2.oma.be/lyra/data/bsd/2012/04/07/lyra_20120407-000000_lev2_std.fits',
      'http://proba2.oma.be/lyra/data/bsd/2012/04/14/lyra_20120414-000000_lev2_std.fits'
      )
 ])
 def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
-    urls = LCClient._get_url_for_timerange(timerange)
+    qresponse = LCClient.search(timerange, a.Level.two)
+    urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
@@ -57,7 +61,8 @@ def test_query(LCClient, time):
     qr1 = LCClient.search(time, Instrument('lyra'))
     assert isinstance(qr1, QueryResponse)
     assert qr1.time_range().start == time.start
-    assert qr1.time_range().end == time.end
+    almost_day = TimeDelta(1 * u.day - 1 * u.millisecond)
+    assert qr1.time_range().end == time.end + almost_day
 
 
 @pytest.mark.remote_data
@@ -101,19 +106,20 @@ def mock_query_object(LCClient):
     """
     # Creating a Query Response Object
     start = '2016/1/1'
-    end = '2016/1/2'
+    end = '2016/1/1 23:59:59'
     obj = {
-        'TimeRange': TimeRange(parse_time(start), parse_time(end)),
-        'Time_start': parse_time(start),
-        'Time_end': parse_time(end),
-        'source': 'Proba2',
-        'instrument': 'lyra',
-        'physobs': 'irradiance',
-        'provider': 'esa'
+        'Time': TimeRange(parse_time(start), parse_time(end)),
+        'Start Time': parse_time(start),
+        'End Time': parse_time(end),
+        'Instrument': 'LYRA',
+        'Physobs': 'irradiance',
+        'Source': 'PROBA2',
+        'Provider': 'ESA',
+        'Level': '2',
+        'url': ('http://proba2.oma.be/lyra/data/bsd/2016/01/01/'
+                'lyra_20160101-000000_lev2_std.fits')
     }
-    urls = ['http://proba2.oma.be/lyra/data/bsd/2016/01/01/lyra_20160101-000000_lev2_std.fits',
-            'http://proba2.oma.be/lyra/data/bsd/2016/01/02/lyra_20160102-000000_lev2_std.fits']
-    results = QueryResponse.create(obj, urls, client=LCClient)
+    results = QueryResponse([obj], client=LCClient)
     return results
 
 
@@ -121,7 +127,8 @@ def test_show(LCClient):
     mock_qr = mock_query_object(LCClient)
     qrshow0 = mock_qr.show()
     qrshow1 = mock_qr.show('Start Time', 'Instrument')
-    allcols = ['Start Time', 'End Time', 'Source', 'Instrument', 'Wavelength']
+    allcols = ['Start Time', 'End Time', 'Instrument', 'Physobs', 'Source',
+               'Provider', 'Level']
     assert qrshow0.colnames == allcols
     assert qrshow1.colnames == ['Start Time', 'Instrument']
-    assert qrshow0['Instrument'][0] == 'lyra'
+    assert qrshow0['Instrument'][0] == 'LYRA'

--- a/sunpy/net/dataretriever/sources/tests/test_norh.py
+++ b/sunpy/net/dataretriever/sources/tests/test_norh.py
@@ -21,21 +21,22 @@ def LCClient():
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize("timerange,url_start,url_end", [
-    (TimeRange('2012/4/21', '2012/4/21'),
+    (a.Time('2012/4/21', '2012/4/21'),
      'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/04/tca120421',
      'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/04/tca120421'
      ),
-    (TimeRange('2012/12/1', '2012/12/2'),
+    (a.Time('2012/12/1', '2012/12/2'),
      'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/12/tca121201',
      'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/12/tca121202'
      ),
-    (TimeRange('2012/3/7', '2012/3/14'),
+    (a.Time('2012/3/7', '2012/3/14'),
      'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/03/tca120307',
      'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2012/03/tca120314'
      )
 ])
 def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
-    urls = LCClient._get_url_for_timerange(timerange, wavelength=17*u.GHz)
+    qresponse = LCClient.search(timerange, a.Wavelength(17*u.GHz))
+    urls = [i['url'] for i in qresponse]
     assert isinstance(urls, list)
     assert urls[0] == url_start
     assert urls[-1] == url_end
@@ -70,25 +71,6 @@ def test_query(time, wave):
         #  and the end time equal or smaller.
         # hypothesis can give same start-end, but the query will give you from start to end (so +1)
         assert qr1.time_range().end <= time.end + TimeDelta(1*u.day)
-
-
-# Don't use time_attr here for speed.
-def test_query_no_wave(LCClient):
-    with pytest.raises(ValueError):
-        LCClient.search(a.Time("2016/10/1", "2016/10/2"), a.Instrument.norh)
-
-
-def test_wavelength_range(LCClient):
-    with pytest.raises(ValueError):
-        LCClient.search(
-            a.Time("2016/10/1", "2016/10/2"), a.Instrument.norh,
-            a.Wavelength(17 * u.GHz, 34 * u.GHz))
-
-
-def test_query_wrong_wave(LCClient):
-    with pytest.raises(ValueError):
-        LCClient.search(a.Time("2016/10/1", "2016/10/2"), a.Instrument.norh,
-                        a.Wavelength(50*u.GHz))
 
 
 @pytest.mark.remote_data
@@ -130,21 +112,19 @@ def mock_query_object(LCClient):
     """
     # Creating a Query Response Object
     start = '2016/1/1'
-    end = '2016/1/2'
-    wave = 17000000*u.kHz
+    end = '2016/1/1 23:59:59'
+    wave = 17*u.GHz
     obj = {
-        'TimeRange': TimeRange(parse_time(start), parse_time(end)),
-        'Time_start': parse_time(start),
-        'Time_end': parse_time(end),
-        'source': 'NAOJ',
-        'instrument': 'NORH',
-        'physobs': '',
-        'provider': 'NRO',
-        'wavelength': wave
+        'Time': TimeRange(parse_time(start), parse_time(end)),
+        'Start Time': parse_time(start),
+        'End Time': parse_time(end),
+        'Instrument': 'NORH',
+        'Source': 'NAOJ',
+        'Provider': 'NRO',
+        'Wavelength': wave,
+        'url': 'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/01/tca160101'
     }
-    urls = ['ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/01/tca160101',
-            'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/2016/01/tca160102']
-    results = QueryResponse.create(obj, urls, client=LCClient)
+    results = QueryResponse([obj], client=LCClient)
     return results
 
 
@@ -152,8 +132,9 @@ def test_show(LCClient):
     mock_qr = mock_query_object(LCClient)
     qrshow0 = mock_qr.show()
     qrshow1 = mock_qr.show('Wavelength', 'Instrument')
-    allcols = ['Start Time', 'End Time', 'Source', 'Instrument', 'Wavelength']
+    allcols = ['Start Time', 'End Time', 'Instrument', 'Source',
+               'Provider', 'Wavelength']
     assert qrshow0.colnames == allcols
     assert qrshow1.colnames == ['Wavelength', 'Instrument']
     assert qrshow0['Instrument'][0] == 'NORH'
-    assert qrshow1['Wavelength'][0] == str(17000000*u.kHz)
+    assert qrshow1['Wavelength'][0] == 17*u.GHz

--- a/sunpy/net/dataretriever/sources/tests/test_rhessi.py
+++ b/sunpy/net/dataretriever/sources/tests/test_rhessi.py
@@ -208,20 +208,19 @@ def mock_query_object(LCClient):
     """
     # Creating a Query Response Object
     start = '2016/1/1'
-    end = '2016/1/2'
+    end = '2016/1/1 23:59:59'
     obj = {
-        'TimeRange': TimeRange(parse_time(start), parse_time(end)),
-        'Time_start': parse_time(start),
-        'Time_end': parse_time(end),
-        'source': 'rhessi',
-        'instrument': 'rhessi',
-        'physobs': 'irradiance',
-        'provider': 'nasa'
+        'Time': TimeRange(parse_time(start), parse_time(end)),
+        'Start Time': parse_time(start),
+        'End Time': parse_time(end),
+        'Instrument': 'RHESSI',
+        'Physobs': 'irradiance',
+        'Source': 'RHESSI',
+        'Provider': 'NASA',
+        'url': ('https://hesperia.gsfc.nasa.gov/hessidata/metadata/'
+                'catalog/hsi_obssumm_20160101_078.fits')
     }
-    urls = [
-        'https://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20160101_078.fits',
-        'https://hesperia.gsfc.nasa.gov/hessidata/metadata/catalog/hsi_obssumm_20160102_084.fits']
-    results = QueryResponse.create(obj, urls, client=LCClient)
+    results = QueryResponse([obj], client=LCClient)
     return results
 
 
@@ -229,7 +228,7 @@ def test_show(LCClient):
     mock_qr = mock_query_object(LCClient)
     qrshow0 = mock_qr.show()
     qrshow1 = mock_qr.show('Start Time', 'Instrument')
-    allcols = ['Start Time', 'End Time', 'Source', 'Instrument', 'Wavelength']
+    allcols = ['Start Time', 'End Time', 'Instrument', 'Physobs', 'Source', 'Provider']
     assert qrshow0.colnames == allcols
     assert qrshow1.colnames == ['Start Time', 'Instrument']
-    assert qrshow0['Instrument'][0] == 'rhessi'
+    assert qrshow0['Instrument'][0] == 'RHESSI'

--- a/sunpy/net/dataretriever/tests/test_client.py
+++ b/sunpy/net/dataretriever/tests/test_client.py
@@ -4,10 +4,10 @@ from sunpy.time import parse_time
 
 def test_reprs():
     map_ = {}
-    map_['Time_start'] = parse_time("2012/1/1")
-    map_['Time_end'] = parse_time("2012/1/2")
-    resp = QueryResponse.create(map_, [''])
+    map_['Start Time'] = parse_time("2012/1/1")
+    map_['End Time'] = parse_time("2012/1/2")
+    resp = QueryResponse([map_])
     assert isinstance(resp, QueryResponse)
-    strs = ["2012-01-01 00:00:00", "2012-01-02 00:00:00"]
+    strs = ["2012-01-01T00:00:00.000", "2012-01-02T00:00:00.000"]
     assert all(s in str(resp) for s in strs)
     assert all(s in repr(resp) for s in strs)

--- a/sunpy/net/dataretriever/tests/test_client.py
+++ b/sunpy/net/dataretriever/tests/test_client.py
@@ -3,10 +3,10 @@ from sunpy.time import parse_time
 
 
 def test_reprs():
-    map_ = {}
-    map_['Start Time'] = parse_time("2012/1/1")
-    map_['End Time'] = parse_time("2012/1/2")
-    resp = QueryResponse([map_])
+    rowdict = {}
+    rowdict['Start Time'] = parse_time("2012/1/1")
+    rowdict['End Time'] = parse_time("2012/1/2")
+    resp = QueryResponse([rowdict])
     assert isinstance(resp, QueryResponse)
     strs = ["2012-01-01T00:00:00.000", "2012-01-02T00:00:00.000"]
     assert all(s in str(resp) for s in strs)

--- a/sunpy/net/hek2vso/hek2vso.py
+++ b/sunpy/net/hek2vso/hek2vso.py
@@ -91,7 +91,7 @@ def vso_attribute_parse(phrase):
     try:
         query = [a.Time(phrase['event_starttime'],
                         phrase['event_endtime']),
-                 a.vso.Source(phrase['obs_observatory']),
+                 a.Source(phrase['obs_observatory']),
                  a.Instrument(phrase['obs_instrument'])]
         avg_wave_len = phrase['obs_meanwavel'] * units.Unit(phrase['obs_wavelunit'])
         query.append(a.Wavelength(avg_wave_len, avg_wave_len))

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -330,7 +330,7 @@ class _DeprecatedAttr:
         super().__init__(*args, **kwargs)
 
 
-_deprecated_names = ['Time', 'Instrument', 'Wavelength',
+_deprecated_names = ['Time', 'Instrument', 'Wavelength', 'Source', 'Provider',
                      'Level', 'Sample', 'Detector', 'Resolution', 'Physobs']
 
 for _name in _deprecated_names:

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -26,8 +26,7 @@ from sunpy.util.exceptions import SunpyDeprecationWarning
 from .. import _attrs
 from .. import attr as _attr
 
-__all__ = ['Extent', 'Field', 'Provider', 'Source', 'Pixels',
-           'Filter', 'Quicklook', 'PScale']
+__all__ = ['Extent', 'Field', 'Pixels', 'Filter', 'Quicklook', 'PScale']
 
 _TIMEFORMAT = '%Y%m%d%H%M%S'
 
@@ -62,40 +61,6 @@ class Extent(_attr.DataAttr):
 
     def collides(self, other):
         return isinstance(other, self.__class__)
-
-
-class Provider(_attr.SimpleAttr):
-    """
-    Specifies the VSO data provider to search for data for.
-
-    Parameters
-    ----------
-    value : str
-
-    Notes
-    -----
-    More information about each source may be found within in the VSO Registry.
-    For a list of sources see
-    https://sdac.virtualsolar.org/cgi/show_details?keyword=PROVIDER.
-    """
-
-
-class Source(_attr.SimpleAttr):
-    """
-    Data sources that VSO can search on.
-
-    Parameters
-    ----------
-    value : str
-
-    Notes
-    -----
-    More information about each source may be found within in the VSO Registry.
-    User Interface programmers should note that some names may be encoded as
-    UTF-8. Please note that 'Source' is used internally by VSO to represent
-    what the VSO Data Model refers to as 'Observatory'.  For a list of sources
-    see https://sdac.virtualsolar.org/cgi/show_details?keyword=SOURCE.
-    """
 
 
 class Pixels(_attr.SimpleAttr):

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -26,7 +26,7 @@ class MockQRRecord:
                  extent_type=None):
         self.size = size
         self.time = MockObject(start=start_time, end=end_time)
-        self.source = va.Source(source)
+        self.source = a.Source(source)
         self.instrument = core_attrs.Instrument(instrument)
         self.extent = MockObject(type=None if extent_type is None else extent_type.type)
 
@@ -107,12 +107,12 @@ def test_simpleattr_create(client):
 def test_simpleattr_and_duplicate():
     attr = core_attrs.Instrument('foo')
     pytest.raises(TypeError, lambda: attr & core_attrs.Instrument('bar'))
-    attr |= va.Source('foo')
+    attr |= a.Source('foo')
     pytest.raises(TypeError, lambda: attr & core_attrs.Instrument('bar'))
-    otherattr = core_attrs.Instrument('foo') | va.Source('foo')
+    otherattr = core_attrs.Instrument('foo') | a.Source('foo')
     pytest.raises(TypeError, lambda: attr & otherattr)
     pytest.raises(TypeError, lambda: (attr | otherattr) & core_attrs.Instrument('bar'))
-    tst = core_attrs.Instrument('foo') & va.Source('foo')
+    tst = core_attrs.Instrument('foo') & a.Source('foo')
     pytest.raises(TypeError, lambda: tst & tst)
 
 
@@ -141,7 +141,7 @@ def test_complexattr_and_duplicate():
     attr = core_attrs.Time((2011, 1, 1), (2011, 1, 1, 1))
     pytest.raises(TypeError,
                   lambda: attr & core_attrs.Time((2011, 2, 1), (2011, 2, 1, 1)))
-    attr |= va.Source('foo')
+    attr |= a.Source('foo')
     pytest.raises(TypeError,
                   lambda: attr & core_attrs.Time((2011, 2, 1), (2011, 2, 1, 1)))
 
@@ -155,9 +155,9 @@ def test_complexattr_or_eq():
 
 def test_attror_and():
     attr = core_attrs.Instrument('foo') | core_attrs.Instrument('bar')
-    one = attr & va.Source('bar')
-    other = ((core_attrs.Instrument('foo') & va.Source('bar')) |
-             (core_attrs.Instrument('bar') & va.Source('bar')))
+    one = attr & a.Source('bar')
+    other = ((core_attrs.Instrument('foo') & a.Source('bar')) |
+             (core_attrs.Instrument('bar') & a.Source('bar')))
     assert one == other
 
 
@@ -383,7 +383,7 @@ def test_QueryResponse_build_table_defaults(mock_build_client):
     # Check values we did set by default in 'MockQRRecord'
     source_ = table['Source'].data
     assert len(source_) == 1
-    assert source_[0][:-16] == str(va.Source('SOHO'))[:-16]
+    assert source_[0][:-16] == str(a.Source('SOHO'))[:-16]
 
     instrument_ = table['Instrument'].data
     assert len(instrument_) == 1
@@ -529,7 +529,7 @@ def test_incorrect_content_disposition(client):
 @pytest.mark.parametrize("query, handle", [
     ((a.Time("2011/01/01", "2011/01/02"),), True),
     ((a.Physobs.los_magnetic_field,), False),
-    ((a.Time("2011/01/01", "2011/01/02"), a.vso.Provider("SDAC"),), True),
+    ((a.Time("2011/01/01", "2011/01/02"), a.Provider("SDAC"),), True),
     ((a.jsoc.Series("wibble"), a.Physobs.los_magnetic_field,), False),
 ])
 def test_can_handle_query(query, handle):

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -139,24 +139,10 @@ class Scraper:
             return matches.end() == matches.endpos
         return False
 
-    def _findDatewith_extractor(self, url):
-        exdict = parse(self.extractor, url).named
-        datetypes = ['year', 'month', 'day']
-        timetypes = ['hour', 'minute', 'second']
-        dtlist = []
-        for d in datetypes:
-            dtlist.append(exdict.get(d, 1))
-        for t in timetypes:
-            dtlist.append(exdict.get(t, 0))
-        dt = datetime.datetime(*dtlist)
-        return Time(dt)
-
     def _extractDateURL(self, url):
         """
         Extracts the date from a particular url following the pattern.
         """
-        if hasattr(self, 'extractor'):
-            return self._findDatewith_extractor(url)
         # remove the user and passwd from files if there:
         url = url.replace("anonymous:data@sunpy.org@", "")
 

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -139,10 +139,24 @@ class Scraper:
             return matches.end() == matches.endpos
         return False
 
+    def _findDatewith_extractor(self, url):
+        exdict = parse(self.extractor, url).named
+        datetypes = ['year', 'month', 'day']
+        timetypes = ['hour', 'minute', 'second']
+        dtlist = []
+        for d in datetypes:
+            dtlist.append(exdict.get(d, 1))
+        for t in timetypes:
+            dtlist.append(exdict.get(t, 0))
+        dt = datetime.datetime(*dtlist)
+        return Time(dt)
+
     def _extractDateURL(self, url):
         """
         Extracts the date from a particular url following the pattern.
         """
+        if hasattr(self, 'extractor'):
+            return self._findDatewith_extractor(url)
         # remove the user and passwd from files if there:
         url = url.replace("anonymous:data@sunpy.org@", "")
 


### PR DESCRIPTION
<!--
We know that working on sunpy and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them: https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Key highlights:

- Easy to define a new "simple" Fido client. Only define `pattern`, `baseurl`, and `register_values()`. This further uses scraper and `~sunpy.extern.parse` for extracting metadata.
- More metadata is shown in the response tables. Like `SatelliteNumber`, `Level`, `Detector`, `Resolution`,  `Wavelength` will be shown which earlier were either not present or `np.nan`.
- Nothing is default Attr for any search made to client. So if client supports 3 levels, and we don't specify level in the query, data fo all levels shall be shown.
- Refactoring in `GenericClient`, removed/generalized/updated a lot of methods.

Fixes #3715, Fixes #3337, Fixes  #3321, Fixes #3306, Fixes #2314.