### PR TITLE
removed pytest pin

### DIFF
--- a/.test_package_pins.txt
+++ b/.test_package_pins.txt
@@ -1,2 +1,1 @@
-# until https://github.com/pytest-dev/pytest-rerunfailures/pull/129 is out
-pytest<6.1
+


### PR DESCRIPTION
Fixed up stream: https://github.com/pytest-dev/pytest-rerunfailures/pull/129