### PR TITLE
Make FITS header warning more helpful

### DIFF
--- a/changelog/4335.trivial.rst
+++ b/changelog/4335.trivial.rst
@@ -1,0 +1,2 @@
+Added information on what went wrong when `sunpy.map.GenericMap.wcs` fails to parse
+a FITS header into a WCS.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -426,8 +426,9 @@ class GenericMap(NDData):
             warnings.simplefilter("ignore", SunpyUserWarning)
             try:
                 w2 = astropy.wcs.WCS(header=self.fits_header, _do_set=False)
-            except Exception:
-                warnings.warn("Unable to treat `.meta` as a FITS header, assuming a simple WCS.")
+            except Exception as e:
+                warnings.warn("Unable to treat `.meta` as a FITS header, assuming a simple WCS. "
+                              f"The exception raised was:\n{e}")
                 w2 = astropy.wcs.WCS(naxis=2)
 
         # If the FITS header is > 2D pick the first 2 and move on.


### PR DESCRIPTION
The current warning does not indicate what went wrong. This now prints the error message, allowing the user to see what went wrong.