### PR TITLE
Fixed miscellaneous bugs with GenericMap.draw_rectangle()

### DIFF
--- a/changelog/4929.bugfix.rst
+++ b/changelog/4929.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a handling bug in :meth:`~sunpy.map.GenericMap.draw_rectangle` when the rectangle is specified in a different coordinate frame than that of the map.
+A couple of other minor bugs in :meth:`~sunpy.map.GenericMap.draw_rectangle` were also fixed.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1941,11 +1941,6 @@ class GenericMap(NDData):
         Extra keyword arguments to this function are passed through to the
         `~matplotlib.patches.Rectangle` instance.
         """
-        if isinstance(top_right, u.Quantity) and isinstance(width, u.Quantity):
-            # The decorator assigns the first positional arg to top_right and so on.
-            height = width
-            width = top_right
-            top_right = None
 
         bottom_left, top_right = get_rectangle_coordinates(bottom_left,
                                                            top_right=top_right,

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1941,11 +1941,13 @@ class GenericMap(NDData):
         Extra keyword arguments to this function are passed through to the
         `~matplotlib.patches.Rectangle` instance.
         """
-
         bottom_left, top_right = get_rectangle_coordinates(bottom_left,
                                                            top_right=top_right,
                                                            width=width,
                                                            height=height)
+
+        bottom_left = bottom_left.transform_to(self.coordinate_frame)
+        top_right = top_right.transform_to(self.coordinate_frame)
 
         width = Longitude(top_right.spherical.lon - bottom_left.spherical.lon)
         height = top_right.spherical.lat - bottom_left.spherical.lat
@@ -1957,8 +1959,7 @@ class GenericMap(NDData):
         else:
             axes_unit = self.spatial_units[0]
 
-        coord = bottom_left.transform_to(self.coordinate_frame)
-        bottom_left = u.Quantity((coord.spherical.lon, coord.spherical.lat), unit=axes_unit).value
+        bottom_left = u.Quantity(self._get_lon_lat(bottom_left), unit=axes_unit).value
 
         width = width.to(axes_unit).value
         height = height.to(axes_unit).value

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -19,7 +19,7 @@ from matplotlib.figure import Figure
 
 import astropy.units as u
 import astropy.wcs
-from astropy.coordinates import Latitude, Longitude, SkyCoord, UnitSphericalRepresentation
+from astropy.coordinates import Longitude, SkyCoord, UnitSphericalRepresentation
 from astropy.nddata import NDData
 from astropy.visualization import AsymmetricPercentileInterval, HistEqStretch, ImageNormalize
 from astropy.visualization.wcsaxes import WCSAxes
@@ -1948,7 +1948,7 @@ class GenericMap(NDData):
                                                            height=height)
 
         width = Longitude(top_right.spherical.lon - bottom_left.spherical.lon)
-        height = Latitude(top_right.spherical.lat - bottom_left.spherical.lat)
+        height = top_right.spherical.lat - bottom_left.spherical.lat
 
         if not axes:
             axes = plt.gca()
@@ -1963,7 +1963,7 @@ class GenericMap(NDData):
         width = width.to(axes_unit).value
         height = height.to(axes_unit).value
         kwergs = {'transform': wcsaxes_compat.get_world_transform(axes),
-                  'color': 'white',
+                  'edgecolor': 'white',
                   'fill': False}
         kwergs.update(kwargs)
         rect = plt.Rectangle(bottom_left, width, height, **kwergs)

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -184,7 +184,7 @@ def test_heliographic_rectangle_width_height(heliographic_test_map):
         60 * u.deg, 50 * u.deg, frame=heliographic_test_map.coordinate_frame)
     w = 13 * u.deg
     h = 13 * u.deg
-    heliographic_test_map.draw_rectangle(bottom_left, width=w, height=h, color='cyan')
+    heliographic_test_map.draw_rectangle(bottom_left, width=w, height=h, edgecolor='cyan')
 
 
 @figure_test
@@ -193,7 +193,7 @@ def test_heliographic_rectangle_top_right(heliographic_test_map):
     bottom_left = SkyCoord(
         60 * u.deg, 50 * u.deg, frame=heliographic_test_map.coordinate_frame)
     top_right = SkyCoord(73 * u.deg, 63 * u.deg, frame=heliographic_test_map.coordinate_frame)
