### PR TITLE
Exclude NaNs from map FITS headers

### DIFF
--- a/changelog/4676.bugfix.rst
+++ b/changelog/4676.bugfix.rst
@@ -1,0 +1,3 @@
+`sunpy.io.fits.header_to_fits` now excludes any keys that have associated NaN
+values, as these are not valid in a FITS header, and throws a warning if this
+happens.

--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -23,10 +23,10 @@ Notes
    invalid header tags will result in an error so verifying it early on
    makes the header easier to work with later.
 """
-import math
 import os
 import re
 import sys
+import math
 import warnings
 import traceback
 import collections
@@ -219,7 +219,7 @@ def header_to_fits(header):
 
         if isinstance(v, float) and math.isnan(v):
             warnings.warn(f'The meta key {k} has a NaN value, which is not valid in a FITS '
-                          'header, dropping from the FITS header')
+                          'header, dropping from the FITS header', SunpyUserWarning)
             continue
 
         if k.upper() in ('COMMENT', 'HV_COMMENT'):

--- a/sunpy/io/fits.py
+++ b/sunpy/io/fits.py
@@ -23,6 +23,7 @@ Notes
    invalid header tags will result in an error so verifying it early on
    makes the header easier to work with later.
 """
+import math
 import os
 import re
 import sys
@@ -214,6 +215,11 @@ def header_to_fits(header):
             warnings.warn(f"The meta key {k} is too long, dropping from the FITS header "
                           "(maximum allowed key length is 8 characters).",
                           SunpyUserWarning)
+            continue
+
+        if isinstance(v, float) and math.isnan(v):
+            warnings.warn(f'The meta key {k} has a NaN value, which is not valid in a FITS '
+                          'header, dropping from the FITS header')
             continue
 
         if k.upper() in ('COMMENT', 'HV_COMMENT'):

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -117,6 +117,15 @@ def test_warn_nonascii():
     assert 'BAD' not in fits.keys()
 
 
+def test_warn_nan():
+    # Check that a NaN value raises a warning and not an error
+    with pytest.warns(SunpyUserWarning, match='has a NaN value'):
+        fits = header_to_fits({'bad': float('nan'),
+                               'good': 1.0})
+    assert 'GOOD' in fits.keys()
+    assert 'BAD' not in fits.keys()
+
+
 def test_warn_longkey():
     # Check that a key that is too long raises a warning and not an error
     with pytest.warns(SunpyUserWarning, match='The meta key badlongkey is too long'):


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/3819 - seems reasonable to raise a warning here similar to the other warnings for non-valid FITS keywords.