### PR TITLE
Warn whenever metadata assumptions are made

### DIFF
--- a/changelog/4391.feature.rst
+++ b/changelog/4391.feature.rst
@@ -1,0 +1,7 @@
+sunpy currently makes a number of assumptions about missing or incorrect values
+stored in files from various sources. Previously it was not always clear what
+or when these assumptions were being made. Now any assumptions raise a warning
+stating which key is being modified, and the new value it is being set to.
+
+In order to prevent these warnings, missing metadata must be explicitly set
+before being loaded by `sunpy.map.Map`.

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -111,6 +111,11 @@ demonstrated by the following example.
             super(FutureMap, self).__init__(data, header, **kwargs)
 
             # Any Future Instrument specific keyword manipulation
+            #
+            # If any assumptions are made about metadata that is not present
+            # in the header, a warning MUST be raised to inform the user that
+            # sunpy is modifying the metadata. This can be done using the
+            # _fix_and_warn GenericMap helper method.
 
        # Specify a classmethod that determines if the data-header pair matches
        # the new instrument

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -421,6 +421,29 @@ class GenericMap(NDData):
         r = frame.represent_as(UnitSphericalRepresentation)
         return r.lon.to(self.spatial_units[0]), r.lat.to(self.spatial_units[1])
 
+    @staticmethod
+    def _fix_and_warn_header(header, key, value, replace_old=False):
+        """
+        Update *key* in *header* with a new *value*, and raise a warning. Any present values
+        are only overritten if *replace_old* is True.
+
+        This modifies *header* in place.
+        """
+        if key not in header:
+            warnings.warn(f'Did not find {key} in header, setting it to "{value}".',
+                          SunpyUserWarning)
+        elif replace_old:
+            warnings.warn(f'Fixing "{key}" header entry by replacing the old value '
+                          f'"{header[key]}" with "{value}".',
+                          SunpyUserWarning)
+        else:
+            return
+
+        header[key] = value
+
+    def _fix_and_warn(self, key, value, replace_old=False):
+        self._fix_and_warn_header(self.meta, key, value, replace_old)
+
     @property
     def _meta_hash(self):
         return self.meta.item_hash()

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -36,13 +36,12 @@ class SJIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-        # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
+        self._fix_and_warn_header(header, 'cunit1', 'arcsec')
+        self._fix_and_warn_header(header, 'cunit2', 'arcsec')
         super().__init__(data, header, **kwargs)
 
         self.meta['detector'] = "SJI"
-        self.meta['waveunit'] = "Angstrom"
+        self._fix_and_warn('waveunit', 'Angstrom')
         self.meta['wavelnth'] = header['twave1']
 
     @classmethod

--- a/sunpy/map/sources/mlso.py
+++ b/sunpy/map/sources/mlso.py
@@ -35,10 +35,9 @@ class KCorMap(GenericMap):
         # Fill in some missing info
         self.meta['observatory'] = 'MLSO'
         self.meta['detector'] = 'KCor'
-        self.meta['waveunit'] = 'nanometer'
-        # Since KCor is on Earth, no need to raise the warning in mapbase
-        self.meta['dsun_obs'] = (sun.earth_distance(self.date)).to(u.m).value
-        self.meta['hgln_obs'] = 0.0
+        self._fix_and_warn('waveunit', 'nanometer')
+        self._fix_and_warn('dsun_obs', (sun.earth_distance(self.date)).to(u.m).value)
+        self._fix_and_warn('hgln_obs', 0)
         self._nickname = self.detector
 
         self.plot_settings['cmap'] = self._get_cmap_name()

