### PR TITLE
Remove self_test() references from docs

### DIFF
--- a/docs/guide/installation/advanced.rst
+++ b/docs/guide/installation/advanced.rst
@@ -67,7 +67,7 @@ However if you want to develop sunpy we would strongly recommend reading :ref:`n
     You can read more about how to do this in the `pip documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`__.
 
     Do **not** install sunpy or other third-party packages using ``sudo``.
-    
+
 sunpy's Requirements
 ********************
 

--- a/docs/guide/installation/advanced.rst
+++ b/docs/guide/installation/advanced.rst
@@ -67,25 +67,7 @@ However if you want to develop sunpy we would strongly recommend reading :ref:`n
     You can read more about how to do this in the `pip documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`__.
 
     Do **not** install sunpy or other third-party packages using ``sudo``.
-
-.. _testing-sunpy:
-
-Testing sunpy
-*************
-
-.. warning::
-    The tests will fail if you do not install all the optional dependencies.
-    If you have installed sunpy with conda-forge, you will be missing the ``pytest-mock`` package which will cause the test suite to fail.
-
-The easiest way to test your installed version of sunpy is running correctly is to use the :func:`sunpy.self_test`::
-
-    import sunpy
-    sunpy.self_test()
-
-which will run many of the sunpy tests.
-
-The tests should run and print out any failures, which you can report at the `sunpy issue tracker <https://github.com/sunpy/sunpy/issues>`__.
-
+    
 sunpy's Requirements
 ********************
 

--- a/docs/guide/installation/index.rst
+++ b/docs/guide/installation/index.rst
@@ -41,12 +41,9 @@ First configure conda for sunpy downloads::
     conda config --add channels conda-forge
     conda config --set channel_priority strict
 
-to install sunpy::
+and then to install sunpy::
 
     conda install sunpy
-
-You now have a working sunpy installation.
-You can check your sunpy install by following the instructions in :ref:`testing-sunpy`.
 
 Updating sunpy
 --------------


### PR DESCRIPTION
From a user perspective, using `self_test()` does not seem terribly useful, especially since it requires many un-documented requirements to pass. This has recently caused confusion (https://github.com/sunpy/sunpy/issues/3284, https://github.com/sunpy/sunpy/issues/4480), so I think we should remove mention of it from the user facing docs.

If it is to return, we should run a CI build to check that `self_test()` works fine. I think I am +1 for deprecating and removing `self_test()` altogether though, as I'm not sure what purpose it serves.