### PR TITLE
Define custom __dir__ for attrs

### DIFF
--- a/sunpy/net/dataretriever/attrs/goes.py
+++ b/sunpy/net/dataretriever/attrs/goes.py
@@ -3,6 +3,11 @@ from sunpy.net.attr import SimpleAttr
 __all__ = ["SatelliteNumber"]
 
 
+# Define a custom __dir__ to restrict tab-completion to __all__
+def __dir__():
+    return __all__
+
+
 class SatelliteNumber(SimpleAttr):
     """
     The GOES Satellite Number

--- a/sunpy/net/helio/attrs.py
+++ b/sunpy/net/helio/attrs.py
@@ -3,6 +3,11 @@ from sunpy.net.attr import SimpleAttr
 __all__ = ['MaxRecords', 'TableName']
 
 
+# Define a custom __dir__ to restrict tab-completion to __all__
+def __dir__():
+    return __all__
+
+
 class MaxRecords(SimpleAttr):
     """
     The maximum number of desired records.

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -9,6 +9,11 @@ __all__ = ['Series', 'Protocol', 'Notify', 'Segment', 'Keys', 'PrimeKey',
            'Cutout']
 
 
+# Define a custom __dir__ to restrict tab-completion to __all__
+def __dir__():
+    return __all__
+
+
 class Series(SimpleAttr):
     """
     The JSOC Series to Download.

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -28,6 +28,12 @@ from .. import attr as _attr
 
 __all__ = ['Extent', 'Field', 'Pixels', 'Filter', 'Quicklook', 'PScale']
 
+
+# Define a custom __dir__ to restrict tab-completion to __all__
+def __dir__():
+    return __all__
+
+
 _TIMEFORMAT = '%Y%m%d%H%M%S'
 
 


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/4769. On the [advice of the IPython docs](https://ipython.readthedocs.io/en/stable/config/integrating.html#tab-completion) I have implemented custom `__dir__` methods for each `attrs.py` module, restricting the values that get tab-completed.