### PR TITLE
Add support for TIMEUNIT FITS keyword

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -677,13 +677,23 @@ class GenericMap(NDData):
         return self.meta.get('detector', "")
 
     @property
+    def timeunit(self):
+        """
+        The `~astropy.units.Unit` of the exposure time of this observation.
+
+        Taken from the "TIMEUNIT" FITS keyword, and defaults to seconds (as per)
+        the FITS standard).
+        """
+        return u.Unit(self.meta.get('timeunit', 's'))
+
+    @property
     def exposure_time(self):
         """
         Exposure time of the image in seconds.
 
         This is taken from the 'EXPTIME' FITS keyword.
         """
-        return self.meta.get('exptime', 0.0) * u.s
+        return self.meta.get('exptime', 0.0) * self.timeunit
 
     @property
     def instrument(self):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -143,6 +143,12 @@ def test_detector(generic_map):
     assert generic_map.detector == 'bar'
 
 
+def test_timeunit(generic_map):
+    assert generic_map.timeunit == u.Unit('s')
+    generic_map.meta['timeunit'] = 'h'
+    assert generic_map.timeunit == u.Unit('h')
+
+
 def test_dsun(generic_map):
     assert_quantity_allclose(generic_map.dsun, sun.earth_distance(generic_map.date))
 


### PR DESCRIPTION
https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf section 9.7 says that the unit for exposure time can be specified using the TIMEUNIT keyword. Add support for this, falling back on the mandated default of seconds (which is what sunpy previously always assumed).