### PR TITLE
Document JSOC attrs

### DIFF
--- a/sunpy/net/jsoc/__init__.py
+++ b/sunpy/net/jsoc/__init__.py
@@ -1,4 +1,2 @@
 from sunpy.net.jsoc.attrs import *
 from sunpy.net.jsoc.jsoc import *
-
-__all__ = ['JSOCClient', 'JSOCResponse']


### PR DESCRIPTION
:S these were missing from the docs because there was a too restrictive `__all__` in `jsoc.py`. Instead, rely on each individual file to handle it's own `__all__`.