### PR TITLE
Don't convert float32 to float64 in affine_transform

### DIFF
--- a/changelog/4452.bugfix.rst
+++ b/changelog/4452.bugfix.rst
@@ -1,0 +1,3 @@
+The floating point precision of input to `sunpy.image.transform.affine_transform`
+is now preserved. Previously all input was cast to `numpy.float64`, which could
+cause large increases in memory use for 32 bit data.

--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -232,6 +232,14 @@ def test_nan_scipy(identity):
 def test_int(identity):
     # Test casting of integer array to float array
     in_arr = np.array([[100]], dtype=int)
-    with pytest.warns(SunpyUserWarning, match='Input data has been cast to float64.'):
+    with pytest.warns(SunpyUserWarning, match='Integer input data has been cast to float64'):
         out_arr = affine_transform(in_arr, rmatrix=identity)
     assert np.issubdtype(out_arr.dtype, np.floating)
+
+
+def test_float32(identity):
+    # Check that float32 input remains as float32 output
+    # Test casting of integer array to float array
+    in_arr = np.array([[100]], dtype=np.float32)
+    out_arr = affine_transform(in_arr, rmatrix=identity)
+    assert np.issubdtype(out_arr.dtype, np.float32)

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -1,6 +1,7 @@
 """
 Functions for geometrical image transformation and warping.
 """
+import numbers
 import warnings
 
 import numpy as np
@@ -113,9 +114,10 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         skmatrix[:2, 2] = shift
         tform = skimage.transform.AffineTransform(skmatrix)
 
-        # Transform the image using the skimage function
-        if not np.issubdtype(image.dtype, np.float64):
-            warnings.warn("Input data has been cast to float64.", SunpyUserWarning)
+        if issubclass(image.dtype.type, numbers.Integral):
+            warnings.warn("Integer input data has been cast to float64, "
+                          "which is required for the skikit-image transform.",
+                          SunpyUserWarning)
             adjusted_image = image.astype(np.float64)
         else:
             adjusted_image = image.copy()

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -127,6 +127,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
             adjusted_image = np.nan_to_num(adjusted_image)
 
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
-                                               mode='constant', cval=missing)
+                                               mode='constant', cval=missing,
+                                               preserve_range=True)
 
     return rotated_image


### PR DESCRIPTION
Large (e.g. AIA) maps can take up lots of memory (100MB+). As long as accuracy can be sacrificed, these can be converted from 64 to 32 bit floats to save memory. However, `affine_transform` casts anything that isn't float64 up to float64. Looking at the git history this seems to be to avoid passing integer dytpes to `warp`, but I don't think this needs to be done for float32.

This PR changes the casting check to make it so that only integer dtypes are cast to float64, avoiding float32 being cast up and reducing memory usage.