### PR TITLE
Adjust RotatedSunFrame to rely on supported Astropy machinery

### DIFF
--- a/changelog/4691.breaking.rst
+++ b/changelog/4691.breaking.rst
@@ -1,0 +1,2 @@
+The class inheritance for `~sunpy.coordinates.metaframes.RotatedSunFrame` and the frames it creates has been changed in order to stop depending on unsupported behavior in the underlying machinery.
+The return values for some :func:`isinstance`/:func:`issubclass` calls will be different, but the API for `~sunpy.coordinates.metaframes.RotatedSunFrame` is otherwise unchanged.

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -173,6 +173,9 @@ class BaseHeliographic(SunPyBaseCoordinateFrame):
 
         super().__init__(*args, **kwargs)
 
+        self._make_3d()
+
+    def _make_3d(self):
         # Make 3D if specified as 2D
         if (self._data is not None and self._data.norm().unit is u.one
                 and u.allclose(self._data.norm(), 1*u.one)):

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -55,9 +55,7 @@ def _make_rotatedsun_cls(framecls):
         """
         def __new__(cls, name, bases, members):
 
-            # This has to be done because FrameMeta will set these attributes
-            # to the defaults from BaseCoordinateFrame when it creates the base
-            # SkyOffsetFrame class initially.
+            # Copy over the defaults from the input frame class
             members['_default_representation'] = framecls._default_representation
             members['_default_differential'] = framecls._default_differential
             members['_frame_specific_representation_info'] = \

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -3,7 +3,7 @@ Coordinate frames that are defined relative to other frames
 """
 
 from astropy import units as u
-from astropy.coordinates import SphericalRepresentation
+from astropy.coordinates import SphericalRepresentation, BaseCoordinateFrame
 from astropy.coordinates.attributes import Attribute, QuantityAttribute
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
@@ -54,6 +54,15 @@ def _make_rotatedsun_cls(framecls):
         This metaclass renames the class to be "RotatedSun<framecls>".
         """
         def __new__(cls, name, bases, members):
+
+            # This has to be done because FrameMeta will set these attributes
+            # to the defaults from BaseCoordinateFrame when it creates the base
+            # SkyOffsetFrame class initially.
+            members['_default_representation'] = framecls._default_representation
+            members['_default_differential'] = framecls._default_differential
+            members['_frame_specific_representation_info'] = \
+                framecls._frame_specific_representation_info
+
             newname = name[:-5] if name.endswith('Frame') else name
             newname += framecls.__name__
 
@@ -122,7 +131,7 @@ def _make_rotatedsun_cls(framecls):
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())
-class RotatedSunFrame:
+class RotatedSunFrame(BaseCoordinateFrame):
     """
     A frame that applies solar rotation to a base coordinate frame.
 

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -3,7 +3,7 @@ Coordinate frames that are defined relative to other frames
 """
 
 from astropy import units as u
-from astropy.coordinates import SphericalRepresentation, BaseCoordinateFrame
+from astropy.coordinates import SphericalRepresentation
 from astropy.coordinates.attributes import Attribute, QuantityAttribute
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
@@ -12,7 +12,7 @@ from sunpy import log
 from sunpy.time import parse_time
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
-from .frames import HeliocentricInertial
+from .frames import BaseHeliographic, HeliocentricInertial, SunPyBaseCoordinateFrame
 from .offset_frame import NorthOffsetFrame
 from .transformations import _transformation_debug
 
@@ -45,32 +45,24 @@ def _make_rotatedsun_cls(framecls):
     if framecls in _rotatedsun_cache:
         return _rotatedsun_cache[framecls]
 
-    # Obtain the base frame's metaclass by getting the type of the base frame's class
-    framemeta = type(framecls)
+    members = {'__doc__': f'{RotatedSunFrame.__doc__}\n{framecls.__doc__}'}
 
-    # Subclass the metaclass for the RotatedSunFrame from the base frame's metaclass
-    class RotatedSunMeta(framemeta):
-        """
-        This metaclass renames the class to be "RotatedSun<framecls>".
-        """
-        def __new__(cls, name, bases, members):
+    # Copy over the defaults from the input frame class
+    attrs_to_copy = ['_default_representation',
+                     '_default_differential',
+                     '_frame_specific_representation_info']
+    for attr in attrs_to_copy:
+        members[attr] = getattr(framecls, attr)
 
-            # Copy over the defaults from the input frame class
-            members['_default_representation'] = framecls._default_representation
-            members['_default_differential'] = framecls._default_differential
-            members['_frame_specific_representation_info'] = \
-                framecls._frame_specific_representation_info
+    # Frames based on BaseHeliographic need to include the auto-upgrading from 2D to 3D
+    if issubclass(framecls, BaseHeliographic):
+        def baseheliographic_init(self, *args, **kwargs):
+            RotatedSunFrame.__init__(self, *args, **kwargs)
+            BaseHeliographic._make_3d(self)
 
-            newname = name[:-5] if name.endswith('Frame') else name
-            newname += framecls.__name__
+        members['__init__'] = baseheliographic_init
 
-            return super().__new__(cls, newname, bases, members)
-
-    # We need this to handle the intermediate metaclass correctly, otherwise we could
-    # just subclass RotatedSunFrame.
-    _RotatedSunFramecls = RotatedSunMeta('RotatedSunFrame',
-                                         (RotatedSunFrame, framecls),
-                                         {'__doc__': RotatedSunFrame.__doc__})
+    _RotatedSunFramecls = type(f'RotatedSun{framecls.__name__}', (RotatedSunFrame,), members)
 
     @frame_transform_graph.transform(FunctionTransform, _RotatedSunFramecls, _RotatedSunFramecls)
     @_transformation_debug(f"{_RotatedSunFramecls.__name__}->{_RotatedSunFramecls.__name__}")
@@ -129,7 +121,7 @@ def _make_rotatedsun_cls(framecls):
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())
-class RotatedSunFrame(BaseCoordinateFrame):
+class RotatedSunFrame(SunPyBaseCoordinateFrame):
     """
     A frame that applies solar rotation to a base coordinate frame.
 
