### PR TITLE
Add attr for requesting cutouts from jsoc

### DIFF
--- a/changelog/4595.feature.rst
+++ b/changelog/4595.feature.rst
@@ -1,0 +1,2 @@
+Add `~sunpy.net.jsoc.attrs.Cutout` attr for requesting cutouts
+from JSOC via `~sunpy.net.jsoc.JSOCClient`.

--- a/changelog/4595.feature.rst
+++ b/changelog/4595.feature.rst
@@ -1,2 +1,2 @@
 Add `~sunpy.net.jsoc.attrs.Cutout` attr for requesting cutouts
-from JSOC via `~sunpy.net.jsoc.JSOCClient`.
+from JSOC via `~sunpy.net.jsoc.JSOCClient` and ``Fido``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -259,6 +259,8 @@ def rstjinja(app, docname, source):
         )
         source[0] = rendered
 
+# JSOC email os env
+os.environ["JSOC_EMAIL"] = "jsoc@cadair.com"
 
 # -- Sphinx setup --------------------------------------------------------------
 def setup(app):

--- a/examples/acquiring_data/downloading_cutouts.py
+++ b/examples/acquiring_data/downloading_cutouts.py
@@ -1,40 +1,93 @@
-from aiapy.util import sdo_location
+"""
+===============================================
+Requesting cutouts of AIA images from the JSOC
+===============================================
+
+This example shows how to request a cutout of a series of
+AIA images from the JSOC and animate the resulting sequence.
+"""
+import matplotlib.pyplot as plt
 
 import astropy.time
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from astropy.visualization import ImageNormalize, SqrtStretch
 
-from sunpy.coordinates import Helioprojective
-from sunpy.net import attrs, jsoc
+import sunpy.map
+from sunpy.net import Fido, attrs, jsoc
 
-tstart = astropy.time.Time('2015-10-17T04:33:30.000')
-duration = 12 * u.h
+#####################################################
+# First, query a full frame AIA image.
+t0 = astropy.time.Time('2012-09-24T14:56:03', scale='utc', format='isot')
+q = Fido.search(
+    attrs.Instrument.aia,
+    attrs.Physobs.intensity,
+    attrs.Wavelength(171*u.angstrom),
+    attrs.Time(t0, t0 + 13*u.s),
+)
+m = sunpy.map.Map(Fido.fetch(q))
 
-obs = sdo_location(tstart)
-frame = Helioprojective(observer=obs, obstime=obs.obstime)
+#####################################################
+# Next, we will create a submap from this image. We will
+# crop the field of view to active region NOAA 11575.
+m_cutout = m.submap(
+    SkyCoord(-500*u.arcsec, -275*u.arcsec, frame=m.coordinate_frame),
+    top_right=SkyCoord(150*u.arcsec, 375*u.arcsec, frame=m.coordinate_frame),
+)
+m_cutout.peek()
 
-width = 345.6 * u.arcsec
-height = 345.6 * u.arcsec
-Txc = -517.2 * u.arcsec
-Tyc = -246 * u.arcsec
-
-bottom_left = SkyCoord(Tx=Txc-width/2, Ty=Tyc-height/2, frame=frame)
-
+#####################################################
+# We want to watch the evolution of this active region
+# in time, but we do not want to download the full frame
+# image at each timestep. Instead, we will use our submap
+# to create a cutout request from the JSOC.
+#
+# First, create a `~sunpy.net.jsoc.JSOCClient` instance.
 c = jsoc.JSOCClient()
 
+#####################################################
+# Next, construct the cutout from the submap
+# above using the `~sunpy.net.jsoc.attrs.Cutout` attribute.
+cutout = jsoc.attrs.Cutout(
+    m_cutout.bottom_left_coord,
+    top_right=m_cutout.top_right_coord,
+    tracking=True
+)
+
+#####################################################
+# Now we are ready to construct the query. Note that all of this is
+# the same for a full-frame image except for the
+# cutout component.
 q = c.search(
-    attrs.Time(tstart, tstart + duration),
-    attrs.Wavelength(171*u.angstrom),
+    attrs.Time(m_cutout.date - 6*u.h, m_cutout.date + 6*u.h),
+    attrs.Wavelength(m_cutout.wavelength),
     attrs.Sample(12*u.min),
-    jsoc.attrs.Series('aia.lev1_euv_12s'),
-    jsoc.attrs.Notify('will.t.barnes@gmail.com'),
-    jsoc.attrs.Segment('image'),
-    jsoc.attrs.Cutout(bottom_left, width=width, height=height, tracking=True),
+    jsoc.attrs.Series.aia_lev1_euv_12s,
+    jsoc.attrs.Notify('jsoc@cadair.com'),  # Put your email here
+    jsoc.attrs.Segment.image,
+    cutout,
 )
