### PR TITLE
Fixed a huge performance bug in our transformations

### DIFF
--- a/changelog/4663.bugfix.rst
+++ b/changelog/4663.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a significant performance bug that affected all coordinate transformations.
+Transformations have been sped up by a factor a few.

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -53,14 +53,14 @@ class TimeFrameAttributeSunPy(TimeAttribute):
         if value is None:
             return None, False
 
-        elif value == 'now':
-            return Time(datetime.datetime.now()), True
-
         elif isinstance(value, Time):
             out = value
             converted = False
 
         elif isinstance(value, str):
+            if value == 'now':
+                return Time(datetime.datetime.now()), True
+
             try:
                 out = Time(parse_time(value))
             except Exception as err:


### PR DESCRIPTION
In our time frame attribute (used for `obstime`), we accidentally check for equality with `'now'` prior to making sure that the time input is a string rather than a `Time` object.  This unnecessarily triggers machinery in `astropy.time`, and the call ends up taking several hundred(!) times longer than it should.  Since we have `obstime` on all of our frames, our entire transformation framework was affected.

This PR fixes the bug.  In practical terms, transformations now take half the time (on Astropy <4.2) and a quarter of the time (on Astropy 4.2).  The performance hit is even worse on Astropy 4.2 because there is even more machinery in `astropy.time` for parsing time strings.