### PR TITLE
Remove submap warnings on pixel ordering

### DIFF
--- a/changelog/4491.trivial.rst
+++ b/changelog/4491.trivial.rst
@@ -1,0 +1,4 @@
+If the ``top_right`` corner given to :meth:`sunpy.map.Map.submap` is
+below or to the right of the ``bottom_left`` corner, a warning is no longer
+raised (as the rectangle is still well defined), but a message is still logged
+at the debug level to the sunpy logger.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -33,6 +33,7 @@ from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, ge
 from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.image.resample import resample as sunpy_image_resample
 from sunpy.image.resample import reshape_image_to_4d_superpixel
+from sunpy import log
 from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import MetaDict, expand_list
@@ -1451,6 +1452,15 @@ class GenericMap(NDData):
             A new map instance is returned representing to specified
             sub-region.
 
+        Notes
+        -----
+        The rectangle is defined in pixel space. If coordinate input is given,
+        it is first transformed into pixel space, and the pixel indices of
+        top_right and bottom_left are used as the corners of the rectangle.
+
+        If top_right is below or to the left of bottom_left, a message is logged
+        at the debug level to the sunpy logger.
+
         Examples
         --------
         >>> import astropy.units as u
@@ -1574,12 +1584,10 @@ class GenericMap(NDData):
         x_pixels = u.Quantity([bottom_left[0], top_right[0]]).to_value(u.pix)
         y_pixels = u.Quantity([bottom_left[1], top_right[1]]).to_value(u.pix)
         if x_pixels[0] > x_pixels[1]:
-            warnings.warn("The rectangle is inverted in the left/right direction,  "
-                          "which may lead to unintended behavior.", SunpyUserWarning)
+            log.debug("The rectangle is inverted in the left/right direction.")
 
         if y_pixels[0] > y_pixels[1]:
-            warnings.warn("The rectangle is inverted in the bottom/top direction, "
-                          "which may lead to unintended behavior.", SunpyUserWarning)
+            log.debug("The rectangle is inverted in the bottom/top direction.")
         # Sort the pixel values so we always slice in the correct direction
         x_pixels.sort()
         y_pixels.sort()

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -28,12 +28,11 @@ from astropy.visualization.wcsaxes import WCSAxes
 import sunpy.coordinates
 import sunpy.io as io
 import sunpy.visualization.colormaps
-from sunpy import config
+from sunpy import config, log
 from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, get_earth, sun
 from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.image.resample import resample as sunpy_image_resample
 from sunpy.image.resample import reshape_image_to_4d_superpixel
-from sunpy import log
 from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import MetaDict, expand_list

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -491,8 +491,6 @@ pixel_corners = [
 ]
 
 
-@pytest.mark.filterwarnings('ignore:The rectangle is inverted in the left/right direction')
-@pytest.mark.filterwarnings('ignore:The rectangle is inverted in the bottom/top direction')
 @pytest.mark.parametrize('rect, submap_out', pixel_corners)
 def test_submap_pixel(simple_map, rect, submap_out):
     # Check that result is the same specifying corners either way round
@@ -505,8 +503,6 @@ def test_submap_pixel(simple_map, rect, submap_out):
 # The (0.5, 0.5) case is skipped as boundary points cannot reliably tested when
 # converting to world coordinates due to round-off error when round-tripping
 # through pixel_to_world -> world_to_pixel
-@pytest.mark.filterwarnings('ignore:The rectangle is inverted in the left/right direction')
-@pytest.mark.filterwarnings('ignore:The rectangle is inverted in the bottom/top direction')
 @pytest.mark.parametrize('rect, submap_out', pixel_corners[:2] + pixel_corners[3:])
 def test_submap_world(simple_map, rect, submap_out):
     # Check that coordinates behave the same way
@@ -1073,7 +1069,6 @@ def test_submap_kwarg_only_input_errors(generic_map2, coords):
                                      frame=generic_map2.coordinate_frame))
 
 
-@pytest.mark.filterwarnings('ignore:The rectangle is inverted in the bottom/top direction')
 def test_submap_inputs(generic_map2, coords):
     bl_coord, tr_coord, bl_tr_coord = coords
 


### PR DESCRIPTION
On second thoughts, prompted by https://github.com/sunpy/sunpy/issues/4490, I think that there shouldn't be a check on the pixel ordering. Even though our API names the two corners of the rectangle as `bottom_left` and `top_right`, it does not really matter as a rectangle is uniquely defined by two pairs of un-ordered coordinates.

This removes a bit of the sunpy warning soup, but happy to hear counter arguments as to why this warning should be kept.

Fixes https://github.com/sunpy/sunpy/issues/4490