### PR TITLE
Change default format of carrington_rotation_time return

### DIFF
--- a/changelog/4819.breaking.rst
+++ b/changelog/4819.breaking.rst
@@ -1,0 +1,3 @@
+The time returned from :func:`~sunpy.coordinates.sun.carrington_rotation_number`
+has been changed from TT to the more common UTC scale. To undo this change,
+use ``time_out = time_out.tt`` on the outputted time.

--- a/changelog/4819.trivial.rst
+++ b/changelog/4819.trivial.rst
@@ -1,3 +1,3 @@
-Change the format of the time returned from `~sunpy.coordinates.sun.carrington_rotation_number`
+Change the format of the time returned from :func:`~sunpy.coordinates.sun.carrington_rotation_number`
 from ``'jd'`` to ``'iso'``, so printing the `~astropy.time.Time` returned will now print an ISO
 timestamp instead of the Julian days.

--- a/changelog/4819.trivial.rst
+++ b/changelog/4819.trivial.rst
@@ -1,0 +1,3 @@
+Change the format of the time returned from `~sunpy.coordinates.sun.carrington_rotation_number`
+from ``'jd'`` to ``'iso'``, so printing the `~astropy.time.Time` returned will now print an ISO
+timestamp instead of the Julian days.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -121,7 +121,9 @@ def carrington_rotation_time(crot):
     # Perform two iterations of the correction to achieve sub-second accuracy
     estimate = refine(estimate)
     estimate = refine(estimate)
-    return Time(estimate, scale='tt', format='jd')
+    t = Time(estimate, scale='tt', format='jd')
+    t.format = 'iso'
+    return t
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -121,7 +121,7 @@ def carrington_rotation_time(crot):
     # Perform two iterations of the correction to achieve sub-second accuracy
     estimate = refine(estimate)
     estimate = refine(estimate)
-    t = Time(estimate, scale='tt', format='jd')
+    t = Time(estimate, scale='tt', format='jd').utc
     t.format = 'iso'
     return t
 

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -479,3 +479,9 @@ def test_carrington_rotation_roundtrip():
     dt = t - t_roundtrip
     # Stated precision in the docstring is 0.11 seconds
     assert_quantity_allclose(dt.to(u.s), 0*u.s, atol=0.11*u.s)
+
+
+def test_carrington_rotation_str():
+    # Check that by default a human parseable string is returned
+    t = sun.carrington_rotation_time(2210)
+    assert str(t) == '2018-10-26 20:49:25.321'

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -484,4 +484,4 @@ def test_carrington_rotation_roundtrip():
 def test_carrington_rotation_str():
     # Check that by default a human parseable string is returned
     t = sun.carrington_rotation_time(2210)
-    assert str(t) == '2018-10-26 20:49:25.321'
+    assert str(t) == '2018-10-26 20:48:16.137'


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/4818 - I wasn't sure how to change the scale too here as https://github.com/sunpy/sunpy/issues/4818#issuecomment-754057830 suggests, but happy to with some pointers.