### PR TITLE
Modify tests to be compatible with parfive 1.2

### DIFF
--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -466,14 +466,15 @@ def test_hek_query_download(monkeypatch, database, tmpdir):
 
     def mock_parfive_download(obj, *args, **kwargs):
 
-        assert obj.http_queue.qsize() == 10
-        assert obj.ftp_queue.qsize() == 0
+        assert obj.queued_downloads == 10
 
         queue = obj.http_queue
+        if not isinstance(queue, list):
+            queue = list(queue._queue)
         obj_records = []
 
-        while not queue.empty():
-            url = queue.get_nowait().keywords['url']
+        for item in queue:
+            url = item.keywords['url']
             obj_records.append(url[-24:])
 
         assert obj_records == records

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -417,11 +417,15 @@ def test_retry(mock_retry):
 
 
 def results_generator(dl):
-    http = list(dl.http_queue._queue)
-    ftp = list(dl.ftp_queue._queue)
+    http = dl.http_queue
+    ftp = dl.ftp_queue
+    # Handle compatibility with parfive 1.0
+    if not isinstance(dl.http_queue, list):
+        http = list(dl.http_queue._queue)
+        ftp = list(dl.ftp_queue._queue)
 
     outputs = []
-    for url in http+ftp:
+    for url in http + ftp:
         outputs.append(pathlib.Path(url.keywords['url'].split("/")[-1]))
 
     return Results(outputs)


### PR DESCRIPTION
Some of our mocks were using some private API in parfive which we removed in 1.2 so this makes the code run on both.