### PR TITLE
Only put changed figures on the figure test report page

### DIFF
--- a/sunpy/tests/helpers.py
+++ b/sunpy/tests/helpers.py
@@ -203,6 +203,10 @@ def _generate_fig_html(fname):
     diff_image = figure_base_dir / "difference_images" / generated_image.name
     diff_image.parent.mkdir(parents=True, exist_ok=True)
     if baseline_image_exists:
+        result = compare.compare_images(str(baseline_image), str(generated_image), tol=0)
+        # Result is None if the images are the same
+        if result is None:
+            return ''
         compare.save_diff_image(str(baseline_image), str(generated_image), str(diff_image))
 
     html_block = ('<tr>'


### PR DESCRIPTION
The figure test page is a bit large with all the figures, so just put the ones that changed. Perhaps there is a good reason to put them all on, that I can't think of at the moment?