### PR TITLE
Explicitly specify the encoding for reading in CITATION.rst

### DIFF
--- a/changelog/4422.bugfix.rst
+++ b/changelog/4422.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where SunPy could not be successfully imported if the default text encoding of the running environment was unable to handle non-ASCII characters.

--- a/sunpy/__init__.py
+++ b/sunpy/__init__.py
@@ -42,7 +42,8 @@ def _get_bibtex():
     # Set the bibtex entry to the article referenced in CITATION.rst
     citation_file = os.path.join(os.path.dirname(__file__), 'CITATION.rst')
 
-    with open(citation_file, 'r') as citation:
+    # Explicitly specify UTF-8 encoding in case the system's default encoding is problematic
+    with open(citation_file, 'r', encoding='utf-8') as citation:
         # Extract the first bibtex block:
         ref = citation.read().partition(".. code:: bibtex\n\n")[2]
         lines = ref.split("\n")


### PR DESCRIPTION
A user using MacOS reported the following type of error when trying to import SunPy (I've simulated the error on my local machine):
```python
>>> import sunpy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "c:\users\ayshih\onedrive\code\sunpy\sunpy\__init__.py", line 55, in <module>
    __citation__ = __bibtex__ = _get_bibtex()
  File "c:\users\ayshih\onedrive\code\sunpy\sunpy\__init__.py", line 47, in _get_bibtex
    ref = citation.read().partition(".. code:: bibtex\n\n")[2]
  File "C:\Users\ayshih\anaconda3\lib\encodings\ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 1475: ordinal not in range(128)
```
This appears to result from `locale.getpreferredencoding()` returning 'ascii' instead of a sensible encoding (e.g., UTF-8) that can handle the non-ASCII characters in our `CITATION.rst`.  In principle, this could be fixed on the user side by making sure certain environment variables are set (see https://stackoverflow.com/questions/37162181/python-uses-ascii-codec-in-decoding-where-it-should-use-utf-8).  In this specific case, where we own the file, we can straightforwardly fix the issue by explicitly specifying an appropriate encoding.