### PR TITLE
Improvements to the listings of sample data

### DIFF
--- a/changelog/4838.trivial.rst
+++ b/changelog/4838.trivial.rst
@@ -1,0 +1,1 @@
+The listings for the sample data (`sunpy.data.sample`) are now sorted.

--- a/examples/acquiring_data/2011_06_07_sampledata_overview.py
+++ b/examples/acquiring_data/2011_06_07_sampledata_overview.py
@@ -3,7 +3,7 @@
 Sample data set overview
 ========================
 
-An overview of the coordinated sample data set.
+An overview of the coordinated sample data set (available through `sunpy.data.sample`).
 """
 import matplotlib.pyplot as plt
 

--- a/sunpy/data/sample.py
+++ b/sunpy/data/sample.py
@@ -1,5 +1,15 @@
 """
-The following files are available in this module:
+This module provides the following sample data files.  These files are
+downloaded when this module is imported for the first time.  See
+:ref:`sphx_glr_generated_gallery_acquiring_data_2011_06_07_sampledata_overview.py`
+for plots of some of these files.
+
+.. list-table::
+   :widths: auto
+   :header-rows: 1
+
+   * - Variable name
+     - Name of downloaded file
 """
 import sys
 from pathlib import Path
@@ -8,18 +18,20 @@ from ._sample import _SAMPLE_FILES, download_sample_data
 
 files = download_sample_data()
 
-file_list = []
 file_dict = {}
 for f in files:
     name = Path(f).name
     _key = _SAMPLE_FILES.get(name, None)
-    if not _key:
-        continue
+    if _key:
+        setattr(sys.modules[__name__], _key, str(f))
+        file_dict.update({_key: f})
 
-    setattr(sys.modules[__name__], _key, str(f))
-    file_list.append(f)
-    file_dict.update({_key: f})
-    # Add filename to the docs
-    __doc__ += f'   - ``{_key}``\n'
+# Sort the entries in the dictionary
+file_dict = dict(sorted(file_dict.items()))
+
+file_list = file_dict.values()
+
+for keyname, filename in file_dict.items():
+    __doc__ += f'   * - ``{keyname}``\n     - {Path(filename).name}\n'
 
 __all__ = list(_SAMPLE_FILES.values()) + ['file_dict', 'file_list']


### PR DESCRIPTION
- Sorted the dictionary/list of sample data
- Created a more helpful docstring for `sunpy.data.sample`
- Cross-linked between the docstring for `sunpy.data.sample` and the gallery example that plots many of the files