### PR TITLE
added deprecation to map.size property

### DIFF
--- a/changelog/4338.removal.rst
+++ b/changelog/4338.removal.rst
@@ -1,2 +1,2 @@
-Depreacted the use of `sunpy.map.Map.size` property
+Deprecated the use of `sunpy.map.Map.size` property
 with suggested use of `sunpy.map.Map.data.size` instead.

--- a/changelog/4338.removal.rst
+++ b/changelog/4338.removal.rst
@@ -1,0 +1,2 @@
+depreacted the use of `sunpy.map.Map.size` property
+with suggested use of `sunpy.map.Map.data.size` instead.

--- a/changelog/4338.removal.rst
+++ b/changelog/4338.removal.rst
@@ -1,2 +1,2 @@
-depreacted the use of `sunpy.map.Map.size` property
+Depreacted the use of `sunpy.map.Map.size` property
 with suggested use of `sunpy.map.Map.data.size` instead.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -531,7 +531,7 @@ class GenericMap(NDData):
         return self.data.dtype
 
     @property
-    @deprecated(since="2.1", message="Use map.data.shape instead", alternative="map.data.shape")
+    @deprecated(since="2.1", message="Use map.data.size instead", alternative="map.data.size")
     def size(self):
         """
         The number of pixels in the array of the map.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -36,7 +36,7 @@ from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import expand_list
-from sunpy.util.decorators import deprecate_positional_args_since,deprecated
+from sunpy.util.decorators import deprecate_positional_args_since, deprecated
 from sunpy.util.exceptions import SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
@@ -531,7 +531,7 @@ class GenericMap(NDData):
         return self.data.dtype
 
     @property
-    @deprecated(since="2.1",message="Use map.data.shape instead", alternative="map.data.shape")
+    @deprecated(since="2.1", message="Use map.data.shape instead", alternative="map.data.shape")
     def size(self):
         """
         The number of pixels in the array of the map.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -36,7 +36,7 @@ from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import expand_list
-from sunpy.util.decorators import deprecate_positional_args_since
+from sunpy.util.decorators import deprecate_positional_args_since,deprecated
 from sunpy.util.exceptions import SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
@@ -531,6 +531,7 @@ class GenericMap(NDData):
         return self.data.dtype
 
     @property
+    @deprecated(since="2.1",message="Use map.data.shape instead", alternative="map.data.shape")
     def size(self):
         """
         The number of pixels in the array of the map.

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -152,7 +152,8 @@ def test_dtype(generic_map):
 
 
 def test_size(generic_map):
-    assert generic_map.size == 36 * u.pix
+    with pytest.warns(SunpyDeprecationWarning, match='Use map.data.shape instead'):
+        assert generic_map.size == 36 * u.pix
 
 
 def test_min(generic_map):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -152,7 +152,7 @@ def test_dtype(generic_map):
 
 
 def test_size(generic_map):
-    with pytest.warns(SunpyDeprecationWarning, match='Use map.data.shape instead'):
+    with pytest.warns(SunpyDeprecationWarning, match='Use map.data.size instead'):
         assert generic_map.size == 36 * u.pix
 
 


### PR DESCRIPTION
<!--
We know that working on sunpy and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them: https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
Added the required deprecation for the map.size property to use map.data.shape instead.

Fixes #4337 
