### PR TITLE
Update sun.py to use GeocentricTrueEcliptic

### DIFF
--- a/changelog/4584.trivial.rst
+++ b/changelog/4584.trivial.rst
@@ -1,0 +1,1 @@
+`~sunpy.coordinates.sun.apparent_longitude()` and `~sunpy.coordinates.sun.apparent_latitude()` functions will now use `~astropy.coordinates.GeocentricTrueEcliptic` coordinates

--- a/changelog/4584.trivial.rst
+++ b/changelog/4584.trivial.rst
@@ -1,1 +1,1 @@
-`~sunpy.coordinates.sun.apparent_longitude()` and `~sunpy.coordinates.sun.apparent_latitude()` functions will now use `~astropy.coordinates.GeocentricTrueEcliptic` coordinates
+`sunpy.sun` functions now make use of the `~astropy.coordinates.GeocentricTrueEcliptic` frame to simplify internal calculations, but the returned values are unchanged.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -12,6 +12,7 @@ from astropy.coordinates import (
     Distance,
     GeocentricMeanEcliptic,
     HeliocentricMeanEcliptic,
+    GeocentricTrueEcliptic,
     Latitude,
     Longitude,
     SkyCoord,
@@ -196,12 +197,11 @@ def apparent_longitude(t='now'):
     """
     time = parse_time(t)
     sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
-    coord = sun.transform_to(GeocentricMeanEcliptic(equinox=time))
+    coord = sun.transform_to(GeocentricTrueEcliptic(equinox=time))
 
     # Astropy's GeocentricMeanEcliptic already includes aberration, so only add nutation
-    jd1, jd2 = get_jd12(time, 'tt')
-    nut_lon, _ = erfa.nut06a(jd1, jd2)*u.radian
-    lon = coord.lon + nut_lon
+    # change to "Astropy's GeocentricTrueEcliptic already includes both aberration and nutation"?
+    lon = coord.lon
 
     return Longitude(lon)
 
@@ -241,9 +241,10 @@ def apparent_latitude(t='now'):
     """
     time = parse_time(t)
     sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
-    coord = sun.transform_to(GeocentricMeanEcliptic(equinox=time))
+    coord = sun.transform_to(GeocentricTrueEcliptic(equinox=time))
 
     # Astropy's GeocentricMeanEcliptic does not include nutation, but the contribution is negligible
+    # change to "Astropy's GeocentricTrueEcliptic already includes both aberration and nutation"?
     lat = coord.lat
 
     return Latitude(lat)

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -11,8 +11,8 @@ from astropy.coordinates import (
     Angle,
     Distance,
     GeocentricMeanEcliptic,
-    HeliocentricMeanEcliptic,
     GeocentricTrueEcliptic,
+    HeliocentricMeanEcliptic,
     Latitude,
     Longitude,
     SkyCoord,
@@ -199,8 +199,7 @@ def apparent_longitude(t='now'):
     sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
     coord = sun.transform_to(GeocentricTrueEcliptic(equinox=time))
 
-    # Astropy's GeocentricMeanEcliptic already includes aberration, so only add nutation
-    # change to "Astropy's GeocentricTrueEcliptic already includes both aberration and nutation"?
+    # Astropy's GeocentricTrueEcliptic includes both aberration and nutation
     lon = coord.lon
 
     return Longitude(lon)
@@ -243,8 +242,7 @@ def apparent_latitude(t='now'):
     sun = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='hcrs', obstime=time)
     coord = sun.transform_to(GeocentricTrueEcliptic(equinox=time))
 
-    # Astropy's GeocentricMeanEcliptic does not include nutation, but the contribution is negligible
-    # change to "Astropy's GeocentricTrueEcliptic already includes both aberration and nutation"?
+    # Astropy's GeocentricTrueEcliptic includes both aberration and nutation
     lat = coord.lat
 
     return Latitude(lat)


### PR DESCRIPTION
`GeocentricMeanEcliptic` coordinates were replaced by `GeocentricTrueEcliptic`
coordinates in `apparent_longitude()` and `apparent_latitude()` functions
due to changes in Astropy4.0
(#4000 issue)

Function `apparent_longitude()` contains explicit adding of nutation:
https://github.com/sunpy/sunpy/blob/master/sunpy/coordinates/sun.py#L202, 
which to some extent repeats the change added to the transformation functions for getting to/from ecliptic systems in https://github.com/astropy/astropy/pull/10129
(https://github.com/astropy/astropy/blob/master/astropy/coordinates/builtin_frames/ecliptic_transforms.py#L44)

Therefore this correction in `apparent_longitude()` was removed (after this removal all existing in `coordinates` module tests pass).
Can you review this calculation change please?

Edit by @ayshih : not to be backported