### PR TITLE
Fixed get_dates() not working working properly when less than 24 hours passed

### DIFF
--- a/changelog/4529.bugfix.rst
+++ b/changelog/4529.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue on get_dates() where the function would return the wrong number of days if less than 24 hours had passed

--- a/changelog/4529.bugfix.rst
+++ b/changelog/4529.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed an issue on get_dates() where the function would return the wrong number of days if less than 24 hours had passed
+Fixed an issue on `TimeRange.get_dates()` where the function would return the wrong number of days if less than 24 hours had passed

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from datetime import datetime
 
 import pytest
 
@@ -264,3 +265,10 @@ def test_contains(timerange_a):
         assert '2100/1/1'not in timerange
     assert '2014/05/03 12:00' in timerange
     assert '2014/05/05 21:00' in timerange
+
+def test_get_dates_daylist_less_24_hours():
+    starttime = datetime(2020, 1, 1, 12)
+    endtime = datetime(2020, 1, 2, 11)
+    interval = sunpy.time.TimeRange(starttime, endtime)
+    daylist = interval.get_dates()
+    assert len(daylist) == 2

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -266,9 +266,11 @@ def test_contains(timerange_a):
     assert '2014/05/03 12:00' in timerange
     assert '2014/05/05 21:00' in timerange
 
+
 def test_get_dates_daylist_less_24_hours():
     starttime = datetime(2020, 1, 1, 12)
     endtime = datetime(2020, 1, 2, 11)
     interval = sunpy.time.TimeRange(starttime, endtime)
     daylist = interval.get_dates()
     assert len(daylist) == 2
+    

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -276,4 +276,3 @@ def test_get_dates_daylist_less_24_hours():
     assert len(daylist) == 2
     assert daylist[0] == day_one
     assert daylist[1] == day_two
-    

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -271,5 +271,9 @@ def test_get_dates_daylist_less_24_hours():
     endtime = datetime(2020, 1, 2, 11)
     interval = sunpy.time.TimeRange(starttime, endtime)
     daylist = interval.get_dates()
+    day_one = Time("2020-01-01T00:00:00.000")
+    day_two = Time("2020-01-02T00:00:00.000")
     assert len(daylist) == 2
+    assert daylist[0] == day_one
+    assert daylist[1] == day_two
     

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta 
+from datetime import datetime, timedelta
 
 import pytest
 

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -1,5 +1,4 @@
-from datetime import timedelta
-from datetime import datetime
+from datetime import datetime, timedelta 
 
 import pytest
 

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -2,6 +2,7 @@
 This module provies a object that can handle a time range.
 """
 from datetime import timedelta
+
 import astropy.units as u
 from astropy.time import Time, TimeDelta
 

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -2,7 +2,6 @@
 This module provies a object that can handle a time range.
 """
 from datetime import timedelta
-
 import astropy.units as u
 from astropy.time import Time, TimeDelta
 
@@ -405,10 +404,11 @@ class TimeRange:
         """
         Return all partial days contained within the time range.
         """
+        delta = self.end.to_datetime().date() - self.start.to_datetime().date()
         dates = []
         dates = [
             parse_time(self.start.strftime('%Y-%m-%d')) + TimeDelta(i*u.day)
-            for i in range(int(self.days.value) + 1)
+            for i in range(delta.days + 1)
         ]
         return dates
 


### PR DESCRIPTION
This happened due to the number of dates to output being calculated in
how many days passed, not how many days it covered.

Fixes #4527 
