### PR TITLE
Improve goes peek()

### DIFF
--- a/changelog/4364.bugfix.rst
+++ b/changelog/4364.bugfix.rst
@@ -1,0 +1,2 @@
+The flare class labels in GOES ``peek()`` plots are now drawn at the center of
+the flare classes. Previously they were (ambiguously) drawn on the boundaries.

--- a/sunpy/tests/figure_hashes_mpl_321_ft_261_astropy_401post1.json
+++ b/sunpy/tests/figure_hashes_mpl_321_ft_261_astropy_401post1.json
@@ -28,7 +28,7 @@
     "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "517f18770e29f57d60bdb480bba739124d0b98362d7377c76837944d619fcbbf",
     "sunpy.timeseries.tests.test_timeseriesbase.test_fermi_gbm_peek": "bdf7767e40ff5925ac32aa8b71f66d2f0cf057cdd1a10e911e8a2b5b77f31dbb",
     "sunpy.timeseries.tests.test_timeseriesbase.test_generic_ts_peek": "59e63334b74aaf3595d3702070520c599bc2a970d6915f577a971ea7095da902",
-    "sunpy.timeseries.tests.test_timeseriesbase.test_goes_peek": "066237f4925001eaff073efbf32c4fae3c7fc066467d2633ffe9b6ba69a3e7bc",
+    "sunpy.timeseries.tests.test_timeseriesbase.test_goes_peek": "918569855e7eab40ab258dba0f34364c3af4201af12c6d1910ad200d96be7e43",
     "sunpy.timeseries.tests.test_timeseriesbase.test_lyra_peek": "ddbc764019e115357c727ab1c0fa4d605b31da189e61726a32e52828e1a7d4e0",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_json_ind_peek": "c84b93c4c8202042e0f6f930998718661114d18c6c2902982d3a225afacabbcb",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_json_pre_peek": "d3f194603eb388c1fdb5e149abcc78410e48128e30faffacc923fb57a27e2cfd",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -28,6 +28,7 @@
     "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "fe84a95c9943554660acdf5202cf68ffc13333c5db29cf5ebb1d4f296043c882",
     "sunpy.timeseries.tests.test_timeseriesbase.test_fermi_gbm_peek": "a0addeae9ec0eda509c976e9058b2d90fa748b2c3d4a64df43b3a064d85f34d9",
     "sunpy.timeseries.tests.test_timeseriesbase.test_generic_ts_peek": "73a71e717b7dd0dd345f0f8a8bfa7f06387607417b3ecd123adfd8f630f93d51",
+    "sunpy.timeseries.tests.test_timeseriesbase.test_goes_peek": "5e8a20ed592398ac710798e7995ba7da158743d974820508656b2ba3bf62e152",
     "sunpy.timeseries.tests.test_timeseriesbase.test_lyra_peek": "7b7b335c083ce97ca64655a9ad973d9e84c9b418681e88f20f3ce1af31b57380",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_json_ind_peek": "1bea3a56178db101abca168bc51e127b7b96f9eed58d74e3d19b6ffc14643e80",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_json_pre_peek": "fb58c64ed07d820990af4b2a247cecd3597a50fe17de39e9b620f23539d03b4e",

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -5,6 +5,7 @@ import datetime
 from collections import OrderedDict
 
 import matplotlib.dates
+import matplotlib.ticker as mticker
 import numpy as np
 from matplotlib import pyplot as plt
 from pandas import DataFrame
@@ -94,8 +95,11 @@ class XRSTimeSeries(GenericTimeSeries):
         ax2 = axes.twinx()
         ax2.set_yscale("log")
         ax2.set_ylim(1e-9, 1e-2)
-        ax2.set_yticks((1e-9, 1e-8, 1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2))
-        ax2.set_yticklabels((' ', 'A', 'B', 'C', 'M', 'X', ' '))
+        labels = ['A', 'B', 'C', 'M', 'X']
+        centers = np.logspace(-7.5, -3.5, len(labels))
+        ax2.yaxis.set_minor_locator(mticker.FixedLocator(centers))
+        ax2.set_yticklabels(labels, minor=True)
+        ax2.set_yticklabels([])
 
         axes.yaxis.grid(True, 'major')
         axes.xaxis.grid(False, 'major')


### PR DESCRIPTION
This

- Fixes goes `peek()` on Matplotlib dev
- Puts the labels in the center of the flare classes instead of the boundaries, as in https://www.swpc.noaa.gov/products/goes-x-ray-flux

Here's the new plot:

![sunpy timeseries tests test_timeseriesbase test_goes_peek](https://user-images.githubusercontent.com/6197628/87540096-f40b5980-c696-11ea-9dd7-72e324e25740.png)
