### PR TITLE
Allow jsocClient to download .tar archives from JSOC

### DIFF
--- a/changelog/4405.feature.rst
+++ b/changelog/4405.feature.rst
@@ -1,0 +1,1 @@
+`sunpy.net.jsoc.JSOCClient.request_data` now support additional parameter `download_tar` which allows user to download staged data as single .tar file.

--- a/changelog/4405.feature.rst
+++ b/changelog/4405.feature.rst
@@ -1,1 +1,1 @@
-`sunpy.net.jsoc.JSOCClient.request_data` now support additional parameter `method` which allows user to download staged data as single .tar file.
+`sunpy.net.jsoc.JSOCClient.request_data` now support additional parameter "method" which allows user to download staged data as single .tar file.

--- a/changelog/4405.feature.rst
+++ b/changelog/4405.feature.rst
@@ -1,1 +1,1 @@
-`sunpy.net.jsoc.JSOCClient.request_data` now support additional parameter `download_tar` which allows user to download staged data as single .tar file.
+`sunpy.net.jsoc.JSOCClient.request_data` now support additional parameter `method` which allows user to download staged data as single .tar file.

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -447,11 +447,11 @@ class JSOCClient(BaseClient):
             protocol = block.get('protocol', 'fits')
 
             if protocol not in supported_protocols:
-                error_message = "Protocols other than fits and as-is "\
+                error_message = f"Protocols other than {','.join(supported_protocols)} "\
                                 "are not supported."
                 raise TypeError(error_message)
             if method not in supported_methods:
-                error_message = "Methods other than url-tar, url and url-quick "\
+                error_message = f"Methods other than {','.join(supported_methods)} "\
                                 "are not supported."
                 raise TypeError(error_message)
 

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -424,7 +424,8 @@ class JSOCClient(BaseClient):
             Method for requesting JSOC data, can be 'url-tar', 'url' and 'url-quick'
             If 'url-tar' it will request JSOC to provide single .tar file which contains all data
             If 'url' it will request JSOC to provide all data as separate .fits files
-            If 'url-quick' (only with protocol 'as-is') provide all data as spearate files but only if data is online
+            If 'url-quick' (only with protocol 'as-is') provide all data as separate files,
+            but only if data is online.
 
         Returns
         -------

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -420,8 +420,8 @@ class JSOCClient(BaseClient):
         jsoc_response : `~sunpy.net.jsoc.jsoc.JSOCResponse` object
             The results of a query
 
-        method : `str`
-            Method for requesting JSOC data, can be 'url-tar', 'url' and 'url-quick'
+        method : {'url', 'url-tar', 'url-quick'}
+            Method for requesting JSOC data, can be 'url-tar', 'url' (the default) and 'url-quick'
             If 'url-tar' it will request JSOC to provide single .tar file which contains all data
             If 'url' it will request JSOC to provide all data as separate .fits files
             If 'url-quick' (only with protocol 'as-is') provide all data as separate files,

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -152,6 +152,16 @@ def test_get_request(client):
     aa = client.get_request(bb, path=path)
     assert isinstance(aa, Results)
 
+@pytest.mark.remote_data
+def test_get_request_tar(client):
+    responses = client.search(
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
+
+    bb = client.request_data(responses, download_tar=True)
+    path = tempfile.mkdtemp()
+    aa = client.get_request(bb, path=path)
+    assert isinstance(aa, Results)
 
 @pytest.mark.remote_data
 def test_invalid_query(client):
@@ -317,6 +327,16 @@ def test_request_data_protocol(client):
     req.wait()
     assert req._d['method'] == 'url_quick'
     assert req._d['protocol'] == 'as-is'
+
+@pytest.mark.remote_data
+def test_request_data_method(client):
+    responses = client.search(
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
+    req = client.request_data(responses, download_tar=True)
+    req.wait()
+    assert req._d['method'] == 'url-tar'
+    assert req._d['protocol'] == 'fits'
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -152,6 +152,7 @@ def test_get_request(client):
     aa = client.get_request(bb, path=path)
     assert isinstance(aa, Results)
 
+
 @pytest.mark.remote_data
 def test_get_request_tar(client):
     responses = client.search(
@@ -327,6 +328,7 @@ def test_request_data_protocol(client):
     req.wait()
     assert req._d['method'] == 'url_quick'
     assert req._d['protocol'] == 'as-is'
+
 
 @pytest.mark.remote_data
 def test_request_data_method(client):

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -146,7 +146,6 @@ def test_get_request(client):
     responses = client.search(
         a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
         a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
-
     bb = client.request_data(responses)
     path = tempfile.mkdtemp()
     aa = client.get_request(bb, path=path)
@@ -158,12 +157,21 @@ def test_get_request_tar(client):
     responses = client.search(
         a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
         a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
-
-    bb = client.request_data(responses, download_tar=True)
+    bb = client.request_data(responses, method='url-tar')
+    bb.wait()
     path = tempfile.mkdtemp()
     aa = client.get_request(bb, path=path)
     assert isinstance(aa, Results)
 
+    responses = client.search(
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'),
+        a.jsoc.Protocol('as-is'))
+    bb = client.request_data(responses, method='url-tar')
+    bb.wait()
+    path = tempfile.mkdtemp()
+    aa = client.get_request(bb, path=path)
+    assert isinstance(aa, Results)
 
 @pytest.mark.remote_data
 def test_invalid_query(client):
@@ -336,10 +344,19 @@ def test_request_data_method(client):
     responses = client.search(
         a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
         a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'))
-    req = client.request_data(responses, download_tar=True)
+    req = client.request_data(responses, method='url-tar')
     req.wait()
     assert req._d['method'] == 'url-tar'
     assert req._d['protocol'] == 'fits'
+
+    responses = client.search(
+        a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify('jsoc@cadair.com'),
+        a.jsoc.Protocol('as-is'))
+    req = client.request_data(responses, method='url-tar')
+    req.wait()
+    assert req._d['method'] == 'url-tar'
+    assert req._d['protocol'] == 'as-is'
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -164,6 +164,7 @@ def test_get_request_tar(client):
     aa = client.get_request(bb, path=path)
     assert isinstance(aa, Results)
 
+
 @pytest.mark.remote_data
 def test_invalid_query(client):
     with pytest.raises(ValueError):

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -173,6 +173,7 @@ def test_get_request_tar(client):
     aa = client.get_request(bb, path=path)
     assert isinstance(aa, Results)
 
+
 @pytest.mark.remote_data
 def test_invalid_query(client):
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!--
We know that working on sunpy and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them: https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

This PR allows JSOCClient to download all staged files as single .tar archive while still maintaining file list in base object.

Fixes #4291 
