### PR TITLE
Metadata search returns astropy table, only selected keys

### DIFF
--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -821,13 +821,10 @@ class JSOCClient(BaseClient):
         """
 
         keywords_default = ['T_REC', 'TELESCOP', 'INSTRUME', 'WAVELNTH', 'CAR_ROT']
-        isMeta = iargs.get('meta', False)
         c = drms.Client()
+        is_meta = iargs.get('meta', False)
 
-        if isMeta:
-            keywords = '**ALL**'
-        else:
-            keywords = iargs.get('keys', keywords_default)
+        keywords = iargs.get('keys', '**ALL**' if is_meta else keywords_default)
 
         if 'series' not in iargs:
             error_message = "Series must be specified for a JSOC Query"
@@ -891,12 +888,7 @@ class JSOCClient(BaseClient):
         else:
             key = keywords
 
-        r = c.query(ds, key=key, rec_index=isMeta)
-
-        # If the method was called from search_metadata(), return a Pandas Dataframe,
-        # otherwise return astropy.table
-        if isMeta:
-            return r
+        r = c.query(ds, key=key, rec_index=is_meta)
 
         if r is None or r.empty:
             return astropy.table.Table()


### PR DESCRIPTION
Fixes #3293

Fixes a bug where `JSOCClient.search_metadata` was not respecting `sunpy.net.jsoc.attrs.Keys`. The default keys for `search_metadata` are now `**ALL**`.

Also makes `search_metadata` return an astropy table rather than a Pandas dataframe.

This may clash with #4358 