### PR TITLE
Use clip_interval thoroughly in the gallery examples

### DIFF
--- a/changelog/4573.docfix.rst
+++ b/changelog/4573.docfix.rst
@@ -1,0 +1,1 @@
+The keyword `clip_interval` is now used more extensively in gallery examples when plotting the sample AIA image (e.g., :ref:`sphx_glr_generated_gallery_plotting_aia_example.py`).

--- a/examples/map/map_rotation.py
+++ b/examples/map/map_rotation.py
@@ -29,7 +29,7 @@ aia_rotated = aia_map.rotate(angle=30 * u.deg)
 # Let's now plot the results.
 fig = plt.figure()
 ax = plt.subplot(projection=aia_rotated)
-aia_rotated.plot()
+aia_rotated.plot(clip_interval=(1, 99.99)*u.percent)
 aia_rotated.draw_limb()
 aia_rotated.draw_grid()
 plt.show()

--- a/examples/plotting/aia_example.py
+++ b/examples/plotting/aia_example.py
@@ -7,19 +7,37 @@ How to create a plot of a map.
 """
 import matplotlib.pyplot as plt
 
+import astropy.units as u
+
 import sunpy.map
 from sunpy.data.sample import AIA_171_IMAGE
 
 ###############################################################################
 # We start with the sample data
+
 aiamap = sunpy.map.Map(AIA_171_IMAGE)
 
 ##############################################################################
 # Let's plot the result. Setting the projection is necessary to ensure that
 # pixels can be converted accurately to coordinates values.
+
 plt.figure()
 ax = plt.subplot(projection=aiamap)
 aiamap.plot()
 aiamap.draw_limb()
 aiamap.draw_grid()
+
+##############################################################################
+# The above image looks "dark" because the color scale is accounting for the
+# small set of pixels that are extremely bright.  We can use the keyword
+# ``clip_interval`` to clip out pixels with extreme values.  Here, we clip out
+# the darkest 1% of pixels and the brightest 0.01% of pixels.
+
+plt.figure()
+ax = plt.subplot(projection=aiamap)
+aiamap.plot(clip_interval=(1, 99.99)*u.percent)
+aiamap.draw_limb()
+aiamap.draw_grid()
 plt.show()
+
+# sphinx_gallery_thumbnail_number = 2

--- a/examples/plotting/fading_between_maps.py
+++ b/examples/plotting/fading_between_maps.py
@@ -16,6 +16,8 @@ time from the same observation point.
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider
 
+import astropy.units as u
+
 import sunpy.map
 from sunpy.data.sample import AIA_171_IMAGE, AIA_1600_IMAGE
 
@@ -40,7 +42,7 @@ fig = plt.figure()
 ax = fig.add_axes([0.1, 0.2, 0.9, 0.7], projection=map_171)
 
 im_1600 = map_1600.plot(axes=ax)
-im_171 = map_171.plot(axes=ax, alpha=0.5)
+im_171 = map_171.plot(axes=ax, alpha=0.5, clip_interval=(1, 99.99)*u.percent)
 ax.set_title('AIA 171 + 1600')
 
 # Add the slider axes

--- a/examples/plotting/finegrained_plot.py
+++ b/examples/plotting/finegrained_plot.py
@@ -36,7 +36,7 @@ title_obsdate = aiamap_sub.date.strftime('%Y-%b-%d %H:%M:%S')
 
 fig = plt.figure(figsize=(6, 6))
 ax = plt.subplot(projection=aiamap_sub)
-aiamap_sub.plot()
+aiamap_sub.plot(clip_interval=(1, 99.99)*u.percent)
 aiamap_sub.draw_limb(color='white', linewidth=2, linestyle='dashed')
 
 # To have more control over the Heliographic Stonyhurst grid,

--- a/examples/plotting/great_arc_example.py
+++ b/examples/plotting/great_arc_example.py
@@ -34,7 +34,7 @@ great_arc = GreatArc(start, end)
 # Plot the great arc on the Sun.
 fig = plt.figure()
 ax = plt.subplot(projection=m)
-m.plot(axes=ax)
+m.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
 ax.plot_coord(great_arc.coordinates(), color='c')
 plt.show()
 

--- a/examples/plotting/lat_lon_lines.py
+++ b/examples/plotting/lat_lon_lines.py
@@ -53,7 +53,7 @@ hpc_lat0 = lat0.transform_to(aia.coordinate_frame)
 # grid as well for comparison.
 fig = plt.figure()
 ax = plt.subplot(projection=aia)
-aia.plot()
+aia.plot(clip_interval=(1, 99.99)*u.percent)
 ax.plot_coord(hpc_lat0, color="C0")
 ax.plot_coord(hpc_lon0, color="C0")
 aia.draw_grid()

--- a/examples/plotting/overplot_hek_polygon.py
+++ b/examples/plotting/overplot_hek_polygon.py
@@ -62,7 +62,7 @@ rotated_ch_boundary = solar_rotate_coordinate(ch_boundary, time=aia_map.date)
 # it with hatching.
 fig = plt.figure()
 ax = plt.subplot(projection=aia_map)
-aia_map.plot(axes=ax)
+aia_map.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
 ax.plot_coord(rotated_ch_boundary, color='c')
 ax.set_title('{:s}\n{:s}'.format(aia_map.name, ch['frm_specificid']))
 plt.colorbar()

--- a/examples/plotting/simple_differential_rotation.py
+++ b/examples/plotting/simple_differential_rotation.py
@@ -64,7 +64,7 @@ future_date = aia_map.date + dt
 
 fig = plt.figure()
 ax = plt.subplot(projection=aia_map)
-aia_map.plot()
+aia_map.plot(clip_interval=(1, 99.99)*u.percent)
 ax.set_title('The effect of {} days of differential rotation'.format(dt.to(u.day).value))
 aia_map.draw_grid()
 

--- a/examples/saving_and_loading_data/genericmap_in_asdf.py
+++ b/examples/saving_and_loading_data/genericmap_in_asdf.py
@@ -19,6 +19,7 @@ including ones created using custom FITS files.
 """
 
 import asdf
+import astropy.units as u
 
 import sunpy.data.sample
 import sunpy.map
@@ -27,7 +28,7 @@ import sunpy.map
 # We begin by creating an `~sunpy.map.sources.sdo.AIAMap` object using the
 # sample data.
 aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-aia_map.peek()
+aia_map.peek(clip_interval=(1, 99.99)*u.percent)
 
 ################################################################################
 # We can now save this object to an asdf file to use later. Saving it like this
@@ -49,4 +50,4 @@ with asdf.AsdfFile(tree) as asdf_file:
 # Astropy, SunPy and asdf installed. We can reload it like so:
 with asdf.open("sunpy_map.asdf") as asdf_file:
     reloaded_aia_map = asdf_file['aia_map']
-    reloaded_aia_map.peek()
+    reloaded_aia_map.peek(clip_interval=(1, 99.99)*u.percent)


### PR DESCRIPTION
* Used `clip_interval` for all of the gallery examples that have the dark-looking AIA image, except for the "Finding the brightest pixel" example
* Expanded the "Plotting a map" example to show the usage of `clip_interval`