### PR TITLE
Remove timeseries warning simplefilters

### DIFF
--- a/changelog/4511.bugfix.rst
+++ b/changelog/4511.bugfix.rst
@@ -1,0 +1,2 @@
+Several ``warnings.simplefilter('always', Warning)`` warning filters in
+`sunpy.timeseries` have been removed. 

--- a/changelog/4511.bugfix.rst
+++ b/changelog/4511.bugfix.rst
@@ -1,2 +1,2 @@
 Several ``warnings.simplefilter('always', Warning)`` warning filters in
-`sunpy.timeseries` have been removed. 
+`sunpy.timeseries` have been removed.

--- a/sunpy/instr/lyra.py
+++ b/sunpy/instr/lyra.py
@@ -109,16 +109,16 @@ def remove_lytaf_events_from_timeseries(ts, artifacts=None,
         warn('lytaf_path is deprecated, has no effect and will be removed in SunPy 2.1.',
              SunpyDeprecationWarning)
     # Remove artifacts from time series
-    data_columns = ts.data.columns
+    data_columns = ts.to_dataframe().columns
     time, channels, artifact_status = _remove_lytaf_events(
-        ts.data.index,
-        channels=[np.asanyarray(ts.data[col]) for col in data_columns],
+        ts.to_dataframe().index,
+        channels=[np.asanyarray(ts.to_dataframe()[col]) for col in data_columns],
         artifacts=artifacts, return_artifacts=True, lytaf_path=lytaf_path,
         force_use_local_lytaf=force_use_local_lytaf)
     # Create new copy copy of timeseries and replace data with
     # artifact-free time series.
     ts_new = copy.deepcopy(ts)
-    ts_new.data = pandas.DataFrame(
+    ts_new._data = pandas.DataFrame(
         index=time, data={col: channels[i]
                           for i, col in enumerate(data_columns)})
     if return_artifacts:

--- a/sunpy/instr/tests/test_lyra.py
+++ b/sunpy/instr/tests/test_lyra.py
@@ -82,11 +82,11 @@ def lyra_ts():
     lyrats = timeseries.TimeSeries(
         os.path.join(rootdir, 'lyra_20150101-000000_lev3_std_truncated.fits.gz'),
         source='LYRA')
-    lyrats.data = pandas.DataFrame(index=TIME,
-                                   data={"CHANNEL1": CHANNELS[0],
-                                         "CHANNEL2": CHANNELS[1],
-                                         "CHANNEL3": CHANNELS[0],
-                                         "CHANNEL4": CHANNELS[1]})
+    lyrats._data = pandas.DataFrame(index=TIME,
+                                    data={"CHANNEL1": CHANNELS[0],
+                                          "CHANNEL2": CHANNELS[1],
+                                          "CHANNEL3": CHANNELS[0],
+                                          "CHANNEL4": CHANNELS[1]})
     return lyrats
 
 
@@ -109,10 +109,10 @@ def test_remove_lytaf_events_from_timeseries(lyra_ts):
     # Generate expected data by calling _remove_lytaf_events and
     # constructing expected dataframe manually.
     time, channels, artifact_status_expected = lyra._remove_lytaf_events(
-        lyra_ts.data.index, channels=[np.asanyarray(lyra_ts.data["CHANNEL1"]),
-                                      np.asanyarray(lyra_ts.data["CHANNEL2"]),
-                                      np.asanyarray(lyra_ts.data["CHANNEL3"]),
-                                      np.asanyarray(lyra_ts.data["CHANNEL4"])],
+        lyra_ts.to_dataframe().index, channels=[np.asanyarray(lyra_ts.to_dataframe()["CHANNEL1"]),
+                                                np.asanyarray(lyra_ts.to_dataframe()["CHANNEL2"]),
+                                                np.asanyarray(lyra_ts.to_dataframe()["CHANNEL3"]),
+                                                np.asanyarray(lyra_ts.to_dataframe()["CHANNEL4"])],
         artifacts=["LAR", "Offpoint"], return_artifacts=True,
         force_use_local_lytaf=True)
     dataframe_expected = pandas.DataFrame(index=time,
@@ -121,7 +121,7 @@ def test_remove_lytaf_events_from_timeseries(lyra_ts):
                                                 "CHANNEL3": channels[2],
                                                 "CHANNEL4": channels[3]})
     # Assert expected result is returned
-    pandas.testing.assert_frame_equal(ts_test.data, dataframe_expected)
+    pandas.testing.assert_frame_equal(ts_test.to_dataframe(), dataframe_expected)
     assert artifact_status_test.keys() == artifact_status_expected.keys()
     np.testing.assert_array_equal(artifact_status_test["lytaf"],
                                   artifact_status_expected["lytaf"])
@@ -139,7 +139,7 @@ def test_remove_lytaf_events_from_timeseries(lyra_ts):
             lyra_ts, artifacts=["LAR", "Offpoint"],
             force_use_local_lytaf=True)
     # Assert expected result is returned
