### PR TITLE
Fixing replacing bad GOES values with nans 

### DIFF
--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -214,7 +214,7 @@ class XRSTimeSeries(GenericTimeSeries):
                 raise ValueError(f"The file {filepath} doesn't seem to be a GOES netcdf file.")
 
         data = DataFrame({"xrsa": xrsa, "xrsb": xrsb}, index=times.datetime)
-        data.replace(-9999, np.nan)
+        data = data.replace(-9999, np.nan)
         units = OrderedDict([("xrsa", u.W/u.m**2),
                              ("xrsb", u.W/u.m**2)])
 


### PR DESCRIPTION
### Description
I'm silly and in the GOES source for timeseries I forgot that `pd.replace` returns a new object rather than changing the `DataFrame` --> [here](https://github.com/sunpy/sunpy/blob/master/sunpy/timeseries/sources/goes.py#L217)  🤦  

this now works