### PR TITLE
fix names of test functions that were incorrectly named test_fitstoEIT

### DIFF
--- a/sunpy/map/sources/tests/test_cor_source.py
+++ b/sunpy/map/sources/tests/test_cor_source.py
@@ -17,7 +17,7 @@ cor = Map(fitspath)
 # COR Tests
 
 
-def test_fitstoEIT():
+def test_fitstoCOR():
     """Tests the creation of CORMap using FITS."""
     assert isinstance(cor, CORMap)
 

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -21,7 +21,7 @@ euvi = Map(fitspath)
 
 
 # EUVI Tests
-def test_fitstoEIT():
+def test_fitstoEUVI():
     """Tests the creation of EUVIMap using FITS."""
     assert isinstance(euvi, EUVIMap)
 

--- a/sunpy/map/sources/tests/test_lasco_source.py
+++ b/sunpy/map/sources/tests/test_lasco_source.py
@@ -17,7 +17,7 @@ lasco = Map(fitspath)
 # LASCO Tests
 
 
-def test_fitstoEIT():
+def test_fitstoLASCO():
     """Tests the creation of LASCOMap using FITS."""
     assert isinstance(lasco, LASCOMap)
 


### PR DESCRIPTION
When working on #4561 I noticed that some tests in the `sunpy.map.sources.tests` module were incorrectly named `test_fitstoEIT` even though they are for other instruments than EIT (LASCO, COR, and EUVI). Probably someone forgot to rename these accordingly after copy/paste. I have now adjusted the names of these test functions.