### PR TITLE
Improve section order in dev guide

### DIFF
--- a/docs/dev_guide/index.rst
+++ b/docs/dev_guide/index.rst
@@ -22,9 +22,9 @@ This goes over the basics and has links to useful tutorials on git.
    contents/newcomers
    contents/code_standards
    contents/documentation
+   contents/example_gallery
    contents/tests
    contents/pr_review_procedure
-   contents/example_gallery
    contents/units_quantities
    contents/new_objects
    contents/maintainer_workflow


### PR DESCRIPTION
I think it makes sense to put the example gallery section directly below the documentation section in the contents.