### PR TITLE
Custom SunpyMetadataWarning

### DIFF
--- a/sunpy/instr/tests/test_iris.py
+++ b/sunpy/instr/tests/test_iris.py
@@ -7,7 +7,7 @@ import pytest
 import sunpy.data.test
 import sunpy.map
 from sunpy.instr import iris
-from sunpy.util import SunpyUserWarning
+from sunpy.util.exceptions import SunpyMetadataWarning
 
 
 def test_SJI_to_sequence():
@@ -26,7 +26,7 @@ def test_iris_rot():
                              'iris_l2_20130801_074720_4040000014_SJI_1400_t000.fits')
     iris_cube = iris.SJI_to_sequence(test_data, start=0, stop=None, hdu=0)
     irismap = iris_cube.maps[0]
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for observer'):
+    with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):
         irismap_rot = irismap.rotate()
 
     assert isinstance(irismap_rot, sunpy.map.sources.SJIMap)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -37,7 +37,7 @@ from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import expand_list
 from sunpy.util.decorators import deprecate_positional_args_since, deprecated
-from sunpy.util.exceptions import SunpyUserWarning
+from sunpy.util.exceptions import SunpyMetadataWarning, SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
 
@@ -838,7 +838,7 @@ class GenericMap(NDData):
         warning_message = "".join(
             [f"For frame '{frame}' the following metadata is missing: {','.join(keys)}\n" for frame, keys in missing_meta.items()])
         warning_message = "Missing metadata for observer: assuming Earth-based observer.\n" + warning_message
-        warnings.warn(warning_message, SunpyUserWarning)
+        warnings.warn(warning_message, SunpyMetadataWarning, stacklevel=3)
 
         return get_earth(self.date)
 

--- a/sunpy/map/sources/tests/test_mdi_source.py
+++ b/sunpy/map/sources/tests/test_mdi_source.py
@@ -16,7 +16,7 @@ import sunpy.data.test
 from sunpy.coordinates import frames
 from sunpy.map import Map
 from sunpy.map.sources.soho import MDIMap, MDISynopticMap
-from sunpy.util.exceptions import SunpyUserWarning
+from sunpy.util.exceptions import SunpyMetadataWarning
 
 
 @pytest.fixture
@@ -156,5 +156,5 @@ def test_carrington(mdi):
 def test_synoptic_source(mdi_synoptic):
     assert isinstance(mdi_synoptic, MDISynopticMap)
     # Check that the WCS is valid
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for observer'):
+    with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):
         mdi_synoptic.wcs

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -26,6 +26,7 @@ import sunpy.sun
 from sunpy.coordinates import sun
 from sunpy.time import parse_time
 from sunpy.util import SunpyDeprecationWarning, SunpyUserWarning
+from sunpy.util.exceptions import SunpyMetadataWarning
 
 testpath = sunpy.data.test.rootdir
 
@@ -261,7 +262,7 @@ def test_heliographic_longitude_crln(hmi_test_map):
 
 def test_remove_observers(aia171_test_map):
     aia171_test_map._remove_existing_observer_location()
-    with pytest.warns(SunpyUserWarning,
+    with pytest.warns(SunpyMetadataWarning,
                       match='Missing metadata for observer: assuming Earth-based observer.*'):
         aia171_test_map.observer_coordinate
 
@@ -272,7 +273,7 @@ def test_partially_missing_observers(generic_map):
     generic_map.meta['crlt_obs'] = 0
     generic_map.meta['crln_obs'] = 0
     generic_map.meta.pop('dsun_obs')
-    with pytest.warns(SunpyUserWarning,
+    with pytest.warns(SunpyMetadataWarning,
                       match="Missing metadata for observer: assuming Earth-based observer.\n" +
                             "For frame 'heliographic_stonyhurst' the following metadata is missing: dsun_obs\n" +
                             "For frame 'heliographic_carrington' the following metadata is missing: dsun_obs\n"):
@@ -874,7 +875,7 @@ def test_missing_metadata_warnings():
         array_map = sunpy.map.Map(np.random.rand(20, 15), header)
         array_map.peek()
     # There should be 2 warnings for missing metadata (obstime and observer location)
-    assert len([w for w in record if w.category is SunpyUserWarning]) == 2
+    assert len([w for w in record if w.category in (SunpyMetadataWarning, SunpyUserWarning)]) == 2
 
 
 def test_fits_header(aia171_test_map):

--- a/sunpy/util/exceptions.py
+++ b/sunpy/util/exceptions.py
@@ -8,7 +8,7 @@ but rather in the particular package.
 from astropy.utils.exceptions import AstropyWarning
 
 __all__ = ["SunpyWarning", "SunpyUserWarning", "SunpyDeprecationWarning",
-           "SunpyPendingDeprecationWarning"]
+           "SunpyPendingDeprecationWarning", "SunpyMetadataWarning"]
 
 
 class SunpyWarning(AstropyWarning):
@@ -26,6 +26,15 @@ class SunpyUserWarning(UserWarning, SunpyWarning):
     The primary warning class for Sunpy.
 
     Use this if you do not need a specific type of warning.
+    """
+
+
+class SunpyMetadataWarning(UserWarning):
+    """
+    Warning class for cases metadata is missing.
+
+    This does not inherit from SunpyWarning because we want to use
+    stacklevel=3 to show the user where the issue occurred in their code.
     """
 
 


### PR DESCRIPTION
Fixes #4008

By not using `AstropyWarning` we restore the information on where the warning is raised which is useful for debugging. The logger from astropy hides this and there isn't an easy way to change this.

If Astropy want to show a warning location, they do not inherit from `AstropyWarning` and create a custom warning. So we could create a custom metadata warning that handles this?