### PR TITLE
differential rotation now uses isot time instead of custom string.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,6 @@ asdf_extensions =
   sunpy = sunpy.io.special.asdf.extension:SunpyExtension
 
 [tool:pytest]
-minversion = 3.0
 testpaths = "sunpy" "docs"
 norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "examples" "sunpy[/\]cm" ".jupyter" ".history" "tools" "sunpy[\/]extern"
 doctest_plus = enabled

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -597,7 +597,7 @@ def differential_rotate(smap, observer=None, time=None, **diff_rot_kwargs):
     out_meta = deepcopy(smap.meta)
     if out_meta.get('date_obs', False):
         del out_meta['date_obs']
-    out_meta['date-obs'] = new_observer.obstime.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    out_meta['date-obs'] = new_observer.obstime.isot
 
     # Need to update the observer location for the output map.
     # Remove all the possible observer keys

--- a/sunpy/physics/tests/test_differential_rotation.py
+++ b/sunpy/physics/tests/test_differential_rotation.py
@@ -189,7 +189,7 @@ def test_differential_rotate_observer_full_disk(aia171_test_map):
     new_observer = get_earth(aia171_test_map.date + 6*u.hr)
     dmap = differential_rotate(aia171_test_map, observer=new_observer)
     assert dmap.data.shape == aia171_test_map.data.shape
-    assert dmap.date == new_observer.obstime
+    assert dmap.date.isot == new_observer.obstime.isot
     assert dmap.heliographic_latitude == new_observer.lat
     assert dmap.heliographic_longitude == new_observer.lon
 
@@ -204,7 +204,7 @@ def test_differential_rotate_observer_all_on_disk(all_on_disk_map):
     new_observer = get_earth(all_on_disk_map.date + 48*u.hr)
     dmap = differential_rotate(all_on_disk_map, observer=new_observer)
     assert dmap.data.shape[1] > all_on_disk_map.data.shape[1]
-    assert dmap.date == new_observer.obstime
+    assert dmap.date.isot == new_observer.obstime.isot
     assert dmap.heliographic_latitude == new_observer.lat
     assert dmap.heliographic_longitude == new_observer.lon
 
@@ -219,7 +219,7 @@ def test_differential_rotate_observer_straddles_limb(straddles_limb_map):
         dmap = differential_rotate(straddles_limb_map, observer=new_observer)
     assert dmap.data.shape[1] < straddles_limb_map.data.shape[1]
     # The output map should have the positional properties of the observer
-    assert dmap.date == new_observer.obstime
+    assert dmap.date.isot == new_observer.obstime.isot
     assert dmap.heliographic_latitude == new_observer.lat
     assert dmap.heliographic_longitude == new_observer.lon
 
@@ -232,7 +232,7 @@ def test_differential_rotate_time_full_disk(aia171_test_map):
         dmap = differential_rotate(aia171_test_map, time=new_time)
     assert dmap.data.shape == aia171_test_map.data.shape
     # The output map should have the same time as the new time now.
-    assert dmap.date == new_time
+    assert dmap.date.isot == new_time.isot
 
 
 def test_differential_rotate_time_all_on_disk(all_on_disk_map):
@@ -248,7 +248,7 @@ def test_differential_rotate_time_all_on_disk(all_on_disk_map):
         dmap = differential_rotate(all_on_disk_map, time=new_time)
     assert dmap.data.shape[1] > all_on_disk_map.data.shape[1]
     # The output map should have the same time as the new time now.
-    assert dmap.date == new_time
+    assert dmap.date.isot == new_time.isot
 
 
 def test_differential_rotate_time_straddles_limb(straddles_limb_map):
@@ -262,7 +262,7 @@ def test_differential_rotate_time_straddles_limb(straddles_limb_map):
             dmap = differential_rotate(straddles_limb_map, time=new_time)
     assert dmap.data.shape[1] < straddles_limb_map.data.shape[1]
     # The output map should have the same time as the new time now.
-    assert dmap.date == new_time
+    assert dmap.date.isot == new_time.isot
 
 
 def test_differential_rotate_time_off_disk(all_off_disk_map):

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ description =
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest -vvv -ra --pyargs sunpy --cov-report= --cov=sunpy --cov-config={toxinidir}/setup.cfg {toxinidir}/docs
+    PYTEST_COMMAND = pytest -vvv -s -ra --pyargs sunpy --cov-report= --cov=sunpy --cov-config={toxinidir}/setup.cfg {toxinidir}/docs
     devdeps,build_docs,online: HOME = {envtmpdir}
     SUNPY_SAMPLEDIR = {env:SUNPY_SAMPLEDIR:{toxinidir}/.tox/{envname}/sample_data/}
 passenv =
@@ -46,6 +46,9 @@ deps =
     setuptools
     # All our tests run in parallel which this plugin allows us to.
     pytest-xdist
+    # Since xdist uses stdout in order for it to work, we have to bypass this and use to
+    # capture any logging we might put in a test for debugging.
+    pytest-logger
     # The devdeps factor is intended to be used to install the latest developer version.
     # of key dependencies.
     devdeps: git+https://github.com/astropy/astropy


### PR DESCRIPTION
See if we compare the iso formatting instead if we avoid the 32bit fail.

Fixes https://github.com/sunpy/sunpy/issues/4559