### PR TITLE
Added appropriate error message for a JSOC search when Notify isn't passed

### DIFF
--- a/changelog/4950.bugfix.rst
+++ b/changelog/4950.bugfix.rst
@@ -1,1 +1,1 @@
-Error message in `Fido.fetch` when `Notify` is missing is now specified.
+Improved error message from :meth:`sunpy.net.Fido.fetch` when no email has been supplied for JSOC data.

--- a/changelog/4950.bugfix.rst
+++ b/changelog/4950.bugfix.rst
@@ -1,0 +1,1 @@
+Error message in `Fido.fetch` when `Notify` is missing is now specified.

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -463,7 +463,7 @@ class JSOCClient(BaseClient):
        """
         for resp in jsoc_response.query_args:
             if 'notify' not in resp:
-                raise ValueError('Email address is not specified by a.jsoc.Notify')
+                raise ValueError('Pass attrs.jsoc.Notify with a JSOC registered email as an argument to fido.search')
 
         if len(jsoc_response) != jsoc_response._original_num_rows:
             warnings.warn("Downloading of sliced JSOC results is not supported. "

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -465,7 +465,7 @@ class JSOCClient(BaseClient):
             if 'notify' not in resp:
                 raise ValueError('A registered email is required to get data from JSOC. '
                                  'Please supply an email with attrs.jsoc.Notify to Fido.search. '
-                                 'Then pass those news results back into Fido.fetch')
+                                 'Then pass those new results back into Fido.fetch')
 
         if len(jsoc_response) != jsoc_response._original_num_rows:
             warnings.warn("Downloading of sliced JSOC results is not supported. "

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -463,7 +463,9 @@ class JSOCClient(BaseClient):
        """
         for resp in jsoc_response.query_args:
             if 'notify' not in resp:
-                raise ValueError('Pass attrs.jsoc.Notify with a JSOC registered email as an argument to fido.search')
+                raise ValueError('A registered email is required to get data from JSOC. '
+                                 'Please supply an email with attrs.jsoc.Notify to Fido.search. '
+                                 'Then pass those news results back into Fido.fetch')
 
         if len(jsoc_response) != jsoc_response._original_num_rows:
             warnings.warn("Downloading of sliced JSOC results is not supported. "

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -462,7 +462,7 @@ class JSOCClient(BaseClient):
 
        """
         for resp in jsoc_response.query_args:
-            if not 'notify' in resp:
+            if 'notify' not in resp:
                 raise ValueError('Email address is not specified by a.jsoc.Notify')
 
         if len(jsoc_response) != jsoc_response._original_num_rows:

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -461,6 +461,10 @@ class JSOCClient(BaseClient):
             A Results object
 
        """
+        for resp in jsoc_response.query_args:
+            if not 'notify' in resp:
+                raise ValueError('Email address is not specified by a.jsoc.Notify')
+
         if len(jsoc_response) != jsoc_response._original_num_rows:
             warnings.warn("Downloading of sliced JSOC results is not supported. "
                           "All the files present in the original response will "

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -496,9 +496,9 @@ def test_fido_no_time(mocker):
 def test_jsoc_missing_email():
     res = Fido.search(a.Time("2011/01/01", "2011/01/01 00:01"), a.jsoc.Series.aia_lev1_euv_12s)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="Pass attrs.jsoc.Notify with a JSOC registered email as an argument to fido.search"):
         Fido.fetch(res)
-    assert excinfo.value.args[0] == 'Pass attrs.jsoc.Notify with a JSOC registered email as an argument to fido.search'
+
 
 @pytest.mark.remote_data
 def test_slice_jsoc():

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -496,9 +496,9 @@ def test_fido_no_time(mocker):
 def test_jsoc_missing_email():
     res = Fido.search(a.Time("2011/01/01", "2011/01/01 00:01"), a.jsoc.Series.aia_lev1_euv_12s)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         Fido.fetch(res)
-
+    assert excinfo.value.args[0] == 'Pass attrs.jsoc.Notify with a JSOC registered email as an argument to fido.search'
 
 @pytest.mark.remote_data
 def test_slice_jsoc():

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -494,6 +494,14 @@ def test_fido_no_time(mocker):
 
 @pytest.mark.remote_data
 def test_slice_jsoc():
+    res = Fido.search(a.Time("2011/01/01", "2011/01/01 00:01"), a.jsoc.Series.aia_lev1_euv_12s)
+
+    with pytest.raises(ValueError):
+        Fido.fetch(res)
+
+
+@pytest.mark.remote_data
+def test_slice_jsoc():
     tstart = '2011/06/07 06:32:45'
     tend = '2011/06/07 06:33:15'
     res = Fido.search(a.Time(tstart, tend), a.jsoc.Series('hmi.M_45s'),

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -496,7 +496,7 @@ def test_fido_no_time(mocker):
 def test_jsoc_missing_email():
     res = Fido.search(a.Time("2011/01/01", "2011/01/01 00:01"), a.jsoc.Series.aia_lev1_euv_12s)
 
-    with pytest.raises(ValueError, match="Pass attrs.jsoc.Notify with a JSOC registered email as an argument to fido.search"):
+    with pytest.raises(ValueError, match=r"A registered email is required to get data from JSOC.*"):
         Fido.fetch(res)
 
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -493,7 +493,7 @@ def test_fido_no_time(mocker):
 
 
 @pytest.mark.remote_data
-def test_slice_jsoc():
+def test_jsoc_missing_email():
     res = Fido.search(a.Time("2011/01/01", "2011/01/01 00:01"), a.jsoc.Series.aia_lev1_euv_12s)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #4923
Raises an appropriate error when ```attrs.jsoc.Notify``` isn't specified by ```Fido.fetch```
