### PR TITLE
Linux OpenBLAS test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -122,6 +122,7 @@ conda_deps =
     lxml
     matplotlib
     numpy
+    libopenblas=*=*openmp*
     openjpeg
     pandas
     parfive

--- a/tox.ini
+++ b/tox.ini
@@ -119,10 +119,10 @@ conda_deps =
     glymur
     hypothesis
     jinja2
+    libopenblas=0.3.9
     lxml
     matplotlib
     numpy
-    libopenblas=*=*openmp*
     openjpeg
     pandas
     parfive

--- a/tox.ini
+++ b/tox.ini
@@ -119,7 +119,7 @@ conda_deps =
     glymur
     hypothesis
     jinja2
-    libopenblas=0.3.9
+    libopenblas=0.3.10=h5*
     lxml
     matplotlib
     numpy


### PR DESCRIPTION
Previously the `libopenblas` feedstock for conda-forge provided a build for Linux using OpenMP threads.  Yesterday, they added a build for Linux that uses pthreads threads instead, and that is the new default for conda solutions.  We're getting severe test failures when using the pthreads build, so this PR tests whether we get test failures if we explicitly specify the OpenMP build.