### PR TITLE
Raise an error if a file contains no HDUs with NAXIS > 1

### DIFF
--- a/changelog/4426.trivial.rst
+++ b/changelog/4426.trivial.rst
@@ -1,0 +1,2 @@
+Raise a better error message if trying to load a FITS file that contains only
+one dimensional data.

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -16,7 +16,7 @@ from astropy.wcs import WCS
 import sunpy
 import sunpy.data.test
 import sunpy.map
-from sunpy.util.exceptions import SunpyUserWarning
+from sunpy.util.exceptions import NoMapsInFileError, SunpyUserWarning
 
 filepath = pathlib.Path(sunpy.data.test.rootdir)
 a_list_of_many = [os.fspath(f) for f in pathlib.Path(filepath, "EIT").glob("*")]
@@ -267,3 +267,16 @@ def test_map_list_urls_cache():
 def test_sources(file, mapcls):
     m = sunpy.map.Map(file)
     assert isinstance(m, mapcls)
+
+
+def test_no_2d_hdus(tmpdir):
+    # Create a fake FITS file with a valid header but 1D data
+    tmp_fpath = str(tmpdir / 'data.fits')
+    with fits.open(AIA_171_IMAGE, ignore_blank=True) as hdul:
+        fits.writeto(tmp_fpath, np.arange(100), hdul[0].header)
+
+    with pytest.raises(NoMapsInFileError, match='Found no HDUs with >= 2D data'):
+        sunpy.map.Map(tmp_fpath)
+
+    with pytest.warns(SunpyUserWarning, match='One of the arguments failed to parse'):
+        sunpy.map.Map([tmp_fpath, AIA_171_IMAGE], silence_errors=True)

--- a/sunpy/util/exceptions.py
+++ b/sunpy/util/exceptions.py
@@ -7,8 +7,15 @@ but rather in the particular package.
 
 from astropy.utils.exceptions import AstropyWarning
 
-__all__ = ["SunpyWarning", "SunpyUserWarning", "SunpyDeprecationWarning",
+__all__ = ["NoMapsInFileError",
+           "SunpyWarning", "SunpyUserWarning", "SunpyDeprecationWarning",
            "SunpyPendingDeprecationWarning", "SunpyMetadataWarning"]
+
+
+class NoMapsInFileError(Exception):
+    """
+    An error raised when a file is opened and no maps are found.
+    """
 
 
 class SunpyWarning(AstropyWarning):


### PR DESCRIPTION
In #4413 it was proposed that in the future some of the files returned by the JSOC might have no array data in them, but these files would be potentially mixed in with a bunch of files which did in the results of a search. This lead me to wonder what would happen if you gave sunpy a list of FITS, where one has no array data in it, but all the others do, can you still load the ones that do, do you get errors, warnings or anything else?

So I created such a file with:
```python
fits.writeto(header=fits.Header(head), data=np.array(()), filename="test.fits", overwrite=True)
```

and then loaded it into Map, both on it's own and with other files. Map completely ignored it, no error (unless it was the only file, where a `NoMap` error was raised) no warning, error or anything.

On further investigation, it seems that we are dropping all HDUs with `NAXIS = 1` here:

https://github.com/sunpy/sunpy/blob/7a8e7f9a74b558908a58ef35891ec6c8ff18e2ab/sunpy/map/map_factory.py#L171-L174

This PR changes this behaviour to raise an error if *all* HDUs in the file have `NAXIS = 1` and are therefore dropped. This error is then later caught during the `__call__` method and converted to a warning if `silence_errors=True` in the call to `Map`.

Fixes #4413


