### PR TITLE
Allow the observer designation of 'self' for a HeliographicCarrington coordinate

### DIFF
--- a/changelog/4659.feature.rst
+++ b/changelog/4659.feature.rst
@@ -1,0 +1,2 @@
+The `~sunpy.coordinates.frames.HeliographicCarrington` frame now accepts the specification of ``observer='self'`` to indicate that the coordinate itself is also the observer for the coordinate frame.
+This functionality greatly simplifies working with locations of observatories that are provided in Carrington coordinates.

--- a/docs/code_ref/coordinates/index.rst
+++ b/docs/code_ref/coordinates/index.rst
@@ -240,6 +240,8 @@ transformations cannot be performed.
 The location of the observer is automatically populated from meta data when
 coordinate frames are created using map.
 
+In the case of `~sunpy.coordinates.frames.HeliographicCarrington`, one can specify ``observer='self'`` to indicate that the coordinate itself should be used as the observer for defining the coordinate frame.
+
 It is possible to convert from a `~sunpy.coordinates.frames.Helioprojective`
 frame with one observer location to another
 `~sunpy.coordinates.frames.Helioprojective` frame with a different observer

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -135,7 +135,7 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
             # If the observer is a string and we have obstime then calculate
             # the position of the observer.
             if isinstance(observer, str):
-                if obstime is not None:
+                if observer != "self" and obstime is not None:
                     new_observer = self._convert_string_to_coord(observer.lower(), obstime)
                     new_observer.object_name = observer
                     setattr(instance, '_' + self.name, new_observer)

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -259,6 +259,12 @@ class HeliographicCarrington(BaseHeliographic):
         HeliographicCarrington(lon, lat, obstime=obstime, observer=observer)
         HeliographicCarrington(lon, lat, radius, obstime=obstime, observer=observer)
 
+    If you want to define the location in HGC such that the observer for the coordinate frame is
+    the same as that location (e.g., the location of an observatory in its corresponding HGC
+    frame), use ``observer='self'``::
+
+        HeliographicCarrington(lon, lat, radius, obstime=obstime, observer='self')
+
     Parameters
     ----------
     {data}
@@ -281,9 +287,11 @@ class HeliographicCarrington(BaseHeliographic):
         (1., 2., 3.)>
 
     >>> sc = SkyCoord([1,2,3]*u.deg, [4,5,6]*u.deg, [5,6,7]*u.km,
-    ...               obstime="2010/01/01T00:00:45", frame="heliographic_carrington")
+    ...               obstime="2010/01/01T00:00:45",
+    ...               observer="self",
+    ...               frame="heliographic_carrington")
     >>> sc
-    <SkyCoord (HeliographicCarrington: obstime=2010-01-01T00:00:45.000, observer=None): (lon, lat, radius) in (deg, deg, km)
+    <SkyCoord (HeliographicCarrington: obstime=2010-01-01T00:00:45.000, observer=self): (lon, lat, radius) in (deg, deg, km)
         [(1., 4., 5.), (2., 5., 6.), (3., 6., 7.)]>
 
     >>> sc = SkyCoord(CartesianRepresentation(0*u.km, 45*u.km, 2*u.km),

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -9,7 +9,7 @@ from astropy.time import Time
 from sunpy.coordinates import frames, get_earth
 from sunpy.time import parse_time
 from ..frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy
-from ..frames import HeliocentricInertial, HeliographicStonyhurst, Helioprojective
+from ..frames import HeliocentricInertial, HeliographicCarrington, HeliographicStonyhurst, Helioprojective
 
 
 @pytest.fixture
@@ -153,6 +153,14 @@ def test_coord_get():
     assert hasattr(obs, "object_name")
     assert obs.object_name == "mars"
     assert str(obs) == "<HeliographicStonyhurst Coordinate for 'mars'>"
+
+
+def test_observer_self_get():
+    hgc_noobstime = HeliographicCarrington(observer="self")
+    assert hgc_noobstime.observer == "self"
+
+    hgc_obstime = HeliographicCarrington(observer="self", obstime="2001-01-01")
+    assert hgc_obstime.observer == "self"
 
 
 def test_default_hcc_observer():

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -399,6 +399,24 @@ def test_hgc_self_observer():
     assert_quantity_allclose(hgc_loop.radius, hgc.radius)
 
 
+def test_hgc_loopback_self_observer():
+    # Test the HGC loopback where only one end has observer='self'
+    obstime = Time('2001-01-01')
+    coord = HeliographicCarrington(10*u.deg, 20*u.deg, 3*u.AU, observer='self', obstime=obstime)
+
+    new_observer = HeliographicStonyhurst(40*u.deg, 50*u.deg, 6*u.AU)
+    new_frame = HeliographicCarrington(observer=new_observer, obstime=obstime)
+
+    new_coord = coord.transform_to(new_frame)
+
+    # Manually calculate the longitude shift due to the difference in Sun-observer distance
+    lon = (6*u.AU - 3*u.AU) / speed_of_light * sidereal_rotation_rate
+
+    assert_quantity_allclose(new_coord.lon, coord.lon + lon)
+    assert_quantity_allclose(new_coord.lat, coord.lat)
+    assert_quantity_allclose(new_coord.radius, coord.radius)
+
+
 def test_hcc_hcc():
     # Test same observer and changing obstime
     observer = HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU, obstime='2001-02-01')

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -372,6 +372,33 @@ def test_hgc_hgc_different_observers():
     assert_quantity_allclose(sc_hgc_mars.lon - sc_hgc_sun.lon, ltt_mars * sidereal_rotation_rate)
 
 
