### PR TITLE
Fixed a miniscule inaccuracy in the calculation of the angular radius of the Sun

### DIFF
--- a/changelog/4518.bugfix.rst
+++ b/changelog/4518.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a calculation bug with :func:`sunpy.coordinates.sun.angular_radius` that resulted in an inaccuracy of ~0.01 arcseconds.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -60,7 +60,7 @@ def angular_radius(t='now'):
 
 
 def _angular_radius(sol_radius, distance):
-    solar_semidiameter_rad = np.arcsin(sol_radius / distance)
+    solar_semidiameter_rad = np.arctan(sol_radius / distance)
     return Angle(solar_semidiameter_rad.to(u.arcsec))
 
 

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -69,16 +69,18 @@ def test_apparent_latitude(t1, t2):
 def test_angular_radius(t2):
     # Validate against a published value from the Astronomical Almanac (2013, C13)
     # The Astromomical Almanac uses a slightly different radius for the Sun (6.96e5 km)
+    # The Astronomical Almanac also uses a small-angle approximation
+    # See https://archive.org/details/131123ExplanatorySupplementAstronomicalAlmanac/page/n212/mode/1up
     assert_quantity_allclose(sun.angular_radius(t2),
                              Angle('0d15m44.61s') / (6.96e5*u.km) * radius,  # scale to IAU radius
-                             atol=0.005*u.arcsec)
+                             atol=0.01*u.arcsec)
 
     # Regression-only test
-    assert_quantity_allclose(sun.angular_radius("2012/11/11"), 968.875*u.arcsec, atol=1e-3*u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2012/11/11"), 968.864*u.arcsec, atol=1e-3*u.arcsec)
     with pytest.warns(ErfaWarning):
         assert_quantity_allclose(sun.angular_radius("2043/03/01"),
-                                 968.330*u.arcsec, atol=1e-3*u.arcsec)
-    assert_quantity_allclose(sun.angular_radius("2001/07/21"), 944.042*u.arcsec, atol=1e-3*u.arcsec)
+                                 968.319*u.arcsec, atol=1e-3*u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2001/07/21"), 944.032*u.arcsec, atol=1e-3*u.arcsec)
 
 
 def test_mean_obliquity_of_ecliptic(t1, t2):


### PR DESCRIPTION
The function `coordinates.sun.angular_radius()` incorrectly used the arcsine instead of the arctangent for the calculation, which resulted in an inaccuracy of ~0.01 arcseconds.