### PR TITLE
Test for bugs on Linux with OpenBLAS 0.3.10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,14 @@ jobs:
       - linux: py38-hypothesis
 
       - linux: py38-conda
-        name: py38_conda
+        name: py38_conda_linux
+        libraries: {}
+
+      - linux: py38-singlethread-conda
+        libraries: {}
+
+      - macos: py38-conda
+        name: py38_conda_macos
         libraries: {}
 
       - linux: py37-oldestdeps

--- a/tox.ini
+++ b/tox.ini
@@ -120,7 +120,7 @@ conda_deps =
     glymur
     hypothesis
     jinja2
-    libopenblas<0.3.10
+    libopenblas=0.3.10
     lxml
     matplotlib
     numpy
@@ -144,3 +144,19 @@ install_command = pip install --no-deps {opts} {packages}
 commands =
     conda list
     {env:PYTEST_COMMAND} {posargs}
+
+# This env requires tox-conda.
+[testenv:py38-singlethread-conda]
+pypi_filter =
+basepython = python3.8
+extras =
+deps =
+conda_deps =
+    {[testenv:py38-conda]conda_deps}
+conda_channels = {[testenv:py38-conda]conda_channels}
+install_command = {[testenv:py38-conda]install_command}
+setenv =
+    OMP_NUM_THREADS=1
+    {[testenv]setenv}
+commands =
+    {[testenv:py38-conda]commands}


### PR DESCRIPTION
We apparently have massive issues with OpenBLAS 0.3.10 on Linux.  This PR undoes the pinning in #4369 for investigation into the bugs (see also #4368).