### PR TITLE
Fixed label in changelog readme

### DIFF
--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -21,7 +21,8 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>[.<COUNTER>].rst``, where 
 * ``breaking``: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
 * ``feature``: New user facing features and any new behavior.
 * ``bugfix``: Fixes a reported bug.
-* ``docfix``: Documentation addition or improvement, like rewording an entire session or adding missing docs.
+* ``doc``: Documentation addition or improvement, like rewording an entire session or adding missing docs.
+* ``docfix``: Correction to existing documentation, such as fixing a typo or adding a missing input parameter.
 * ``removal``: Feature deprecation and/or feature removal.
 * ``trivial``: A change which has no user facing effect or is tiny change.
 

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -21,7 +21,7 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>[.<COUNTER>].rst``, where 
 * ``breaking``: A change which requires users to change code and is not backwards compatible. (Not to be used for removal of deprecated features.)
 * ``feature``: New user facing features and any new behavior.
 * ``bugfix``: Fixes a reported bug.
-* ``doc``: Documentation addition or improvement, like rewording an entire session or adding missing docs.
+* ``docfix``: Documentation addition or improvement, like rewording an entire session or adding missing docs.
 * ``removal``: Feature deprecation and/or feature removal.
 * ``trivial``: A change which has no user facing effect or is tiny change.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,12 @@ build-backend = 'setuptools.build_meta'
 
     [[tool.towncrier.type]]
       directory = "doc"
-      name = "Improved Documentation"
+      name = "Added/Improved Documentation"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "docfix"
+      name = "Documentation Fixes"
       showcontent = true
 
     [[tool.towncrier.type]]


### PR DESCRIPTION
Relabels `doc` as `docfix` as we seem to only use `docfix` in all of our changelogs

- [x] Include both `doc` and `docfix`
- [x] Fix `pyproject.toml` 