### PR TITLE
Update oldestdeps for 2.0.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,9 +56,11 @@ deps =
 
     # Oldest deps we pin against.
     oldestdeps: astropy<4.0
-    oldestdeps: numpy<1.15.0
+    oldestdeps: numpy<1.16.0
     oldestdeps: matplotlib<3.0
     oldestdeps: parfive<1.2
+    oldestdeps: scipy<1.1
+    oldestdeps: pandas<0.24
 
     # These are specific online extras we use to run the online tests.
     online: pytest-rerunfailures


### PR DESCRIPTION
I thought it would be sensible to do a similar thing as https://github.com/sunpy/sunpy/pull/4767 for the 2.0.x series, so here we go. Since we changed how dependencies work a bit for 2.1, doing it directly seemed easier than a backport.