### PR TITLE
Force use of units when contouring

### DIFF
--- a/examples/map/map_contouring.py
+++ b/examples/map/map_contouring.py
@@ -18,11 +18,17 @@ from sunpy.data.sample import AIA_193_IMAGE
 aiamap = sunpy.map.Map(AIA_193_IMAGE)
 
 ###############################################################################
-# Now find the contours
+# In find a set of contours, we have to provide the level to contour in the
+# same units as the map data. To find out the units we can inspect
+# `sunpy.map.Map.unit`.
+print(aiamap.unit)
+###############################################################################
+# We can see that the units of this map are ``ct``, or counts. We can now
+# chose a contour level, and use the contour method to extract the contours.
 contours = aiamap.contour(50000 * u.ct)
 
 ##############################################################################
-# Finally, plot the map and add the contours
+# Finally, we can plot the map, and add each of the contours in turn.
 plt.figure()
 ax = plt.subplot(projection=aiamap)
 aiamap.plot()

--- a/examples/map/map_contouring.py
+++ b/examples/map/map_contouring.py
@@ -6,8 +6,9 @@ Finding contours of a map
 
 This example shows how to find and plot contours on a map.
 """
-
 import matplotlib.pyplot as plt
+
+import astropy.units as u
 
 import sunpy.map
 from sunpy.data.sample import AIA_193_IMAGE
@@ -18,7 +19,7 @@ aiamap = sunpy.map.Map(AIA_193_IMAGE)
 
 ###############################################################################
 # Now find the contours
-contours = aiamap.contour(50000)
+contours = aiamap.contour(50000 * u.ct)
 
 ##############################################################################
 # Finally, plot the map and add the contours

--- a/examples/map/map_contouring.py
+++ b/examples/map/map_contouring.py
@@ -24,7 +24,8 @@ aiamap = sunpy.map.Map(AIA_193_IMAGE)
 print(aiamap.unit)
 ###############################################################################
 # We can see that the units of this map are ``ct``, or counts. We can now
-# chose a contour level, and use the contour method to extract the contours.
+# chose a contour level, and use the :meth:`~sunpy.map.GenericMap.contour`
+# method to extract the contours.
 contours = aiamap.contour(50000 * u.ct)
 
 ##############################################################################

--- a/examples/map/map_contouring.py
+++ b/examples/map/map_contouring.py
@@ -18,7 +18,7 @@ from sunpy.data.sample import AIA_193_IMAGE
 aiamap = sunpy.map.Map(AIA_193_IMAGE)
 
 ###############################################################################
-# In find a set of contours, we have to provide the level to contour in the
+# In finding a set of contours, we have to provide the level to contour in the
 # same units as the map data. To find out the units we can inspect
 # `sunpy.map.GenericMap.unit`.
 print(aiamap.unit)

--- a/examples/map/map_contouring.py
+++ b/examples/map/map_contouring.py
@@ -20,8 +20,9 @@ aiamap = sunpy.map.Map(AIA_193_IMAGE)
 ###############################################################################
 # In find a set of contours, we have to provide the level to contour in the
 # same units as the map data. To find out the units we can inspect
-# `sunpy.map.Map.unit`.
+# `sunpy.map.GenericMap.unit`.
 print(aiamap.unit)
+
 ###############################################################################
 # We can see that the units of this map are ``ct``, or counts. We can now
 # chose a contour level, and use the :meth:`~sunpy.map.GenericMap.contour`

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2203,7 +2203,7 @@ class GenericMap(NDData):
         if self.unit is not None:
             try:
                 level = level.to_value(self.unit)
-            # Catch cases where level is a float or can't be converted
+            # Catch cases where level can't be converted or isn't a Quantity
             except (AttributeError, u.UnitConversionError) as e:
                 raise ValueError(f'level must be an astropy quantity convertible to {self.unit}') from e
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2181,6 +2181,20 @@ class GenericMap(NDData):
         contours: list of (n,2) `~astropy.coordinates.SkyCoord`
             Coordinates of each contour.
 
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> from astropy.coordinates import SkyCoord
+        >>> import sunpy.map
+        >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
+        >>> aia = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
+        >>> contours = aia.contour(50000 * u.ct)  # doctest: +REMOTE_DATA
+        >>> print(contours[0])  # doctest: +REMOTE_DATA
+            <SkyCoord (Helioprojective: obstime=2011-06-07T06:33:02.770, rsun=696000000.0 m, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.770): (lon, lat, radius) in (deg, deg, m)
+        (-0.00406308, 0.04787238, 1.51846026e+11)>): (Tx, Ty) in arcsec
+        [(719.59798458, -352.60839064), (717.19243987, -353.75348121),
+        ...
+
         See also
         --------
         `skimage.measure.find_contours`

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2205,7 +2205,7 @@ class GenericMap(NDData):
                 level = level.to_value(self.unit)
             # Catch cases where level can't be converted or isn't a Quantity
             except (AttributeError, u.UnitConversionError) as e:
-                raise ValueError(f'level must be an astropy quantity convertible to {self.unit}') from e
+                raise u.UnitsError(f'level must be an astropy quantity convertible to {self.unit}') from e
 
         contours = measure.find_contours(self.data, level=level, **kwargs)
         contours = [self.wcs.array_index_to_world(c[:, 0], c[:, 1]) for c in contours]

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2184,7 +2184,6 @@ class GenericMap(NDData):
         Examples
         --------
         >>> import astropy.units as u
-        >>> from astropy.coordinates import SkyCoord
         >>> import sunpy.map
         >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
         >>> aia = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1035,6 +1035,22 @@ def test_contour(simple_map):
     assert u.allclose(contour.Ty, [0.5, 0, -0.5, 0, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
 
 
+def test_contour_units(simple_map):
+    # Check that contouring with units works as intended
+    simple_map.meta['bunit'] = 'm'
+    contours = simple_map.contour(1.5 * u.m)
+    assert len(contours) == 1
+
+    contours_cm = simple_map.contour(150 * u.cm)
+    for c1, c2 in zip(contours, contours_cm):
+        np.all(c1 == c2)
+
+    with pytest.raises(ValueError, match='level must be an astropy quantity convertible to m'):
+        simple_map.contour(1.5)
+    with pytest.raises(ValueError, match='level must be an astropy quantity convertible to m'):
+        simple_map.contour(1.5 * u.s)
+
+
 def test_print_map(generic_map):
     out_repr = generic_map.__repr__()
     assert isinstance(out_repr, str)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1045,9 +1045,9 @@ def test_contour_units(simple_map):
     for c1, c2 in zip(contours, contours_cm):
         np.all(c1 == c2)
 
-    with pytest.raises(ValueError, match='level must be an astropy quantity convertible to m'):
+    with pytest.raises(u.UnitsError, match='level must be an astropy quantity convertible to m'):
         simple_map.contour(1.5)
-    with pytest.raises(ValueError, match='level must be an astropy quantity convertible to m'):
+    with pytest.raises(u.UnitsError, match='level must be an astropy quantity convertible to m'):
         simple_map.contour(1.5 * u.s)
 
 


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/4651. This forces the use of a quantity to contour when a map has it's unit attribute set.