### PR TITLE
Add note about observer_coord in fits header helper

### DIFF
--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -89,6 +89,11 @@ def make_fitswcs_header(data, coordinate,
     `~sunpy.util.MetaDict`
         The header information required for making a `sunpy.map.GenericMap`.
 
+    Notes
+    -----
+    The observer coordinate is taken from the observer property of the ``reference_pixel``
+    argument.
+
     Examples
     --------
     >>> import sunpy.map


### PR DESCRIPTION
I seem to periodically get confused about how to give an observer coordinate to the header helper, and last time I opened an issue before someone pointed out that it is just the observer on the `reference_pixel` coordinate. Hopefully this small addition will prevent that confusion in the future (both for me and others).