### PR TITLE
Clarify measurement docstring

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -693,9 +693,10 @@ class GenericMap(NDData):
     @property
     def measurement(self):
         """
-        Measurement name, defaults to the wavelength of image.
+        Measurement wavelength.
 
-        This is taken from the 'WAVELNTH' FITS keyword.
+        This is taken from the 'WAVELNTH' FITS keyword. If the keyword is not
+        present, defaults to 0.
         """
         return u.Quantity(self.meta.get('wavelnth', 0),
                           self.waveunit)


### PR DESCRIPTION
- Previously "Measurement name" implied a string, but this returns a Quantity, so change to "Measurement wavelength".
- Note that it defaults to zero.