### PR TITLE
[Backport 2.0] Always use the same ERFA package used by Astropy

### DIFF
--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -4,7 +4,6 @@ Sun-specific coordinate calculations
 import numpy as np
 
 import astropy.units as u
-from astropy import _erfa as erfa
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (
     ITRS,
@@ -20,6 +19,8 @@ from astropy.coordinates import (
 )
 from astropy.coordinates.builtin_frames.utils import get_jd12
 from astropy.coordinates.representation import CartesianRepresentation, SphericalRepresentation
+# Import erfa via astropy to make sure we are using the same ERFA library as Astropy
+from astropy.coordinates.sky_coordinate import erfa
 from astropy.time import Time
 
 from sunpy import log

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -4,12 +4,7 @@ Sun-specific coordinate calculations
 import numpy as np
 
 import astropy.units as u
-
-try:
-    import erfa
-except ModuleNotFoundError:
-    import astropy._erfa as erfa
-
+from astropy import _erfa as erfa
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (
     ITRS,

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -20,7 +20,6 @@ from contextlib import contextmanager
 import numpy as np
 
 import astropy.units as u
-from astropy._erfa import obl06
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (
     HCRS,
@@ -41,6 +40,8 @@ from astropy.coordinates.representation import (
     SphericalRepresentation,
     UnitSphericalRepresentation,
 )
+# Import erfa via astropy to make sure we are using the same ERFA library as Astropy
+from astropy.coordinates.sky_coordinate import erfa
 from astropy.coordinates.transformations import (
     AffineTransform,
     FunctionTransform,
@@ -889,7 +890,7 @@ def _rotation_matrix_obliquity(time):
     """
     Return the rotation matrix from Earth equatorial to ecliptic coordinates
     """
-    return rotation_matrix(obl06(*get_jd12(time, 'tt'))*u.radian, 'x')
+    return rotation_matrix(erfa.obl06(*get_jd12(time, 'tt'))*u.radian, 'x')
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -20,12 +20,7 @@ from contextlib import contextmanager
 import numpy as np
 
 import astropy.units as u
-
-try:
-    from erfa import obl06
-except ModuleNotFoundError:
-    from astropy._erfa import obl06
-
+from astropy._erfa import obl06
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (
     HCRS,


### PR DESCRIPTION
Backport #4343.

This PR reverts a commit in #4681 in favor of the approach in #4343