### PR TITLE
Add some missing bits to the API docs

### DIFF
--- a/changelog/4418.docfix.rst
+++ b/changelog/4418.docfix.rst
@@ -1,0 +1,2 @@
+Added `sunpy.data.data_manager.downloader`, `sunpy.data.data_manager.storage`,
+and `sunpy.net.hek.HEKTable` to the docs.

--- a/docs/code_ref/data.rst
+++ b/docs/code_ref/data.rst
@@ -12,3 +12,7 @@ for running the SunPy test suite.
 .. automodapi:: sunpy.data.test
 
 .. automodapi:: sunpy.data.data_manager
+
+.. automodapi:: sunpy.data.data_manager.downloader
+
+.. automodapi:: sunpy.data.data_manager.storage

--- a/docs/code_ref/sun.rst
+++ b/docs/code_ref/sun.rst
@@ -6,5 +6,7 @@ SunPy sun
 The sun submodule contains constants, parameters and models of the Sun.
 
 .. automodapi:: sunpy.sun.constants
+   :include-all-objects:
 
 .. automodapi:: sunpy.sun.models
+   :include-all-objects:

--- a/sunpy/net/hek/hek.py
+++ b/sunpy/net/hek/hek.py
@@ -15,7 +15,7 @@ from sunpy.net.hek import attrs
 from sunpy.util import dict_keys_same, unique
 from sunpy.util.xml import xml_to_dict
 
-__all__ = ['HEKClient']
+__all__ = ['HEKClient', 'HEKTable']
 
 DEFAULT_URL = 'https://www.lmsal.com/hek/her?'
 

--- a/sunpy/sun/constants.py
+++ b/sunpy/sun/constants.py
@@ -30,12 +30,13 @@ def get(key):
 
     Returns
     -------
-    constant : `~astropy.units.Constant`
+    constant : `~astropy.constants.Constant`
 
     See Also
     --------
     `sunpy.sun.constants`
-        Contains the description of ``constants``, which, as a dictionary literal object, does not itself possess a docstring.
+        Contains the description of ``constants``, which, as a dictionary literal object, does not
+        itself possess a docstring.
 
     Examples
     --------
@@ -43,7 +44,9 @@ def get(key):
     >>> constants.get('mass')
     <<class 'astropy.constants.iau2015.IAU2015'> name='Solar mass' value=1.9884754153381438e+30 uncertainty=9.236140093538353e+25 unit='kg' reference='IAU 2015 Resolution B 3 + CODATA 2014'>
     """
-    return constants[key]
+    ret = constants[key]
+    ret.__doc__ = ret.name
+    return ret
 
 
 def find(sub=None):
@@ -116,7 +119,9 @@ if __doc__ is not None:
     __doc__ += _build_docstring()
 
 # Spectral class is not included in physical constants since it is not a number
+#: Spectral classification
 spectral_classification = 'G2V'
+
 au = astronomical_unit = get('mean distance')
 # The following variables from _gets are brought out by making them
 # accessible through a call such as sun.volume
@@ -134,5 +139,7 @@ sfu = get('solar flux unit')
 # Observable parameters
 average_angular_size = get('average angular size')
 sidereal_rotation_rate = get('sidereal rotation rate')
+
+#: Time of the start of the first Carrington rotation
 first_carrington_rotation = Time(get('first Carrington rotation (JD TT)'), format='jd', scale='tt')
 mean_synodic_period = get('mean synodic period')


### PR DESCRIPTION
Pulled out of https://github.com/sunpy/sunpy/pull/4178. Adds some previously missing API docs that are linked to in other bits of the documentation.