### PR TITLE
Propagate max_conn to fetch methods

### DIFF
--- a/changelog/4565.bugfix.rst
+++ b/changelog/4565.bugfix.rst
@@ -1,4 +1,4 @@
 The ``max_conn`` argument to :meth:`Fido.fetch` is now correctly handed to
 client fetch methods. This means clients that create their own downloader
-(e.g. the JSOC client) now properly respect ``max_conn`` when it is user
-specified.
+(e.g. the JSOC and VSO clients) now properly respect ``max_conn`` when it is
+user specified.

--- a/changelog/4565.bugfix.rst
+++ b/changelog/4565.bugfix.rst
@@ -1,0 +1,4 @@
+The ``max_conn`` argument to :meth:`Fido.fetch` is now correctly handed to
+client fetch methods. This means clients that create their own downloader
+(e.g. the JSOC client) now properly respect ``max_conn`` when it is user
+specified.

--- a/sunpy/net/base_client.py
+++ b/sunpy/net/base_client.py
@@ -239,7 +239,7 @@ class BaseClient(ABC):
             Replace files with the same name if True.
         progress : `bool`, optional
             Print progress info to terminal.
-        max_conns : `int`, optional
+        max_conn : `int`, optional
             Maximum number of download connections.
         downloader : `parfive.Downloader`, optional
             The download manager to use.

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -294,7 +294,7 @@ class GenericClient(BaseClient):
         return QueryResponse(metalist, client=self)
 
     def fetch(self, qres, path=None, overwrite=False,
-              progress=True, downloader=None, wait=True):
+              progress=True, max_conn=5, downloader=None, wait=True):
         """
         Download a set of results.
 
@@ -314,6 +314,8 @@ class GenericClient(BaseClient):
         progress : `bool`, optional
             If `True` show a progress bar showing how many of the total files
             have been downloaded. If `False`, no progress bar will be shown.
+        max_conn : `int`, optional
+            Maximum number of download connections.
         downloader : `parfive.Downloader`, optional
             The download manager to use.
         wait : `bool`, optional
@@ -337,7 +339,8 @@ class GenericClient(BaseClient):
         dl_set = True
         if not downloader:
             dl_set = False
-            downloader = Downloader(progress=progress, overwrite=overwrite)
+            downloader = Downloader(progress=progress, overwrite=overwrite,
+                                    max_conn=max_conn)
 
         for url, filename in zip(urls, paths):
             downloader.enqueue_file(url, filename=filename)

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -364,7 +364,8 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
             for block in query_result.responses:
                 reslist.append(block.client.fetch(block, path=path,
                                                   downloader=downloader,
-                                                  wait=False, **kwargs))
+                                                  wait=False, max_conn=max_conn,
+                                                  **kwargs))
 
         results = downloader.download()
         # Combine the results objects from all the clients into one Results

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -524,7 +524,7 @@ class VSOClient(BaseClient):
         return fname
 
     def fetch(self, query_response, path=None, methods=None, site=None,
-              progress=True, overwrite=False, downloader=None, wait=True):
+              progress=True, max_conn=5, overwrite=False, downloader=None, wait=True):
         """
         Download data specified in the query_response.
 
@@ -569,6 +569,9 @@ class VSOClient(BaseClient):
             If `True` show a progress bar showing how many of the total files
             have been downloaded. If `False`, no progress bars will be shown at all.
 
+        max_conn : `int`, optional
+            Maximum number of download connections.
+
         overwrite : `bool` or `str`, optional
             Determine how to handle downloading if a file already exists with the
             same name. If `False` the file download will be skipped and the path
@@ -602,7 +605,7 @@ class VSOClient(BaseClient):
         dl_set = True
         if not downloader:
             dl_set = False
-            downloader = Downloader(progress=progress)
+            downloader = Downloader(progress=progress, max_conn=max_conn)
 
         fileids = VSOClient.by_fileid(query_response)
         if not fileids:


### PR DESCRIPTION
Previously this wasn't handed, so for clients that created their own `Downloader` (e.g. JSOC) `max_conn` wasn't respected when passed to `Fido.fetch()`. Not sure what the best way is to add a test for this?