### PR TITLE
Use wcs.pixel_to_world in map.pixel_to_world

### DIFF
--- a/changelog/4700.bugfix.rst
+++ b/changelog/4700.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed an assumption in `sunpy.map.GenericMap.pixel_to_world` that the first
+data axis is longitude, and the second is latitude. This will affect you if
+you are using data where the x/y axes are latitude/longitude, and now returns
+correct values in methods and properties that call `pixel_to_world`,
+such as `bottom_left_coord`, `top_right_coord`, `center`.

--- a/changelog/4700.bugfix.rst
+++ b/changelog/4700.bugfix.rst
@@ -1,5 +1,5 @@
 Fixed an assumption in `sunpy.map.GenericMap.pixel_to_world` that the first
 data axis is longitude, and the second is latitude. This will affect you if
 you are using data where the x/y axes are latitude/longitude, and now returns
-correct values in methods and properties that call `pixel_to_world`,
-such as `bottom_left_coord`, `top_right_coord`, `center`.
+correct values in methods and properties that call ``pixel_to_world``,
+such as ``bottom_left_coord``, ``top_right_coord``, ``center``.

--- a/changelog/4700.removal.rst
+++ b/changelog/4700.removal.rst
@@ -2,6 +2,6 @@ The ``origin`` argument to `sunpy.map.GenericMap.pixel_to_world` and
 `sunpy.map.GenericMap.world_to_pixel` is deprecated.
 
 - If passing ``0``, not using the ``origin`` argument will have the same effect.
-- If passing ``1``, manually subtract 1 pixel from the input to `pixel_to_world`,
-  or manually add 1 pixel to the output of `world_to_pixel`, and do not use the
+- If passing ``1``, manually subtract 1 pixel from the input to ``pixel_to_world``,
+  or manually add 1 pixel to the output of ``world_to_pixel``, and do not use the
   ``origin`` argument.

--- a/changelog/4700.removal.rst
+++ b/changelog/4700.removal.rst
@@ -1,0 +1,7 @@
+The ``origin`` argument to `sunpy.map.GenericMap.pixel_to_world` and
+`sunpy.map.GenericMap.world_to_pixel` is deprecated.
+
+- If passing ``0``, not using the ``origin`` argument will have the same effect.
+- If passing ``1``, manually subtract 1 pixel from the input to `pixel_to_world`,
+  or manually add 1 pixel to the output of `world_to_pixel`, and do not use the
+  ``origin`` argument.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1123,8 +1123,8 @@ class GenericMap(NDData):
         self._check_origin(origin)
         x, y = self.wcs.world_to_pixel(coordinate)
         if origin == 1:
-            x += 1 * u.pixel
-            y += 1 * u.pixel
+            x += 1
+            y += 1
 
         return PixelPair(x * u.pixel, y * u.pixel)
 
@@ -1155,8 +1155,8 @@ class GenericMap(NDData):
         """
         self._check_origin(origin)
         if origin == 1:
-            x -= 1 * u.pixel
-            y -= 1 * u.pixel
+            x = x - 1 * u.pixel
+            y = y - 1 * u.pixel
 
         return self.wcs.pixel_to_world(x, y)
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -37,7 +37,7 @@ from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import MetaDict, expand_list
 from sunpy.util.decorators import cached_property_based_on, deprecated
-from sunpy.util.exceptions import SunpyMetadataWarning, SunpyUserWarning
+from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyMetadataWarning, SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
 
@@ -1083,10 +1083,22 @@ class GenericMap(NDData):
                           SunpyUserWarning)
 
 # #### Data conversion routines #### #
-    def world_to_pixel(self, coordinate, origin=0):
+
+    @staticmethod
+    def _check_origin(origin):
         """
-        Convert a world (data) coordinate to a pixel coordinate by using
-        `~astropy.wcs.WCS.wcs_world2pix`.
+        Check origin is valid, and raise a deprecation warning if it's not None.
+        """
+        if origin is not None:
+            warnings.warn('The origin argument is deprecated. If using origin=1, '
+                          'manually subtract 1 from your pixels do not pass a value for origin.',
+                          SunpyDeprecationWarning)
+        if origin not in [None, 0, 1]:
+            raise ValueError('origin must be 0 or 1.')
+
+    def world_to_pixel(self, coordinate, origin=None):
+        """
+        Convert a world (data) coordinate to a pixel coordinate.
 
         Parameters
         ----------
@@ -1094,10 +1106,11 @@ class GenericMap(NDData):
             The coordinate object to convert to pixel coordinates.
 
         origin : int
+            Deprecated.
+
             Origin of the top-left corner. i.e. count from 0 or 1.
             Normally, origin should be 0 when passing numpy indices, or 1 if
             passing values from FITS header or map attributes.
-            See `~astropy.wcs.WCS.wcs_world2pix` for more information.
 
         Returns
         -------
