### PR TITLE
Added explanation in 'Differentially rotating a map' example

### DIFF
--- a/changelog/4548.doc.rst
+++ b/changelog/4548.doc.rst
@@ -1,0 +1,1 @@
+Added description for a counter-intuitive section in the 'Differentially rotating a map' example.

--- a/changelog/4548.doc.rst
+++ b/changelog/4548.doc.rst
@@ -1,1 +1,1 @@
-Added description for a counter-intuitive section in the 'Differentially rotating a map' example.
+Added description for a counter-intuitive section in the :ref:`sphx_glr_generated_gallery_differential_rotation_reprojected_map.py` example.

--- a/examples/differential_rotation/reprojected_map.py
+++ b/examples/differential_rotation/reprojected_map.py
@@ -44,11 +44,12 @@ out_frame = Helioprojective(observer='earth', obstime=out_time)
 # counter-intuitive. Reprojection should be performed between two frames that
 # point to inertial locations at the same time, but ``out_frame`` is not at
 # the same time as the original frame (``out_time`` versus ``in_time``).
-# The `~sunpy.coordinates.metaframes.RotatedSunFrame` metaframe allows one to specify coordinates in a
-# coordinate frame at one time (here, ``out_frame``) to refer to inertial
-# locations at a different time (here, ``in_time``, which is supplied through
-# the keyword argument ``rotated_time``). `~sunpy.coordinates.metaframes.RotatedSunFrame` will account
-# for the appropriate amount of solar (differential) rotation for the time
+# The `~sunpy.coordinates.metaframes.RotatedSunFrame` metaframe allows one to
+# specify coordinates in a coordinate frame at one time (here, ``out_frame``)
+# to refer to inertial locations at a different time (here, ``in_time``,
+# which is supplied through the keyword argument ``rotated_time``).
+# `~sunpy.coordinates.metaframes.RotatedSunFrame` will account for the
+# appropriate amount of solar (differential) rotation for the time
 # difference between ``out_time`` and ``in_time``.
 
 rot_frame = RotatedSunFrame(base=out_frame, rotated_time=in_time)

--- a/examples/differential_rotation/reprojected_map.py
+++ b/examples/differential_rotation/reprojected_map.py
@@ -44,10 +44,10 @@ out_frame = Helioprojective(observer='earth', obstime=out_time)
 # counter-intuitive. Reprojection should be performed between two frames that
 # point to inertial locations at the same time, but ``out_frame`` is not at
 # the same time as the original frame (``out_time`` versus ``in_time``).
-# The ``RotatedSunFrame`` metaframe allows one to specify coordinates in a
+# The `~sunpy.coordinates.metaframes.RotatedSunFrame` metaframe allows one to specify coordinates in a
 # coordinate frame at one time (here, ``out_frame``) to refer to inertial
 # locations at a different time (here, ``in_time``, which is supplied through
-# the keyword argument ``rotated_time``). ``RotatedSunFrame`` will account
+# the keyword argument ``rotated_time``). `~sunpy.coordinates.metaframes.RotatedSunFrame` will account
 # for the appropriate amount of solar (differential) rotation for the time
 # difference between ``out_time`` and ``in_time``.
 

--- a/examples/differential_rotation/reprojected_map.py
+++ b/examples/differential_rotation/reprojected_map.py
@@ -41,9 +41,15 @@ out_frame = Helioprojective(observer='earth', obstime=out_time)
 
 ##############################################################################
 # For the reprojection, the definition of the target frame can be
-# counter-intuitive.  We will be transforming from the original frame to the
-# `~sunpy.coordinates.metaframes.RotatedSunFrame` version of the output frame
-# with ``rotated_time`` set to the time of the original frame.
+# counter-intuitive. Reprojection should be performed between two frames that
+# point to inertial locations at the same time, but ``out_frame`` is not at
+# the same time as the original frame (``out_time`` versus ``in_time``).
+# The ``RotatedSunFrame`` metaframe allows one to specify coordinates in a
+# coordinate frame at one time (here, ``out_frame``) to refer to inertial
+# locations at a different time (here, ``in_time``, which is supplied through
+# the keyword argument ``rotated_time``). ``RotatedSunFrame`` will account
+# for the appropriate amount of solar (differential) rotation for the time
+# difference between ``out_time`` and ``in_time``.
 
 rot_frame = RotatedSunFrame(base=out_frame, rotated_time=in_time)
 print(rot_frame)


### PR DESCRIPTION
There is a potentially confusing section in the 'Differentially rotating a map' example. This PR adds an explanation for it.

Fixes #4456 