### PR TITLE
Support reading GOES XRS daily background files

### DIFF
--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -210,7 +210,11 @@ class XRSTimeSeries(GenericTimeSeries):
                 xrsb = np.array(d["xrsb_flux"])
                 start_time_str = d["time"].attrs["units"].astype(str).lstrip("seconds since")
                 times = parse_time(start_time_str) + TimeDelta(d["time"], format="sec")
-
+            elif "bkd1d_xrsa_flux" in d.variables:
+                xrsa = np.array(d["bkd1d_xrsa_flux"])
+                xrsb = np.array(d["bkd1d_xrsb_flux"])
+                start_time_str = d["time"].attrs["units"].astype(str).lstrip("seconds since")
+                times = parse_time(start_time_str) + TimeDelta(d["time"], format="sec")
             else:
                 raise ValueError(f"The file {filepath} doesn't seem to be a GOES netcdf file.")
 


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

This adds support to `XRSTimeseries` for the XRS daily background files. These are described in section 7 of the [user guide](https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/goes16/l2/docs/GOES-R_XRS_L2_Data_Users_Guide.pdf) and more details are provided in appendix B of that document.

I'm not completely sure if this is a good idea or if perhaps this needs its own client or if we should even support these at all?