### PR TITLE
Fixed heading now that there is no SunPy-specific minigallery directive

### DIFF
--- a/docs/dev_guide/documentation.rst
+++ b/docs/dev_guide/documentation.rst
@@ -155,8 +155,8 @@ Then change to the :file:`docs/` directory and run::
 
 For more information on how to use Sphinx, consult the `Sphinx documentation <http://www.sphinx-doc.org/en/stable/contents.html>`_.
 
-SunPy-Specific Additions
-------------------------
+Special Sphinx directives
+-------------------------
 
 ``minigallery`` directive
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Our version of the `minigallery` Sphinx directive was removed in #4377, so a heading in the docs should be changed.