### PR TITLE
pin drms to 0.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ map =
 net =
   beautifulsoup4
   pandas>=0.24.0
-  drms>=0.6
+  drms>=0.6.1
   python-dateutil
   tqdm
   zeep


### PR DESCRIPTION
Pin `drms` to v0.6.1 as it fixes a bug that was introduced in 0.6.0. 

I almost forgot about this, but that little bug is annoying and potentially means downloads of files from JSOC are skipped so I think this is needed. Ideally no one should be on 0.6.0.