### PR TITLE
Units equivalency for converting between arcsec and km on the Sun

### DIFF
--- a/changelog/4443.feature.rst
+++ b/changelog/4443.feature.rst
@@ -1,1 +1,1 @@
-Added `~sunpy.coordinates.utils.solar_angle_equivalencies` to convert between a physical distance on the Sun (e.g., km) to an angular separation as seen by an observer (e.g., arcsec).
+Added `~sunpy.coordinates.utils.solar_angle_equivalency` to convert between a physical distance on the Sun (e.g., km) to an angular separation as seen by an observer (e.g., arcsec).

--- a/changelog/4443.feature.rst
+++ b/changelog/4443.feature.rst
@@ -1,0 +1,1 @@
+Added `~sunpy.coordinates.utils.solar_angle_equivalencies` to convert between arcsec on the Sun and km using the small angle approximation.

--- a/changelog/4443.feature.rst
+++ b/changelog/4443.feature.rst
@@ -1,1 +1,1 @@
-Added `~sunpy.coordinates.utils.solar_angle_equivalencies` to convert between arcsec on the Sun and km using the small angle approximation.
+Added `~sunpy.coordinates.utils.solar_angle_equivalencies` to convert between a physical distance on the Sun (e.g., km) to an angular separation as seen by an observer (e.g., arcsec).

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -2,12 +2,12 @@ import numpy as np
 import pytest
 
 import astropy.units as u
-from astropy.coordinates import ConvertError, SkyCoord, get_body
-from astropy.time import Time
+from astropy.coordinates import ConvertError, SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
 
 import sunpy.data.test as test
 import sunpy.map as smap
-from sunpy.coordinates import frames, sun
+from sunpy.coordinates import frames, sun, get_earth
 from sunpy.coordinates.utils import GreatArc, get_rectangle_coordinates, solar_angle_equivalency
 
 
@@ -326,7 +326,7 @@ def test_rectangle_bottom_left_vector():
     assert top_right.spherical.lat == bottom_left_vector[1].spherical.lat
 
 
-def test_solar_angle_equivalencies_inputs():
+def test_solar_angle_equivalency_inputs():
 
     with pytest.raises(TypeError):
         solar_angle_equivalency("earth")
@@ -336,13 +336,12 @@ def test_solar_angle_equivalencies_inputs():
         solar_angle_equivalency(test_coord)
 
 
-def test_solar_angle_equivalencies_outputs():
-
-    observer = get_body("earth", Time("2020-11-16"))
+def test_solar_angle_equivalency_outputs():
+    observer = get_earth("2020-11-16")
 
     distance_in_arcsec = 1*u.arcsec
     distance_in_km = distance_in_arcsec.to(u.km, equivalencies=solar_angle_equivalency(observer))
     distance_back_to_arcsec = distance_in_km.to(u.arcsec, equivalencies=solar_angle_equivalency(observer))
 
-    np.testing.assert_almost_equal(distance_in_km.value, 717.25668, decimal=5)
-    assert distance_in_arcsec == distance_back_to_arcsec
+    assert_quantity_allclose(distance_in_km, 717.25668*u.km)
+    assert_quantity_allclose(distance_back_to_arcsec, distance_in_arcsec)

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -3,6 +3,7 @@ import pytest
 
 import astropy.units as u
 from astropy.coordinates import ConvertError, SkyCoord, get_body
+from astropy.time import Time
 
 import sunpy.data.test as test
 import sunpy.map as smap

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -7,7 +7,7 @@ from astropy.tests.helper import assert_quantity_allclose
 
 import sunpy.data.test as test
 import sunpy.map as smap
-from sunpy.coordinates import frames, sun, get_earth
+from sunpy.coordinates import frames, get_earth, sun
 from sunpy.coordinates.utils import GreatArc, get_rectangle_coordinates, solar_angle_equivalency
 
 

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -2,12 +2,12 @@ import numpy as np
 import pytest
 
 import astropy.units as u
-from astropy.coordinates import ConvertError, SkyCoord
+from astropy.coordinates import ConvertError, SkyCoord, get_body
 
 import sunpy.data.test as test
 import sunpy.map as smap
 from sunpy.coordinates import frames, sun
-from sunpy.coordinates.utils import GreatArc, get_rectangle_coordinates
+from sunpy.coordinates.utils import GreatArc, get_rectangle_coordinates, solar_angle_equivalency
 
 
 @pytest.fixture
@@ -323,3 +323,25 @@ def test_rectangle_bottom_left_vector():
     assert bottom_left.spherical.lat == bottom_left_vector[0].spherical.lat
     assert top_right.spherical.lon == bottom_left_vector[1].spherical.lon
     assert top_right.spherical.lat == bottom_left_vector[1].spherical.lat