--- a/sunpy/map/sources/rhessi.py
+++ b/sunpy/map/sources/rhessi.py
@@ -34,24 +34,19 @@ class RHESSIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-        # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
-
+        # Fix some broken/misapplied keywords
+        if header['ctype1'] == 'arcsec':
+            header['cunit1'] = 'arcsec'
+            self._fix_and_warn_header(header, 'ctype1', 'HPLN-TAN', replace_old=True)
+        if header['ctype2'] == 'arcsec':
+            header['cunit2'] = 'arcsec'
+            self._fix_and_warn_header(header, 'ctype2', 'HPLT-TAN', replace_old=True)
         super().__init__(data, header, **kwargs)
 
         self._nickname = self.detector
         # TODO Currently (8/29/2011), cannot read fits files containing more
         # than one image (schriste)
-        # Fix some broken/misapplied keywords
-        if self.meta['ctype1'] == 'arcsec':
-            self.meta['cunit1'] = 'arcsec'
-            self.meta['ctype1'] = 'HPLN-TAN'
-        if self.meta['ctype2'] == 'arcsec':
-            self.meta['cunit2'] = 'arcsec'
-            self.meta['ctype2'] = 'HPLT-TAN'
-
-        self.meta['waveunit'] = 'keV'
+        self._fix_and_warn('waveunit', 'keV')
         self.meta['wavelnth'] = [self.meta['energy_l'], self.meta['energy_h']]
         self.plot_settings['cmap'] = 'rhessi'
 

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -36,10 +36,8 @@ class EITMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-        # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
-
+        self._fix_and_warn_header(header, 'cunit1', 'arcsec')
+        self._fix_and_warn_header(header, 'cunit2', 'arcsec')
         super().__init__(data, header, **kwargs)
 
         self._nickname = self.detector
@@ -175,10 +173,10 @@ class MDIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-        # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
+        self._fix_and_warn_header(header, 'cunit1', 'arcsec')
+        self._fix_and_warn_header(header, 'cunit2', 'arcsec')
         super().__init__(data, header, **kwargs)
+        self._fix_and_warn('waveunit', 'Angstrom', replace_old=True)
 
         # Fill in some missing or broken info
         self._nickname = self.detector + " " + self.measurement
@@ -207,10 +205,6 @@ class MDIMap(GenericMap):
     @property
     def detector(self):
         return "MDI"
-
-    @property
-    def waveunit(self):
-        return "Angstrom"
 
     @property
     def measurement(self):

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -37,7 +37,8 @@ class EUVIMap(GenericMap):
         self.plot_settings['cmap'] = 'sohoeit{wl:d}'.format(wl=int(self.wavelength.value))
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
-        self.meta['waveunit'] = 'Angstrom'
+        replace_old = self.meta['waveunit'] is None
+        self._fix_and_warn('waveunit', 'Angstrom', replace_old=replace_old)
 
         # Try to identify when the FITS meta data does not have the correct
         # date FITS keyword

--- a/sunpy/map/sources/tests/test_mdi_source.py
+++ b/sunpy/map/sources/tests/test_mdi_source.py
@@ -152,7 +152,6 @@ def test_carrington(mdi):
     assert u.allclose(mdi.carrington_latitude, mdi.meta['obs_b0']*u.deg)
 
 
-@pytest.mark.filterwarnings("error")
 def test_synoptic_source(mdi_synoptic):
     assert isinstance(mdi_synoptic, MDISynopticMap)
     # Check that the WCS is valid

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -46,10 +46,8 @@ class TRACEMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-        # Assume pixel units are arcesc if not given
-        header['cunit1'] = header.get('cunit1', 'arcsec')
-        header['cunit2'] = header.get('cunit2', 'arcsec')
-
+        self._fix_and_warn_header(header, 'cunit1', 'arcsec')
+        self._fix_and_warn_header(header, 'cunit2', 'arcsec')
         GenericMap.__init__(self, data, header, **kwargs)
 
         # It needs to be verified that these must actually be set and are not


### PR DESCRIPTION
In the map sources, there are quite a few times where sunpy assumes default values. This PR makes sure that a warning is emitted every time a value is assumed with no reference to other information in the header to validate the assumption.