### PR TITLE
Clean up timeseries plotting

### DIFF
--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -197,7 +197,7 @@ class EVESpWxTimeSeries(GenericTimeSeries):
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
 
-        figure = plt.figure()
+        fig = plt.figure()
         # Choose title if none was specified
         if "title" not in kwargs and column is None:
             if len(self.to_dataframe().columns) > 1:
@@ -217,7 +217,7 @@ class EVESpWxTimeSeries(GenericTimeSeries):
                 kwargs['title'] = 'EVE ' + column.replace('_', ' ')
             data.plot(**kwargs)
 
-        return figure
+        return fig
 
     @classmethod
     def _parse_file(cls, filepath):

--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -79,23 +79,22 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
 
-        figure = plt.figure()
-        axes = plt.gca()
+        fig, ax = plt.subplots()
         data_lab = self.to_dataframe().columns.values
 
         for d in data_lab:
-            axes.plot(self.to_dataframe().index, self.to_dataframe()[d], label=d, **kwargs)
+            ax.plot(self.to_dataframe().index, self.to_dataframe()[d], label=d, **kwargs)
 
-        axes.set_yscale("log")
-        axes.set_title('Fermi GBM Summary data ' + str(self.meta.get(
+        ax.set_yscale("log")
+        ax.set_title('Fermi GBM Summary data ' + str(self.meta.get(
             'DETNAM').values()))
-        axes.set_xlabel('Start time: ' + self.to_dataframe().index[0].strftime(
+        ax.set_xlabel('Start time: ' + self.to_dataframe().index[0].strftime(
             '%Y-%m-%d %H:%M:%S UT'))
-        axes.set_ylabel('Counts/s/keV')
-        axes.legend()
-        figure.autofmt_xdate()
+        ax.set_ylabel('Counts/s/keV')
+        ax.legend()
+        fig.autofmt_xdate()
 
-        return figure
+        return fig
 
     @classmethod
     def _parse_file(cls, filepath):

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -76,23 +76,22 @@ class XRSTimeSeries(GenericTimeSeries):
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
 
-        figure = plt.figure()
-        axes = plt.gca()
+        fig, ax = plt.subplots()
 
         dates = matplotlib.dates.date2num(parse_time(self.to_dataframe().index).datetime)
 
-        axes.plot_date(dates, self.to_dataframe()['xrsa'], '-',
-                       label=r'0.5--4.0 $\AA$', color='blue', lw=2, **kwargs)
-        axes.plot_date(dates, self.to_dataframe()['xrsb'], '-',
-                       label=r'1.0--8.0 $\AA$', color='red', lw=2, **kwargs)
+        ax.plot_date(dates, self.to_dataframe()['xrsa'], '-',
+                     label=r'0.5--4.0 $\AA$', color='blue', lw=2, **kwargs)
+        ax.plot_date(dates, self.to_dataframe()['xrsb'], '-',
+                     label=r'1.0--8.0 $\AA$', color='red', lw=2, **kwargs)
 
-        axes.set_yscale("log")
-        axes.set_ylim(1e-9, 1e-2)
-        axes.set_title(title)
-        axes.set_ylabel('Watts m$^{-2}$')
-        axes.set_xlabel(datetime.datetime.isoformat(self.to_dataframe().index[0])[0:10])
+        ax.set_yscale("log")
+        ax.set_ylim(1e-9, 1e-2)
+        ax.set_title(title)
+        ax.set_ylabel('Watts m$^{-2}$')
+        ax.set_xlabel(datetime.datetime.isoformat(self.to_dataframe().index[0])[0:10])
 
-        ax2 = axes.twinx()
+        ax2 = ax.twinx()
         ax2.set_yscale("log")
         ax2.set_ylim(1e-9, 1e-2)
         labels = ['A', 'B', 'C', 'M', 'X']
@@ -101,18 +100,18 @@ class XRSTimeSeries(GenericTimeSeries):
         ax2.set_yticklabels(labels, minor=True)
         ax2.set_yticklabels([])
 
-        axes.yaxis.grid(True, 'major')
-        axes.xaxis.grid(False, 'major')
-        axes.legend()
+        ax.yaxis.grid(True, 'major')
+        ax.xaxis.grid(False, 'major')
+        ax.legend()
 
         # TODO: display better tick labels for date range (e.g. 06/01 - 06/05)
         formatter = matplotlib.dates.DateFormatter('%H:%M')
-        axes.xaxis.set_major_formatter(formatter)
+        ax.xaxis.set_major_formatter(formatter)
 
-        axes.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M')
-        figure.autofmt_xdate()
+        ax.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M')
+        fig.autofmt_xdate()
 
-        return figure
+        return fig
 
     # TODO: is this part of the DL pipeline? If so delete.
     @staticmethod

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -91,8 +91,11 @@ class LYRATimeSeries(GenericTimeSeries):
 
         axes[0].set_title("LYRA ({0:{1}})".format(self.to_dataframe().index[0], TIME_FORMAT))
         axes[-1].set_xlabel("Time")
-        for axe in axes:
-            axe.locator_params(axis='y', nbins=6)
+        for ax in axes:
+            ax.locator_params(axis='y', nbins=6)
+
+        fig = axes[-1].get_figure()
+        fig.subplots_adjust(left=0.17, top=0.94, right=0.94, bottom=0.15)
 
         fig = axes[0].get_figure()
         fig.subplots_adjust(left=0.17, top=0.94, right=0.94, bottom=0.15)

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -4,7 +4,6 @@ This module provies NOAA Solar Cycle `~sunpy.timeseries.TimeSeries` source.
 from pathlib import Path
 from collections import OrderedDict
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from pandas.io.parsers import read_csv
@@ -31,9 +30,11 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
 
     * The SWO sunspot number is issued by the NOAA Space Weather Prediction Center (SWPC)
     * The RI sunspot number is the official International Sunspot Number and is
-      issued by the `Solar Influence Data Analysis Center (SDIC) <http://sidc.oma.be>`_ in Brussels, Belgium.
+      issued by the `Solar Influence Data Analysis Center (SDIC)
+      <http://sidc.oma.be>`_ in Brussels, Belgium.
     * The ratio between the SWO and RI indices.
-    * Radio flux at 10.7 cm is produced by `Penticon/Ottawa <https://www.ngdc.noaa.gov/stp/solar/flux.html>`_ and the units are in sfu.
+    * Radio flux at 10.7 cm is produced by
+      `Penticon/Ottawa <https://www.ngdc.noaa.gov/stp/solar/flux.html>`_ and the units are in sfu.
     * The Ap Geomagnetic Index is produced by the United States Air Force (USAF).
 
     .. note::
@@ -80,8 +81,6 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
 
-        figure = plt.figure()
-        axes = plt.gca()
         dataframe = self.to_dataframe()
         if type == 'sunspot SWO':
             axes = dataframe['sunspot SWO'].plot(**kwargs)
@@ -113,7 +112,8 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         axes.xaxis.grid(True, 'major')
         axes.legend()
 
-        return figure
+        fig = axes.get_figure()
+        return fig
 
     @classmethod
     def _parse_file(cls, filepath):
@@ -271,8 +271,6 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         """
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
-        figure = plt.figure()
-        axes = plt.gca()
         dataframe = self.to_dataframe()
         axes = dataframe['sunspot'].plot(color='b', **plot_args)
         dataframe['sunspot low'].plot(linestyle='--', color='b', **plot_args)
@@ -286,7 +284,8 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         axes.xaxis.grid(True, 'major')
         axes.legend()
 
-        return figure
+        fig = axes.get_figure()
+        return fig
 
     @ classmethod
     def _parse_file(cls, filepath):

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -31,10 +31,10 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
     * The SWO sunspot number is issued by the NOAA Space Weather Prediction Center (SWPC)
     * The RI sunspot number is the official International Sunspot Number and is
       issued by the `Solar Influence Data Analysis Center (SDIC)
-      <http://sidc.oma.be>`_ in Brussels, Belgium.
+      <http://sidc.oma.be>`__ in Brussels, Belgium.
     * The ratio between the SWO and RI indices.
     * Radio flux at 10.7 cm is produced by
-      `Penticon/Ottawa <https://www.ngdc.noaa.gov/stp/solar/flux.html>`_ and the units are in sfu.
+      `Penticon/Ottawa <https://www.ngdc.noaa.gov/stp/solar/flux.html>`__ and the units are in sfu.
     * The Ap Geomagnetic Index is produced by the United States Air Force (USAF).
 
     .. note::

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -74,19 +74,18 @@ class NoRHTimeSeries(GenericTimeSeries):
         # Check we have a timeseries valid for plotting
         self._validate_data_for_plotting()
 
-        figure = plt.figure()
-        axes = plt.gca()
+        fig, ax = plt.subplots()
         data_lab = str(self.meta.get('OBS-FREQ').values()).replace('[', '').replace(
             ']', '').replace('\'', '')
-        axes.plot(self.to_dataframe().index, self.to_dataframe(), label=data_lab, **kwargs)
-        axes.set_yscale("log")
-        axes.set_ylim(1e-4, 1)
-        axes.set_title('Nobeyama Radioheliograph')
-        axes.set_xlabel('Start time: ' + self.to_dataframe().index[0].strftime(TIME_FORMAT))
-        axes.set_ylabel('Correlation')
-        axes.legend()
+        ax.plot(self.to_dataframe().index, self.to_dataframe(), label=data_lab, **kwargs)
+        ax.set_yscale("log")
+        ax.set_ylim(1e-4, 1)
+        ax.set_title('Nobeyama Radioheliograph')
+        ax.set_xlabel('Start time: ' + self.to_dataframe().index[0].strftime(TIME_FORMAT))
+        ax.set_ylabel('Correlation')
+        ax.legend()
 
-        return figure
+        return fig
 
     @classmethod
     def _parse_file(cls, filepath):

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -89,32 +89,31 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
                           'tab:brown')
         colors = kwargs.pop('colors', default_colors)
 
-        figure = plt.figure()
-        axes = plt.gca()
+        fig, ax = plt.subplots()
 
         for color, (item, frame) in zip(itertools.cycle(colors),
                                         self.to_dataframe().items()):
-            axes.plot(self.to_dataframe().index, frame.values,
-                      color=color, label=item, **kwargs)
+            ax.plot(self.to_dataframe().index, frame.values,
+                    color=color, label=item, **kwargs)
 
-        axes.set_yscale("log")
-        axes.set_xlabel(datetime.datetime.isoformat(self.to_dataframe().index[0])[0:10])
+        ax.set_yscale("log")
+        ax.set_xlabel(datetime.datetime.isoformat(self.to_dataframe().index[0])[0:10])
 
-        axes.set_title(title)
-        axes.set_ylabel('Count Rate s$^{-1}$ detector$^{-1}$')
+        ax.set_title(title)
+        ax.set_ylabel('Count Rate s$^{-1}$ detector$^{-1}$')
 
-        axes.yaxis.grid(True, 'major')
-        axes.xaxis.grid(False, 'major')
-        axes.legend()
+        ax.yaxis.grid(True, 'major')
+        ax.xaxis.grid(False, 'major')
+        ax.legend()
 
         # TODO: display better tick labels for date range (e.g. 06/01 - 06/05)
         formatter = matplotlib.dates.DateFormatter('%H:%M:%S')
-        axes.xaxis.set_major_formatter(formatter)
+        ax.xaxis.set_major_formatter(formatter)
 
-        axes.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M:%S')
-        figure.autofmt_xdate()
+        ax.fmt_xdata = matplotlib.dates.DateFormatter('%H:%M:%S')
+        fig.autofmt_xdate()
 
-        return figure
+        return fig
 
     @classmethod
     def _parse_file(cls, filepath):


### PR DESCRIPTION
Clean up of timeseries plotting code, no bugfixes/API changes/new features, but slightly nicer code.

- Use `fig` and `ax` as variable names (`axes` is often used for multiple axes instead of just one).
- Use `plt.subplots` instead of `plt.gca()` to create a new axes.
- Rely on `pandas` to automatically create a new figure where appropriate.