### PR TITLE
Added longitude argument and broadcasting capabilites to carrington_rotation_time()

### DIFF
--- a/changelog/4879.feature.rst
+++ b/changelog/4879.feature.rst
@@ -1,0 +1,1 @@
+Added a ``longitude`` keyword argument to :func:`~sunpy.sun.carrington_rotation_time` as an alternate way to specify a fractional Carrington rotation.

--- a/changelog/4879.feature.rst
+++ b/changelog/4879.feature.rst
@@ -1,1 +1,1 @@
-Added a ``longitude`` keyword argument to :func:`~sunpy.sun.carrington_rotation_time` as an alternate way to specify a fractional Carrington rotation.
+Added a ``longitude`` keyword argument to :func:`~sunpy.coordinates.sun.carrington_rotation_time` as an alternate way to specify a fractional Carrington rotation.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -118,6 +118,17 @@ def carrington_rotation_time(crot, longitude: u.deg = None):
     Returns
     -------
     `astropy.time.Time`
+
+    Examples
+    --------
+    >>> from sunpy.coordinates.sun import carrington_rotation_time
+    >>> import astropy.units as u
+    >>> carrington_rotation_time(2242)
+    <Time object: scale='utc' format='iso' value=2021-03-17 22:31:37.030>
+    >>> carrington_rotation_time(2000.25)
+    <Time object: scale='utc' format='iso' value=2003-02-27 02:52:57.315>
+    >>> carrington_rotation_time(2000, 270*u.deg)
+    <Time object: scale='utc' format='iso' value=2003-02-27 02:52:57.315>
     """
     crot = crot << u.one
     if longitude is not None:

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -93,7 +93,7 @@ def sky_position(t='now', equinox_of_date=True):
 
 
 @u.quantity_input
-def carrington_rotation_time(crot: u.one, longitude: u.deg = None):
+def carrington_rotation_time(crot, longitude: u.deg = None):
     """
     Return the time of a given Carrington rotation.
 
@@ -108,7 +108,7 @@ def carrington_rotation_time(crot: u.one, longitude: u.deg = None):
 
     Parameters
     ----------
-    crot : `~astropy.units.Quantity`
+    crot : `int`, `float`, `~astropy.units.Quantity`
         Carrington rotation number(s). Can be a fractional rotation number.
 
     longitude : `~astropy.units.Quantity`
@@ -119,6 +119,7 @@ def carrington_rotation_time(crot: u.one, longitude: u.deg = None):
     -------
     `astropy.time.Time`
     """
+    crot = crot << u.one
     if longitude is not None:
         if not quantity_allclose(crot%1, 0):
             raise ValueError("Carrington rotation number(s) must be integral if `longitude` is provided.")

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -1,5 +1,6 @@
 import warnings
 
+import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
@@ -470,6 +471,39 @@ def test_carrington_rotation_starttime(crot, julian_days):
         warnings.filterwarnings("ignore", category=ErfaWarning)
         assert_quantity_allclose(sun.carrington_rotation_time(crot).tt.jd * u.day,
                                  julian_days * u.day, atol=0.11*u.s)
+
+
+@pytest.mark.parametrize("crot, longitude, crot_fractional",
+                         [(2000, 360, 2000.0),
+                          (2000.0, 270, 2000.25)
+                          ])
+def test_carrington_rotation_time_longitude(crot, longitude, crot_fractional):
+    assert sun.carrington_rotation_time(crot*u.one, longitude*u.deg) == \
+        sun.carrington_rotation_time(crot_fractional*u.one)
+
+
+@pytest.mark.parametrize("crot, longitude, crot_fractional",
+                         [
+                             (np.array([2000, 2000]), np.array(
+                                 [180, 90]), np.array([2000.5, 2000.75])),
+                             (2000, np.array([180, 90]), np.array([2000.5, 2000.75])),
+                             (np.array([2000, 2000]), 180, np.array([2000.5, 2000.5]))
+                         ])
+def test_carrington_rotation_time_longitude_numpy(crot, longitude, crot_fractional):
+    assert all(sun.carrington_rotation_time(crot*u.one, longitude*u.deg) ==
+               sun.carrington_rotation_time(crot_fractional*u.one))
+
+
+@pytest.mark.parametrize("crot, longitude",
+                         [
+                             (2000, 0),
+                             (2000, -10),
+                             (2000, 400),
+                             (2000.5, 180),
+                         ])
+def test_carrington_rotation_time_longitude_err(crot, longitude):
+    with pytest.raises(ValueError):
+        sun.carrington_rotation_time(crot*u.one, longitude*u.deg)
 
 
 def test_carrington_rotation_roundtrip():


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #4821
Fixes #4863 

Added the longitude feature as requested in #4821. Also in #4863 it was mentioned that this function also works with Numpy arrays so I added a kind of "broadcasting" capability so that we can calculate multiple rotation times at once.

Would appreciate feedback before adding tests for this.