+
+
+def test_solar_angle_equivalencies_inputs():
+
+    with pytest.raises(TypeError):
+        solar_angle_equivalency("earth")
+
+    test_coord = SkyCoord(0*u.arcsec, 0*u.arcsec)
+    with pytest.raises(ValueError):
+        solar_angle_equivalency(test_coord)
+
+
+def test_solar_angle_equivalencies_outputs():
+
+    observer = get_body("earth", Time("2020-11-16"))
+
+    distance_in_arcsec = 1*u.arcsec
+    distance_in_km = distance_in_arcsec.to(u.km, equivalencies=solar_angle_equivalency(observer))
+    distance_back_to_arcsec = distance_in_km.to(u.arcsec, equivalencies=solar_angle_equivalency(observer))
+
+    np.testing.assert_almost_equal(distance_in_km.value, 717.25668, decimal=5)
+    assert distance_in_arcsec == distance_back_to_arcsec

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -409,6 +409,8 @@ def solar_angle_equivalency(observer):
 
     Examples
     --------
+    >>> import astropy.units as u
+    >>> from sunpy.coordinates import get_body_heliographic_stonyhurst
     >>> earth_observer = get_body_heliographic_stonyhurst("earth", "2013-10-28")
     >>> distance_in_km = 725*u.km
     >>> distance_in_km.to(u.arcsec, equivalencies=solar_angle_equivalency(earth_observer))

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -5,11 +5,11 @@ Miscellaneous utilities related to coordinates
 import numpy as np
 
 import astropy.units as u
-from astropy.coordinates import BaseCoordinateFrame, SkyCoord
-
+from astropy.coordinates import BaseCoordinateFrame, SkyCoord, solar_system_ephemeris, get_body
+from astropy.time import Time
 from sunpy.coordinates import Heliocentric
 
-__all__ = ['GreatArc', 'get_rectangle_coordinates']
+__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalencies']
 
 
 class GreatArc:
@@ -384,3 +384,50 @@ def get_rectangle_coordinates(bottom_left, *, top_right=None,
             top_right = top_right.frame
 
     return bottom_left, top_right
+
+
+def solar_angle_equivalencies(observer, obstime=None):
+    """
+    Return the equivalency to convert between arcsec on the Sun and km.
+
+    Parameters
+    ----------
+    observer : `~astropy.coordinates.SkyCoord` or str inputs to `~astropy.coordinates.get_body()`
+        Observer for which equivalency is calculated.
+    obstime : `astropy.time.Time`, optional.
+        Time for which the conversion should be made is inputs to 'observer' is to get_body
+
+    Returns
+    -------
+    equiv : equivalency function that can be used as keyword `equivalencies` for astropy unit conversion.
+
+    Examples
+    --------
+
+    >>> earth_observer = get_body("earth", Time('2013-10-28'))
+    >>> distance_in_km = 725*u.km
+    >>> distance_in_km.to(u.arcsec, equivalencies=solar_angle_equivalencies(earth_observer))
+         <Quantity 1.00603718 arcsec>
+    """
+
+    if observer in solar_system_ephemeris.bodies:
+        if isinstance(Time(obstime), Time):
+            observer = get_body(observer, Time(obstime))
+        else:
+            raise ValueError(
+                    "Obstime needs to given with solar system body input")
+
+    if not isinstance(observer, SkyCoord):
+        raise ValueError(
+                "Observer needs to be a SkyCoord or a solar system body to astropy.coordinates.get_body()")
+
+    obstime = observer.obstime
+    sun_coord = get_body("sun", time=obstime)
+    sun_earth_distance = sun_coord.separation_3d(observer).to_value(u.m)
+
+    equiv = [(u.radian,
+              u.meter,
+              lambda x: np.tan(x)*sun_earth_distance,
+              lambda x: np.arctan(x/sun_earth_distance))]
+
+    return equiv

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -419,6 +419,9 @@ def solar_angle_equivalency(observer):
     if not isinstance(observer, (SkyCoord, BaseCoordinateFrame)):
         raise TypeError(
             "Invalid input, observer must be of type SkyCoord or BaseCoordinateFrame.")
+    if observer.obstime is None:
+        raise ValueError(
+            "Observer must have an observation time, `obstime`.")
 
     obstime = observer.obstime
     sun_coord = get_body_heliographic_stonyhurst("sun", time=obstime, observer=observer)

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -7,7 +7,6 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 
-from sunpy import log
 from sunpy.coordinates import Heliocentric, get_body_heliographic_stonyhurst
 
 __all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalencies']
@@ -391,6 +390,10 @@ def solar_angle_equivalencies(observer):
     """
     Return the equivalency to convert between arcsec on the Sun and km.
 
+    .. note::
+        The equivalency uses a small angle conversion using tangent,
+        this does not approximate well for large angles.
+
     Parameters
     ----------
     observer : `~astropy.coordinates.SkyCoord`
@@ -405,6 +408,7 @@ def solar_angle_equivalencies(observer):
     >>> earth_observer = get_body_heliographic_stonyhurst("earth", "2013-10-28")
     >>> distance_in_km = 725*u.km
     >>> distance_in_km.to(u.arcsec, equivalencies=solar_angle_equivalencies(earth_observer))
+    INFO: Apparent body location accounts for 495.82 seconds of light travel time [sunpy.coordinates.ephemeris]
     <Quantity 1.00603718 arcsec>
     """
 
@@ -421,5 +425,4 @@ def solar_angle_equivalencies(observer):
               lambda x: np.tan(x)*sun_observer_distance,
               lambda x: np.arctan(x/sun_observer_distance))]
 