-resp = c.request_data(q, method='url', protocol='fits')
-while not resp.has_succeeded():
+
+#####################################################
+# Submit the export request and download the data. This
+# may take some time as the data has to be processed and
+# downloaded.
+req = c.request_data(q, method='url', protocol='fits')
+while not req.has_succeeded():
     continue
-req = c.get_request(
-    resp,
-    path='/Users/willbarnes/Desktop/cutout-request-tests', max_conn=2,
-)
+files = c.get_request(req, max_conn=2)
+files.sort()
+
+#####################################################
+# Now that we've downloaded the files, we can create
+# a `~sunpy.map.MapSequence` from them.
+m_seq = sunpy.map.Map(files, sequence=True)
+
+#####################################################
+# Finally, we can construct an animation in time from
+# our stack of cutouts and interactively flip through
+# each image in our sequence.
+for m in m_seq:
+    m.plot_settings['norm'] = ImageNormalize(vmin=0, vmax=5e3, stretch=SqrtStretch())
+m_seq.peek()
+plt.show()

--- a/examples/acquiring_data/downloading_cutouts.py
+++ b/examples/acquiring_data/downloading_cutouts.py
@@ -1,0 +1,40 @@
+from aiapy.util import sdo_location
+
+import astropy.time
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+from sunpy.coordinates import Helioprojective
+from sunpy.net import attrs, jsoc
+
+tstart = astropy.time.Time('2015-10-17T04:33:30.000')
+duration = 12 * u.h
+
+obs = sdo_location(tstart)
+frame = Helioprojective(observer=obs, obstime=obs.obstime)
+
+width = 345.6 * u.arcsec
+height = 345.6 * u.arcsec
+Txc = -517.2 * u.arcsec
+Tyc = -246 * u.arcsec
+
+bottom_left = SkyCoord(Tx=Txc-width/2, Ty=Tyc-height/2, frame=frame)
+
+c = jsoc.JSOCClient()
+
+q = c.search(
+    attrs.Time(tstart, tstart + duration),
+    attrs.Wavelength(171*u.angstrom),
+    attrs.Sample(12*u.min),
+    jsoc.attrs.Series('aia.lev1_euv_12s'),
+    jsoc.attrs.Notify('will.t.barnes@gmail.com'),
+    jsoc.attrs.Segment('image'),
+    jsoc.attrs.Cutout(bottom_left, width=width, height=height, tracking=True),
+)
+resp = c.request_data(q, method='url', protocol='fits')
+while not resp.has_succeeded():
+    continue
+req = c.get_request(
+    resp,
+    path='/Users/willbarnes/Desktop/cutout-request-tests', max_conn=2,
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,8 +59,8 @@ map =
   scipy>=1.2.0
 net =
   beautifulsoup4
-  drms
   pandas>=0.23.0
+  drms>=0.6
   python-dateutil
   tqdm
   zeep

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -91,8 +91,8 @@ class Cutout(DataAttr):
 
     @u.quantity_input
     def __init__(self, bottom_left, top_right=None, width: u.arcsec = None,
-                 height: u.arcsec = None, tracking=False, register=False,
-                 nan_off_limb=False):
+                 height: u.arcsec = None, tracking = False, register = False,
+                 nan_off_limb = False):
         super().__init__()
         bl, tr = get_rectangle_coordinates(bottom_left, top_right=top_right, width=width,
                                            height=height)

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -92,7 +92,7 @@ class Cutout(DataAttr):
         self.value = {
             't_ref': bottom_left.obstime.isot,
             # JSOC input is disable tracking so take the negative
-            't': int(bool(~tracking)),
+            't': int(not tracking),
             'r': int(register),
             'c': int(nan_off_limb),
             'locunits': 'arcsec',

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -77,22 +77,43 @@ class Notify(SimpleAttr):
 
 class Cutout(DataAttr):
     """
-    Select a cutout region to be processed by JSOC
+    Select a cutout region.
+
+    The JSOC allows for users to request cutouts. This process is performed server
+    side so as to allow users to download only the portions of the full-disk images
+    they are interested in. For a detailed explanation of the routine
+    used to perform these cutouts on the JSOC server, see
+    http://jsoc.stanford.edu/doxygen_html/group__im__patch.html.
 
     Parameters
     ----------
-    bottom_left
-    width
-    height
-    tracking
-    register
-    nan_off_limb
+    bottom_left : `~astropy.coordinates.SkyCoord`
+        Coordinate for the bottom left corner of the cutout.
+    top_right : `~astropy.coordinates.SkyCoord`, optional
+        Coordinate for the top right corner of the cutout. If this is
+        not specified, both `width` and `height` must both be specified.
+    width : `~astropy.units.Quantity`, optional
+        Width of the cutout. If this parameter, along with `height`, is
+        not specified, `top_right` must be specified.
+    height : `~astropy.units.Quantity`, optional
+        Height of the cutout. If this parameter, along with `width`, is
+        not specified, `top_right` must be specified.
+    tracking : `bool`, optional
+        If True, the field of view follows the rotation of the Sun
+    register : `bool`, optional
+        If True, use sub-pixel registration when cropping to the target location.
+    nan_off_limb : `bool`, optional
+        If True, all off-limb pixels are set to NaN
+
+    See Also
+    --------
+    sunpy.coordinate.utils.get_rectangle_coordinates
     """
 
     @u.quantity_input
     def __init__(self, bottom_left, top_right=None, width: u.arcsec = None,
-                 height: u.arcsec = None, tracking = False, register = False,
-                 nan_off_limb = False):
+                 height: u.arcsec = None, tracking=False, register=False,
+                 nan_off_limb=False):
         super().__init__()
         bl, tr = get_rectangle_coordinates(bottom_left, top_right=top_right, width=width,
                                            height=height)

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -448,6 +448,7 @@ class JSOCClient(BaseClient):
             ds = self._make_recordset(**block)
             cd = drms.Client(email=block.get('notify', ''))
             protocol = block.get('protocol', 'fits')
