### PR TITLE
Remove deprecated positional arguments to map methods

### DIFF
--- a/changelog/4616.breaking.rst
+++ b/changelog/4616.breaking.rst
@@ -1,0 +1,6 @@
+The following `~sunpy.map.Map` methods have had support for specific positional
+arguments removed. They must now be passed as keyword arguments
+(i.e. ``m.method(keyword_arg=value)``).
+
+- :meth:`~sunpy.map.Map.submap`: ``width``, ``height``.
+- :meth:`~sunpy.map.Map.draw_rectangle`: ``width``, ``height``, ``axes``, ``top_right``.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1445,8 +1445,6 @@ class GenericMap(NDData):
         top_right : `astropy.units.Quantity` or `~astropy.coordinates.SkyCoord`, optional
             The top-right coordinate of the rectangle. If ``top_right`` is
             specified ``width`` and ``height`` must be omitted.
-            Passing this as a positional argument is deprecated, you must pass
-            it as ``top_right=...``.
         width : `astropy.units.Quantity`, optional
             The width of the rectangle. Required if ``top_right`` is omitted.
         height : `astropy.units.Quantity`
@@ -1889,13 +1887,10 @@ class GenericMap(NDData):
             have shape ``(2,)`` to simultaneously define ``top_right``.
         top_right : `~astropy.coordinates.SkyCoord`
             The top-right coordinate of the rectangle.
-            Passing this as a positional argument is deprecated.
         width : `astropy.units.Quantity`, optional
             The width of the rectangle. Required if ``top_right`` is omitted.
-            Passing this as a positional argument is deprecated.
         height : `astropy.units.Quantity`
             The height of the rectangle. Required if ``top_right`` is omitted.
-            Passing this as a positional argument is deprecated.
         axes : `matplotlib.axes.Axes`
             The axes on which to plot the rectangle, defaults to the current
             axes.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -36,7 +36,7 @@ from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import MetaDict, expand_list
-from sunpy.util.decorators import cached_property_based_on, deprecate_positional_args_since, deprecated
+from sunpy.util.decorators import cached_property_based_on, deprecated
 from sunpy.util.exceptions import SunpyMetadataWarning, SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
@@ -1427,7 +1427,6 @@ class GenericMap(NDData):
 
         return new_map
 
-    @deprecate_positional_args_since(since='2.0', keyword_only=('width', 'height'))
     @u.quantity_input
     def submap(self, bottom_left, *, top_right=None, width: (u.deg, u.pix) = None, height: (u.deg, u.pix) = None):
         """
@@ -1870,7 +1869,6 @@ class GenericMap(NDData):
 
         return [circ]
 
-    @deprecate_positional_args_since(since='2.0')
     @u.quantity_input
     def draw_rectangle(self, bottom_left, *, width: u.deg = None, height: u.deg = None,
                        axes=None, top_right=None, **kwargs):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -989,46 +989,6 @@ height_pix = 2 * u.pix
 width_deg = 20 * u.arcsec
 height_deg = 20 * u.arcsec
 
-
-def test_deprecated_submap_inputs(generic_map2, coords):
-    bl_coord, tr_coord, bl_tr_coord = coords
-    # deprecated
-    with pytest.warns(SunpyDeprecationWarning):
-        smap = generic_map2.submap(bl_coord, tr_coord)
-    assert u.allclose(smap.dimensions, (3, 3) * u.pix)
-
-    with pytest.warns(SunpyDeprecationWarning):
-        smap = generic_map2.submap(bl_pix, tr_pix)
-    assert u.allclose(smap.dimensions, (3, 3) * u.pix)
-
-    # error
-    with pytest.raises(TypeError, match="width must be specified as a keyword argument"):
-        generic_map2.submap(bl_coord, width_deg, height_deg)
-
-    with pytest.raises(TypeError, match="width must be specified as a keyword argument"):
-        generic_map2.submap(bl_pix, width_pix, height_pix)
-
-    with pytest.warns(SunpyDeprecationWarning):
-        with pytest.raises(ValueError,
-                           match="Either top_right alone or both width and height must be specified."):
-            generic_map2.submap(bl_coord, width_deg, height=height_deg)
-
-    with pytest.warns(SunpyDeprecationWarning):
-        with pytest.raises(ValueError,
-                           match="Either top_right alone or both width and height must be specified"):
-            generic_map2.submap(bl_pix, width_pix, height=height_pix)
-
-    with pytest.warns(SunpyDeprecationWarning):
-        with pytest.raises(TypeError,
-                           match="Invalid input, top_right must be of type SkyCoord or BaseCoordinateFrame."):
-            generic_map2.submap(bl_coord, width_deg)
-
-    with pytest.warns(SunpyDeprecationWarning):
-        with pytest.raises(ValueError,
-                           match="Either top_right alone or both width and height must be specified"):
-            generic_map2.submap(bl_pix, width_pix, height=height_pix)
-
-
 @pytest.mark.skip
 def test_submap_kwarg_only_input_errors(generic_map2, coords):
     """

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -989,7 +989,7 @@ height_pix = 2 * u.pix
 width_deg = 20 * u.arcsec
 height_deg = 20 * u.arcsec
 
-@pytest.mark.skip
+
 def test_submap_kwarg_only_input_errors(generic_map2, coords):
     """
     This test replaces the one above when the deprecation period is over.
@@ -1007,42 +1007,6 @@ def test_submap_kwarg_only_input_errors(generic_map2, coords):
     for args, kwargs in inputs:
         with pytest.raises(TypeError, match="too many positional arguments"):
             generic_map2.submap(*args, **kwargs)
-
-
-def test_submap_kwarg_only_input_errors(generic_map2, coords):
-    bl_coord, tr_coord, bl_tr_coord = coords
-
-    inputs = (
-        dict(width=width_pix),
-        dict(top_right=tr_pix, width=width_pix),
-        dict(top_right=tr_pix, height=height_pix),
-        dict(),  # Only post deprecation
-    )
-    for kwargs in inputs:
-        with pytest.raises(ValueError, match="top_right alone or both width and height "
-                                             "must be specified"):
-            generic_map2.submap(bl_pix, **kwargs)
-
-    with pytest.raises(TypeError, match="width and height must be a Quantity in units of pixels"):
-        generic_map2.submap(bl_pix, width=width_deg, height=height_deg)
-
-    with pytest.raises(TypeError,
-                       match="top_right must be a Quantity in units of pixels."):
-        generic_map2.submap([10, 10]*u.deg, top_right=[10, 10]*u.deg)
-
-    with pytest.raises(ValueError, match=r"must have shape \(2\, \)"):
-        generic_map2.submap(10*u.pix, top_right=10*u.pix)
-
-    with pytest.raises(ValueError, match=r"must have shape \(2\, \)"):
-        generic_map2.submap([10, 10, 10]*u.pix, top_right=[10, 10, 10]*u.pix)
-
-    with pytest.raises(u.UnitsError):
-        generic_map2.submap([10, 10]*u.deg, width=10*u.km, height=10*u.J)
-
-    with pytest.raises(ValueError,
-                       match="either bottom_left and top_right or bottom_left and height and width should be provided"):
-        generic_map2.submap(SkyCoord([10, 10, 10]*u.deg, [10, 10, 10]*u.deg,
-                                     frame=generic_map2.coordinate_frame))
 
 
 def test_submap_inputs(generic_map2, coords):


### PR DESCRIPTION
These were deprecated in 2.0 (an LTS), so good to go in 2.1.