### PR TITLE
Fix velocity transformations

### DIFF
--- a/changelog/4613.bugfix.rst
+++ b/changelog/4613.bugfix.rst
@@ -1,0 +1,2 @@
+The transformations between `~astropy.coordinates.HCRS` and `~sunpy.coordinates.frames.HeliographicStonyhurst` have been re-implemented to enable the proper transformations of velocities.
+All ephemeris functions (e.g., :func:`~sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst`) now return properly calculated velocities when ``include_velocity=True`` is specified.

--- a/docs/code_ref/coordinates/velocities.rst
+++ b/docs/code_ref/coordinates/velocities.rst
@@ -17,13 +17,13 @@ For SunPy's frames, the names of the velocities components are the names of the 
     >>> import sunpy.coordinates
 
     >>> sc = SkyCoord(lon=10*u.deg, lat=20*u.deg, distance=1*u.AU,
-    ...               d_lon=3*u.deg/u.hr, d_lat=4*u.arcmin/u.s, d_distance=5*u.km/u.min,
+    ...               d_lon=3*u.arcmin/u.week, d_lat=4*u.arcmin/u.d, d_distance=5*u.km/u.min,
     ...               frame='heliocentricinertial', obstime='2021-01-01')
     >>> sc
     <SkyCoord (HeliocentricInertial: obstime=2021-01-01T00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
         (10., 20., 1.)
      (d_lon, d_lat, d_distance) in (arcsec / s, arcsec / s, km / s)
-        (3., 240., 0.08333333)>
+        (0.00029762, 0.00277778, 0.08333333)>
 
 See :ref:`astropy-coordinates-velocities` for ways to add velocity information to existing coordinates.
 
@@ -37,7 +37,7 @@ For any of these functions, if ``include_velocity=True`` is specified, the retur
     <HeliographicStonyhurst Coordinate (obstime=2021-01-01T00:00:00.000): (lon, lat, radius) in (deg, deg, AU)
         (-156.46460438, -1.38836399, 0.43234904)
      (d_lon, d_lat, d_radius) in (arcsec / s, arcsec / s, km / s)
-        (0.22182829, 0.01918094, 4.48628112)>
+        (0.09138133, 0.00720229, -7.2513617)>
 
 Transforming velocities
 =======================
@@ -49,29 +49,27 @@ The transformation of the velocity vector between two coordinate frames takes in
 Orientation change
 ------------------
 To illustrate the orientation change, let's start with the `~astropy.coordinates.SkyCoord` created at the beginning, which was defined in the `~sunpy.coordinates.frames.HeliocentricInertial` frame.
-We transform to Astropy's `~astropy.coordinates.HeliocentricMeanEcliptic` frame, which is a different (inertial) frame that is also centered at the Sun::
+We transform to Astropy's `~astropy.coordinates.HCRS` frame, which is a different inertial [#inertial]_ frame that is also centered at the Sun::
 
-    >>> from astropy.coordinates import HeliocentricMeanEcliptic
-    >>> sc_hme = sc.transform_to(HeliocentricMeanEcliptic(obstime=sc.obstime, equinox=sc.obstime))
-    >>> sc_hme
-    <SkyCoord (HeliocentricMeanEcliptic: equinox=2021-01-01T00:00:00.000, obstime=2021-01-01T00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
-        (83.36817059, 21.0956815, 1.)
-     (pm_lon_coslat, pm_lat, radial_velocity) in (mas / yr, mas / yr, km / s)
-        (-9.20951242e+11, 7.51812315e+12, -8.39980585)>
+    >>> sc_hcrs = sc.transform_to('hcrs')
+    >>> sc_hcrs
+    <SkyCoord (HCRS: obstime=2021-01-01T00:00:00.000): (ra, dec, distance) in (deg, deg, AU)
+        (80.95428245, 44.31500877, 1.)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (-8828397.4990187, 87659732.13232313, 0.08333338)>
 
-
-Even though the velocity vectors are oriented very differently, their amplitudes are (nearly) the same::
+Even though the velocity vectors are oriented very differently in their respective spherical coordinates, their amplitudes are essentially the same::
 
     >>> sc.velocity.norm()
-    <Quantity 174077.03416762 km / s>
-    >>> sc_hme.velocity.norm()
-    <Quantity 174076.43119097 km / s>
+    <Quantity 2.02654081 km / s>
+    >>> sc_hcrs.velocity.norm()
+    <Quantity 2.02654083 km / s>
 
 Induced velocity
 ----------------
 To illustrate "induced" velocity, consider the `~sunpy.coordinates.frames.HeliographicStonyhurst` frame, which is defined such that the Earth is always at zero degrees longitude.
 That is, this frame rotates around the Sun over time to "follow" the Earth.
-Accordingly, the Earth's velocity vector will be negligible in this frame::
+Accordingly, the longitude component of Earth's velocity vector will be negligible in this frame::
 
     >>> from sunpy.coordinates import get_earth
     >>> earth = get_earth('2021-01-01', include_velocity=True)
@@ -79,7 +77,7 @@ Accordingly, the Earth's velocity vector will be negligible in this frame::
     <SkyCoord (HeliographicStonyhurst: obstime=2021-01-01T00:00:00.000): (lon, lat, radius) in (deg, deg, AU)
         (0., -3.02983361, 0.98326486)
      (d_lon, d_lat, d_radius) in (arcsec / s, arcsec / s, km / s)
-        (0., 0., 0.)>
+        (1.82278759e-09, -0.00487486, -0.01720926)>
 
 Transforming this coordinate to the `~sunpy.coordinates.frames.HeliocentricInertial` frame, which does not rotate over time, confirms that the Earth is moving in inertial space at the expected ~1 degree/day in heliographic longitude::
 
@@ -87,13 +85,13 @@ Transforming this coordinate to the `~sunpy.coordinates.frames.HeliocentricInert
     <SkyCoord (HeliocentricInertial: obstime=2021-01-01T00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
         (24.55623543, -3.02983361, 0.98326486)
      (d_lon, d_lat, d_distance) in (arcsec / s, arcsec / s, km / s)
-        (0.0422321, -1.20583253e-13, -1.62464e-09)>
+        (0.0422321, -0.00487486, -0.01720925)>
     >>> earth.heliocentricinertial.d_lon.to('deg/d')
     <Quantity 1.01357048 deg / d>
 
 Transforming over time
 ======================
-As the transformation framework is currently implemented, transforming between frames with different values of ``obstime`` takes into account any time dependency for the definitions of the frames, but does *not* incorporate any notion of the coordinate itself in moving in inertial space.
+As the transformation framework is currently implemented, transforming between frames with different values of ``obstime`` takes into account any time dependency for the definitions of the frames, but does *not* incorporate any notion of the coordinate itself moving in inertial space.
 This behavior does not change even if there is velocity information attached to the coordinate.
 For example, if we take the same coordinate created earlier for Earth, and transform it to one day later::
 
@@ -102,7 +100,7 @@ For example, if we take the same coordinate created earlier for Earth, and trans
     <SkyCoord (HeliographicStonyhurst: obstime=2021-01-02T00:00:00.000): (lon, lat, radius) in (deg, deg, AU)
         (-1.01325847, -3.02987313, 0.98326043)
      (d_lon, d_lat, d_radius) in (arcsec / s, arcsec / s, km / s)
-        ...
+        (-1.15705401e-05, -0.00487486, -0.01698849)>
 
 Note that the location of the Earth in the new frame is ~-1 degree in longitude, as opposed to zero degrees.
 That is, this coordinate represents the location of Earth on 2021 January 1 using axes that are defined using the location of Earth on 2021 January 2.
@@ -111,3 +109,4 @@ Footnotes
 =========
 
 .. [#differentials] Differentials of position with respect to units other than time are also possible, but are not currently well supported.
+.. [#inertial] While `~sunpy.coordinates.frames.HeliocentricInertial` and `~astropy.coordinates.HCRS` have fixed axes directions, strictly speaking the small motion of the origin (the Sun) will induce a translational velocity relative to `~astropy.coordinates.ICRS`, but that aspect will cancel out in the transformation.

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -90,7 +90,7 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include
     <HeliographicStonyhurst Coordinate (obstime=2001-02-03T00:00:00.000): (lon, lat, radius) in (deg, deg, AU)
         (63.03105777, -5.20656151, 1.6251161)
      (d_lon, d_lat, d_radius) in (arcsec / s, arcsec / s, km / s)
-        (0.007552, 0.00037353, -28.43105538)>
+        (-0.02323686, 0.00073376, -1.4798387)>
 
     Transform that same location and velocity of Mars to a different frame using
     `~astropy.coordinates.SkyCoord`.
@@ -102,7 +102,7 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include
         (7.835757e-15, -0.00766698, 1.01475668)>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
         (-298029.94625805, -21753.50941181, 1.40010091)
      (d_Tx, d_Ty, d_distance) in (arcsec / s, arcsec / s, km / s)
-        (-0.02787759, -0.00312481, -58.67123579)>
+        (-0.01652981, -0.00059216, -15.14320414)>
     """
     obstime = parse_time(time)
 
@@ -164,9 +164,9 @@ def get_earth(time='now', *, include_velocity=False):
 
     Notes
     -----
-    The Earth's velocity in the output coordinate will invariably be negligible because the
-    `~sunpy.coordinates.frames.HeliographicStonyhurst` frame rotates in time such that the XZ-plane
-    tracks Earth.
+    The Earth's velocity in the output coordinate will invariably be negligible in the longitude
+    direction because the `~sunpy.coordinates.frames.HeliographicStonyhurst` frame rotates in time
+    such that the plane of zero longitude (the XZ-plane) tracks Earth.
 
     Examples
     --------
@@ -178,12 +178,12 @@ def get_earth(time='now', *, include_velocity=False):
     <SkyCoord (HeliographicStonyhurst: obstime=2001-02-03T04:05:06.000): (lon, lat, radius) in (deg, deg, AU)
         (0., -6.18656962, 0.98567647)
      (d_lon, d_lat, d_radius) in (arcsec / s, arcsec / s, km / s)
-        (0., 0., 0.)>
+        (6.42643739e-11, -0.00279484, 0.24968506)>
     >>> get_earth('2001-02-03 04:05:06', include_velocity=True).transform_to('heliocentricinertial')
     <SkyCoord (HeliocentricInertial: obstime=2001-02-03T04:05:06.000): (lon, lat, distance) in (deg, deg, AU)
         (58.41594489, -6.18656962, 0.98567647)
      (d_lon, d_lat, d_distance) in (arcsec / s, arcsec / s, km / s)
-        (0.0424104, 0., 0.)>
+        (0.0424104, -0.00279484, 0.2496851)>
     """
     earth = get_body_heliographic_stonyhurst('earth', time=time, include_velocity=include_velocity)
 

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import astropy
 import astropy.units as u
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (
@@ -515,7 +514,6 @@ def test_hpc_hgs_implicit_hcc():
     assert_quantity_allclose(implicit.separation_3d(explicit2), 0*u.AU, atol=1e-10*u.AU)
 
 
-@pytest.mark.skipif(astropy.__version__ < '3.2.0', reason="Not supported by Astropy <3.2")
 def test_velocity_hcrs_hgs():
     # Obtain the position/velocity of Earth in ICRS
     obstime = Time(['2019-01-01', '2019-04-01', '2019-07-01', '2019-10-01'])
@@ -523,18 +521,14 @@ def test_velocity_hcrs_hgs():
     loc = pos.with_differentials(vel.represent_as(CartesianDifferential))
     earth = SkyCoord(loc, frame='icrs', obstime=obstime)
 
-    # The velocity of Earth in HGS should be very close to zero.  The velocity in the HGS Y
-    # direction is slightly further away from zero because there is true latitudinal motion.
+    # The velocity of Earth in HGS Y should be very close to zero because the XZ plane tracks
+    # the Earth.
     new = earth.heliographic_stonyhurst
-    assert_quantity_allclose(new.velocity.d_x, 0*u.km/u.s, atol=1e-15*u.km/u.s)
-    assert_quantity_allclose(new.velocity.d_y, 0*u.km/u.s, atol=1e-14*u.km/u.s)
-    assert_quantity_allclose(new.velocity.d_x, 0*u.km/u.s, atol=1e-15*u.km/u.s)
+    assert_quantity_allclose(new.velocity.d_y, 0*u.km/u.s, atol=1e-5*u.km/u.s)
 
     # Test the loopback to ICRS
     newer = new.icrs
-    assert_quantity_allclose(newer.velocity.d_x, vel.x)
-    assert_quantity_allclose(newer.velocity.d_y, vel.y)
-    assert_quantity_allclose(newer.velocity.d_z, vel.z)
+    assert_quantity_allclose(newer.velocity.d_xyz, vel.xyz)
 
 
 def test_velocity_hgs_hgc():


### PR DESCRIPTION
It turns out that I screwed up the velocity transformations for the HCRS<->HGS transformations (currently implemented as `AffineTransform`), due to a fundamental misbelief that I could correct for the induced angular velocity that results from the HGS frame rotating over time relative to the HCRS frames.  My correction was additionally flawed even given that misbelief, but there's actually no right way to do it while using `AffineTransform`.  Because the HCRS<->HGS transformation gets used for all the ephemeris functions (e.g., `get_body_heliographic_stonyhurst()`), all of the returned velocities were wrong, even for the Earth.

This PR re-implements the HCRS<->HGS transformations as `FunctionTransformWithFiniteDifference`.  The induced angular velocity is then automatically calculated as part of the finite-difference approach to transforming velocities. 
 Two new tests have been added, and existing tests and documentation have been updated.

In principle this fix should be backported because this flaw has been present since 1.1, but the velocity functionality hasn't actually been exposed to the user prior to 2.1.