### PR TITLE
Pin tox-conda to use OpenBLAS below 0.3.10 due to apparent bugs on Linux

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -119,6 +119,7 @@ conda_deps =
     glymur
     hypothesis
     jinja2
+    libopenblas<0.3.10
     lxml
     matplotlib
     numpy
@@ -136,7 +137,7 @@ conda_deps =
     sqlalchemy
     towncrier
     zeep
-    pillow < 7.1.0
+    pillow
 conda_channels = conda-forge
 install_command = pip install --no-deps {opts} {packages}
 commands =


### PR DESCRIPTION
The conda-forge Linux builds of OpenBLAS 0.3.10 appear to result in catastrophic errors, from massively inaccurate calculations to segmentation faults.  These errors appear to be associated with OpenBLAS multithreading, because there are no errors if the environmental variable `OMP_NUM_THREADS=1` is set to force OpenBLAS to use only one thread.  (Due to a quirk in the code, this environmental variable works regardless of whether OpenBLAS is using OpenMP threads or pthreads threads.  On the other hand, the similarly named `OPENBLAS_NUM_THREADS`, which you'd think would be more general, does not work for both types of threading.)

For the time being, we'll pin our tox-conda dependencies to below 0.3.10 so that our CI will function.

Fixes #4356