### PR TITLE
Improve differential rotation documentation

### DIFF
--- a/changelog/4876.doc.rst
+++ b/changelog/4876.doc.rst
@@ -1,0 +1,1 @@
+Improved documentation for :func:`sunpy.physics.differential_rotation.diff_rot`.

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -148,6 +148,8 @@ class RotatedSunFrame(SunPyBaseCoordinateFrame):
         between this time and the observation time in ``base``.
     rotation_model : `str`
         Accepted model names are ``'howard'`` (default), ``'snodgrass'``, and ``'allen'``.
+        See the documentation for :func:`~sunpy.physics.differential_rotation.diff_rot` for differences
+        between these models.
 
     Notes
     -----

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -25,7 +25,7 @@ __all__ = ['diff_rot', 'solar_rotate_coordinate', 'differential_rotate']
 
 @u.quantity_input
 def diff_rot(duration: u.s, latitude: u.deg, rot_type='howard', frame_time='sidereal'):
-    """
+    r"""
     This function computes the change in longitude over days in degrees.
 
     Parameters
@@ -51,10 +51,29 @@ def diff_rot(duration: u.s, latitude: u.deg, rot_type='howard', frame_time='side
     longitude_delta : `~astropy.units.Quantity`
         The change in longitude over days (units=degrees)
 
+    Notes
+    -----
+    The rotation rate at a heliographic latitude :math:`\theta` is given by
+
+    .. math::
+
+        A + B \sin^{2} \left (\theta \right ) + C \sin^{4} \left ( \theta \right )
+
+    where :math:`A, B, C` are constants that depend on the model:
+
+    ========= ===== ====== ====== ==========
+    Model     A     B      C      Unit
+    ========= ===== ====== ====== ==========
+    howard    2.894 -0.428 -0.370 microrad/s
+    snodgrass 2.851 -0.343 -0.474 microrad/s
+    allen     14.44 -3.0   0      deg/day
+    ========= ===== ====== ====== ==========
+
+    1 microrad/s is approximately 4.95 deg/day.
+
     References
     ----------
 
-    * `IDL code equivalent <https://hesperia.gsfc.nasa.gov/ssw/gen/idl/solar/diff_rot.pro>`__
     * `Solar surface velocity fields determined from small magnetic features (Howard et al. 1990) <https://doi.org/10.1007/BF00156795>`__
     * `A comparison of differential rotation measurements (Beck 2000, includes Snodgrass values) <https://doi.org/10.1023/A:1005226402796>`__
 
@@ -66,15 +85,26 @@ def diff_rot(duration: u.s, latitude: u.deg, rot_type='howard', frame_time='side
     >>> import numpy as np
     >>> import astropy.units as u
     >>> from sunpy.physics.differential_rotation import diff_rot
-    >>> rotation = diff_rot(2 * u.day, 30 * u.deg)
+    >>> diff_rot(2 * u.day, 30 * u.deg)
+    <Longitude 27.36432679 deg>
 
     Default rotation over two days for a number of latitudes:
 
-    >>> rotation = diff_rot(2 * u.day, np.linspace(-70, 70, 20) * u.deg)
+    >>> diff_rot(2 * u.day, np.linspace(-70, 70, 20) * u.deg)
+    <Longitude [22.05449682, 23.03214991, 24.12033958, 25.210281  ,
+                26.21032832, 27.05716463, 27.71932645, 28.19299667,
+                28.49196765, 28.63509765, 28.63509765, 28.49196765,
+                28.19299667, 27.71932645, 27.05716463, 26.21032832,
+                25.210281  , 24.12033958, 23.03214991, 22.05449682] deg>
 
     With rotation type 'allen':
 
-    >>> rotation = diff_rot(2 * u.day, np.linspace(-70, 70, 20) * u.deg, 'allen')
+    >>> diff_rot(2 * u.day, np.linspace(-70, 70, 20) * u.deg, 'allen')
+    <Longitude [23.58186667, 24.14800185, 24.82808733, 25.57737945,
+            26.34658134, 27.08508627, 27.74430709, 28.28087284,
+            28.6594822 , 28.85522599, 28.85522599, 28.6594822 ,
+            28.28087284, 27.74430709, 27.08508627, 26.34658134,
+            25.57737945, 24.82808733, 24.14800185, 23.58186667] deg>
     """
 
     latitude = latitude.to(u.deg)


### PR DESCRIPTION
- Add a listing of the different models to the `Notes` section.
- Reference this from the `RotatedSunFrame` docs.
- Remove the link to the IDL equivalent, as I think the rest of the docstring is sufficient to explain the function (unless anyone feels like this should stay?)