### PR TITLE
Cache map.wcs

### DIFF
--- a/changelog/4467.feature.rst
+++ b/changelog/4467.feature.rst
@@ -1,0 +1,5 @@
+The `sunpy.map.GenericMap.wcs` property is now cached, and will be recomputed
+only if changes are made to the map metadata. This improves performance of a
+number of places in the code base, and only one warning will now be raised
+about WCS fixes for a given set of metadata (as opposed to a warning each time
+``.wcs`` is accessed)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -36,7 +36,7 @@ from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import MetaDict, expand_list
-from sunpy.util.decorators import deprecate_positional_args_since, deprecated
+from sunpy.util.decorators import cached_property_based_on, deprecate_positional_args_since, deprecated
 from sunpy.util.exceptions import SunpyMetadataWarning, SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
@@ -421,7 +421,11 @@ class GenericMap(NDData):
         r = frame.represent_as(UnitSphericalRepresentation)
         return r.lon.to(self.spatial_units[0]), r.lat.to(self.spatial_units[1])
 
+    def _meta_hash(self):
+        return self.meta.item_hash()
+
     @property
+    @cached_property_based_on(_meta_hash)
     def wcs(self):
         """
         The `~astropy.wcs.WCS` property of the map.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -425,7 +425,7 @@ class GenericMap(NDData):
         return self.meta.item_hash()
 
     @property
-    @cached_property_based_on(_meta_hash)
+    @cached_property_based_on('_meta_hash')
     def wcs(self):
         """
         The `~astropy.wcs.WCS` property of the map.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -421,6 +421,7 @@ class GenericMap(NDData):
         r = frame.represent_as(UnitSphericalRepresentation)
         return r.lon.to(self.spatial_units[0]), r.lat.to(self.spatial_units[1])
 
+    @property
     def _meta_hash(self):
         return self.meta.item_hash()
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -903,7 +903,7 @@ def test_bad_coordframe_repr(generic_map):
 def test_non_str_key():
     header = {'cunit1': 'arcsec',
               'cunit2': 'arcsec',
-              None: None,  # Cannot parse this into WCS
+              'None': None,  # Cannot parse this into WCS
               }
     with pytest.raises(ValueError, match='All MetaDict keys must be strings'):
         sunpy.map.GenericMap(np.zeros((10, 10)), header)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -144,6 +144,22 @@ def test_wcs(aia171_test_map):
     np.testing.assert_allclose(wcs.wcs.pc, aia171_test_map.rotation_matrix)
 
 
+def test_wcs_cache(aia171_test_map):
+    wcs1 = aia171_test_map.wcs
+    wcs2 = aia171_test_map.wcs
+    # Check that without any changes to the header, retreiving the wcs twice
+    # returns the same object instead of recomputing the wcs
+    assert wcs1 is wcs2
+
+    # Change the header and make sure the wcs is re-computed
+    new_crpix = 20
+    assert new_crpix != wcs2.wcs.crpix[0]
+    aia171_test_map.meta['crpix1'] = new_crpix
+
+    new_wcs = aia171_test_map.wcs
+    assert new_wcs.wcs.crpix[0] == new_crpix
+
+
 def test_header_immutability(aia171_test_map):
     # Check that accessing the wcs of a map doesn't modify the meta data
     assert 'KEYCOMMENTS' in aia171_test_map.meta

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -903,7 +903,7 @@ def test_bad_coordframe_repr(generic_map):
 def test_non_str_key():
     header = {'cunit1': 'arcsec',
               'cunit2': 'arcsec',
-              'None': None,  # Cannot parse this into WCS
+              None: None,  # Cannot parse this into WCS
               }
     with pytest.raises(ValueError, match='All MetaDict keys must be strings'):
         sunpy.map.GenericMap(np.zeros((10, 10)), header)

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -356,6 +356,7 @@ def cached_property_based_on(meth):
         """
         prop: the property method being decorated
         """
+        @wraps(outer)
         def inner(instance):
             """
             instance: the class instance of the property being decorated

--- a/sunpy/util/metadata.py
+++ b/sunpy/util/metadata.py
@@ -115,6 +115,22 @@ class MetaDict(OrderedDict):
         OrderedDict.__delitem__(self, key.lower())
         self._prune_keycomments()
 
+    def item_hash(self):
+        """
+        Create a hash based on the stored items.
+
+        This relies on all the items themselves being hashable. For this reason
+        the 'keycomments' item, which is a dict, is excluded from the hash.
+
+        If creating the hash fails, returns `None`.
+        """
+        self_copy = self.copy()
+        self_copy.pop('keycomments', None)
+        try:
+            return hash(frozenset(self_copy.items()))
+        except Exception:
+            return
+
     def get(self, key, default=None):
         """
         Override ``.get()`` indexing.


### PR DESCRIPTION
Although creating the `.wcs` property is relatively in-expensive once, creating it many times can turn into a bottleneck for some code. As an example, `contains_full_disk` (after https://github.com/sunpy/sunpy/pull/4463) spends ~70% of its time constructing the `.wcs` property from the metadata 4 times. If we cache `.wcs`, the runtime improves from 0.3s to 0.1s.

Another advantage of caching the `.wcs` property is that warnings raised in its creation are only emitted once - currently they can be emitted a lot of times in a row when doing some tasks such as plotting.

This PR manually caches the `.wcs` property. In order to protect against changes in the metadata, `.wcs` is regenerated if any changes are made to `.meta`. Feedback very welcome on whether this is a sensible/silly idea!