### PR TITLE
Revert "MPL workaround?"

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2109,11 +2109,7 @@ class GenericMap(NDData):
                               SunpyUserWarning)
 
         # Normal plot
-        try:
-            plot_settings = copy.deepcopy(self.plot_settings)
-        except NotImplementedError:
-            # MPL dev at the moment does not support deepcopy and this is a workaround.
-            plot_settings = self.plot_settings
+        plot_settings = copy.deepcopy(self.plot_settings)
         if 'title' in plot_settings:
             plot_settings_title = plot_settings.pop('title')
         else:
@@ -2142,11 +2138,7 @@ class GenericMap(NDData):
 
         # Take a deep copy here so that a norm in imshow_kwargs doesn't get modified
         # by setting it's vmin and vmax
-        try:
-            imshow_args.update(copy.deepcopy(imshow_kwargs))
-        except NotImplementedError:
-            # MPL dev at the moment does not support deepcopy and this is a workaround.
-            imshow_args.update(imshow_kwargs)
+        imshow_args.update(copy.deepcopy(imshow_kwargs))
 
         if clip_interval is not None:
             if len(clip_interval) == 2:


### PR DESCRIPTION
This reverts commit 6fcb4e2f69118919e5f12a4ed1164eddbd574ebd, which was a workaround for a regresssion on the matplotlib development branch that has subsequently been fixed: https://github.com/matplotlib/matplotlib/issues/18119#event-4215568818