### PR TITLE
Added offline hypothesis tests to the tox online build and show hypothesis statistics

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ description =
     run tests
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
-    online: that require remote data
+    online: that require remote data (plus offline hypothesis tests)
     hypothesis: using hypothesis (both offline and online)
     figure: runs the figure test suite.
 setenv =
@@ -80,7 +80,7 @@ extras =
     dev
 commands =
     !online-!hypothesis-!figure: {env:PYTEST_COMMAND} {posargs}
-    online: {env:PYTEST_COMMAND} --reruns 2 --timeout=180 --remote-data=any -m "remote_data" {posargs}
+    online: {env:PYTEST_COMMAND} --hypothesis-show-statistics --reruns 2 --timeout=180 --remote-data=any -k "remote_data or hypothesis" {posargs}
     devdeps-!figure: bash -ec "for f in {toxinidir}/examples/*/*.py; do [[ $f == *skip* ]] && continue; echo "$f" && python "$f"; done"
     hypothesis: {env:PYTEST_COMMAND} --hypothesis-show-statistics --remote-data=any -m "hypothesis" {posargs}
     figure: /bin/bash -c "mkdir -p ./figure_test_images; python -c 'import matplotlib as mpl; print(mpl.ft2font.__file__, mpl.ft2font.__freetype_version__, mpl.ft2font.__freetype_build_type__)' > ./figure_test_images/figure_version_info.txt"


### PR DESCRIPTION
I want a CI build that reports detailed `hypothesis` statistics.  This was added in #4019 as a dedicated build with just the hypothesis tests, but this build was removed from CI in #4641 to reduce the number of CI builds.  As discussed on element, the proposed compromise is to modify the `online` build to include the offline hypothesis tests and have that build report the statistics.