### PR TITLE
Propagate units to map statistical methods

### DIFF
--- a/changelog/4912.breaking.rst
+++ b/changelog/4912.breaking.rst
@@ -1,0 +1,4 @@
+``Map`` statistical methods (`~sunpy.map.GenericMap.std`,
+`~sunpy.map.GenericMap.mean`, `~sunpy.map.GenericMap.min`,
+`~sunpy.map.GenericMap.max`) now return a `~astropy.units.Quantity`.
+To get the raw number use the ``.value`` attribute of the returned Quantity.

--- a/changelog/4912.feature.rst
+++ b/changelog/4912.feature.rst
@@ -1,0 +1,4 @@
+``Map`` statistical methods (`~sunpy.map.GenericMap.std`,
+`~sunpy.map.GenericMap.mean`, `~sunpy.map.GenericMap.min`,
+`~sunpy.map.GenericMap.max`) now return a `~astropy.units.Quantity` with the
+correct units set.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -573,25 +573,39 @@ class GenericMap(NDData):
         """
         Calculate the standard deviation of the data array.
         """
-        return self.data.std(*args, **kwargs)
+        return np.std(self._data_as_quantity, *args, **kwargs)
 
     def mean(self, *args, **kwargs):
         """
         Calculate the mean of the data array.
         """
-        return self.data.mean(*args, **kwargs)
+        return np.mean(self._data_as_quantity, *args, **kwargs)
 
     def min(self, *args, **kwargs):
         """
         Calculate the minimum value of the data array.
         """
-        return self.data.min(*args, **kwargs)
+        return np.min(self._data_as_quantity, *args, **kwargs)
 
     def max(self, *args, **kwargs):
         """
         Calculate the maximum value of the data array.
         """
-        return self.data.max(*args, **kwargs)
+        return np.max(self._data_as_quantity, *args, **kwargs)
+
+    @property
+    def _data_as_quantity(self):
+        """
+        Create a Quantity from the data and unit of the map.
+
+        This doesn't make a copy with the data, so be careful what
+        you do with it. It is only intended for internal use.
+
+        We have to explicitly set dtype to avoid astropy casting integer data
+        to floating point and therefore implicitly taking a copy.
+        """
+        return u.Quantity(self.data, unit=self.unit, copy=False,
+                          dtype=self.data.dtype)
 
     @property
     def unit(self):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -91,19 +91,19 @@ def test_size(generic_map):
 
 
 def test_min(generic_map):
-    assert generic_map.min() == 1
+    assert generic_map.min() == 1 * u.ct / u.s
 
 
 def test_max(generic_map):
-    assert generic_map.max() == 1
+    assert generic_map.max() == 1 * u.ct / u.s
 
 
 def test_mean(generic_map):
-    assert generic_map.mean() == 1
+    assert generic_map.mean() == 1 * u.ct / u.s
 
 
 def test_std(generic_map):
-    assert generic_map.std() == 0
+    assert generic_map.std() == 0 * u.ct / u.s
 
 
 def test_unit(generic_map):


### PR DESCRIPTION
- This is a breaking change, but I think one worth making. Does anyone else have opinions on this?
- Unfortunately e.g. `np.mean(NDData_instance)` doesn't propagate the unit, so I had to create a quantity. I've done this in place though, so there shouldn't be (much) memory overhead
- Still needs a changelog, but in the meantime feedback welcome.