### PR TITLE
Added an alternate histogram and colormap shading to Map quicklook

### DIFF
--- a/changelog/4931.feature.rst
+++ b/changelog/4931.feature.rst
@@ -1,0 +1,2 @@
+For :meth:`sunpy.map.GenericMap.quicklook` and :meth:`sunpy.map.MapSequence.quicklook` (also used for the HTML reprsentation shown in Jupyter notebooks), the histogram is now shaded corresponding to the colormap of the plotted image.
+Clicking on the histogram will toggle an alternate version of the histogram.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -345,7 +345,7 @@ class GenericMap(NDData):
 
         # Plot the CDF of the pixel values using a symmetric-log horizontal scale
         fig = Figure(figsize=(4.8, 2.4), constrained_layout=True)
-        # Figure instances in matplotlib<3.1 do not create a canvas by default
+        # TODO: Figure instances in matplotlib<3.1 do not create a canvas by default
         if fig.canvas is None:
             FigureCanvasBase(fig)
         ax = fig.subplots()

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -328,15 +328,41 @@ class GenericMap(NDData):
         if fig.canvas is None:
             FigureCanvasBase(fig)
         ax = fig.subplots()
-        ax.hist(finite_data.ravel(), bins=100, histtype='stepfilled')
+        values, bins, patches = ax.hist(finite_data.ravel(), bins=100)
+        norm_centers = norm(0.5 * (bins[:-1] + bins[1:])).data
+        for c, p in zip(norm_centers, patches):
+            plt.setp(p, "facecolor", cmap(c))
+        ax.plot(np.array([bins[:-1], bins[1:]]).T.ravel(),
+                np.array([values, values]).T.ravel())
         ax.set_facecolor('white')
         ax.semilogy()
         # Explicitly set the power limits for the X axis formatter to avoid text overlaps
         ax.xaxis.get_major_formatter().set_powerlimits((-3, 4))
-        ax.set_xlabel('Pixel value')
+        ax.set_xlabel('Pixel value (linear binning)')
         ax.set_ylabel('# of pixels')
-        ax.set_title('Distribution of pixels with finite values')
+        ax.set_title('Distribution of pixel values [click for cumulative]')
         hist_src = _figure_to_base64(fig)
+
+        # Plot the CDF of the pixel values using a symmetric-log horizontal scale
+        fig = Figure(figsize=(4.8, 2.4), constrained_layout=True)
+        # Figure instances in matplotlib<3.1 do not create a canvas by default
+        if fig.canvas is None:
+            FigureCanvasBase(fig)
+        ax = fig.subplots()
+        n_bins = 256
+        bins = norm.inverse(np.arange(n_bins + 1) / n_bins)
+        values, _, patches = ax.hist(finite_data.ravel(), bins=bins, cumulative=True)
+        for i, p in enumerate(patches):
+            plt.setp(p, "facecolor", cmap((i + 0.5) / n_bins))
+        ax.plot(np.array([bins[:-1], bins[1:]]).T.ravel(),
+                np.array([values, values]).T.ravel())
+        ax.set_facecolor('white')
+        ax.set_xscale('symlog')
+        ax.set_yscale('log')
+        ax.set_xlabel('Pixel value (equalized binning)')
+        ax.set_ylabel('Cumulative # of pixels')
+        ax.set_title('Cumulative distribution of pixel values')
+        cdf_src = _figure_to_base64(fig)
 
         return textwrap.dedent(f"""\
             <pre>{html.escape(object.__repr__(self))}</pre>
@@ -362,7 +388,13 @@ class GenericMap(NDData):
                 <tr>
                 </tr>
                 <tr>
-                    <td><img src='data:image/png;base64,{hist_src}'/></td>
+                    <td><img src='data:image/png;base64,{hist_src}'
+                             src2='data:image/png;base64,{cdf_src}'
+                             onClick='var temp = this.src;
+                                      this.src = this.getAttribute("src2");
+                                      this.setAttribute("src2", temp)'
+                        />
+                    </td>
                 </tr>
             </table>""")
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -338,7 +338,7 @@ class GenericMap(NDData):
         ax.semilogy()
         # Explicitly set the power limits for the X axis formatter to avoid text overlaps
         ax.xaxis.get_major_formatter().set_powerlimits((-3, 4))
-        ax.set_xlabel('Pixel value (linear binning)')
+        ax.set_xlabel('Pixel value in linear bins')
         ax.set_ylabel('# of pixels')
         ax.set_title('Distribution of pixel values [click for cumulative]')
         hist_src = _figure_to_base64(fig)
@@ -359,7 +359,7 @@ class GenericMap(NDData):
         ax.set_facecolor('white')
         ax.set_xscale('symlog')
         ax.set_yscale('log')
-        ax.set_xlabel('Pixel value (equalized binning)')
+        ax.set_xlabel('Pixel value in equalized bins')
         ax.set_ylabel('Cumulative # of pixels')
         ax.set_title('Cumulative distribution of pixel values')
         cdf_src = _figure_to_base64(fig)


### PR DESCRIPTION
Closes #4864

Map `quicklook()`'s histogram of pixel values has been enhanced with shading to correspond to the colormap.  For many maps, this is not exceptionally useful since the colormap is not distributed well across a linear scale of pixel values.  I've also added a secondary histogram – switch to it by clicking on the histogram – that uses a symmetric-log scale for the pixel values.

For our stock EIT 195 image:
![hist1](https://user-images.githubusercontent.com/991759/107986800-cb37a380-6f9a-11eb-9bf1-1ad0e416f1af.png)

And if you click on the histogram:
![hist2](https://user-images.githubusercontent.com/991759/107986808-cecb2a80-6f9a-11eb-91e0-ddecd8be052e.png)