### PR TITLE
Make Map.rotate dask-aware with dask_image

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ asdf =
   asdf>=2.6.0
 dask =
   dask[array]>=2.0.0
+  dask_image>=0.6.0
 database =
   sqlalchemy>=1.3.4
 image =

--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -262,3 +262,12 @@ def test_reproducible_matrix_multiplication():
             print(f"{mismatches[i]} mismatching elements in multiplication #{i}")
 
     assert np.sum(mismatches != 0) == 0
+
+
+def test_dask(original, identity):
+    import dask.array
+    original_dask = dask.array.from_array(original)
+    derot = affine_transform(original, rmatrix=identity, use_scipy=True)
+    derot_dask = affine_transform(original_dask, rmatrix=identity, use_scipy=True)
+    assert isinstance(derot_dask, dask.array.Array)
+    assert np.all(derot == derot_dask.compute())

--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -264,10 +264,11 @@ def test_reproducible_matrix_multiplication():
     assert np.sum(mismatches != 0) == 0
 
 
-def test_dask(original, identity):
+@pytest.mark.parametrize('order', [1, 2, 3, 4])
+def test_dask(original, identity, order):
     import dask.array
     original_dask = dask.array.from_array(original)
-    derot = affine_transform(original, rmatrix=identity, use_scipy=True)
+    derot = affine_transform(original, rmatrix=identity, use_scipy=True, prefilter=False)
     derot_dask = affine_transform(original_dask, rmatrix=identity, use_scipy=True)
     assert isinstance(derot_dask, dask.array.Array)
     assert np.all(derot == derot_dask.compute())

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -122,9 +122,10 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
     if use_scipy:
         if np.any(np.isnan(image)):
             warnings.warn("Setting NaNs to 0 for SciPy rotation.", SunpyUserWarning)
+            image = np.nan_to_num(image)
         # Transform the image using the scipy affine transform
         rotated_image = scipy_affine_transform(
-            np.nan_to_num(image).T,
+            image.T,
             rmatrix,
             offset=shift,
             order=order,

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -25,7 +25,7 @@ __all__ = ['affine_transform']
 
 
 def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
-                     recenter=False, missing=0.0, use_scipy=False):
+                     recenter=False, missing=0.0, use_scipy=False, **kwargs):
     """
     Rotates, shifts and scales an image.
 
@@ -129,7 +129,8 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
             offset=shift,
             order=order,
             mode='constant',
-            cval=missing
+            cval=missing,
+            **kwargs,
         ).T
     else:
         # Make the rotation matrix 3x3 to include translation of the image

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -120,12 +120,12 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
     else:
         scipy_affine_transform = scipy.ndimage.interpolation.affine_transform
     if use_scipy:
-        if np.any(np.isnan(image)):
-            warnings.warn("Setting NaNs to 0 for SciPy rotation.", SunpyUserWarning)
-            image = np.nan_to_num(image)
+        if kwargs.pop('check_nans', True):
+            if np.any(np.isnan(image)):
+                warnings.warn("Setting NaNs to 0 for SciPy rotation.", SunpyUserWarning)
         # Transform the image using the scipy affine transform
         rotated_image = scipy_affine_transform(
-            image.T,
+            np.nan_to_num(image).T,
             rmatrix,
             offset=shift,
             order=order,

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1416,7 +1416,7 @@ class GenericMap(NDData):
 
     @u.quantity_input
     def rotate(self, angle: u.deg = None, rmatrix=None, order=4, scale=1.0,
-               recenter=False, missing=0.0, use_scipy=False):
+               recenter=False, missing=0.0, use_scipy=False, **kwargs):
         """
         Returns a new rotated and rescaled map.
 
@@ -1547,10 +1547,13 @@ class GenericMap(NDData):
         # Apply the rotation to the image data
         new_data = affine_transform(new_data.T,
                                     np.asarray(rmatrix),
-                                    order=order, scale=scale,
+                                    order=order,
+                                    scale=scale,
                                     image_center=np.flipud(pixel_center),
-                                    recenter=recenter, missing=missing,
-                                    use_scipy=use_scipy).T
+                                    recenter=recenter,
+                                    missing=missing,
+                                    use_scipy=use_scipy,
+                                    **kwargs).T
 
         if recenter:
             new_reference_pixel = pixel_array_center

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -867,6 +867,14 @@ def test_rotate_invalid_order(generic_map):
         generic_map.rotate(order=-1)
 
 
+def test_rotate_dask_array(generic_map):
+    import dask.array
+    dask_map = generic_map._new_instance(
+        dask.array.from_array(generic_map.data), generic_map.meta)
+    dask_map_rot = dask_map.rotate(use_scipy=True)
+    assert isinstance(dask_map_rot.data, dask.array.Array)
+
+
 def test_as_mpl_axes_aia171(aia171_test_map):
     ax = plt.subplot(projection=aia171_test_map)
     assert isinstance(ax, wcsaxes.WCSAxes)


### PR DESCRIPTION
Fixes #3266. 

There's a lot going on here and this is very incomplete at the moment. The current version of `dask-image` does not include `affine_transform` (see dask/dask-image#180) so we'll at least need to wait on that. Furthermore, the simple test I've included fails because the Dask and non-Dask results do not match.

EDIT: The latest version of `dask-image` with `affine_transform` is now released and available on PyPI