-    pandas.testing.assert_frame_equal(ts_test.data, dataframe_expected)
+    pandas.testing.assert_frame_equal(ts_test.to_dataframe(), dataframe_expected)
 
 
 @pytest.fixture()

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -29,7 +29,7 @@
     "sunpy.timeseries.tests.test_timeseriesbase.test_fermi_gbm_peek": "a0addeae9ec0eda509c976e9058b2d90fa748b2c3d4a64df43b3a064d85f34d9",
     "sunpy.timeseries.tests.test_timeseriesbase.test_generic_ts_peek": "73a71e717b7dd0dd345f0f8a8bfa7f06387607417b3ecd123adfd8f630f93d51",
     "sunpy.timeseries.tests.test_timeseriesbase.test_goes_peek": "5e8a20ed592398ac710798e7995ba7da158743d974820508656b2ba3bf62e152",
-    "sunpy.timeseries.tests.test_timeseriesbase.test_lyra_peek": "f97e0dbbbda228673bb7543f962388cdfd8396fcf00cbeb4e5a65559db173da4",
+    "sunpy.timeseries.tests.test_timeseriesbase.test_lyra_peek": "d134646089aa9cb217b798e61fbfbfdcf6acf50a18f9292e95294d2cae6d24ea",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_json_ind_peek": "1bea3a56178db101abca168bc51e127b7b96f9eed58d74e3d19b6ffc14643e80",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_json_pre_peek": "4c4a4a299ed04547a70ea8da89871e05a897d5f8937d5cefc0359d04cf079c04",
     "sunpy.timeseries.tests.test_timeseriesbase.test_noaa_txt_ind_peek": "01fa7e5baa13f996f686d18505f177f0884deb394384a129522aa18f9c6b61ac",

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -73,10 +73,9 @@ class ESPTimeSeries(GenericTimeSeries):
 
         names = ('Flux \n 0.1-7nm', 'Flux \n 18nm', 'Flux \n 26nm', 'Flux \n 30nm', 'Flux \n 36nm')
 
-        figure = plt.figure()
-        axes = plt.gca()
-        axes = self.to_dataframe().plot(ax=axes, subplots=True, sharex=True, **kwargs)
-        plt.xlim(self.to_dataframe().index[0], self.to_dataframe().index[-1])
+        axes = self.to_dataframe().plot(subplots=True, sharex=True, **kwargs)
+
+        axes[-1].set_xlim(self.to_dataframe().index[0], self.to_dataframe().index[-1])
 
         axes[0].set_title(title)
         for i, ax in enumerate(axes):
@@ -84,10 +83,11 @@ class ESPTimeSeries(GenericTimeSeries):
             ax.legend(loc='upper right')
         axes[-1].set_xlabel('Time (UT) ' + str(self.to_dataframe().index[0])[0:11])
         axes[-1].xaxis.set_major_formatter(dates.DateFormatter('%H:%M'))
-        plt.tight_layout()
-        plt.subplots_adjust(hspace=0.05)
 
-        return figure
+        fig = axes[0].get_figure()
+        fig.tight_layout()
+        fig.subplots_adjust(hspace=0.05)
+        return fig
 
     @classmethod
     def _parse_file(cls, filepath):

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -80,11 +80,8 @@ class LYRATimeSeries(GenericTimeSeries):
 
         lyranames = (('Lyman alpha', 'Herzberg cont.', 'Al filter', 'Zr filter'),
                      ('120-123nm', '190-222nm', '17-80nm + <5nm', '6-20nm + <2nm'))
