### PR TITLE
Support observer information in WCS

### DIFF
--- a/changelog/4620.breaking.rst
+++ b/changelog/4620.breaking.rst
@@ -1,0 +1,2 @@
+The sunpy specific attributes ``.heliographic_observer`` and ``.rsun``
+are no longer set on the `~astropy.wcs.WCS` returned by `sunpy.map.Map.wcs`.

--- a/changelog/4620.feature.rst
+++ b/changelog/4620.feature.rst
@@ -1,0 +1,3 @@
+sunpy now sets auxillary parameters on `sunpy.map.Map.wcs` using the
+`astropy.wcs.wcs.aux` attribute. This stores observer information, along with
+the reference solar radius if present.

--- a/changelog/4620.removal.rst
+++ b/changelog/4620.removal.rst
@@ -1,0 +1,3 @@
+Support for :func:`sunpy.coordinates.wcs_utils.solar_wcs_frame_mapping` to
+use the ``.heliographic_observer`` and ``.rsun`` attributes on a
+`~astropy.wcs.WCS` is depreacted, and will raise an error in sunpy 3.1.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -94,11 +94,10 @@ Here's an example of creating a header from some generic data and an `astropy.co
     crval2: 0.0
     ...
     date-obs: 2013-10-28T00:00:00.000
+    rsun_ref: 695700000.0
+    dsun_obs: 148644585949.49
     hgln_obs: 0.0
     hglt_obs: 4.7711570596394
-    dsun_obs: 148644585949.49176
-    rsun_ref: 695700000.0
-    rsun_obs: 965.3829548285768
 
 
 From this we can see now that the function returned a `sunpy.util.MetaDict` that populated
@@ -127,11 +126,10 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
     crval2: 0.0
     ...
     date-obs: 2013-10-28T00:00:00.000
+    rsun_ref: 695700000.0
+    dsun_obs: 148644585949.49
     hgln_obs: 0.0
     hglt_obs: 4.7711570596394
-    dsun_obs: 148644585949.49176
-    rsun_ref: 695700000.0
-    rsun_obs: 965.3829548285768
 
 As we can see, a list of WCS and observer meta information is contained within the generated headers,
 however we may want to include other meta information including the observatory name, the wavelength and

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -2,8 +2,8 @@
 import numpy as np
 import pytest
 
-from astropy.coordinates import BaseCoordinateFrame
 import astropy.units as u
+from astropy.coordinates import BaseCoordinateFrame
 from astropy.wcs import WCS
 
 import sunpy.map

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -1,7 +1,9 @@
 
 import numpy as np
+import pytest
 
 from astropy.coordinates import BaseCoordinateFrame
+import astropy.units as u
 from astropy.wcs import WCS
 
 import sunpy.map
@@ -11,7 +13,8 @@ from sunpy.coordinates.frames import (
     HeliographicStonyhurst,
     Helioprojective,
 )
-from ..wcs_utils import solar_frame_to_wcs_mapping, solar_wcs_frame_mapping
+from sunpy.util import SunpyUserWarning
+from ..wcs_utils import _set_wcs_aux_obs_coord, solar_frame_to_wcs_mapping, solar_wcs_frame_mapping
 
 
 def test_hpc():
@@ -68,13 +71,10 @@ def test_none():
     assert result is None
 
 
