### PR TITLE
[Backport 2.0] Added a warning if lower-than-native-precision floats are seen by Helioprojective.make_3d()

### DIFF
--- a/changelog/4724.bugfix.rst
+++ b/changelog/4724.bugfix.rst
@@ -1,0 +1,2 @@
+Added a warning when a 2D `~sunpy.coordinates.frames.Helioprojective` coordinate is upgraded to a 3D coordinate and the number type is lower precision than the native Python float.
+This 2D->3D upgrade is performed internally when transforming a 2D `~sunpy.coordinates.frames.Helioprojective` coordinate to any other coordinate frame.

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -20,6 +20,7 @@ from astropy.time import Time
 from sunpy.sun.constants import radius as _RSUN
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring, deprecated
+from sunpy.util.exceptions import SunpyUserWarning
 from .frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy
 
 _J2000 = Time('J2000.0', scale='tt')
@@ -482,6 +483,18 @@ class Helioprojective(SunPyBaseCoordinateFrame):
         rep = self.represent_as(UnitSphericalRepresentation)
         lat, lon = rep.lat, rep.lon
         alpha = np.arccos(np.cos(lat) * np.cos(lon)).to(lat.unit)
+
+        # Check for the use of floats with lower precision than the native Python float
+        lon_type = lon.dtype.type if hasattr(lon, 'dtype') else type(lon)
+        lat_type = lat.dtype.type if hasattr(lat, 'dtype') else type(lat)
+        if not set([lon_type, lat_type]).issubset([float, np.float64, np.longdouble]):
+            raise SunpyUserWarning("The Helioprojective component values appear to be lower "
+                                   "precision than the native Python float: "
+                                   f"Tx is {lon_type.__name__}, and Ty is {lat_type.__name__}. "
+                                   "To minimize precision loss, you may want to cast the values to "
+                                   "`float` or `numpy.float64` via the NumPy method `.astype()`.")
+
+        # Calculate the distance to the surface of the Sun using the law of cosines
         c = self.observer.radius**2 - self.rsun**2
         b = -2 * self.observer.radius * np.cos(alpha)
         # Ingore sqrt of NaNs

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -485,12 +485,10 @@ class Helioprojective(SunPyBaseCoordinateFrame):
         alpha = np.arccos(np.cos(lat) * np.cos(lon)).to(lat.unit)
 
         # Check for the use of floats with lower precision than the native Python float
-        lon_type = lon.dtype.type if hasattr(lon, 'dtype') else type(lon)
-        lat_type = lat.dtype.type if hasattr(lat, 'dtype') else type(lat)
-        if not set([lon_type, lat_type]).issubset([float, np.float64, np.longdouble]):
+        if not set([lon.dtype.type, lat.dtype.type]).issubset([float, np.float64, np.longdouble]):
             raise SunpyUserWarning("The Helioprojective component values appear to be lower "
                                    "precision than the native Python float: "
-                                   f"Tx is {lon_type.__name__}, and Ty is {lat_type.__name__}. "
+                                   f"Tx is {lon.dtype.name}, and Ty is {lat.dtype.name}. "
                                    "To minimize precision loss, you may want to cast the values to "
                                    "`float` or `numpy.float64` via the NumPy method `.astype()`.")
 

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -14,6 +14,7 @@ from astropy.coordinates import (
 from astropy.tests.helper import assert_quantity_allclose
 
 from sunpy.time import parse_time
+from sunpy.util.exceptions import SunpyUserWarning
 from ... import sun
 from ..frames import Heliocentric, HeliographicCarrington, HeliographicStonyhurst, Helioprojective
 
@@ -214,6 +215,15 @@ def test_hpc_default_observer():
 
     hpc = Helioprojective(0*u.arcsec, 0*u.arcsec, obstime='2019-06-01')
     assert not hpc.is_frame_attr_default('observer')
+
+
+def test_hpc_low_precision_float_warning():
+    hpc = Helioprojective(u.Quantity(0, u.deg, dtype=np.float32),
+                          u.Quantity(0, u.arcsec, dtype=np.float16),
+                          observer=HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU))
+
+    with pytest.raises(SunpyUserWarning, match="Tx is float32, and Ty is float16"):
+        hpc.make_3d()
 
 
 # ==============================================================================


### PR DESCRIPTION
Backport #4724.