### PR TITLE
Tidying up example with new Fido client with HEK

### DIFF
--- a/examples/acquiring_data/querying_the_GOES_event_list.py
+++ b/examples/acquiring_data/querying_the_GOES_event_list.py
@@ -23,12 +23,17 @@ result = Fido.search(a.Time(tstart, tend),
                      a.hek.OBS.Observatory == 'GOES')
 
 ###################################################################
-# The result is returned as a `~sunpy.net.hek.hek.HEKResponse`.
-# We can print the number of flares and inspect the result information.
-# We can also print the key-values that correspond to the HEK parameters
-# returned in result.
-print(len(result))
+# The result is returned as a `~sunpy.net.fido_factory.UnifiedResponse`,
+# from which we can see a table from one provider is found and returned.
 print(result)
+
+# We can now inspect the results in `result` by indexing to return get the data
+# from the `~sunpy.net.hek.hek.HEKResponse`. Lets print the number of flares and
+# inspect the result information.
+print(len(result[0]))
+# We can also print the key-values that correspond to the HEK parameters returned
+# in result[0]. The .table attribute returns an `~astropy.table.Table`.
+print(result[0].table.keys())
 
 ###################################################################
 # We can also specify what GOES class flares we want to query.
@@ -41,17 +46,17 @@ result_m1 = Fido.search(a.Time(tstart, tend),
                         a.hek.FL.GOESCls > 'M1.0',
                         a.hek.OBS.Observatory == 'GOES')
 
-print(result_m1)
+print(result_m1[0])
 
 ###################################################################
 # The results returned to the `~sunpy.net.hek.hek.HEKResponse`
 # contain a lot of information and we may only want to keep some main
 # results such as start time, end time, peak time, GOES-class, and
 # active region number. This can be done as so:
-new_table = result_m1.show('event_starttime', 'event_peaktime',
-                           'event_endtime', 'fl_goescls', 'ar_noaanum')
+new_table = result_m1[0].table['event_starttime', 'event_peaktime',
+                               'event_endtime', 'fl_goescls', 'ar_noaanum']
 
 ###################################################################
 # These results can then be saved to a CSV file, or any other file
 # format that `~astropy.table.Table` supports
-new_table[0].write('october_M1_flares.csv', format='csv')
+new_table.write('october_M1_flares.csv', format='csv')


### PR DESCRIPTION
### Description
Now that the metadata clients  following #4358 the example to query using the HEK client the example needed some clarification given that now the search returns a `sunpy.net.fido_factory.UnifiedResponse` rather than a `sunpy.net.hek.hek.HEKResponse`

