### PR TITLE
Reduce the length of the BaseClient repr

### DIFF
--- a/sunpy/net/base_client.py
+++ b/sunpy/net/base_client.py
@@ -358,8 +358,8 @@ def _print_client(client, html=False, visible_entries=None):
     lines = [class_name, dedent(client.__doc__.partition("\n\n")[0])]
     if html:
         lines = [f"<p>{line}</p>" for line in lines]
-        lines.extend(t.pformat_all(max_lines=visible_entries, show_dtype=False,
-                                   max_width=width, align="<", html=html))
+    lines.extend(t.pformat_all(max_lines=visible_entries, show_dtype=False,
+                               max_width=width, align="<", html=html))
     return '\n'.join(lines)
 
 
@@ -423,7 +423,7 @@ class BaseClient(ABC):
         """
         Returns the normal repr plus the pretty client __str__.
         """
-        return _print_client(visible_entries=15, client=self)
+        return object.__repr__(self) + "\n" + _print_client(visible_entries=15, client=self)
 
     def __str__(self):
         """

--- a/sunpy/net/base_client.py
+++ b/sunpy/net/base_client.py
@@ -326,7 +326,7 @@ def convert_row_to_table(func):
     return wrapper
 
 
-def _print_client(client, html=False):
+def _print_client(client, html=False, visible_entries=None):
     """
     Given a BaseClient instance will print out each registered attribute.
 
@@ -358,7 +358,8 @@ def _print_client(client, html=False):
     lines = [class_name, dedent(client.__doc__.partition("\n\n")[0])]
     if html:
         lines = [f"<p>{line}</p>" for line in lines]
-    lines.extend(t.pformat_all(show_dtype=False, max_width=width, align="<", html=html))
+        lines.extend(t.pformat_all(max_lines=visible_entries, show_dtype=False,
+                                   max_width=width, align="<", html=html))
     return '\n'.join(lines)
 
 
@@ -422,19 +423,19 @@ class BaseClient(ABC):
         """
         Returns the normal repr plus the pretty client __str__.
         """
-        return object.__repr__(self) + "\n" + str(self)
+        return _print_client(visible_entries=15, client=self)
 
     def __str__(self):
         """
         This enables the "pretty" printing of BaseClient.
         """
-        return _print_client(self)
+        return _print_client(client=self)
 
     def _repr_html_(self):
         """
         This enables the "pretty" printing of the BaseClient with html.
         """
-        return _print_client(self, html=True)
+        return _print_client(visible_entries=15, client=self, html=True)
 
     @abstractmethod
     def search(self, *args, **kwargs):

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -517,7 +517,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         return results
 
     def __repr__(self):
-        return object.__repr__(self) + "\n" + str(self)
+        return object.__repr__(self) + "\n" + self._print_clients(visible_entries=15)
 
     def __str__(self):
         """
@@ -529,9 +529,9 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         """
         This enables the "pretty" printing of the Fido Clients with html.
         """
-        return self._print_clients(html=True)
+        return self._print_clients(visible_entries=15, html=True)
 
-    def _print_clients(self, html=False) -> str:
+    def _print_clients(self, html=False, visible_entries=None) -> str:
         width = -1 if html else get_width()
 
         t = Table(names=["Client", "Description"], dtype=["U80", "U120"])
@@ -541,7 +541,8 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         for key in BaseClient._registry.keys():
             t.add_row((key.__name__, dedent(
                 key.__doc__.partition("\n\n")[0].replace("\n    ", " "))))
-        lines.extend(t.pformat_all(show_dtype=False, max_width=width, align="<", html=html))
+        lines.extend(t.pformat_all(max_lines=visible_entries,
+                                   show_dtype=False, max_width=width, align="<", html=html))
         return '\n'.join(lines)
 
 


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #4884
Removes the part in __repr__ method of the BaseClient class so that the method only returns a VSOClient object. 
