### PR TITLE
Fix ylim setting by LineAnimator

### DIFF
--- a/changelog/4554.bugfix.rst
+++ b/changelog/4554.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes a bug which occurs in setting the ylims by LineAnimator when there are non-finite values in the data array to be animated.

--- a/changelog/4554.bugfix.rst
+++ b/changelog/4554.bugfix.rst
@@ -1,1 +1,1 @@
-Fixes a bug which occurs in setting the ylims by LineAnimator when there are non-finite values in the data array to be animated.
+Fixes a bug which occurs in setting the ``ylims`` by `sunpy.visualization.animator.line.LineAnimator` when there are non-finite values in the data array to be animated.

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -108,9 +108,11 @@ class LineAnimator(ArrayAnimator):
                 self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]),
                                                  plot_axis_index)
         if ylim is None:
-            ylim = (data.min(), data.max())
+            data_is_finite = np.isfinite(data)
+            ylim = (data[data_is_finite].min(), data[data_is_finite].max())
         if xlim is None:
-            xlim = (self.xdata.min(), self.xdata.max())
+            xdata_is_finite = np.isfinite(xdata)
+            xlim = (self.xdata[xdata_is_finite].min(), self.xdata[xdata_is_finite].max())
         self.ylim = ylim
         self.xlim = xlim
         self.xlabel = xlabel

--- a/sunpy/visualization/animator/line.py
+++ b/sunpy/visualization/animator/line.py
@@ -108,11 +108,9 @@ class LineAnimator(ArrayAnimator):
                 self.xdata = edges_to_centers_nd(np.asarray(axis_ranges[self.plot_axis_index]),
                                                  plot_axis_index)
         if ylim is None:
-            data_is_finite = np.isfinite(data)
-            ylim = (data[data_is_finite].min(), data[data_is_finite].max())
+            ylim = (np.nanmin(data), np.nanmax(data))
         if xlim is None:
-            xdata_is_finite = np.isfinite(xdata)
-            xlim = (self.xdata[xdata_is_finite].min(), self.xdata[xdata_is_finite].max())
+            xlim = (np.nanmin(self.xdata), np.nanmax(self.xdata))
         self.ylim = ylim
         self.xlim = xlim
         self.xlabel = xlabel

--- a/sunpy/visualization/animator/tests/test_basefuncanimator.py
+++ b/sunpy/visualization/animator/tests/test_basefuncanimator.py
@@ -166,16 +166,27 @@ def test_sanitize_axis_ranges(axis_ranges, exp_extent, exp_axis_ranges):
     assert np.array_equal(exp_axis_ranges[0], out_axis_ranges[0](np.arange(10)))
 
 
-xdata = np.tile(np.linspace(0, 100, 11), (5, 5, 1))
+XDATA = np.tile(np.linspace(0, 100, 11), (5, 5, 1))
 
 
 @pytest.mark.parametrize('plot_axis_index, axis_ranges, xlabel, xlim',
                          [(-1, None, None, None),
-                          (-1, [None, None, xdata], 'x-axis', None)])
+                          (-1, [None, None, XDATA], 'x-axis', None)])
 def test_lineanimator_init(plot_axis_index, axis_ranges, xlabel, xlim):
     data = np.random.random((5, 5, 10))
     LineAnimator(data=data, plot_axis_index=plot_axis_index, axis_ranges=axis_ranges,
                  xlabel=xlabel, xlim=xlim)
+
+
+def test_lineanimator_init_nans():
+    data = np.random.random((5, 5, 10))
+    data[0][0][:] = np.nan
+    line_anim = LineAnimator(data=data, plot_axis_index=-1, axis_ranges=[None, None, XDATA],
+                             xlabel='x-axis', xlim=None, ylim=None)
+    assert line_anim.ylim[0] is not None
+    assert line_anim.ylim[1] is not None
+    assert line_anim.xlim[0] is not None
+    assert line_anim.xlim[1] is not None
 
 
 @figure_test
@@ -187,7 +198,5 @@ def test_lineanimator_figure():
     slider_axis0 = 0
     xdata = np.tile(np.linspace(
         0, 100, (data_shape0[plot_axis0] + 1)), (data_shape0[slider_axis0], 1))
-
     ani = LineAnimator(data0, plot_axis_index=plot_axis0, axis_ranges=[None, xdata])
-
     return ani.fig


### PR DESCRIPTION
This PR fixes a bug which occurs in setting the ylims by ```LineAnimator``` when there are non-finite values in the data array to be animated.