### PR TITLE
Added a warning if lower-than-native-precision floats are seen by Helioprojective.make_3d()

### DIFF
--- a/changelog/4724.bugfix.rst
+++ b/changelog/4724.bugfix.rst
@@ -1,0 +1,2 @@
+Added a warning when a 2D `~sunpy.coordinates.frames.Helioprojective` coordinate is upgraded to a 3D coordinate and the number type is lower precision than the native Python float.
+This 2D->3D upgrade is performed internally when transforming a 2D `~sunpy.coordinates.frames.Helioprojective` coordinate to any other coordinate frame.

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -477,12 +477,10 @@ class Helioprojective(SunPyBaseCoordinateFrame):
         lat, lon = rep.lat, rep.lon
 
         # Check for the use of floats with lower precision than the native Python float
-        lon_type = lon.dtype.type if hasattr(lon, 'dtype') else type(lon)
-        lat_type = lat.dtype.type if hasattr(lat, 'dtype') else type(lat)
-        if not set([lon_type, lat_type]).issubset([float, np.float64, np.longdouble]):
+        if not set([lon.dtype.type, lat.dtype.type]).issubset([float, np.float64, np.longdouble]):
             raise SunpyUserWarning("The Helioprojective component values appear to be lower "
                                    "precision than the native Python float: "
-                                   f"Tx is {lon_type.__name__}, and Ty is {lat_type.__name__}. "
+                                   f"Tx is {lon.dtype.name}, and Ty is {lat.dtype.name}. "
                                    "To minimize precision loss, you may want to cast the values to "
                                    "`float` or `numpy.float64` via the NumPy method `.astype()`.")
 

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -14,6 +14,7 @@ from astropy.coordinates import (
 from astropy.tests.helper import assert_quantity_allclose
 
 from sunpy.time import parse_time
+from sunpy.util.exceptions import SunpyUserWarning
 from ... import sun
 from ..frames import Heliocentric, HeliographicCarrington, HeliographicStonyhurst, Helioprojective
 
@@ -214,6 +215,15 @@ def test_hpc_default_observer():
 
     hpc = Helioprojective(0*u.arcsec, 0*u.arcsec, obstime='2019-06-01')
     assert not hpc.is_frame_attr_default('observer')
+
+
+def test_hpc_low_precision_float_warning():
+    hpc = Helioprojective(u.Quantity(0, u.deg, dtype=np.float32),
+                          u.Quantity(0, u.arcsec, dtype=np.float16),
+                          observer=HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU))
+
+    with pytest.raises(SunpyUserWarning, match="Tx is float32, and Ty is float16"):
+        hpc.make_3d()
 
 
 # ==============================================================================


### PR DESCRIPTION
Closes #4723

_Originally posted by @ayshih in https://github.com/sunpy/sunpy/issues/4723#issuecomment-742940414_

> In short, this behavior is occurring because the source data arrays are 32-bit float data arrays.  That bit depth gets preserved in the `SkyCoord` as well, so all of the transformation calculations are performed on 32-bit floats.  Unfortunately, `Helioprojective.make_3d()` – which calculates the distance from the observer to the surface of the Sun – uses the law of cosines, and cosines of the small angles of HPC coordinates on the solar disk lose accuracy in 32-bit floats.
> ...
> To help users not get tripped up by this behavior, we can add a check to `Helioprojective.make_3d()` that would raise a warning if it sees that it's working with 32-bit floats.  I'm not keen on an automatic upgrade to 64-bit floats since the user may not want or need that.