### PR TITLE
Update list of oldest test dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ database =
   sqlalchemy
 instr =
   matplotlib>=2.2.2
-  pandas>=0.23.0
+  pandas>=0.24.0
   scipy>=1.2.0
 image =
   scikit-image
@@ -59,7 +59,7 @@ map =
   scipy>=1.2.0
 net =
   beautifulsoup4
-  pandas>=0.23.0
+  pandas>=0.24.0
   drms>=0.6
   python-dateutil
   tqdm
@@ -67,7 +67,7 @@ net =
 timeseries =
   h5netcdf>=0.8.1
   matplotlib>=2.2.2
-  pandas>=0.23.0
+  pandas>=0.24.0
 visualization =
   matplotlib>=2.2.2
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,6 +127,9 @@ filterwarnings =
     # is being ignored
     #
     #
+    # See https://github.com/pandas-dev/pandas/issues/26367; this can be
+    # removed when our minimum pandas version is >=0.25
+    ignore:can't resolve package from __spec__ or __package__:ImportWarning
     # See https://github.com/spacetelescope/asdf/issues/789
     ignore:direct construction of AsdfSchemaFile has been deprecated
     ignore:direct construction of AsdfSchemaItem has been deprecated

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,10 @@ deps =
     oldestdeps: matplotlib<3.0
     oldestdeps: scipy<1.3
     oldestdeps: parfive<1.2
+    oldestdeps: pandas<0.24
+    oldestdeps: parfive<1.2
+    oldestdeps: drms<0.7
+    oldestdeps: h5netcdf<0.9
     # These are specific online extras we use to run the online tests.
     online: pytest-rerunfailures
     online: pytest-timeout

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ deps =
     oldestdeps: matplotlib<3.0
     oldestdeps: scipy<1.3
     oldestdeps: parfive<1.2
-    oldestdeps: pandas<0.24
+    oldestdeps: pandas<0.25
     oldestdeps: parfive<1.2
     oldestdeps: drms<0.7
     oldestdeps: h5netcdf<0.9


### PR DESCRIPTION
I noticed whilst reviewing https://github.com/sunpy/sunpy/pull/4758 that we don't pin everything we should in the oldesttestdeps test run. This adds some extra packages that should be pinned here.