### PR TITLE
Pin libopenblas to resolve macOS bug

### DIFF
--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -243,3 +243,22 @@ def test_float32(identity):
     in_arr = np.array([[100]], dtype=np.float32)
     out_arr = affine_transform(in_arr, rmatrix=identity)
     assert np.issubdtype(out_arr.dtype, np.float32)
+
+
+def test_reproducible_matrix_multiplication():
+    # Test whether matrix multiplication involving a large matrix always gives the same answer
+    # This indirectly tests whichever BLAS/LAPACK libraries that NumPy is linking to (if any)
+    x = np.arange(500000, dtype=np.float64)
+    src = np.vstack((x, -10*x)).T
+    matrix = np.array([[0, 1], [1, 0]])
+
+    expected = np.vstack((-10*x, x)).T  # src @ matrix
+
+    mismatches = np.zeros(500, int)
+    for i in range(len(mismatches)):
+        result = src @ matrix
+        mismatches[i] = (~np.isclose(result, expected)).sum()
+        if mismatches[i] != 0:
+            print(f"{mismatches[i]} mismatching elements in multiplication #{i}")
+
+    assert np.sum(mismatches != 0) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ conda_deps =
     hypothesis
     h5netcdf
     jinja2
-    libopenblas
+    libopenblas>=0.3.12
     lxml
     matplotlib
     numpy


### PR DESCRIPTION
See #4290 and #4293 for the craziness of intermittent corrupted matrix multiplications on macOS when using conda-forge builds.

As confirmed in test PR #4319, the bug is no longer present with libopenblas 0.3.12 from conda-forge.