### PR TITLE
Remove global ignore of nanoseconds warning in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,9 +101,6 @@ filterwarnings =
     # add a comment or ideally a link to an issue that explains why the warning
     # is being ignored
     #
-    # Several timeseries data products have nanoseconds, that python/pandas
-    # can't handle; ignore these warnings, as they do not directly affect sunpy
-    ignore:Discarding nonzero nanoseconds in conversion
     #
     # See https://github.com/spacetelescope/asdf/issues/789
     ignore:direct construction of AsdfSchemaFile has been deprecated


### PR DESCRIPTION
I think https://github.com/sunpy/sunpy/pull/4409 should have got rid of these warnings, so see what happens if globally ignoring these warnings is removed.