### PR TITLE
Remove all transformations from a frame instance to a frame class

### DIFF
--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -49,7 +49,7 @@ def test_hcc_to_hgs():
     lon = 20 * u.deg
     observer = HeliographicStonyhurst(lat=lat, lon=lon)
     hcc_in = Heliocentric(x=0*u.km, y=0*u.km, z=1*u.km, observer=observer)
-    hgs_out = hcc_in.transform_to(HeliographicStonyhurst)
+    hgs_out = hcc_in.transform_to(HeliographicStonyhurst())
 
     assert_quantity_allclose(hgs_out.lat, lat)
     assert_quantity_allclose(hgs_out.lon, lon)
@@ -781,7 +781,7 @@ def assert_no_obstime_on_target_end(start_class, end_class):
     else:
         coord = start_class(CartesianRepresentation(0, 0, 0)*u.km, obstime=start_obstime)
 
-    result = coord.transform_to(end_class)
+    result = coord.transform_to(end_class(obstime=None))
     assert result.obstime == start_obstime
 
 

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -694,7 +694,7 @@ def hme_to_hee(hmecoord, heeframe):
 
     # Convert to the HME frame with mean equinox of date at the HEE obstime, through HCRS
     int_frame = HeliocentricMeanEcliptic(obstime=heeframe.obstime, equinox=heeframe.obstime)
-    int_coord = hmecoord.transform_to(HCRS).transform_to(int_frame)
+    int_coord = hmecoord.transform_to(HCRS(obstime=hmecoord.obstime)).transform_to(int_frame)
 
     # Rotate the intermediate coord to the HEE frame
     total_matrix = _rotation_matrix_hme_to_hee(int_frame)
@@ -722,7 +722,7 @@ def hee_to_hme(heecoord, hmeframe):
     int_coord = int_frame.realize_frame(int_repr)
 
     # Convert to the HME frame through HCRS
-    return int_coord.transform_to(HCRS).transform_to(hmeframe)
+    return int_coord.transform_to(HCRS(obstime=int_coord.obstime)).transform_to(hmeframe)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
@@ -737,7 +737,7 @@ def hee_to_hee(from_coo, to_frame):
     elif to_frame.obstime is None:
         return from_coo
     else:
-        return from_coo.transform_to(HCRS).transform_to(to_frame)
+        return from_coo.transform_to(HCRS(obstime=from_coo.obstime)).transform_to(to_frame)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
@@ -806,7 +806,8 @@ def gse_to_gse(from_coo, to_frame):
     if np.all(from_coo.obstime == to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
-        return from_coo.transform_to(HeliocentricEarthEcliptic).transform_to(to_frame)
+        heecoord = from_coo.transform_to(HeliocentricEarthEcliptic(obstime=from_coo.obstime))
+        return heecoord.transform_to(to_frame)
 
 
 def _rotation_matrix_hgs_to_hci(obstime):
@@ -905,7 +906,7 @@ def hme_to_gei(hmecoord, geiframe):
 
     # Use an intermediate frame of HME at the GEI observation time, through HCRS
     int_frame = HeliocentricMeanEcliptic(obstime=geiframe.obstime, equinox=geiframe.equinox)
-    int_coord = hmecoord.transform_to(HCRS).transform_to(int_frame)
+    int_coord = hmecoord.transform_to(HCRS(obstime=int_frame.obstime)).transform_to(int_frame)
 
     # Get the Sun-Earth vector in the intermediate frame
     sun_earth = HCRS(_sun_earth_icrf(int_frame.obstime), obstime=int_frame.obstime)
@@ -948,7 +949,7 @@ def gei_to_hme(geicoord, hmeframe):
     int_coord = int_frame.realize_frame(sun_object_int)
 
     # Convert to the final frame through HCRS
-    return int_coord.transform_to(HCRS).transform_to(hmeframe)
+    return int_coord.transform_to(HCRS(obstime=int_coord.obstime)).transform_to(hmeframe)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
@@ -961,7 +962,7 @@ def gei_to_gei(from_coo, to_frame):
     if np.all((from_coo.equinox == to_frame.equinox) and (from_coo.obstime == to_frame.obstime)):
         return to_frame.realize_frame(from_coo.data)
     else:
-        return from_coo.transform_to(HCRS).transform_to(to_frame)
+        return from_coo.transform_to(HCRS(obstime=from_coo.obstime)).transform_to(to_frame)
 
 
 def _make_sunpy_graph():

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -823,7 +823,7 @@ class GenericMap(NDData):
                     fake_observer = HeliographicStonyhurst(0*u.deg, 0*u.deg, sc.radius,
                                                            obstime=sc.obstime)
                     fake_frame = sc.frame.replicate(observer=fake_observer)
-                    hgs = fake_frame.transform_to(HeliographicStonyhurst)
+                    hgs = fake_frame.transform_to(HeliographicStonyhurst(obstime=sc.obstime))
 
                     # HeliographicStonyhurst doesn't need an observer, but adding the observer
                     # facilitates a conversion back to HeliographicCarrington


### PR DESCRIPTION
This PR replaces all internal cases where a frame instance is transformed to a frame class with an explicitly instantiated destination frame.  All results are unchanged.  This change anticipates the pending astropy/astropy#10475, but does not need to wait for that PR to be merged.