### PR TITLE
Respect max_conn in JSOC

### DIFF
--- a/changelog/4567.bugfix.rst
+++ b/changelog/4567.bugfix.rst
@@ -1,0 +1,3 @@
+The ``max_conn`` argument to :meth:`Fido.fetch` is now correctly respected by
+the JSOC client. Previously the JSOC client would default to 4 connections no
+matter what the value passed to :meth:`Fido.fetch` was.

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -618,18 +618,16 @@ class JSOCClient(BaseClient):
                     fname = os.path.expanduser(fname)
                     paths.append(fname)
 
-        if max_conn * kwargs['max_splits'] > 10:
-            warnings.warn(("JSOC does not support more than 10 parallel connections. " +
-                           "Changing the number of parallel connections to 8."), SunpyUserWarning)
-            kwargs['max_splits'] = 2
-            max_conn = 4
-
         dl_set = True
         if not downloader:
             dl_set = False
             downloader = Downloader(progress=progress, overwrite=overwrite, max_conn=max_conn)
-        else:
-            downloader.max_conn = max_conn
+
+        if max_conn * kwargs['max_splits'] > 10:
+            warnings.warn(("JSOC does not support more than 10 parallel connections. " +
+                           "Changing the number of parallel connections to 8."), SunpyUserWarning)
+            kwargs['max_splits'] = 2
+            downloader.max_conn = 4
 
         urls = []
         for request in requests:


### PR DESCRIPTION
The problem was that `downloader.max_conn` was manually set on an existing downloader, even if that downloader already had a custom value of `max_conn` set.