### PR TITLE
Always use the same ERFA package used by Astropy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -124,8 +124,6 @@ filterwarnings =
     ignore:direct construction of AsdfSchemaExampleItem has been deprecated
     # See https://github.com/scikit-image/scikit-image/issues/4848
     ignore:Converting `np.inexact` or `np.floating` to a dtype is deprecated
-    # See https://github.com/sunpy/sunpy/pull/4343
-    ignore:The private astropy._erfa module has been made into its own package
     # See https://github.com/astropy/astropy/pull/10570
     ignore:leap-second auto-update failed
     # See https://github.com/astropy/extension-helpers/issues/23

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -4,7 +4,6 @@ Sun-specific coordinate calculations
 import numpy as np
 
 import astropy.units as u
-from astropy import _erfa as erfa
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (
     ITRS,
@@ -20,6 +19,8 @@ from astropy.coordinates import (
 )
 from astropy.coordinates.builtin_frames.utils import get_jd12
 from astropy.coordinates.representation import CartesianRepresentation, SphericalRepresentation
+# Import erfa via astropy to make sure we are using the same ERFA library as Astropy
+from astropy.coordinates.sky_coordinate import erfa
 from astropy.time import Time
 
 from sunpy import log

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -20,7 +20,6 @@ from contextlib import contextmanager
 import numpy as np
 
 import astropy.units as u
-from astropy._erfa import obl06
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (
     HCRS,
@@ -41,6 +40,8 @@ from astropy.coordinates.representation import (
     SphericalRepresentation,
     UnitSphericalRepresentation,
 )
+# Import erfa via astropy to make sure we are using the same ERFA library as Astropy
+from astropy.coordinates.sky_coordinate import erfa
 from astropy.coordinates.transformations import (
     AffineTransform,
     FunctionTransform,
@@ -889,7 +890,7 @@ def _rotation_matrix_obliquity(time):
     """
     Return the rotation matrix from Earth equatorial to ecliptic coordinates
     """
-    return rotation_matrix(obl06(*get_jd12(time, 'tt'))*u.radian, 'x')
+    return rotation_matrix(erfa.obl06(*get_jd12(time, 'tt'))*u.radian, 'x')
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,


### PR DESCRIPTION
Edit by @ayshih: This PR underwent a few significant variations, so the following discussion may be confusing when compared to the actual changes.

This fixes deprecation warnings like

```python
pfsspy/__init__.py:12: in <module>

    from sunpy.coordinates import frames

../../../miniconda/envs/testenv/lib/python3.8/site-packages/sunpy/coordinates/__init__.py:21: in <module>

    from . import sun

../../../miniconda/envs/testenv/lib/python3.8/site-packages/sunpy/coordinates/sun.py:7: in <module>

    from astropy import _erfa as erfa

../../../miniconda/envs/testenv/lib/python3.8/site-packages/astropy/_erfa/__init__.py:13: in <module>

    warnings.warn('The private astropy._erfa module has been made into its '

E   astropy.utils.exceptions.AstropyDeprecationWarning: The private astropy._erfa module has been made into its own package, pyerfa, 
```

Not sure if it wants to be backported?