### PR TITLE
Removed explicit calls to get_rectangle_coordinates in draw_rectangle figure tests

### DIFF
--- a/changelog/4830.bugfix.rst
+++ b/changelog/4830.bugfix.rst
@@ -1,2 +1,0 @@
-Edited the repeated tests for draw_rectangle and added a test where the
-coordinates are correctly specified.

--- a/changelog/4830.bugfix.rst
+++ b/changelog/4830.bugfix.rst
@@ -1,0 +1,2 @@
+Edited the repeated tests for draw_rectangle and added a test where the
+coordinates are correctly specified.

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -193,7 +193,7 @@ def test_heliographic_rectangle_top_right(heliographic_test_map):
     heliographic_test_map.plot()
     bottom_left = SkyCoord(
         60 * u.deg, 50 * u.deg, frame=heliographic_test_map.coordinate_frame)
-    top_right = SkyCoord(80 * u.deg,90 * u.deg, frame=hmap.coordinate_frame)
+    top_right = SkyCoord(80 * u.deg, 90 * u.deg, frame=hmap.coordinate_frame)
     heliographic_test_map.draw_rectangle(bottom_left, top_right=top_right, color='cyan')
 
 

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -15,7 +15,6 @@ import sunpy
 import sunpy.coordinates
 import sunpy.data.test
 import sunpy.map
-from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.tests.helpers import figure_test, fix_map_wcs
 from sunpy.util.exceptions import SunpyUserWarning
 
@@ -124,7 +123,7 @@ def test_rectangle_aia171_top_right(aia171_test_map):
     bottom_left = SkyCoord(
         0 * u.arcsec, 0 * u.arcsec, frame=aia171_test_map.coordinate_frame)
     top_right = SkyCoord(
-        200 * u.arcsec, 500 * u.arcsec, frame=aia171_test_map.coordinate_frame)
+        100 * u.arcsec, 100 * u.arcsec, frame=aia171_test_map.coordinate_frame)
     aia171_test_map.draw_rectangle(bottom_left, top_right=top_right)
 
 
@@ -193,7 +192,7 @@ def test_heliographic_rectangle_top_right(heliographic_test_map):
     heliographic_test_map.plot()
     bottom_left = SkyCoord(
         60 * u.deg, 50 * u.deg, frame=heliographic_test_map.coordinate_frame)
-    top_right = SkyCoord(80 * u.deg, 90 * u.deg, frame=hmap.coordinate_frame)
+    top_right = SkyCoord(73 * u.deg, 63 * u.deg, frame=heliographic_test_map.coordinate_frame)
     heliographic_test_map.draw_rectangle(bottom_left, top_right=top_right, color='cyan')
 
 

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -123,9 +123,8 @@ def test_rectangle_aia171_top_right(aia171_test_map):
     aia171_test_map.plot()
     bottom_left = SkyCoord(
         0 * u.arcsec, 0 * u.arcsec, frame=aia171_test_map.coordinate_frame)
-    w = 100 * u.arcsec
-    h = 100 * u.arcsec
-    bottom_left, top_right = get_rectangle_coordinates(bottom_left, width=w, height=h)
+    top_right = SkyCoord(
+        200 * u.arcsec, 500 * u.arcsec, frame=aia171_test_map.coordinate_frame)
     aia171_test_map.draw_rectangle(bottom_left, top_right=top_right)
 
 
@@ -194,10 +193,8 @@ def test_heliographic_rectangle_top_right(heliographic_test_map):
     heliographic_test_map.plot()
     bottom_left = SkyCoord(
         60 * u.deg, 50 * u.deg, frame=heliographic_test_map.coordinate_frame)
-    w = 13 * u.deg
-    h = 13 * u.deg
-    bottom_left, top_right = get_rectangle_coordinates(bottom_left, width=w, height=h)
-    heliographic_test_map.draw_rectangle(bottom_left, width=w, height=h, color='cyan')
+    top_right = SkyCoord(80 * u.deg,90 * u.deg, frame=hmap.coordinate_frame)
+    heliographic_test_map.draw_rectangle(bottom_left, top_right=top_right, color='cyan')
 
 
 # See https://github.com/sunpy/sunpy/issues/4294 to track this warning. Ideally


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Changed tests for draw_rectangle where the top_right coordinate was specified instead of using width and height ( removed repeated tests ).
