### PR TITLE
Revert "Use default mpl colour cycle for RHESSI peek"

### DIFF
--- a/changelog/4326.feature.rst
+++ b/changelog/4326.feature.rst
@@ -1,7 +1,0 @@
-`sunpy.timeseries.RHESSISummaryTimeSeries.peek()` has had the following minor
-changes:
-
-- The default matplotlib color cycle is now used
-- The default matplotlib linewidth is now used
-- It is now possible to pass in a user specified linewidth
-- Seconds have been added to the x-axis labels (previously it was just hours and minutes)

--- a/sunpy/tests/figure_hashes_mpl_321_ft_261_astropy_401post1.json
+++ b/sunpy/tests/figure_hashes_mpl_321_ft_261_astropy_401post1.json
@@ -32,7 +32,7 @@
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_ind_peek": "7f72b08b4525186472b5748a8f85257f185d6006ff349b82206ddce23e009727",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_pre_peek": "fa39e07e36e4e98b97dfb353dcb850b619d7e0848e3e2e3c6a59f743245e7c1f",
     "sunpy.timeseries.tests.test_timeseriesbase.test_norh_peek": "a898e56374a4194ff89a0de5f2336361b4155b453321437fc090254b13f6d803",
-    "sunpy.timeseries.tests.test_timeseriesbase.test_rhessi_peek": "45647a871f3514a19e26159552f7e3dcab89202a3e2ea99534f7bac6c9157924",
+    "sunpy.timeseries.tests.test_timeseriesbase.test_rhessi_peek": "4d908604f59f5e5b9d37cd8e4e1a7fddd47de938d9f9458a88afe63e1bca428c",
     "sunpy.visualization.animator.tests.test_basefuncanimator.test_imageanimator_figure": "9d6bd03d14a9374f654733ecc4d2c79a56f78800b8f7a5e657db5fcd6151f54e",
     "sunpy.visualization.animator.tests.test_basefuncanimator.test_lineanimator_figure": "452bbca60e081eec63108839851554cf6384966cb372456c5b264370c4af0378",
     "sunpy.visualization.animator.tests.test_wcs.test_array_animator_wcs_1d_update_plot": "d7cf96cf18410d604ffb23060dc55d6a9d0062d5814bce60a621c963e8362d8f",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -32,7 +32,7 @@
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_ind_peek": "01fa7e5baa13f996f686d18505f177f0884deb394384a129522aa18f9c6b61ac",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_pre_peek": "fbda770f164bd38a7741d3393e9f93040b188e928521cc53379ba2b78beb582c",
     "sunpy.timeseries.tests.test_timeseriesbase.test_norh_peek": "7450e024d469cb16e7b6c3b8b2b5a69c667a9cb9a4aa8da168dfb8c9c54aa07f",
-    "sunpy.timeseries.tests.test_timeseriesbase.test_rhessi_peek": "e11c52028c2a616fddbb42cbd2ce5e6bc02c3204c1f1d9835caea9f1027c6343",
+    "sunpy.timeseries.tests.test_timeseriesbase.test_rhessi_peek": "e4d273433e6ebea84ce4e48baf306d0a393265042a7e342137045be3865fdad7",
     "sunpy.visualization.animator.tests.test_basefuncanimator.test_imageanimator_figure": "17bacb2f785de06d2a0a78f9e60ca0e6ff4c60db2ae4bccb83e20ba2e856bb49",
     "sunpy.visualization.animator.tests.test_basefuncanimator.test_lineanimator_figure": "dbf47ab983a844621f912b2f5a2d9ee657d3f661678c16a07afc7217f50e3fd4",
     "sunpy.visualization.animator.tests.test_wcs.test_array_animator_wcs_1d_update_plot": "58e799859b877fd8a5f73377eeab2686f0567241093c244779143797d4cef778",

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -85,9 +85,11 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
         figure = plt.figure()
         axes = plt.gca()
 
-        for item, frame in self.to_dataframe().items():
+        lc_linecolors = rhessi.hsi_linecolors()
+
+        for lc_color, (item, frame) in zip(lc_linecolors, self.to_dataframe().items()):
             axes.plot_date(self.to_dataframe().index, frame.values, '-',
-                           label=item, **kwargs)
+                           label=item, lw=2, color=lc_color, **kwargs)
 
         axes.set_yscale("log")
         axes.set_xlabel(datetime.datetime.isoformat(self.to_dataframe().index[0])[0:10])
@@ -100,10 +102,10 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
         axes.legend()
 
         # TODO: display better tick labels for date range (e.g. 06/01 - 06/05)
-        formatter = matplotlib.dates.DateFormatter('%H:%M:%S')
+        formatter = matplotlib.dates.DateFormatter('%H:%M')
         axes.xaxis.set_major_formatter(formatter)
 
-        axes.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M:%S')
+        axes.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M')
         figure.autofmt_xdate()
 
         return figure


### PR DESCRIPTION
Reverts sunpy/sunpy#4326

For discussion following @ayshih's comment on the original PR after merge: https://github.com/sunpy/sunpy/pull/4326#issuecomment-651774789