-    log.info(f"The equivalency uses an approximate conversion using tangent, this does not approximate well for large angles.")
     return equiv

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -9,7 +9,7 @@ from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 
 from sunpy.coordinates import Heliocentric, get_body_heliographic_stonyhurst
 
-__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalencies']
+__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency']
 
 
 class GreatArc:
@@ -386,18 +386,22 @@ def get_rectangle_coordinates(bottom_left, *, top_right=None,
     return bottom_left, top_right
 
 
-def solar_angle_equivalencies(observer):
+def solar_angle_equivalency(observer):
     """
-    Return the equivalency to convert between arcsec on the Sun and km.
+    Return the equivalency to convert between a physical distance on the Sun
+    and an angular separation as seen by a specified observer.
 
     .. note::
-        The equivalency uses a small angle conversion using tangent,
-        this does not approximate well for large angles.
+        This equivalency assumes that the physical distance is perpendicular to
+        the Sun-observer line.  That is, the tangent of the angular separation
+        is equal to the ratio of the physical distance to the Sun-observer
+        distance.  For large physical distances, a different assumption may be
+        more appropriate.
 
     Parameters
     ----------
     observer : `~astropy.coordinates.SkyCoord`
-        Observer for which equivalency is calculated.
+        Observer location for which the equivalency is calculated.
 
     Returns
     -------
@@ -407,7 +411,7 @@ def solar_angle_equivalencies(observer):
     --------
     >>> earth_observer = get_body_heliographic_stonyhurst("earth", "2013-10-28")
     >>> distance_in_km = 725*u.km
-    >>> distance_in_km.to(u.arcsec, equivalencies=solar_angle_equivalencies(earth_observer))
+    >>> distance_in_km.to(u.arcsec, equivalencies=solar_angle_equivalency(earth_observer))
     INFO: Apparent body location accounts for 495.82 seconds of light travel time [sunpy.coordinates.ephemeris]
     <Quantity 1.00603718 arcsec>
     """

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -384,7 +384,7 @@ def get_rectangle_coordinates(bottom_left, *, top_right=None,
         if isinstance(bottom_left, BaseCoordinateFrame):
             top_right = top_right.frame
 
-    return bottom_left, top_righty
+    return bottom_left, top_right
 
 
 def solar_angle_equivalencies(observer):

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -5,8 +5,9 @@ Miscellaneous utilities related to coordinates
 import numpy as np
 
 import astropy.units as u
-from astropy.coordinates import BaseCoordinateFrame, SkyCoord, solar_system_ephemeris, get_body
+from astropy.coordinates import BaseCoordinateFrame, SkyCoord, get_body, solar_system_ephemeris
 from astropy.time import Time
+
 from sunpy.coordinates import Heliocentric
 
 __all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalencies']
@@ -414,12 +415,10 @@ def solar_angle_equivalencies(observer, obstime=None):
         if isinstance(Time(obstime), Time):
             observer = get_body(observer, Time(obstime))
         else:
-            raise ValueError(
-                    "Obstime needs to given with solar system body input")
+            raise ValueError("Obstime needs to given with solar system body input")
 
     if not isinstance(observer, SkyCoord):
-        raise ValueError(
-                "Observer needs to be a SkyCoord or a solar system body to astropy.coordinates.get_body()")
+        raise ValueError("Observer needs to be a SkyCoord or a solar system body to astropy.coordinates.get_body()")
 
     obstime = observer.obstime
     sun_coord = get_body("sun", time=obstime)


### PR DESCRIPTION
### Description
Adds a function to use unit conversions between radians on Sun (i.e. arcsec) to distance in km etc. 

This is something that I think will be useful, definitely have found a need for it myself lots

The function takes an observer as a `SkyCoord`, or a body and obstime to `astropy.coordinates.get_body`

Example:

```python
>>> from sunpy.coordinates.utils import solar_angle_equivalencies
>>> from astropy.coordinates import get_body
>>> from astropy import units as u
>>> from astropy.time import Time

>>> observer = get_body("earth", Time("2013-10-28"))
>>> distance_in_km = 1000*u.km
>>> distance_in_km.to(u.arcsec, equivalencies=solar_angle_equivalencies(observer))
    <Quantity 1.38763748 arcsec>

>>> distance_in_arcsec = 1*u.arcsec
>>> distance_in_arcsec.to(u.km, equivalencies=solar_angle_equivalencies(observer))
    <Quantity 720.64931382 km>


```