@@ -166,6 +158,10 @@ class RotatedSunFrame(BaseCoordinateFrame):
     """
     # This code reuses significant code from Astropy's implementation of SkyOffsetFrame
     # See licenses/ASTROPY.rst
+
+    # We don't want to inherit the frame attributes of SunPyBaseCoordinateFrame (namely `obstime`)
+    # Note that this does not work for Astropy 4.3+, so we need to manually remove it below
+    _inherit_descriptors_ = False
 
     # Even though the frame attribute `base` is a coordinate frame, we use `Attribute` instead of
     # `CoordinateAttribute` because we are preserving the supplied frame rather than converting to
@@ -238,3 +234,8 @@ class RotatedSunFrame(BaseCoordinateFrame):
         Returns the sum of the base frame's observation time and the rotation of duration.
         """
         return self.base.obstime + self.duration
+
+
+# For Astropy 4.3+, we need to manually remove the `obstime` frame attribute from RotatedSunFrame
+if 'obstime' in RotatedSunFrame.frame_attributes:
+    del RotatedSunFrame.frame_attributes['obstime']

--- a/sunpy/coordinates/tests/test_metaframes.py
+++ b/sunpy/coordinates/tests/test_metaframes.py
@@ -80,15 +80,15 @@ def test_class_creation(indirect_fixture):
 
     rot_class = type(rot_frame)
 
-    # Check that that the RotatedSunFrame metaclass is derived from the frame's metaclass
-    assert issubclass(type(rot_class), type(base_class))
-
     # Check that the RotatedSunFrame class name has both 'RotatedSun' and the name of the base
     assert 'RotatedSun' in rot_class.__name__
     assert base_class.__name__ in rot_class.__name__
 
     # Check that the base class is in fact the specified class
     assert type(rot_frame.base) == base_class
+
+    # Check that the new class does *not* have the `obstime` frame attribute
+    assert 'obstime' not in rot_frame.frame_attributes
 
     # Check that one-leg transformations have been created
     assert len(frame_transform_graph.get_transform(rot_class, rot_class).transforms) == 1
@@ -101,6 +101,10 @@ def test_class_creation(indirect_fixture):
     # Check that the component data has been migrated
     assert rot_frame.has_data
     assert not rot_frame.base.has_data
+
+
+def test_no_obstime_frame_attribute():
+    assert 'obstime' not in RotatedSunFrame.frame_attributes
 
 
 def test_as_base(rot_hgs):


### PR DESCRIPTION
Edit by @ayshih: This PR makes changes to `RotatedSunFrame` so that it relies on supported (versus unsupported) Astropy machinery for its frame attributes (`base`, `duration`, `rotation_model`, and no others).  This is important for being compatible with Astropy 4.3 at the same time as older versions of Astropy, and minimizing the potential for future Astropy changes to break `RotatedSunFrame`.

Sunpy uses `RotatedSunFrame` a little differently than astropy uses `SkyOffsetFrame`, so, in order for the tests to pass, and for `RotatedSunFrame` to subclass from `BaseCoordinateFrame`, I had to copy over the  frame-specific representation information of the frame class passed in to `RotatedSunFrame`. See also my comments in astropy/astropy#11096