### PR TITLE
Use bunit in sunpy.map

### DIFF
--- a/changelog/4451.feature.rst
+++ b/changelog/4451.feature.rst
@@ -1,0 +1,3 @@
+`sunpy.map.Map` instances now have their ``.unit`` attribute set from the
+``'BUNIT'`` FITS keyword. If the keyword cannot be parsed, or is not present
+the unit is set to `None`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -45,6 +45,8 @@ TIME_FORMAT = config.get("general", "time_format")
 PixelPair = namedtuple('PixelPair', 'x y')
 SpatialPair = namedtuple('SpatialPair', 'axis1 axis2')
 
+_META_FIX_URL = 'https://docs.sunpy.org/en/stable/code_ref/map.html#fixing-map-metadata'
+
 __all__ = ['GenericMap']
 
 
@@ -585,10 +587,13 @@ class GenericMap(NDData):
         if unit_str is None:
             return
         else:
-            unit = u.Unit(unit_str, parse_strict='warn')
+            unit = u.Unit(unit_str, format='fits', parse_strict='silent')
             if isinstance(unit, u.UnrecognizedUnit):
-                warnings.warn(f'Could not parse unit string "{unit_str}". '
-                              'See the above warning for more information',
+                warnings.warn(f'Could not parse unit string "{unit_str}" as a valid FITS unit.\n'
+                              f'See {_META_FIX_URL} for how to fix metadata before loading it '
+                              'with sunpy.map.Map.\n'
+                              'See https://fits.gsfc.nasa.gov/fits_standard.html for'
+                              'the FITS unit standards.',
                               SunpyMetadataWarning)
                 unit = None
             return unit
@@ -1040,8 +1045,7 @@ class GenericMap(NDData):
 
         if err_message:
             err_message.append(
-                'See https://docs.sunpy.org/en/stable/code_ref/map.html#fixing-map-metadata` for '
-                'instructions on how to add missing metadata.')
+                f'See {_META_FIX_URL} for instructions on how to add missing metadata.')
             raise MapMetaValidationError('\n'.join(err_message))
 
         for meta_property in ('waveunit', ):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -586,17 +586,17 @@ class GenericMap(NDData):
         unit_str = self.meta.get('bunit', None)
         if unit_str is None:
             return
-        else:
-            unit = u.Unit(unit_str, format='fits', parse_strict='silent')
-            if isinstance(unit, u.UnrecognizedUnit):
-                warnings.warn(f'Could not parse unit string "{unit_str}" as a valid FITS unit.\n'
-                              f'See {_META_FIX_URL} for how to fix metadata before loading it '
-                              'with sunpy.map.Map.\n'
-                              'See https://fits.gsfc.nasa.gov/fits_standard.html for'
-                              'the FITS unit standards.',
-                              SunpyMetadataWarning)
-                unit = None
-            return unit
+
+        unit = u.Unit(unit_str, format='fits', parse_strict='silent')
+        if isinstance(unit, u.UnrecognizedUnit):
+            warnings.warn(f'Could not parse unit string "{unit_str}" as a valid FITS unit.\n'
+                          f'See {_META_FIX_URL} for how to fix metadata before loading it '
+                          'with sunpy.map.Map.\n'
+                          'See https://fits.gsfc.nasa.gov/fits_standard.html for'
+                          'the FITS unit standards.',
+                          SunpyMetadataWarning)
+            unit = None
+        return unit
 
 # #### Keyword attribute and other attribute definitions #### #
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -572,6 +572,27 @@ class GenericMap(NDData):
         """
         return self.data.max(*args, **kwargs)
 
+    @property
+    def unit(self):
+        """
+        Unit of the map data.
+
+        This is taken from the 'BUNIT' FITS keyword. If no 'BUNIT' entry is
+        present in the metadata then this returns `None`. If the 'BUNIT' value
+        cannot be parsed into a unit a warning is raised, and `None` returned.
+        """
+        unit_str = self.meta.get('bunit', None)
+        if unit_str is None:
+            return
+        else:
+            unit = u.Unit(unit_str, parse_strict='warn')
+            if isinstance(unit, u.UnrecognizedUnit):
+                warnings.warn(f'Could not parse unit string "{unit_str}". '
+                              'See the above warning for more information',
+                              SunpyMetadataWarning)
+                unit = None
+            return unit
+
 # #### Keyword attribute and other attribute definitions #### #
 
     def _base_name(self):

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -52,6 +52,9 @@ class AIAMap(GenericMap):
         self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, AsinhStretch(0.01)), clip=False)
+        # DN/s is not a FITS standard unit, so convert to counts/second
+        if self.meta.get('bunit', None) == 'DN/s':
+            self.meta['bunit'] = 'ct/s'
 
     @property
     def _supported_observer_coordinates(self):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -97,7 +97,8 @@ def generic_map():
         'obsrvtry': 'Foo',
         'detector': 'bar',
         'wavelnth': 10,
-        'waveunit': 'm'
+        'waveunit': 'm',
+        'bunit': 'ct/s',
     }
     return sunpy.map.Map((data, header))
 
@@ -173,6 +174,13 @@ def test_mean(generic_map):
 
 def test_std(generic_map):
     assert generic_map.std() == 0
+
+
+def test_unit(generic_map):
+    assert generic_map.unit == u.ct / u.s
+    generic_map.meta['bunit'] = 'not a unit'
+    with pytest.warns(SunpyMetadataWarning, match='Could not parse unit string "not a unit"'):
+        assert generic_map.unit is None
 
 
 # ==============================================================================


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/1753

Several design decisions I have made, that are up for discussion:
- Override `NDData`s `unit()` method, and use `self.meta['bunit']` as the immutable ground truth
- Warn if 'bunit' is present but cannot be parsed
- Return `None` if `bunit` not present or can't be parsed

Still needs tests and a changelog.