+            cutout = block.get('cutout')
 
             if protocol not in supported_protocols:
                 error_message = f"Protocols other than {','.join(supported_protocols)} "\
@@ -457,10 +458,12 @@ class JSOCClient(BaseClient):
                 error_message = f"Methods other than {','.join(supported_methods)} "\
                                 "are not supported."
                 raise TypeError(error_message)
+            if cutout is not None:
+                process = {'im_patch': cutout}
 
             if method != 'url-tar':
                 method = 'url' if protocol == 'fits' else 'url_quick'
-            r = cd.export(ds, method=method, protocol=protocol)
+            r = cd.export(ds, method=method, protocol=protocol, process=process)
 
             requests.append(r)
 

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -458,8 +458,7 @@ class JSOCClient(BaseClient):
                 error_message = f"Methods other than {','.join(supported_methods)} "\
                                 "are not supported."
                 raise TypeError(error_message)
-            if cutout is not None:
-                process = {'im_patch': cutout}
+            process = {'im_patch': cutout} if cutout is not None else None
 
             if method != 'url-tar':
                 method = 'url' if protocol == 'fits' else 'url_quick'

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -915,7 +915,8 @@ class JSOCClient(BaseClient):
 
         required = {a.jsoc.Series}
         optional = {a.jsoc.Protocol, a.jsoc.Notify, a.Wavelength, a.Time,
-                    a.jsoc.Segment, a.jsoc.Keys, a.jsoc.PrimeKey, a.Sample}
+                    a.jsoc.Segment, a.jsoc.Keys, a.jsoc.PrimeKey, a.Sample,
+                    a.jsoc.Cutout}
         return cls.check_attr_types_in_query(query, required, optional)
 
     @classmethod


### PR DESCRIPTION
Fixes #1259 

Currently, this PR also relies on sunpy/drms#43 and should not be merged until a new version of drms is released that includes that PR.

- [x] Add example usage in `JSOCClient` docs or example gallery
- [x] Attr docstring
- [x] Tests???
- [x] Changelog

Documentation for the `im_patch`: http://jsoc.stanford.edu/doxygen_html/group__im__patch.html

Example usage:

```python
import astropy.time
import astropy.units as u
from astropy.coordinates import SkyCoord

from sunpy.net import jsoc
from sunpy.net import attrs
from sunpy.coordinates import Helioprojective

from aiapy.util import sdo_location

tstart = astropy.time.Time('2015-10-17T04:33:30.000')
duration = 1 * u.minute

obs = sdo_location(tstart)
frame = Helioprojective(observer=obs, obstime=obs.obstime)

width = 345.6 * u.arcsec
height = 345.6 * u.arcsec
Txc = -517.2 * u.arcsec
Tyc = -246 * u.arcsec

bottom_left = SkyCoord(Tx=Txc-width/2, Ty=Tyc-height/2, frame=frame)

c = jsoc.JSOCClient()

q = c.search(
    attrs.Time(tstart, tstart + duration),
    attrs.Wavelength(171*u.angstrom),
    attrs.Sample(12*u.s),
    jsoc.attrs.Series('aia.lev1_euv_12s'),
    jsoc.attrs.Notify('first.last@email.com'),
    jsoc.attrs.Segment('image'),
    jsoc.attrs.Cutout(bottom_left, width, height, tracking=True),
)

req = c.request_data(q)
resp = c.get_request(req)
```