-def test_wcs_extras():
+def test_wcs_aux():
     """
-    To enable proper creation of the coordinate systems, Map sticks three extra
-    attributes on the WCS object:
-    * heliographic_longitude
-    * heliographic_latitude
-    * dsun
+    Make sure auxillary information round trips properly from coordinate frames
+    to WCS and back.
     """
     data = np.ones([6, 6], dtype=np.float64)
     header = {'CRVAL1': 0,
@@ -105,11 +105,10 @@ def test_wcs_extras():
     generic_map = sunpy.map.Map((data, header))
 
     wcs = generic_map.wcs
-
-    assert wcs.heliographic_observer.lat.value == 0
-    assert wcs.heliographic_observer.lon.value == 0
-    assert wcs.heliographic_observer.radius.value == 10
-    assert wcs.rsun.value == header['rsun_ref']
+    assert wcs.wcs.aux.hglt_obs == 0
+    assert wcs.wcs.aux.hgln_obs == 0
+    assert wcs.wcs.aux.dsun_obs == 10
+    assert wcs.wcs.aux.rsun_ref == header['rsun_ref']
 
     result = solar_wcs_frame_mapping(wcs)
 
@@ -129,8 +128,10 @@ def test_hpc_frame_to_wcs():
     assert result_wcs.wcs.ctype[0] == 'HPLN-TAN'
     assert result_wcs.wcs.cunit[0] == 'arcsec'
     assert result_wcs.wcs.dateobs == '2013-10-28T00:00:00.000'
-    assert isinstance(result_wcs.heliographic_observer, HeliographicStonyhurst)
-    assert result_wcs.rsun == frame.rsun
+
+    new_frame = solar_wcs_frame_mapping(result_wcs)
+    assert isinstance(new_frame.observer, HeliographicStonyhurst)
+    assert new_frame.rsun == frame.rsun
 
     # Test a frame with no obstime and no observer
     frame = Helioprojective()
@@ -141,8 +142,10 @@ def test_hpc_frame_to_wcs():
     assert result_wcs.wcs.ctype[0] == 'HPLN-TAN'
     assert result_wcs.wcs.cunit[0] == 'arcsec'
     assert result_wcs.wcs.dateobs == ''
-    assert result_wcs.heliographic_observer is None
-    assert result_wcs.rsun == frame.rsun
+
+    new_frame = solar_wcs_frame_mapping(result_wcs)
+    assert new_frame.observer is None
+    assert new_frame.rsun == frame.rsun
 
 
 def test_hgs_frame_to_wcs():
@@ -195,7 +198,9 @@ def test_hcc_frame_to_wcs():
 
     assert result_wcs.wcs.ctype[0] == 'SOLX'
     assert result_wcs.wcs.dateobs == '2013-10-28T00:00:00.000'
-    assert isinstance(result_wcs.heliographic_observer, HeliographicStonyhurst)
+
+    new_frame = solar_wcs_frame_mapping(result_wcs)
+    assert isinstance(new_frame.observer, HeliographicStonyhurst)
 
     # Test a frame with no obstime and no observer
     frame = Heliocentric()
@@ -205,10 +210,50 @@ def test_hcc_frame_to_wcs():
 
     assert result_wcs.wcs.ctype[0] == 'SOLX'
     assert result_wcs.wcs.dateobs == ''
-    assert result_wcs.heliographic_observer is None
+
+    new_frame = solar_wcs_frame_mapping(result_wcs)
+    assert new_frame.observer is None
 
 
 def test_non_sunpy_frame_to_wcs():
     # For a non-SunPy frame, our mapping should return None
     frame = BaseCoordinateFrame()
     assert solar_frame_to_wcs_mapping(frame) is None
+
+
+def test_attribute_warnings():
+    # Check that warnings are raised if we try to convert a WCS with .rsun
+    # or .heliographic_observer attributes
+    wcs = WCS(naxis=2)
+    wcs.rsun = None
+    with pytest.warns(SunpyUserWarning,
+                      match='Support for the .rsun attribute on a WCS is deprecated'):
+        solar_wcs_frame_mapping(wcs)
+
+    wcs = WCS(naxis=2)
+    wcs.heliographic_observer = None
+    with pytest.warns(SunpyUserWarning,
+                      match='upport for the .heliographic_observer attribute on a WCS is deprecated'):
+        solar_wcs_frame_mapping(wcs)
+
+
+def test_set_wcs_aux():
+    wcs = WCS(naxis=2)
+    observer = Helioprojective(observer="earth", obstime='2013-10-28').observer
+    _set_wcs_aux_obs_coord(wcs, observer)
+    assert wcs.wcs.aux.hgln_obs == 0
+    assert u.allclose(wcs.wcs.aux.hglt_obs, 4.7711570596394015)
+    assert u.allclose(wcs.wcs.aux.dsun_obs, 148644585949.4918)
+    assert wcs.wcs.aux.crln_obs is None
+
+    wcs = WCS(naxis=2)
+    observer = observer.transform_to(HeliographicCarrington(observer=observer))
+    _set_wcs_aux_obs_coord(wcs, observer)
+    assert wcs.wcs.aux.hgln_obs is None
+    assert u.allclose(wcs.wcs.aux.hglt_obs, 4.7711570596394015)
+    assert u.allclose(wcs.wcs.aux.dsun_obs, 148644585949.4918)
+    assert u.allclose(wcs.wcs.aux.crln_obs, 326.05139910339886)
+
+    observer = observer.transform_to(Heliocentric(observer=observer))
+    with pytest.raises(ValueError, match='obs_coord must be in a Stonyhurst or Carrington frame'):
+        _set_wcs_aux_obs_coord(wcs, observer)

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -128,10 +128,6 @@ def make_fitswcs_header(data, coordinate,
 
     meta_wcs = _get_wcs_meta(coordinate, projection_code)
 
-    if hasattr(coordinate, "observer") and isinstance(coordinate.observer, frames.BaseCoordinateFrame):
-        meta_observer = get_observer_meta(coordinate.observer, getattr(coordinate, 'rsun', None))
-        meta_wcs.update(meta_observer)
-
     meta_instrument = _get_instrument_meta(instrument, telescope, observatory, wavelength, exposure)
     meta_wcs.update(meta_instrument)
 

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -89,7 +89,7 @@ def test_make_fits_header(map_data, hpc_test_header, hgc_test_header,
     assert header['crval1'] == 0
     assert header['crpix1'] == 5.5
     assert header['ctype1'] == 'HPLN-TAN'
-    assert header['dsun_obs'] == hpc_test_header.frame.observer.radius.to_value(u.m)
+    assert u.allclose(header['dsun_obs'], hpc_test_header.frame.observer.radius.to_value(u.m))
     assert isinstance(WCS(header), WCS)
 
     # Check no observer info for HGS
@@ -99,7 +99,7 @@ def test_make_fits_header(map_data, hpc_test_header, hgc_test_header,
 
     # Check for observer info for HGC
     header = sunpy.map.make_fitswcs_header(map_data, hgc_test_header)
-    assert header['dsun_obs'] == hgc_test_header.frame.observer.radius.to_value(u.m)
+    assert u.allclose(header['dsun_obs'], hgc_test_header.frame.observer.radius.to_value(u.m))
     assert isinstance(WCS(header), WCS)
 
     # Check arguments not given as astropy Quantities

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -577,14 +577,14 @@ def test_resample(simple_map, shape):
     # Check that the corner coordinates of the input and output are the same
     resampled_lower_left = resampled.pixel_to_world(-0.5 * u.pix, -0.5 * u.pix)
     original_lower_left = simple_map.pixel_to_world(-0.5 * u.pix, -0.5 * u.pix)
-    assert resampled_lower_left.Tx == original_lower_left.Tx
-    assert resampled_lower_left.Ty == original_lower_left.Ty
+    assert u.allclose(resampled_lower_left.Tx, original_lower_left.Tx)
+    assert u.allclose(resampled_lower_left.Ty, original_lower_left.Ty)
 
     resampled_upper_left = resampled.pixel_to_world((shape[0] - 0.5) * u.pix,
                                                     (shape[1] - 0.5) * u.pix)
     original_upper_left = simple_map.pixel_to_world(2.5 * u.pix, 2.5 * u.pix)
-    assert resampled_upper_left.Tx == original_upper_left.Tx
-    assert resampled_upper_left.Ty == original_upper_left.Ty
+    assert u.allclose(resampled_upper_left.Tx, original_upper_left.Tx)
+    assert u.allclose(resampled_upper_left.Ty, original_upper_left.Ty)
 
 
 resample_test_data = [('linear', (100, 200) * u.pixel), ('neighbor', (128, 256) * u.pixel),
@@ -772,12 +772,7 @@ def test_rotate_invalid_order(generic_map):
 def test_as_mpl_axes_aia171(aia171_test_map):
     ax = plt.subplot(projection=aia171_test_map)
     assert isinstance(ax, wcsaxes.WCSAxes)
-    # This test doesn't work, it seems that WCSAxes copies or changes the WCS
-    # object.
-    #  assert ax.wcs is aia171_test_map.wcs
     assert all([ct1 == ct2 for ct1, ct2 in zip(ax.wcs.wcs.ctype, aia171_test_map.wcs.wcs.ctype)])
-    # Map adds these attributes, so we use them to check.
-    assert hasattr(ax.wcs, 'heliographic_observer')
 
 
 def test_pixel_to_world_no_projection(generic_map):

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_403.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_403.json
@@ -22,7 +22,7 @@
     "sunpy.map.tests.test_plotting.test_plot_masked_aia171_nowcsaxes": "69e28235fa42379a94f7da6cc39b375f361d1e26dc0f94e6b8c5f05894cc64c7",
     "sunpy.map.tests.test_plotting.test_plot_masked_aia171_superpixel": "154586d5635f895b5f9170353f70f427e23ab0be4ccabf743e668864653f54e3",
     "sunpy.map.tests.test_plotting.test_plot_masked_aia171_superpixel_nowcsaxes": "ec4cfe2687ea0a1f62f1a80f07e69ef5a89ef5aa2dbebc58599fb16b98ebafcb",
-    "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "878fedb8b890018434ca66aa09b8aacc5c2bd6a39b4cbefed36121998aca2bcc",
+    "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "06ed44d872a6e1e5ec2dd6a522ee81f68a2c8420dea1bc7491bc64d9e3d3e147",
     "sunpy.map.tests.test_plotting.test_rectangle_aia171_top_right": "455246d338564add5be94c1dc0ff5740a90d21d8ef7da9f392ba3a01237ef5b8",
     "sunpy.map.tests.test_plotting.test_rectangle_aia171_width_height": "455246d338564add5be94c1dc0ff5740a90d21d8ef7da9f392ba3a01237ef5b8",
     "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -22,7 +22,7 @@
     "sunpy.map.tests.test_plotting.test_plot_masked_aia171_nowcsaxes": "69e28235fa42379a94f7da6cc39b375f361d1e26dc0f94e6b8c5f05894cc64c7",
     "sunpy.map.tests.test_plotting.test_plot_masked_aia171_superpixel": "154586d5635f895b5f9170353f70f427e23ab0be4ccabf743e668864653f54e3",
     "sunpy.map.tests.test_plotting.test_plot_masked_aia171_superpixel_nowcsaxes": "ec4cfe2687ea0a1f62f1a80f07e69ef5a89ef5aa2dbebc58599fb16b98ebafcb",
-    "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "332a529f1fd181d20381a290df889bdd2e6873277a0989c9ba5d97de024ffe76",
+    "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "d07b653c762bf20478ea33e9712e4eacd7bd0a0fc8dbe16964e8b4374f40120d",
     "sunpy.map.tests.test_plotting.test_rectangle_aia171_top_right": "455246d338564add5be94c1dc0ff5740a90d21d8ef7da9f392ba3a01237ef5b8",
     "sunpy.map.tests.test_plotting.test_rectangle_aia171_width_height": "455246d338564add5be94c1dc0ff5740a90d21d8ef7da9f392ba3a01237ef5b8",
     "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ deps =
     32bit: cryptography<3.0
 
     # Figure tests need a tightly controlled environment
-    figure-!devdeps: astropy==4.0.1.post1
+    figure-!devdeps: astropy==4.0.3
     figure-!devdeps: matplotlib==3.3.2
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/3643, fixes https://github.com/sunpy/sunpy/issues/2910.

This is the minimal update needed to get observer coordinates stored in the WCS working properly. There are more general ways to do this, but I went down that rabbit hole and it is not pretty (AIA, I'm looking at you and your many observer coordinate keywords...).

Hopefully this is a good base to start from and make improvements though. I have milestoned as 2.1 as it would be good to get this in 1 release before a LTS to make sure it works.