### PR TITLE
Remove pinned version for OpenBLAS from conda-forge

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -120,7 +120,7 @@ conda_deps =
     glymur
     hypothesis
     jinja2
-    libopenblas<0.3.10
+    libopenblas
     lxml
     matplotlib
     numpy


### PR DESCRIPTION
As confirmed via the test PR #4384, the Linux OpenBLAS 0.3.10 builds on conda-forge no longer result in segmentation faults, so it is safe to remove the version pin (set in #4369, see also #4368).