### PR TITLE
Fixed the WCS->frame mapping when the observer location is given in HGC coordinates

### DIFF
--- a/changelog/4669.bugfix.rst
+++ b/changelog/4669.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with the mapping of a WCS header to a coordinate frame if the observer location is provided in Carrington coordinates.

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -45,10 +45,14 @@ def solar_wcs_frame_mapping(wcs):
     for frame, attr_names in required_attrs.items():
         attrs = [getattr(wcs.wcs.aux, attr_name) for attr_name in attr_names]
         if all([attr is not None for attr in attrs]):
+            kwargs = {'obstime': dateobs}
+            if issubclass(frame, HeliographicCarrington):
+                kwargs['observer'] = 'self'
+
             observer = frame(attrs[0] * u.deg,
                              attrs[1] * u.deg,
                              attrs[2] * u.m,
-                             obstime=dateobs)
+                             **kwargs)
 
     # Get rsun from the WCS auxillary information
     rsun = wcs.wcs.aux.rsun_ref
@@ -104,9 +108,8 @@ def _set_wcs_aux_obs_coord(wcs, obs_frame):
     wcs : astropy.wcs.WCS
     obs_frame : astropy.coordinates.SkyCoord, astropy.coordinates.CoordinateFrame
     """
-    # Sometimes obs_coord can be a frame (with data); convert to a SkyCoord to
-    # ensure the .frame attribute is present
-    if not isinstance(obs_frame, BaseCoordinateFrame):
+    # Sometimes obs_coord can be a SkyCoord, so convert down to a frame
+    if hasattr(obs_frame, 'frame'):
         obs_frame = obs_frame.frame
 
     if isinstance(obs_frame, HeliographicStonyhurst):


### PR DESCRIPTION
The WCS->frame mapping would error for an observer location provided in Carrington coordinates because no `observer` attribute was specified for the `HeliographicCarrington` frame.  After #4659, it's straightforward to fix this bug.