### PR TITLE
Reduce data downloaded by tseries metadata example

### DIFF
--- a/examples/time_series/timeseriesmetadata_example.py
+++ b/examples/time_series/timeseriesmetadata_example.py
@@ -16,9 +16,11 @@ from sunpy.time import TimeRange, parse_time
 ##############################################################################
 # Search for Data
 
-goes_res = Fido.search(a.Time("2010-11-03", "2010-11-04"), a.Instrument.xrs, a.goes.SatelliteNumber(15))
-norh_res = Fido.search(a.Time("2010-11-03", "2010-11-04"), a.Instrument.norh,
+goes_res = Fido.search(a.Time("2010-11-03", "2010-11-03 23:59:59"), a.Instrument.xrs,
+                       a.goes.SatelliteNumber(15))
+norh_res = Fido.search(a.Time("2010-11-03", "2010-11-03 23:59:59"), a.Instrument.norh,
                        a.Wavelength(17 * u.GHz))
+
 ##############################################################################
 # Download the data and load it
 goes_files = Fido.fetch(goes_res)


### PR DESCRIPTION
This reduces the amount of data from 2 days (2 files) to 1 day (1 file). Really we should rewrite this example to use sample data, but this is a simple improvement for now. xref https://github.com/sunpy/sunpy/issues/4836