### PR TITLE
Fixed issue with hypothesis testing and setting the Astropy ephemeris

### DIFF
--- a/changelog/4852.trivial.rst
+++ b/changelog/4852.trivial.rst
@@ -1,0 +1,1 @@
+Changed the implementation of a `hypothesis`-based test so that it does not raise an error with `hypothesis` 6.0.0.


### PR DESCRIPTION
Fixes #4851 

To avoid `hypothesis` worrying about interacting with function-scoped `pytest` fixtures, the temporary setting of the Astropy ephemeris in coordinate tests is now accomplished through the setup/teardown of an enclosing class rather than a fixture.