### PR TITLE
Fix net doc headings

### DIFF
--- a/docs/code_ref/net.rst
+++ b/docs/code_ref/net.rst
@@ -22,7 +22,7 @@ is an interface to multiple sources including all the sources implemented in
 
 
 VSO
----
+===
 
 .. automodapi:: sunpy.net.vso
 
@@ -30,7 +30,7 @@ VSO
 
 
 Dataretriever
--------------
+=============
 
 .. automodapi:: sunpy.net.dataretriever
 
@@ -45,7 +45,7 @@ JSOC
 
 
 HEK
----
+===
 
 .. automodapi:: sunpy.net.hek
 

--- a/sunpy/net/dataretriever/__init__.py
+++ b/sunpy/net/dataretriever/__init__.py
@@ -8,16 +8,12 @@ subclass. All these subclasses are then registered with the `sunpy.net.Fido` fac
 class, so do not need to be called individually.
 """
 
-from .client import GenericClient, QueryResponse
-from .sources.eve import EVEClient
-from .sources.fermi_gbm import GBMClient
-from .sources.goes import SUVIClient, XRSClient
-from .sources.gong import GONGClient
-from .sources.lyra import LYRAClient
-from .sources.noaa import NOAAIndicesClient, NOAAPredictClient, SRSClient
-from .sources.norh import NoRHClient
-from .sources.rhessi import RHESSIClient
-
-__all__ = ['QueryResponse', 'GenericClient', 'EVEClient', 'GBMClient', 'XRSClient',
-           'GONGClient', 'SUVIClient', 'LYRAClient', 'NOAAIndicesClient',
-           'NOAAPredictClient', 'NoRHClient', 'RHESSIClient', 'SRSClient']
+from .client import *
+from .sources.eve import *
+from .sources.fermi_gbm import *
+from .sources.goes import *
+from .sources.gong import *
+from .sources.lyra import *
+from .sources.noaa import *
+from .sources.norh import *
+from .sources.rhessi import *


### PR DESCRIPTION
- Fix headings
- Also clear up the `dataretriever.py`  `__init__.py` to remove two(!) redundant specifications of everything it imports. Everything is now just directly pulled from `__all__` in all of the sub-files.