### PR TITLE
More BUNIT fixes for AIAMap

### DIFF
--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -48,11 +48,15 @@ class AIAMap(GenericMap):
 
         # Fill in some missing info
         self.meta['detector'] = self.meta.get('detector', "AIA")
+        if 'pixlunit' in self.meta:
+            self.meta['bunit'] = self.meta['pixlunit']  # PIXLUNIT is not a FITS standard keyword
         self._nickname = self.detector
         self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, AsinhStretch(0.01)), clip=False)
-        # DN/s is not a FITS standard unit, so convert to counts/second
+        # DN is not a FITS standard unit, so convert to counts
+        if self.meta.get('bunit', None) == 'DN':
+            self.meta['bunit'] = 'ct'
         if self.meta.get('bunit', None) == 'DN/s':
             self.meta['bunit'] = 'ct/s'
 

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -49,7 +49,8 @@ class AIAMap(GenericMap):
         # Fill in some missing info
         self.meta['detector'] = self.meta.get('detector', "AIA")
         if 'bunit' not in self.meta and 'pixlunit' in self.meta:
-            self.meta['bunit'] = self.meta['pixlunit']  # PIXLUNIT is not a FITS standard keyword
+            # PIXLUNIT is not a FITS standard keyword
+            self.meta['bunit'] = self.meta['pixlunit']
         self._nickname = self.detector
         self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -48,7 +48,7 @@ class AIAMap(GenericMap):
 
         # Fill in some missing info
         self.meta['detector'] = self.meta.get('detector', "AIA")
-        if 'pixlunit' in self.meta:
+        if 'bunit' not in self.meta and 'pixlunit' in self.meta:
             self.meta['bunit'] = self.meta['pixlunit']  # PIXLUNIT is not a FITS standard keyword
         self._nickname = self.detector
         self.plot_settings['cmap'] = self._get_cmap_name()

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -370,7 +370,10 @@ def test_save(aia171_test_map, generic_map):
     aiamap.save(afilename, filetype='fits', overwrite=True)
     loaded_save = sunpy.map.Map(afilename)
     assert isinstance(loaded_save, sunpy.map.sources.AIAMap)
-    assert loaded_save.meta == aiamap.meta
+    # Compare metadata without considering ordering of keys
+    assert loaded_save.meta.keys() == aiamap.meta.keys()
+    for k in aiamap.meta:
+        assert loaded_save.meta[k] == aiamap.meta[k]
     assert_quantity_allclose(loaded_save.data, aiamap.data)
 
 


### PR DESCRIPTION
This is an add-on to #4451 to better handle units in AIA images.

Update `DN` to `ct` in the case of normalized and un-normalized counts. 

Also, add `BUNIT` in the case where an image contains the `PIXLUNIT` keyword which is not a FITS standard keyword. However, it seems that this is the keyword that AIA has chosen to denote units in their data products. See http://jsoc.stanford.edu/~jsoc/keywords/AIA/AIA02840_K_AIA-SDO_FITS_Keyword_Document.pdf