### PR TITLE
Don't assume earth observer when calculating rsun_obs

### DIFF
--- a/changelog/4375.bugfix.rst
+++ b/changelog/4375.bugfix.rst
@@ -1,0 +1,5 @@
+`sunpy.GenericMap.rsun_obs` no longer assumes the observer is at Earth if
+ ``rsun_obs`` was not present in the map metadata. The sun-observer
+ distance is now taken directly from the observer coordinate. If the observer
+ coordinate is not present, this defaults to the Earth, retaining previous
+ behaviour.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -55,7 +55,11 @@ def angular_radius(t='now'):
     t : {parse_time_types}
         Time to use in a parse-time-compatible format
     """
-    solar_semidiameter_rad = np.arcsin(constants.radius / earth_distance(t))
+    return _angular_radius(constants.radius, earth_distance(t))
+
+
+def _angular_radius(sol_radius, distance):
+    solar_semidiameter_rad = np.arcsin(sol_radius / distance)
     return Angle(solar_semidiameter_rad.to(u.arcsec))
 
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -748,7 +748,8 @@ class GenericMap(NDData):
         Notes
         -----
         This value is taken the ``'rsun_obs'``, ``'solar_r'``, or ``radius``
-        FITS keywords.
+        FITS keywords. If none of these keys are present the photospheric limb
+        as seen from the observer coordinate is returned.
         """
         rsun_arcseconds = self.meta.get('rsun_obs',
                                         self.meta.get('solar_r',

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -756,11 +756,14 @@ class GenericMap(NDData):
                                                                     None)))
 
         if rsun_arcseconds is None:
-            warnings.warn("Missing metadata for solar radius: assuming photospheric limb as seen from Earth.",
+            warnings.warn("Missing metadata for solar angular radius: assuming photospheric limb "
+                          "as seen from observer coordinate.",
                           SunpyUserWarning)
-            rsun_arcseconds = sun.angular_radius(self.date).to('arcsec').value
-
-        return u.Quantity(rsun_arcseconds, 'arcsec')
+            dsun = self.dsun
+            rsun = sun._angular_radius(constants.radius, dsun)
+        else:
+            rsun = rsun_arcseconds * u.arcsec
+        return rsun
 
     @property
     def coordinate_system(self):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -742,7 +742,14 @@ class GenericMap(NDData):
 
     @property
     def rsun_obs(self):
-        """Radius of the Sun."""
+        """
+        Angular radius of the Sun.
+
+        Notes
+        -----
+        This value is taken the ``'rsun_obs'``, ``'solar_r'``, or ``radius``
+        FITS keywords.
+        """
         rsun_arcseconds = self.meta.get('rsun_obs',
                                         self.meta.get('solar_r',
                                                       self.meta.get('radius',

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -12,6 +12,7 @@ import sunpy.data.test
 from sunpy.coordinates import sun
 from sunpy.map import Map
 from sunpy.map.sources.stereo import EUVIMap
+from sunpy.sun import constants
 from sunpy.util.exceptions import SunpyUserWarning
 
 path = sunpy.data.test.rootdir
@@ -51,8 +52,8 @@ def test_rsun_missing():
     """Tests output if 'rsun' is missing"""
     euvi_no_rsun = Map(fitspath)
     euvi_no_rsun.meta['rsun'] = None
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for solar radius'):
-        assert euvi_no_rsun.rsun_obs.value == sun.angular_radius(euvi.date).to('arcsec').value
+    r = euvi_no_rsun.observer_coordinate.radius
+    assert euvi_no_rsun.rsun_obs == sun._angular_radius(constants.radius, r)
 
 
 def test_norm_clip():

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -6,14 +6,11 @@ This particular test file pertains to EUVIMap.
 import os
 import glob
 
-import pytest
-
 import sunpy.data.test
 from sunpy.coordinates import sun
 from sunpy.map import Map
 from sunpy.map.sources.stereo import EUVIMap
 from sunpy.sun import constants
-from sunpy.util.exceptions import SunpyUserWarning
 
 path = sunpy.data.test.rootdir
 fitspath = glob.glob(os.path.join(path, "euvi_20090615_000900_n4euA_s.fts"))

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -211,8 +211,10 @@ def test_rsun_meters(generic_map):
 
 
 def test_rsun_obs(generic_map):
-    with pytest.warns(SunpyUserWarning, match='Missing metadata for solar radius'):
-        assert generic_map.rsun_obs == sun.angular_radius(generic_map.date)
+    with pytest.warns(SunpyUserWarning,
+                      match='Missing metadata for solar angular radius: assuming '
+                      'photospheric limb as seen from observer coordinate.'):
+        assert_quantity_allclose(generic_map.rsun_obs, sun.angular_radius(generic_map.date))
 
 
 def test_coordinate_system(generic_map):


### PR DESCRIPTION
Currently `sunpy` ignores any observer coordinate information when choosing a default value of `rsun_obs`, and assumes the observer is Earth. This PR changes that to calculate `rsun_obs` from `map.dsun`. `map.dsun` in turn is drawn from `self.observer_coordinate.radius.to('m')`.

This keeps the previous behaviour when `observer_coordinate` is not defined, because that defaults to Earth anyway.

This is pretty important I think because `draw_limb` relies on `map.rsun_obs`, so Solar Orbiter images would currently not have the limb drawn properly.