### PR TITLE
Convert ResourceWarnings into errors during tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,7 @@ junit_family=xunit1
 filterwarnings =
     error
     error::sunpy.util.exceptions.SunpyDeprecationWarning
+    error::ResourceWarning
     # Do not fail on pytest config issues (i.e. missing plugins) but do show them
     always::pytest.PytestConfigWarning
     #


### PR DESCRIPTION
python [by default ignores these](https://docs.python.org/3/library/warnings.html#default-warning-filter), but we probably want to catch them in our tests (and there's a couple I spotted looking through the logs recently).

The full list is
```
ignore::DeprecationWarning
ignore::PendingDeprecationWarning
ignore::ImportWarning
ignore::ResourceWarning
```
Do we want to error on any of these other ones?