-    heliographic_test_map.draw_rectangle(bottom_left, top_right=top_right, color='cyan')
+    heliographic_test_map.draw_rectangle(bottom_left, top_right=top_right, edgecolor='cyan')
 
 
 # See https://github.com/sunpy/sunpy/issues/4294 to track this warning. Ideally

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -128,6 +128,16 @@ def test_rectangle_aia171_top_right(aia171_test_map):
 
 
 @figure_test
+def test_rectangle_aia171_hgs_width_height(aia171_test_map):
+    aia171_test_map.plot()
+    bottom_left = SkyCoord(
+        0 * u.deg, -60 * u.deg, frame='heliographic_stonyhurst', obstime=aia171_test_map.date)
+    w = 45 * u.deg
+    h = 120 * u.deg
+    aia171_test_map.draw_rectangle(bottom_left, width=w, height=h)
+
+
+@figure_test
 def test_plot_masked_aia171(aia171_test_map_with_mask):
     aia171_test_map_with_mask.plot()
 

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_403.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_403.json
@@ -15,6 +15,7 @@
   "sunpy.map.tests.test_plotting.test_plot_aia171_nowcsaxes": "6e9cdda3aa9ed603f4be536634543ce8c1a6718b79aed57f850a187f8150446e",
   "sunpy.map.tests.test_plotting.test_rectangle_aia171_width_height": "455246d338564add5be94c1dc0ff5740a90d21d8ef7da9f392ba3a01237ef5b8",
   "sunpy.map.tests.test_plotting.test_rectangle_aia171_top_right": "455246d338564add5be94c1dc0ff5740a90d21d8ef7da9f392ba3a01237ef5b8",
+  "sunpy.map.tests.test_plotting.test_rectangle_aia171_hgs_width_height": "53cdb641cb2de3223dc1c0fa7e22857ed9ff62d71d27b08186b98d19958f1af6",
   "sunpy.map.tests.test_plotting.test_plot_masked_aia171": "2dff076c0eaaf5cf5849ad541b434bfbda00d99491db51eb35d2ab0ee729bbb2",
   "sunpy.map.tests.test_plotting.test_plot_masked_aia171_nowcsaxes": "69e28235fa42379a94f7da6cc39b375f361d1e26dc0f94e6b8c5f05894cc64c7",
   "sunpy.map.tests.test_plotting.test_plot_aia171_superpixel": "b147682850aad35e4c414de836c5880dcdba9f9e9fed13e53854b6685dffb39f",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -15,6 +15,7 @@
   "sunpy.map.tests.test_plotting.test_plot_aia171_nowcsaxes": "6e9cdda3aa9ed603f4be536634543ce8c1a6718b79aed57f850a187f8150446e",
   "sunpy.map.tests.test_plotting.test_rectangle_aia171_width_height": "455246d338564add5be94c1dc0ff5740a90d21d8ef7da9f392ba3a01237ef5b8",
   "sunpy.map.tests.test_plotting.test_rectangle_aia171_top_right": "455246d338564add5be94c1dc0ff5740a90d21d8ef7da9f392ba3a01237ef5b8",
+  "sunpy.map.tests.test_plotting.test_rectangle_aia171_hgs_width_height": "53cdb641cb2de3223dc1c0fa7e22857ed9ff62d71d27b08186b98d19958f1af6",
   "sunpy.map.tests.test_plotting.test_plot_masked_aia171": "2dff076c0eaaf5cf5849ad541b434bfbda00d99491db51eb35d2ab0ee729bbb2",
   "sunpy.map.tests.test_plotting.test_plot_masked_aia171_nowcsaxes": "69e28235fa42379a94f7da6cc39b375f361d1e26dc0f94e6b8c5f05894cc64c7",
   "sunpy.map.tests.test_plotting.test_plot_aia171_superpixel": "b147682850aad35e4c414de836c5880dcdba9f9e9fed13e53854b6685dffb39f",


### PR DESCRIPTION
This PR fixes miscellaneous bugs with `GenericMap.draw_rectangle()`:
- Removes code associated with handling positional arguments, which could potentially cause wackiness now.  Should not be backported to 2.0.
- Transforms the corners of the rectangle to the map's coordinate frame *before* determining the dimensions of the rectangle.
- Does not use `Latitude` for the "height" of the rectangle because the height is a latitude difference, which can be greater than 90 degrees.
- Specifies the color of the rectangle using `edgecolor` instead of `color` so that it can be properly overridden by the user.