### PR TITLE
Allow sunpy.timeseries.TimeSeries to read in from pathlib.Path

### DIFF
--- a/changelog/4589.feature.rst
+++ b/changelog/4589.feature.rst
@@ -1,0 +1,1 @@
+Add support for pathlib.Path objects to be passed to `sunpy.timeseries.TimeSeries`.

--- a/changelog/4589.feature.rst
+++ b/changelog/4589.feature.rst
@@ -1,1 +1,1 @@
-Add support for pathlib.Path objects to be passed to `sunpy.timeseries.TimeSeries`.
+Add support for `pathlib.Path` objects to be passed to `sunpy.timeseries.TimeSeries`.

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import datetime
+from pathlib import Path
 from collections import OrderedDict
 
 import numpy as np
@@ -90,6 +91,12 @@ class TestTimeSeries:
             filepath, "eve", "*"), source='EVE', concatenate=True)
         assert isinstance(ts_from_glob, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
 
+    @pytest.mark.filterwarnings('ignore:Unknown units')
+    def test_factory_generate_from_pathlib(self):
+        # Test making a TimeSeries from a : pathlib.PosixPath
+        ts_from_pathlib = sunpy.timeseries.TimeSeries(Path(filepath).joinpath("gbm.fits"),
+                                                      source="GBMSummary")
+        assert isinstance(ts_from_pathlib, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)
 # =============================================================================
 # Individual Implicit Source Tests
 # =============================================================================

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -4,7 +4,6 @@ This module provies the `~sunpy.timeseries.TimeSeriesFactory` class.
 import os
 import copy
 import glob
-import pathlib
 from collections import OrderedDict
 from urllib.request import urlopen
 
@@ -327,7 +326,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                 data_header_pairs, filepaths = _apply_result(data_header_pairs, filepaths, result)
 
             # pathlib.Path
-            elif (isinstance(arg, pathlib.Path)):
+            elif (isinstance(arg, os.PathLike)):
                 result = self._read_file(arg.expanduser())
                 data_header_pairs, filepaths = _apply_result(data_header_pairs, filepaths, result)
 

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -327,7 +327,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                 data_header_pairs, filepaths = _apply_result(data_header_pairs, filepaths, result)
 
             # pathlib.Path
-            elif (isinstance(arg, pathlib.PosixPath)):
+            elif (isinstance(arg, pathlib.Path)):
                 result = self._read_file(arg.expanduser())
                 data_header_pairs, filepaths = _apply_result(data_header_pairs, filepaths, result)
 

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -248,7 +248,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         * tuples of (data, header, unit) (1)
         * data, header not in a tuple (1)
         * filename, which will be read
-        * pathlib.PosixPath, which is the filepath to a file to be read.
+        * `pathlib.Path`, which is the filepath to a file to be read.
         * directory, from which all files will be read
         * glob, from which all files will be read
         * url, which will be downloaded and read

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -4,6 +4,7 @@ This module provies the `~sunpy.timeseries.TimeSeriesFactory` class.
 import os
 import copy
 import glob
+import pathlib
 from collections import OrderedDict
 from urllib.request import urlopen
 
@@ -140,7 +141,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         """
         if 'source' not in kwargs.keys() or not kwargs['source']:
             try:
-                pairs = read_file(fname, **kwargs)
+                pairs = read_file(os.fspath(fname), **kwargs)
 
                 new_pairs = []
                 for pair in pairs:
@@ -247,6 +248,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         * tuples of (data, header, unit) (1)
         * data, header not in a tuple (1)
         * filename, which will be read
+        * pathlib.PosixPath, which is the filepath to a file to be read.
         * directory, from which all files will be read
         * glob, from which all files will be read
         * url, which will be downloaded and read
@@ -324,6 +326,11 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                 result = self._read_file(path, **kwargs)
                 data_header_pairs, filepaths = _apply_result(data_header_pairs, filepaths, result)
 
+            # pathlib.Path
+            elif (isinstance(arg, pathlib.PosixPath)):
+                result = self._read_file(arg.expanduser())
+                data_header_pairs, filepaths = _apply_result(data_header_pairs, filepaths, result)
+
             # Directory
             elif (isinstance(arg, str) and
                   os.path.isdir(os.path.expanduser(arg))):
@@ -359,6 +366,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                 path = download_file(url, get_and_create_download_dir())
                 result = self._read_file(path, **kwargs)
                 data_header_pairs, filepaths = _apply_result(data_header_pairs, filepaths, result)
+
             else:
                 raise NoMatchError("File not found or invalid input")
             i += 1


### PR DESCRIPTION
This PR is to allow `pathlib.Path` objects to be passed to to `sunpy.timeseries.TimeSeries()`

sunpy.map.Map already allows this
