### PR TITLE
Add aiapy docs to the intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,7 @@ intersphinx_mapping = {
     'drms': ('https://docs.sunpy.org/projects/drms/en/stable/', None),
     'parfive': ('https://parfive.readthedocs.io/en/latest/', None),
     'reproject': ('https://reproject.readthedocs.io/en/stable/', None),
+    'aiapy': ('https://aiapy.readthedocs.io/en/stable/', None),
 }
 
 # -- Options for HTML output ---------------------------------------------------


### PR DESCRIPTION
As the title says. This may be useful in the future if in the docs, we want to defer to aiapy for AIA-specific functionality.