-        figure = plt.figure()
-        plt.subplots_adjust(left=0.17, top=0.94, right=0.94, bottom=0.15)
-        axes = plt.gca()
 
-        axes = self.to_dataframe().plot(ax=axes, subplots=True, sharex=True, **kwargs)
+        axes = self.to_dataframe().plot(subplots=True, sharex=True, **kwargs)
 
         for i, name in enumerate(self.to_dataframe().columns):
             if names < 3:
@@ -98,7 +95,9 @@ class LYRATimeSeries(GenericTimeSeries):
         for axe in axes:
             axe.locator_params(axis='y', nbins=6)
 
-        return figure
+        fig = axes[0].get_figure()
+        fig.subplots_adjust(left=0.17, top=0.94, right=0.94, bottom=0.15)
+        return fig
 
     @classmethod
     def _parse_file(cls, filepath):

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -5,7 +5,6 @@ import sys
 from collections import OrderedDict
 
 import pandas
-from matplotlib import pyplot as plt
 
 import astropy.units as u
 from astropy.time import TimeDelta

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -4,7 +4,6 @@ This module provies the `~sunpy.timeseries.TimeSeriesFactory` class.
 import os
 import copy
 import glob
-import warnings
 from collections import OrderedDict
 from urllib.request import urlopen
 

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -184,7 +184,6 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         `sunpy.util.metadict.MetaDict`) with only `astropy.units` for
         values.
         """
-        warnings.simplefilter('always', Warning)
         result = True
 
         # It must be a dictionary

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -61,7 +61,9 @@ class GenericTimeSeries:
     >>> times = parse_time("now") - TimeDelta(np.arange(24 * 60)*u.minute)
     >>> intensity = np.sin(np.arange(0, 12 * np.pi, step=(12 * np.pi) / (24 * 60)))
     >>> df = pd.DataFrame(intensity, index=times, columns=['intensity'])
-    >>> ts = TimeSeries(df)
+    >>> header = {}
+    >>> units = {'intensity': u.W/u.m**2}
+    >>> ts = TimeSeries(df, header, units)
     >>> ts.peek()  # doctest: +SKIP
 
     References

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -486,8 +486,6 @@ class GenericTimeSeries:
         specific validation should be handled in the relevant file in
         the "sunpy.timeseries.sources".
         """
-        warnings.simplefilter('always', Warning)
-
         for meta_property in ('cunit1', 'cunit2', 'waveunit'):
             if (self.meta.get(meta_property) and
                 u.Unit(self.meta.get(meta_property),
@@ -505,8 +503,6 @@ class GenericTimeSeries:
         specific validation should be handled in the relevant file in
         the "sunpy.timeseries.sources".
         """
-        warnings.simplefilter('always', Warning)
-
         result = True
         for key in units:
             if not isinstance(units[key], astropy.units.UnitBase):
@@ -526,8 +522,6 @@ class GenericTimeSeries:
         * Add unitless entries for columns with no units defined.
         * Re-arrange the order of the dictionary to match the columns.
         """
-        warnings.simplefilter('always', Warning)
-
         # Populate unspecified units:
         for column in set(self._data.columns.tolist()) - set(self.units.keys()):
             # For all columns not present in the units dictionary.
@@ -553,8 +547,6 @@ class GenericTimeSeries:
         * Remove column references in the metadata that don't match to a column in the data.
         * Remove metadata entries that have no columns matching the data.
         """
-        warnings.simplefilter('always', Warning)
-
         # Truncate the metadata
         self.meta._truncate(self.time_range)
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
 
     # Figure tests need a tightly controlled environment
     figure-!devdeps: astropy==4.0.1.post1
-    figure-!devdeps: matplotlib==3.2.1
+    figure-!devdeps: matplotlib==3.2.2
 
 # The following indicates which extras_require from setup.cfg will be installed
 # dev is special in that it installs everything


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/4509. I'm not entirely sure why, but I don't think we should have these filters in the code anyway.

Will need to catch the warnings in the test suite, but will let CI run through first to get a list that needs fixing.