### PR TITLE
Fixed the introspection of arguments for subclasses of DataAttr

### DIFF
--- a/changelog/4916.docfix.rst
+++ b/changelog/4916.docfix.rst
@@ -1,0 +1,1 @@
+Fixed the display of arguments in the documentation for `~sunpy.net.Fido` attributes (`sunpy.net.attrs`).

--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -14,6 +14,7 @@ Please note that & is evaluated first, so A & B | C is equivalent to
 """
 import re
 import string
+import inspect
 import keyword
 import textwrap
 from textwrap import dedent
@@ -279,6 +280,23 @@ class DataAttr(Attr):
             raise TypeError("You should not directly instantiate DataAttr, only it's subclasses.")
 
         return super().__new__(cls)
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        # Because __new__() is defined, this will block natural introspection of the arguments for
+        # __init__() in all subclasses because the signature of __new__() takes precedence over the
+        # signature of __init__().  We add a __new__() to all subclasses that do not explicitly
+        # define it with a signature that matches __init__().
+        if '__new__' not in cls.__dict__:
+            unsigned_new = cls.__new__  # the inherited __new__()
+
+            def signed_new(cls, *args, **kwargs):
+                return unsigned_new(cls, *args, **kwargs)
+
+            signed_new.__signature__ = inspect.signature(cls.__init__)
+
+            cls.__new__ = signed_new
 
 
 class DummyAttr(Attr):


### PR DESCRIPTION
Fixes #4913 

> Currently Fido attributes have a generic (*args, **kwargs) function signature in the docs: https://docs.sunpy.org/en/stable/code_ref/net.html#classes

> Detective work on element has uncovered that this is because `DataAttr` has a `__new__(*args, **kwargs)`, which takes precedence over the `__init__` signatures defined in the sub-classes.

This PR fixes the introspected arguments for the `Fido` attributes.  It uses `__init_subclasses__()` to create a `__new__()` in any subclass of `DataAttr`, which simply calls the inherited `__new__()`, but with its signature matching the `__init__()` signature.