### PR TITLE
Fixed all calculations of the solar angular radius to use the same correct code (arcsine)

### DIFF
--- a/changelog/4518.bugfix.rst
+++ b/changelog/4518.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a calculation bug with :func:`sunpy.coordinates.sun.angular_radius` that resulted in an inaccuracy of ~0.01 arcseconds.

--- a/changelog/4524.bugfix.rst
+++ b/changelog/4524.bugfix.rst
@@ -1,0 +1,3 @@
+All calculations of the angular radius of the Sun now use the same underlying code with the correct calculation.
+The inaccuracies were at the level of ~0.01 arcseconds.
+A previous fix to :func:`sunpy.coordinates.sun.angular_radius` was incorrect and has been reverted.

--- a/changelog/4524.bugfix.rst
+++ b/changelog/4524.bugfix.rst
@@ -1,3 +1,2 @@
-All calculations of the angular radius of the Sun now use the same underlying code with the correct calculation.
-The inaccuracies were at the level of ~0.01 arcseconds.
-A previous fix to :func:`sunpy.coordinates.sun.angular_radius` was incorrect and has been reverted.
+All calculations of the angular radius of the Sun now use the same underlying code with the accurate calculation.
+The previous inaccuracy was a relative error of ~0.001% (0.01 arcseconds) for an observer at 1 AU, but could be as large as ~0.5% for Parker Solar Probe perihelia.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -51,6 +51,11 @@ def angular_radius(t='now'):
     """
     Return the angular radius of the Sun as viewed from Earth.
 
+    The tangent vector from the Earth to the edge of the Sun forms a
+    right-angle triangle with the radius of the Sun as the far side and the
+    Sun-Earth distance as the hypotenuse.  Thus, the sine of the angular
+    radius of the Sun is ratio of these two distances.
+
     Parameters
     ----------
     t : {parse_time_types}
@@ -60,7 +65,7 @@ def angular_radius(t='now'):
 
 
 def _angular_radius(sol_radius, distance):
-    solar_semidiameter_rad = np.arctan(sol_radius / distance)
+    solar_semidiameter_rad = np.arcsin(sol_radius / distance)
     return Angle(solar_semidiameter_rad.to(u.arcsec))
 
 

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -73,14 +73,14 @@ def test_angular_radius(t2):
     # See https://archive.org/details/131123ExplanatorySupplementAstronomicalAlmanac/page/n212/mode/1up
     assert_quantity_allclose(sun.angular_radius(t2),
                              Angle('0d15m44.61s') / (6.96e5*u.km) * radius,  # scale to IAU radius
-                             atol=0.01*u.arcsec)
+                             atol=0.005*u.arcsec)
 
     # Regression-only test
-    assert_quantity_allclose(sun.angular_radius("2012/11/11"), 968.864*u.arcsec, atol=1e-3*u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2012/11/11"), 968.875*u.arcsec, atol=1e-3*u.arcsec)
     with pytest.warns(ErfaWarning):
         assert_quantity_allclose(sun.angular_radius("2043/03/01"),
-                                 968.319*u.arcsec, atol=1e-3*u.arcsec)
-    assert_quantity_allclose(sun.angular_radius("2001/07/21"), 944.032*u.arcsec, atol=1e-3*u.arcsec)
+                                 968.330*u.arcsec, atol=1e-3*u.arcsec)
+    assert_quantity_allclose(sun.angular_radius("2001/07/21"), 944.042*u.arcsec, atol=1e-3*u.arcsec)
 
 
 def test_mean_obliquity_of_ecliptic(t1, t2):

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -5,7 +5,7 @@ import astropy.units as u
 import astropy.wcs
 from astropy.coordinates import SkyCoord
 
-from sunpy.coordinates import frames
+from sunpy.coordinates import frames, sun
 from sunpy.util import MetaDict
 
 __all__ = ['meta_keywords', 'make_fitswcs_header']
@@ -224,7 +224,7 @@ def get_observer_meta(observer, rsun: (u.Mm, None)):
     coord_meta['dsun_obs'] = observer.radius.to_value(u.m)
     if rsun is not None:
         coord_meta['rsun_ref'] = rsun.to_value(u.m)
-        coord_meta['rsun_obs'] = np.arctan(rsun / observer.radius).to_value(u.arcsec)
+        coord_meta['rsun_obs'] = sun._angular_radius(rsun, observer.radius).to_value(u.arcsec)
 
     return coord_meta
 

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -8,7 +8,7 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
-from sunpy.coordinates import Helioprojective
+from sunpy.coordinates import Helioprojective, sun
 
 __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'map_edges', 'solar_angular_radius', 'sample_at_coords',
@@ -85,9 +85,10 @@ def solar_angular_radius(coordinates):
     """
     Calculates the solar angular radius as seen by the observer.
 
-    The tangent of the angular size of the Sun is equal to the radius
-    of the Sun divided by the distance between the observer and the
-    center of the Sun.
+    The tangent vector from the observer to the edge of the Sun forms a
+    right-angle triangle with the radius of the Sun as the far side and the
+    Sun-observer distance as the hypotenuse.  Thus, the sine of the angular
+    radius of the Sun is ratio of these two distances.
 
     Parameters
     ----------
@@ -100,7 +101,7 @@ def solar_angular_radius(coordinates):
     angle : `~astropy.units.Quantity`
         The solar angular radius.
     """
-    return np.arctan(coordinates.rsun / coordinates.observer.radius)
+    return sun._angular_radius(coordinates.rsun, coordinates.observer.radius)
 
 
 def sample_at_coords(smap, coordinates):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -109,7 +109,7 @@ def simple_map():
     # each direction
     data = np.arange(9).reshape((3, 3))
     ref_coord = SkyCoord(0.0, 0.0, frame='helioprojective', obstime='now', unit='deg',
-                         observer=SkyCoord(0 * u.deg, 0 * u.deg, 1 * u.m,
+                         observer=SkyCoord(0 * u.deg, 0 * u.deg, 1 * u.AU,
                                            frame='heliographic_stonyhurst'))
     ref_pix = [1, 1] * u.pix
     scale = [2, 1] * u.arcsec / u.pix


### PR DESCRIPTION
Context:
- #4239 fixed `coordinates.sun.angular_radius()` to use arcsine
- #4375 split off the calculation code to a private function so that it could be used in `map/mapbase.py`
- #4516 identified that other places in the codebase did not use the same code, and differed by using arctangent instead of arcsine.
- In #4518, I incorrectly changed `coordinates.sun.angular_radius()` to use arctangent to match the other places in the code, but @Neel2904 pointed out that was wrong.

This PR:
- Effectively reverts #4518 
- `map/maputils.py` and `map/header_helper.py` now use the correct arcsine instead of the incorrect arctangent because they use the private function from `coordinates.sun`.  The differences are on the order of ~0.01 arcsecond.
- Docstrings now explain why the arcsine is correct
- Fixed a bug with in `map/tests/test_mapbase.py` where the observer location was specified as 1 meter from the center of the Sun
