### PR TITLE
Handle time scale FITS metadata in map.date

### DIFF
--- a/changelog/4881.bugfix.rst
+++ b/changelog/4881.bugfix.rst
@@ -1,0 +1,4 @@
+`sunpy.map.GenericMap.date` now has its time scale set from the 'TIMESYS' FITS keyword,
+if it is present. If it isn't present the time scale defaults to 'utc', which is unchanged
+default behaviour, so this change will only affect maps with a 'TIMESYS' keyword
+that is not set to 'UTC'.

--- a/changelog/4881.bugfix.rst
+++ b/changelog/4881.bugfix.rst
@@ -1,4 +1,4 @@
 `sunpy.map.GenericMap.date` now has its time scale set from the 'TIMESYS' FITS keyword,
-if it is present. If it isn't present the time scale defaults to 'utc', which is unchanged
+if it is present. If it isn't present the time scale defaults to 'UTC', which is unchanged
 default behaviour, so this change will only affect maps with a 'TIMESYS' keyword
 that is not set to 'UTC'.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -666,7 +666,7 @@ class GenericMap(NDData):
             timesys_meta = self.meta.get('timesys', '').upper()
             if timesys_meta != 'TAI':
                 warnings.warn('Found "TAI" in time string, ignoring TIMESYS keyword '
-                              f'which is set to "{timesys_meta}".')
+                              f'which is set to "{timesys_meta}".', SunpyUserWarning)
         else:
             # UTC is the FITS standard default
             timesys = self.meta.get('timesys', 'UTC')

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -657,6 +657,20 @@ class GenericMap(NDData):
         This is taken from the 'DATE-OBS' FITS keyword.
         """
         time = self.meta.get('date-obs', None)
+        # Get the time scale
+        if time is not None and 'TAI' in time:
+            # SDO specifies the 'TAI' scale in their time string, which is parsed
+            # by parse_time(). If a different timescale is also present, warn the
+            # user that it will be ignored.
+            timesys = 'TAI'
+            timesys_meta = self.meta.get('timesys', '').upper()
+            if timesys_meta != 'TAI':
+                warnings.warn('Found "TAI" in time string, ignoring TIMESYS keyword '
+                              f'which is set to "{timesys_meta}".')
+        else:
+            # UTC is the FITS standard default
+            timesys = self.meta.get('timesys', 'UTC')
+
         if time is None:
             if self._default_time is None:
                 warnings.warn("Missing metadata for observation time, "
@@ -665,7 +679,8 @@ class GenericMap(NDData):
                               SunpyUserWarning)
                 self._default_time = parse_time('now')
             time = self._default_time
-        return parse_time(time)
+
+        return parse_time(time, scale=timesys.lower())
 
     @property
     def detector(self):

--- a/sunpy/map/sources/rhessi.py
+++ b/sunpy/map/sources/rhessi.py
@@ -3,6 +3,7 @@
 __author__ = "Steven Christe"
 __email__ = "steven.d.christe@nasa.gov"
 
+from sunpy import log
 from sunpy.map import GenericMap
 
 __all__ = ['RHESSIMap']
@@ -54,6 +55,11 @@ class RHESSIMap(GenericMap):
         self.meta['waveunit'] = 'keV'
         self.meta['wavelnth'] = [self.meta['energy_l'], self.meta['energy_h']]
         self.plot_settings['cmap'] = 'rhessi'
+
+        if ('TIMESYS' in self.meta and
+                self.meta['keycomments']['TIMESYS'] == 'Reference Time'):
+            log.debug('Moving "TIMESYS" FITS keyword to "DATEREF"')
+            self.meta['DATEREF'] = self.meta.pop('TIMESYS')
 
     @property
     def detector(self):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -135,6 +135,14 @@ def test_date(generic_map):
     assert isinstance(generic_map.date, Time)
 
 
+def test_date_scale(generic_map):
+    # Check that default time scale is UTC
+    assert 'timesys' not in generic_map.meta
+    assert generic_map.date.scale == 'utc'
+    generic_map.meta['timesys'] = 'tai'
+    assert generic_map.date.scale == 'tai'
+
+
 def test_date_aia(aia171_test_map):
     assert aia171_test_map.date == parse_time('2011-02-15T00:00:00.34')
 


### PR DESCRIPTION
Section 9.2.1 https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf says there is a TIMESYS keyword, that can be set to denote the time scale of times in a FITS header. This PR:

- Sets the time scale from TIMESYS if present
- Explicitly sets the timescale to 'utc', which is the mandated default, if TIMESYS isn't present.

It looks like the timescale was implicitly set to UTC anyway by default (either by us or astropy?), so this shouldn't be a big issue, but we should still support alternative time scales from the FITS header.