@@ -1107,26 +1120,21 @@ class GenericMap(NDData):
         y : `~astropy.units.Quantity`
             Pixel coordinate on the CTYPE2 axis.
         """
-        if not isinstance(coordinate, (SkyCoord,
-                                       astropy.coordinates.BaseCoordinateFrame)):
-            raise ValueError(
-                "world_to_pixel takes a Astropy coordinate frame or SkyCoord instance.")
-
-        native_frame = coordinate.transform_to(self.coordinate_frame)
-        lon, lat = u.Quantity(self._get_lon_lat(native_frame)).to(u.deg)
-        x, y = self.wcs.wcs_world2pix(lon, lat, origin)
+        self._check_origin(origin)
+        x, y = self.wcs.world_to_pixel(coordinate)
+        if origin == 1:
+            x += 1 * u.pixel
+            y += 1 * u.pixel
 
         return PixelPair(x * u.pixel, y * u.pixel)
 
     @u.quantity_input
-    def pixel_to_world(self, x: u.pixel, y: u.pixel, origin=0):
+    def pixel_to_world(self, x: u.pixel, y: u.pixel, origin=None):
         """
-        Convert a pixel coordinate to a data (world) coordinate by using
-        `~astropy.wcs.WCS.wcs_pix2world`.
+        Convert a pixel coordinate to a data (world) coordinate.
 
         Parameters
         ----------
-
         x : `~astropy.units.Quantity`
             Pixel coordinate of the CTYPE1 axis. (Normally solar-x).
 
@@ -1134,31 +1142,23 @@ class GenericMap(NDData):
             Pixel coordinate of the CTYPE2 axis. (Normally solar-y).
 
         origin : int
+            Deprecated.
+
             Origin of the top-left corner. i.e. count from 0 or 1.
             Normally, origin should be 0 when passing numpy indices, or 1 if
             passing values from FITS header or map attributes.
-            See `~astropy.wcs.WCS.wcs_pix2world` for more information.
 
         Returns
         -------
-
         coord : `astropy.coordinates.SkyCoord`
             A coordinate object representing the output coordinate.
-
         """
+        self._check_origin(origin)
+        if origin == 1:
+            x -= 1 * u.pixel
+            y -= 1 * u.pixel
 
-        # Hold the WCS instance here so we can inspect the output units after
-        # the pix2world call
-        temp_wcs = self.wcs
-
-        x, y = temp_wcs.wcs_pix2world(x, y, origin)
-
-        out_units = list(map(u.Unit, temp_wcs.wcs.cunit))
-
-        x = u.Quantity(x, out_units[0])
-        y = u.Quantity(y, out_units[1])
-
-        return SkyCoord(x, y, frame=self.coordinate_frame)
+        return self.wcs.pixel_to_world(x, y)
 
 # #### I/O routines #### #
 
@@ -1371,8 +1371,7 @@ class GenericMap(NDData):
         temp_map = self._new_instance(new_data, new_meta, self.plot_settings)
 
         # Convert the axis of rotation from data coordinates to pixel coordinates
-        pixel_rotation_center = u.Quantity(temp_map.world_to_pixel(self.reference_coordinate,
-                                                                   origin=0)).value
+        pixel_rotation_center = u.Quantity(temp_map.world_to_pixel(self.reference_coordinate)).value
         del temp_map
 
         if recenter:

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -391,7 +391,7 @@ def test_world_to_pixel(generic_map):
 
 
 def test_world_to_pixel_error(generic_map):
-    strerr = 'world_to_pixel takes a Astropy coordinate frame or SkyCoord instance'
+    strerr = 'Expected the following order of world arguments: SkyCoord'
     with pytest.raises(ValueError, match=strerr):
         generic_map.world_to_pixel(1)
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -396,6 +396,17 @@ def test_world_to_pixel_error(generic_map):
         generic_map.world_to_pixel(1)
 
 
+@pytest.mark.parametrize('origin', [0, 1])
+def test_world_pixel_roundtrip(simple_map, origin):
+    pix = 1 * u.pix, 1 * u.pix
+    with pytest.warns(SunpyDeprecationWarning, match='The origin argument is deprecated'):
+        coord = simple_map.pixel_to_world(*pix, origin=origin)
+        pix_roundtrip = simple_map.world_to_pixel(coord, origin=origin)
+
+    assert u.allclose(pix_roundtrip.x, pix[0], atol=1e-10 * u.pix)
+    assert u.allclose(pix_roundtrip.y, pix[1], atol=1e-10 * u.pix)
+
+
 def test_save(aia171_test_map, generic_map):
     """Tests the map save function"""
     aiamap = aia171_test_map


### PR DESCRIPTION
This removes a baked in assumption that CTYPE1 is longitude and CTYPE2 is latitude. Fixes https://github.com/sunpy/sunpy/issues/4699, and fixes the recent mailing list issue.