### PR TITLE
Enable RotatedSunFrame to work with non-SunPy frames

### DIFF
--- a/changelog/4577.breaking.rst
+++ b/changelog/4577.breaking.rst
@@ -1,0 +1,1 @@
+The ``.size`` property of a coordinate frame with no associated data will now raise an error instead of returning 0.

--- a/changelog/4577.feature.rst
+++ b/changelog/4577.feature.rst
@@ -1,0 +1,1 @@
+Enable `~sunpy.coordinates.metaframes.RotatedSunFrame` to work with non-SunPy frames (e.g., `~astropy.coordinates.HeliocentricMeanEcliptic`).

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -140,14 +140,6 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
             data.lon.wrap_angle = self._wrap_angle
         return data
 
-    @property
-    def size(self):
-        """
-        Returns the size of the underlying data if it exists, else returns 0.  This overrides the
-        property in `~astropy.coordinates.BaseCoordinateFrame`.
-        """
-        return self.data.size if self.has_data else 0
-
     def __str__(self):
         """
         We override this here so that when you print a SkyCoord it shows the

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -12,7 +12,7 @@ from sunpy import log
 from sunpy.time import parse_time
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
-from .frames import HeliocentricInertial, SunPyBaseCoordinateFrame
+from .frames import HeliocentricInertial
 from .offset_frame import NorthOffsetFrame
 from .transformations import _transformation_debug
 
@@ -180,10 +180,6 @@ class RotatedSunFrame:
             # If a SkyCoord is provided, use the underlying frame
             if hasattr(base_frame, 'frame'):
                 base_frame = base_frame.frame
-
-            # The base frame needs to be a SunPy frame to have the overridden size() property
-            if not isinstance(base_frame, SunPyBaseCoordinateFrame):
-                raise TypeError("Only SunPy coordinate frames are currently supported.")
 
             newcls = _make_rotatedsun_cls(base_frame.__class__)
             return newcls.__new__(newcls, *args, **kwargs)

--- a/sunpy/coordinates/tests/test_metaframes.py
+++ b/sunpy/coordinates/tests/test_metaframes.py
@@ -2,7 +2,7 @@ import pytest
 from hypothesis import given, settings
 
 import astropy.units as u
-from astropy.coordinates import BaseCoordinateFrame, SkyCoord, frame_transform_graph
+from astropy.coordinates import HeliocentricMeanEcliptic, SkyCoord, frame_transform_graph
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 
@@ -64,8 +64,17 @@ def rot_hpc():
                             duration=4*u.day))
 
 
+# Test a non-SunPy frame
+@pytest.fixture
+def rot_hme():
+    return (HeliocentricMeanEcliptic,
+            RotatedSunFrame(lon=1*u.deg, lat=2*u.deg, distance=3*u.AU,
+                            base=HeliocentricMeanEcliptic(obstime='2001-01-01', equinox='2001-01-01'),
+                            duration=4*u.day))
+
+
 @pytest.mark.parametrize("indirect_fixture",
-                         ["rot_hgs", "rot_hgc", "rot_hci", "rot_hcc", "rot_hpc"], indirect=True)
+                         ["rot_hgs", "rot_hgc", "rot_hci", "rot_hcc", "rot_hpc", "rot_hme"], indirect=True)
 def test_class_creation(indirect_fixture):
     base_class, rot_frame = indirect_fixture
 
@@ -108,11 +117,6 @@ def test_as_base(rot_hgs):
 def test_no_base():
     with pytest.raises(TypeError):
         RotatedSunFrame()
-
-
-def test_no_sunpy_frame():
-    with pytest.raises(TypeError):
-        RotatedSunFrame(base=BaseCoordinateFrame)
 
 
 def test_no_obstime():


### PR DESCRIPTION
Edit by @ayshih : This PR enables `RotatedSunFrame` to work with non-SunPy frames.  This change required our minimum Astropy version to be at least 4.0, so this PR should not be backported.

There are two changes for #4000 issue