### PR TITLE
Make sure figures are closed after animator tests

### DIFF
--- a/sunpy/visualization/animator/tests/test_basefuncanimator.py
+++ b/sunpy/visualization/animator/tests/test_basefuncanimator.py
@@ -47,7 +47,7 @@ def test_base_func_init(fig, colorbar, buttons):
     tfa._set_active_slider(1)
     assert tfa.active_slider == 1
 
-    fig = plt.figure()
+    fig = tfa.fig
     event = mback.KeyEvent(name='key_press_event', canvas=fig.canvas, key='down')
     tfa._key_press(event)
     assert tfa.active_slider == 0


### PR DESCRIPTION
I think this should fix the remote tests failure. Not sure why it's only happening on the remote tests, but it's probably good practice to close all figures after individual tests to stop them leaking.