### PR TITLE
Removed .sources lines from sunpy/docs/code_ref/net.rst

### DIFF
--- a/docs/code_ref/net.rst
+++ b/docs/code_ref/net.rst
@@ -30,7 +30,7 @@ VSO
 
 
 Dataretriever
-=============
+-------------
 
 .. automodapi:: sunpy.net.dataretriever
 

--- a/docs/code_ref/net.rst
+++ b/docs/code_ref/net.rst
@@ -33,9 +33,6 @@ Dataretriever
 =============
 
 .. automodapi:: sunpy.net.dataretriever
-   :allowed-package-names: sources
-
-.. automodapi:: sunpy.net.dataretriever.sources
 
 .. automodapi:: sunpy.net.dataretriever.attrs.goes
 


### PR DESCRIPTION
### Description

```
 :allowed-package-names: sources
.. automodapi:: sunpy.net.dataretriever.sources
```

These two lines has been removed from documentation as all the imports for the sources module has been moved to sunpy.net.dataretriever

Fixes #4740