### PR TITLE
Set v{min,max} on the norm when plotting

### DIFF
--- a/changelog/4328.breaking.rst
+++ b/changelog/4328.breaking.rst
@@ -1,0 +1,3 @@
+An error is now raised if ``vmin`` or ``vmax`` are passed to
+to `sunpy.map.GenericMap.plot` and they are already set on the map ``norm``.
+This is consistent with upcoming Matplotlib changes.

--- a/examples/computer_vision_techniques/off_limb_enhance.py
+++ b/examples/computer_vision_techniques/off_limb_enhance.py
@@ -70,8 +70,7 @@ scale_factor[r < 1] = 1
 # We set the normalization of the new map to be the same as the original map
 # to compare the two.
 scaled_map = sunpy.map.Map(aia.data * scale_factor, aia.meta)
-scaled_map.plot_settings['norm'] = ImageNormalize(stretch=aia.plot_settings['norm'].stretch,
-                                                  vmin=aia.data.min(), vmax=aia.data.max())
+scaled_map.plot_settings['norm'] = ImageNormalize(stretch=aia.plot_settings['norm'].stretch)
 
 ###############################################################################
 # Let's plot the results

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2075,6 +2075,19 @@ class GenericMap(NDData):
             imshow_args['vmin'] = vmin
             imshow_args['vmax'] = vmax
 
+        if 'norm' in imshow_args:
+            norm = imshow_args['norm']
+            if 'vmin' in imshow_args:
+                if norm.vmin is not None:
+                    raise ValueError('Cannot manually specify vmin, as the norm '
+                                     'already has vmin set')
+                norm.vmin = imshow_args.pop('vmin')
+            if 'vmax' in imshow_args:
+                if norm.vmax is not None:
+                    raise ValueError('Cannot manually specify vmax, as the norm '
+                                     'already has vmax set')
+                norm.vmax = imshow_args.pop('vmax')
+
         if self.mask is None:
             ret = axes.imshow(self.data, **imshow_args)
         else:

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -3,6 +3,7 @@ Test Generic Map
 """
 import os
 
+import matplotlib.colors as mcolor
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -202,3 +203,12 @@ def test_heliographic_rectangle_top_right(heliographic_test_map):
 def test_heliographic_grid_annotations(heliographic_test_map):
     heliographic_test_map.plot()
     heliographic_test_map.draw_grid(annotate=False)
+
+
+def test_plot_norm_error(aia171_test_map):
+    # Check that duplicating vmin, vmax raises an error
+    norm = mcolor.Normalize(vmin=0, vmax=1)
+    with pytest.raises(ValueError, match='Cannot manually specify vmin'):
+        aia171_test_map.plot(norm=norm, vmin=0)
+    with pytest.raises(ValueError, match='Cannot manually specify vmax'):
+        aia171_test_map.plot(norm=norm, vmax=0)


### PR DESCRIPTION
This is in preparation for a deprecation warning in Matplotlib 3.3, which means that a norm and v{min, max} cannot be simulataneously handed to `imshow`. See https://app.circleci.com/pipelines/github/sunpy/sunpy/6725/workflows/45cad83c-7349-4cc1-93c9-796bdfabc1a6/jobs/55990/steps for the actual warning.

In addition, this raises an error if the user hands v{min,max}, but it is already set on the norm. This is breaking behavior without a depreaction warning, but I think is much better than undefined/multiple v{min,max} values. Happy to turn into a deprecation warning though if that's better.