### PR TITLE
Retain nanosecond precision in parse_time for pandas

### DIFF
--- a/changelog/4409.bugfix.rst
+++ b/changelog/4409.bugfix.rst
@@ -1,0 +1,2 @@
+Nanosecond precision is now retained when using `~sunpy.time.parse_time` with
+a `~pandas.Timestamp`.

--- a/docs/guide/time.rst
+++ b/docs/guide/time.rst
@@ -91,7 +91,7 @@ For example::
 
     >>> import pandas
     >>> parse_time(pandas.Timestamp('2007-05-04T21:08:12'))  # pandas.Timestamp
-    <Time object: scale='utc' format='datetime' value=2007-05-04 21:08:12>
+    <Time object: scale='utc' format='datetime64' value=2007-05-04T21:08:12.000000000>
 
     >>> time_ranges = [datetime.datetime(2007, 5, i) for i in range(1, 3)]
     >>> parse_time(pandas.Series(time_ranges))  # pandas.Series

--- a/sunpy/instr/tests/test_goes.py
+++ b/sunpy/instr/tests/test_goes.py
@@ -67,8 +67,7 @@ def test_goes_event_list():
 
 @pytest.fixture
 def goeslc():
-    with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-        return timeseries.TimeSeries(get_test_filepath("go1520110607.fits"))
+    return timeseries.TimeSeries(get_test_filepath("go1520110607.fits"))
 
 
 @pytest.mark.remote_data

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -73,6 +73,15 @@ def test_parse_time_pandas_timestamp():
     assert dt == LANDING
 
 
+def test_parse_time_nanoseconds():
+    # Check that nanosecon precision is retained when parsing pandas timestamps
+    ts = pandas.Timestamp('2020-07-31 00:00:26.166196864')
+    dt = parse_time(ts)
+    assert dt.jd1 == 2459062.0
+    # If nanoseconds are not retained, this value is slightly too low
+    assert dt.jd2 == -0.4996971504992593
+
+
 def test_parse_time_pandas_series():
     inputs = [datetime(2012, 1, i) for i in range(1, 13)]
     ind = pandas.Series(inputs)

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -146,7 +146,7 @@ try:
 
     @convert_time.register(pandas.Timestamp)
     def convert_time_pandasTimestamp(time_string, **kwargs):
-        return Time(time_string.to_pydatetime())
+        return Time(time_string.asm8)
 
     @convert_time.register(pandas.Series)
     def convert_time_pandasSeries(time_string, **kwargs):

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -92,8 +92,7 @@ class TestTimeSeries:
 
     def test_implicit_fermi_gbm(self):
         # Test a GBMSummary TimeSeries
-        with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-            ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath)
+        ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath)
         assert isinstance(ts_gbm, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)
 
     def test_implicit_norh(self):
@@ -103,14 +102,12 @@ class TestTimeSeries:
 
     def test_implicit_goes(self):
         # Test a GOES TimeSeries
-        with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-            ts_goes = sunpy.timeseries.TimeSeries(goes_filepath)
+        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath)
         assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
 
     def test_implicit_goes_com(self):
         # Test a GOES TimeSeries
-        with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-            ts_goes = sunpy.timeseries.TimeSeries(goes_filepath_com)
+        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath_com)
         assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
 
     def test_implicit_lyra(self):
@@ -145,8 +142,7 @@ class TestTimeSeries:
 
     def test_fermi_gbm(self):
         # Test a GBMSummary TimeSeries
-        with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-            ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, source='GBMSummary')
+        ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, source='GBMSummary')
         assert isinstance(ts_gbm, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)
 
     def test_norh(self):
@@ -156,14 +152,12 @@ class TestTimeSeries:
 
     def test_goes(self):
         # Test a GOES TimeSeries
-        with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-            ts_goes = sunpy.timeseries.TimeSeries(goes_filepath, source='XRS')
+        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath, source='XRS')
         assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
 
     def test_goes_com(self):
         # Test a GOES TimeSeries
-        with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-            ts_goes = sunpy.timeseries.TimeSeries(goes_filepath_com, source='XRS')
+        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath_com, source='XRS')
         assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
 
     def test_lyra(self):

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -68,8 +68,7 @@ def esp_test_ts():
 
 @pytest.fixture
 def fermi_gbm_test_ts():
-    with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-        return sunpy.timeseries.TimeSeries(fermi_gbm_filepath, source='GBMSummary')
+    return sunpy.timeseries.TimeSeries(fermi_gbm_filepath, source='GBMSummary')
 
 
 @pytest.fixture
@@ -485,8 +484,7 @@ def test_concatenation_of_slices(eve_test_ts, concatenated_slices_test_ts):
 @pytest.fixture
 def concatenation_different_data_test_ts(eve_test_ts, fermi_gbm_test_ts):
     # Take two different data sources and concatenate
-    with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-        return eve_test_ts.concatenate(fermi_gbm_test_ts)
+    return eve_test_ts.concatenate(fermi_gbm_test_ts)
 
 
 def test_concatenation_of_different_data(eve_test_ts, fermi_gbm_test_ts,
@@ -744,14 +742,11 @@ def test_esp_invalid_peek(esp_test_ts):
 
 
 def test_fermi_gbm_invalid_peek(fermi_gbm_test_ts):
-    with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-        a = fermi_gbm_test_ts.time_range.start - TimeDelta(2*u.day)
-
-    with pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
-        b = fermi_gbm_test_ts.time_range.start - TimeDelta(1*u.day)
+    a = fermi_gbm_test_ts.time_range.start - TimeDelta(2*u.day)
+    b = fermi_gbm_test_ts.time_range.start - TimeDelta(1*u.day)
 
     empty_ts = fermi_gbm_test_ts.truncate(TimeRange(a, b))
-    with pytest.raises(ValueError), pytest.warns(UserWarning, match='Discarding nonzero nanoseconds'):
+    with pytest.raises(ValueError):
         empty_ts.peek()
 
 


### PR DESCRIPTION
Currently `parse_time` called with a `pandas.Timestamp` uses `time_string.to_pydatetime()` to convert the timestamp into something that astropy `Time` understands. This loses nanosecond precision however.

Instead, go via a numpy datetime64, which does not lose nanosecond precision.