### PR TITLE
Filter out some warnings from tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -93,6 +93,10 @@ remote_data_strict = True
 filterwarnings =
     ignore
     error::sunpy.util.exceptions.SunpyDeprecationWarning
+    # See https://github.com/spacetelescope/asdf/issues/789
+    ignore:direct construction of AsdfSchemaFile has been deprecated
+    ignore:direct construction of AsdfSchemaItem has been deprecated
+    ignore:direct construction of AsdfSchemaExampleItem has been deprecated
 
 [pycodestyle]
 max_line_length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,8 @@ filterwarnings =
     ignore:direct construction of AsdfSchemaFile has been deprecated
     ignore:direct construction of AsdfSchemaItem has been deprecated
     ignore:direct construction of AsdfSchemaExampleItem has been deprecated
+    # See https://github.com/Cadair/parfive/issues/41
+    ignore:The loop argument is deprecated
 
 [pycodestyle]
 max_line_length = 100

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -126,7 +126,7 @@ def test_get_horizons_coord_array_time():
 
 # Ignore the warning hypothesis throws, as in this case we don't care that
 # the fixutre isn't reset bewteen tests
-@pytest.mark.filterwarnings('ignore:.*function-scoped fixtures should not be used with.*')
+@pytest.mark.filterwarnings('ignore:.*which is reset between function calls but not between test cases.*')
 @pytest.mark.remote_data
 @given(obstime=times())
 @settings(deadline=5000, max_examples=10)

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -125,7 +125,7 @@ def test_get_horizons_coord_array_time():
 
 
 # Ignore the warning hypothesis throws, as in this case we don't care that
-# the fixutre isn't reset bewteen tests
+# the fixture isn't reset between tests
 @pytest.mark.filterwarnings('ignore:.*which is reset between function calls but not between test cases.*')
 @pytest.mark.remote_data
 @given(obstime=times())

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -124,6 +124,9 @@ def test_get_horizons_coord_array_time():
     assert_quantity_allclose(e[3].radius, 0.9908173*u.AU, atol=5e-7*u.AU)
 
 
+# Ignore the warning hypothesis throws, as in this case we don't care that
+# the fixutre isn't reset bewteen tests
+@pytest.mark.filterwarnings('ignore:.*function-scoped fixtures should not be used with.*')
 @pytest.mark.remote_data
 @given(obstime=times())
 @settings(deadline=5000, max_examples=10)

--- a/sunpy/io/special/asdf/tags/tests/test_coordinate_frames.py
+++ b/sunpy/io/special/asdf/tags/tests/test_coordinate_frames.py
@@ -45,6 +45,9 @@ def coordframe_array(request):
     return frame(*data, obstime='2018-01-01T00:00:00')
 
 
+# Ignore warnings thrown when trying to load the ASDF in a different astropy
+# version to that with which it was created.
+@pytest.mark.filterwarnings('ignore:.*was created with extension.*')
 def test_hgc_100():
     # Test that HeliographicCarrington is populated with Earth as the observer when loading a
     # older schema (1.0.0)

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -64,6 +64,9 @@ class TestMap:
         comp = sunpy.map.Map(AIA_171_IMAGE, RHESSI_IMAGE, composite=True)
         assert isinstance(comp, sunpy.map.CompositeMap)
 
+    # Want to check that patterns work, so ignore this warning that comes from
+    # the AIA test data
+    @pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in header")
     def test_patterns(self):
         # Test different Map pattern matching
 
@@ -183,6 +186,8 @@ class TestMap:
         with pytest.raises(OSError, match=(fr"Failed to read *")):
             sunpy.map.Map(files)
 