+def test_hgc_self_observer():
+    # Test specifying observer='self' for HGC
+    obstime = Time('2001-01-01')
+    hgc = HeliographicCarrington(10*u.deg, 20*u.deg, 3*u.AU, observer='self', obstime=obstime)
+
+    # Transform to HGS (i.e., observer='self' in the source frame)
+    hgs = hgc.transform_to(HeliographicStonyhurst(obstime=obstime))
+
+    # Manually calculate the post-transformation longitude
+    lon = sun.L0(obstime,
+                 light_travel_time_correction=False,
+                 nearest_point=False,
+                 aberration_correction=False)
+    lon += (hgc.radius - _RSUN) / speed_of_light * sidereal_rotation_rate
+
+    assert_quantity_allclose(Longitude(hgs.lon + lon), hgc.lon)
+    assert_quantity_allclose(hgs.lat, hgc.lat)
+    assert_quantity_allclose(hgs.radius, hgc.radius)
+
+    # Transform back to HGC (i.e., observer='self' in the destination frame)
+    hgc_loop = hgs.transform_to(hgc.replicate_without_data())
+
+    assert_quantity_allclose(hgc_loop.lon, hgc.lon)
+    assert_quantity_allclose(hgc_loop.lat, hgc.lat)
+    assert_quantity_allclose(hgc_loop.radius, hgc.radius)
+
+
 def test_hcc_hcc():
     # Test same observer and changing obstime
     observer = HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU, obstime='2001-02-01')

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -200,9 +200,13 @@ def _observers_are_equal(obs_1, obs_2):
                            "requires the destination observer to be specified, as the "
                            f"source observer is set to {obs_1}.")
     if isinstance(obs_1, str):
+        if obs_1 == "self":
+            return False
         raise ConvertError("The source observer needs to have `obstime` set because the "
                            "destination observer is different.")
     if isinstance(obs_2, str):
+        if obs_2 == "self":
+            return False
         raise ConvertError("The destination observer needs to have `obstime` set because the "
                            "source observer is different.")
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -857,22 +857,10 @@ class GenericMap(NDData):
             if all(meta_list):
                 sc = SkyCoord(obstime=self.date, **kwargs)
 
-                # We need to specially handle an observer location provided in Carrington
-                # coordinates.  To create the observer coordinate, we need to specify the
-                # frame, but defining a Carrington frame normally requires specifying the
-                # frame's observer.  This loop is the problem.  Instead, since the
-                # Carrington frame needs only the Sun-observer distance component from the
-                # frame's observer, we create the same frame using a fake observer that has
-                # the same Sun-observer distance.
+                # If the observer location is supplied in Carrington coordinates,
+                # the coordinate's `observer` attribute should be set to "self"
                 if isinstance(sc.frame, HeliographicCarrington):
-                    fake_observer = HeliographicStonyhurst(0*u.deg, 0*u.deg, sc.radius,
-                                                           obstime=sc.obstime)
-                    fake_frame = sc.frame.replicate(observer=fake_observer)
-                    hgs = fake_frame.transform_to(HeliographicStonyhurst(obstime=sc.obstime))
-
-                    # HeliographicStonyhurst doesn't need an observer, but adding the observer
-                    # facilitates a conversion back to HeliographicCarrington
-                    return SkyCoord(hgs, observer=hgs)
+                    sc.frame._observer = "self"
 
                 return sc.heliographic_stonyhurst
             elif any(meta_list) and not set(keys).isdisjoint(self.meta.keys()):


### PR DESCRIPTION
Closes #4279

Some data sets specify the observer location in Carrington coordinates.  Following the change in #3782 where our `HeliographicCarrington` frame requires the observer location to be specified, this resulted in an annoying circular loop in creating such coordinates (see #4273 and #4279).  This PR creates a special observer designation (`observer='self'`) that can be used with `HeliographicCarrington`.  This approach also enables removing hack-ish code in `Map`.

```python
>>> from astropy.coordinates import SkyCoord
>>> import astropy.units as u

>>> sc = SkyCoord(0*u.deg, 0*u.deg, 1*u.AU,
...               frame='heliographic_carrington', obstime='2001-01-01', observer='self')
>>> sc
<SkyCoord (HeliographicCarrington: obstime=2001-01-01T00:00:00.000, observer=self): (lon, lat, radius) in (deg, deg, AU)
    (0., 0., 1.)>

>>> sc.heliographic_stonyhurst
<SkyCoord (HeliographicStonyhurst: obstime=2001-01-01T00:00:00.000): (lon, lat, radius) in (deg, deg, AU)
    (142.71381173, 0., 1.)>
```