### PR TITLE
Re-enable helio SSL check

### DIFF
--- a/sunpy/net/helio/hec.py
+++ b/sunpy/net/helio/hec.py
@@ -4,9 +4,7 @@ Access the Helio Event Catalogue
 import io
 
 from lxml import etree
-from requests import Session
 from zeep import Client
-from zeep.transports import Transport
 
 from astropy.io.votable.table import parse_single_table
 
@@ -69,11 +67,7 @@ class HECClient:
         if link is None:
             # The default wsdl file
             link = parser.wsdl_retriever()
-        # Disable SSL check.
-        session = Session()
-        session.verify = False
-        transport = Transport(session=session)
-        self.hec_client = Client(link, transport=transport)
+        self.hec_client = Client(link)
 
     def time_query(self, start_time, end_time, table=None, max_records=None):
         """


### PR DESCRIPTION
Fixes #4401. The curl example posted in https://github.com/sunpy/sunpy/pull/4240 works fine for me now, so I think authentication is working again on helio.