+    # We want to check errors, so ignore warnings that are thrown
+    @pytest.mark.filterwarnings("ignore:One of the data, header pairs failed to validate")
     @pytest.mark.parametrize('silence,error,match',
                              [(True, RuntimeError, 'No maps loaded'),
                               (False, sunpy.map.mapbase.MapMetaValidationError,
@@ -239,6 +244,9 @@ def test_map_list_urls_cache():
 
 
 # TODO: Test HMIMap, SXTMap
+#
+# Catch Hinode/XRT warning
+@pytest.mark.filterwarnings('ignore:File may have been truncated')
 @pytest.mark.parametrize('file, mapcls',
                          [[filepath / 'EIT' / "efz20040301.000010_s.fits", sunpy.map.sources.EITMap],
                           [filepath / "lasco_c2_25299383_s.fts", sunpy.map.sources.LASCOMap],

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -199,6 +199,9 @@ def test_heliographic_rectangle_top_right(heliographic_test_map):
     heliographic_test_map.draw_rectangle(bottom_left, width=w, height=h, color='cyan')
 
 
+# See https://github.com/sunpy/sunpy/issues/4294 to track this warning. Ideally
+# it should not be filtered, and the cause of it fixed.
+@pytest.mark.filterwarnings(r'ignore:Numpy has detected that you \(may be\) writing to an array with\noverlapping memory')
 @figure_test
 def test_heliographic_grid_annotations(heliographic_test_map):
     heliographic_test_map.plot()

--- a/sunpy/net/dataretriever/sources/tests/test_fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/tests/test_fermi_gbm.py
@@ -31,7 +31,8 @@ def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
 
 
 @given(time_attr())
-def test_can_handle_query(LCClient, time):
+def test_can_handle_query(time):
+    LCClient = fermi_gbm.GBMClient()
     ans1 = LCClient._can_handle_query(time, a.Instrument.gbm)
     assert ans1 is True
     ans2 = LCClient._can_handle_query(time, a.Instrument.gbm,

--- a/sunpy/net/dataretriever/sources/tests/test_goes_suvi.py
+++ b/sunpy/net/dataretriever/sources/tests/test_goes_suvi.py
@@ -19,7 +19,9 @@ def suvi_client():
 
 
 @given(time_attr())
-def test_can_handle_query(suvi_client, time):
+def test_can_handle_query(time):
+    # Don't use the fixture, as hypothesis complains
+    suvi_client = goes.SUVIClient()
     ans1 = suvi_client._can_handle_query(time, a.Instrument.suvi)
     assert ans1 is True
     ans2 = suvi_client._can_handle_query(time, a.Instrument.suvi,

--- a/sunpy/net/dataretriever/sources/tests/test_goes_ud.py
+++ b/sunpy/net/dataretriever/sources/tests/test_goes_ud.py
@@ -143,7 +143,9 @@ def test_fido(time, instrument):
 @settings(deadline=10000, max_examples=5)
 @pytest.mark.remote_data
 @given(goes_time())
-def test_time_for_url(LCClient, time):
+def test_time_for_url(time):
+    # Create a fresh client, as fixtures don't work with @given
+    LCClient = goes.XRSClient()
     time = time.start.strftime("%Y/%m/%d")
     almost_day = TimeDelta(1*u.day - 1*u.millisecond)
 

--- a/sunpy/net/dataretriever/sources/tests/test_lyra_ud.py
+++ b/sunpy/net/dataretriever/sources/tests/test_lyra_ud.py
@@ -40,7 +40,8 @@ def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
 
 
 @given(range_time('2010-01-06'))
-def test_can_handle_query(LCClient, time):
+def test_can_handle_query(time):
+    LCClient = lyra.LYRAClient()
     ans1 = LCClient._can_handle_query(
         time, Instrument('lyra'))
     assert ans1 is True

--- a/sunpy/net/dataretriever/sources/tests/test_norh.py
+++ b/sunpy/net/dataretriever/sources/tests/test_norh.py
@@ -57,7 +57,8 @@ def test_can_handle_query(time):
 @pytest.mark.parametrize("wave", [a.Wavelength(17*u.GHz), a.Wavelength(34*u.GHz)])
 @given(time=range_time(Time('1992-6-1')))
 @settings(max_examples=2, deadline=50000)
-def test_query(LCClient, time, wave):
+def test_query(time, wave):
+    LCClient = norh.NoRHClient()
     qr1 = LCClient.search(time, a.Instrument.norh, wave)
     assert isinstance(qr1, QueryResponse)
     # Not all hypothesis queries are going to produce results, and

--- a/sunpy/net/dataretriever/sources/tests/test_norh.py
+++ b/sunpy/net/dataretriever/sources/tests/test_norh.py
@@ -42,7 +42,8 @@ def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):
 
 
 @given(time_attr())
-def test_can_handle_query(LCClient, time):
+def test_can_handle_query(time):
+    LCClient = norh.NoRHClient()
     ans1 = LCClient._can_handle_query(time, a.Instrument.norh)
     assert ans1 is True
     ans1 = LCClient._can_handle_query(time, a.Instrument.norh,

--- a/sunpy/visualization/animator/tests/test_wcs.py
+++ b/sunpy/visualization/animator/tests/test_wcs.py
@@ -11,6 +11,10 @@ from sunpy.tests.helpers import figure_test
 from sunpy.visualization.animator.wcs import ArrayAnimatorWCS
 
 
+pytestmark = pytest.mark.filterwarnings('ignore:target cannot be converted to ICRS, so will not be '
+                                        'set on SpectralCoord')
+
+
 @pytest.fixture
 def wcs_4d():
     header = dedent("""\

--- a/sunpy/visualization/animator/tests/test_wcs.py
+++ b/sunpy/visualization/animator/tests/test_wcs.py
@@ -10,7 +10,7 @@ from astropy.wcs import WCS
 from sunpy.tests.helpers import figure_test
 from sunpy.visualization.animator.wcs import ArrayAnimatorWCS
 
-
+# See https://github.com/astropy/astropy/pull/10400
 pytestmark = pytest.mark.filterwarnings('ignore:target cannot be converted to ICRS, so will not be '
                                         'set on SpectralCoord')
 


### PR DESCRIPTION
More stuff pulled out of #3648, this time ignoring warnings. This is stuff that I understand well and have commented the reasons for ignoring the various warnings. The one thing that isn't explicitly commented is setting up new clients in the tests, which has to be done as `hypothesis` does not automatically reset fixtures.

Again, if anything does not make sense please let me know!