### PR TITLE
Allow non-pyplot figures to be used by animators

### DIFF
--- a/changelog/4968.behaviour.rst
+++ b/changelog/4968.behaviour.rst
@@ -1,7 +1,0 @@
-The default axes used by :meth:`sunpy.visualisation.animator.BaseFuncAnimator.get_animation`
-is now ``BaseFuncAnimator.axes``, instead of the currently active axes (accessed via.
-:func:`matplotlib.pyplot.gca`). The allows animations to be created on figures
-not created via the pyplot interface.
-
-To revert to the previous behaviour of using the current axes,
-give ``axes=plt.gca()`` to ``get_animation()``.

--- a/changelog/4968.behaviour.rst
+++ b/changelog/4968.behaviour.rst
@@ -1,0 +1,7 @@
+The default axes used by :meth:`sunpy.visualisation.animator.BaseFuncAnimator.get_animation`
+is now ``BaseFuncAnimator.axes``, instead of the currently active axes (accessed via.
+:func:`matplotlib.pyplot.gca`). The allows animations to be created on figures
+not created via the pyplot interface.
+
+To revert to the previous behaviour of using the current axes,
+give ``axes=plt.gca()`` to ``get_animation()``.

--- a/changelog/4968.feature.rst
+++ b/changelog/4968.feature.rst
@@ -1,0 +1,2 @@
+Figures directly created using `matplotlib.figure.Figure` can now be
+used with `sunpy.visualisation.animator.BaseFuncAnimator`.

--- a/changelog/4968.feature.rst
+++ b/changelog/4968.feature.rst
@@ -1,2 +1,7 @@
-Figures directly created using `matplotlib.figure.Figure` can now be
-used with `sunpy.visualisation.animator.BaseFuncAnimator`.
+The default axes used by :meth:`sunpy.visualisation.animator.BaseFuncAnimator.get_animation`
+is now ``BaseFuncAnimator.axes``, instead of the currently active axes (accessed via.
+:func:`matplotlib.pyplot.gca`). The allows animations to be created on figures
+created directly using `matplotlib.figure.Figure`.
+
+To revert to the previous behaviour of using the current axes,
+give ``axes=plt.gca()`` to ``get_animation()``.

--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -46,7 +46,8 @@ class BaseFuncAnimator:
         of values for all points of the slider.
         (The slider update function decides which to support.)
     fig: `matplotlib.figure.Figure`, optional
-        `~matplotlib.figure.Figure` to use. Defaults to `None`.
+        `~matplotlib.figure.Figure` to use. Defaults to `None`, in which case a new
+        figure is created.
     interval: `int`, optional
         Animation interval in milliseconds. Defaults to 200.
     colorbar: `bool`, optional
@@ -151,7 +152,10 @@ class BaseFuncAnimator:
         Parameters
         ----------
         axes: `matplotlib.axes.Axes`, optional
-            The `matplotlib.axes.Axes` to animate. Defaults to `None`.
+            The `matplotlib.axes.Axes` to animate. Defaults to `None`, in which
+            case the Axes associated with this animator are used. Passing a
+            custom Axes can be useful if you want to create the animation on
+            a custom figure that is not the figure set up by this Animator.
         slider: `int`, optional
             The slider to animate along. Defaults to 0.
         startframe: `int`, optional
@@ -166,7 +170,7 @@ class BaseFuncAnimator:
         Extra keywords are passed to `matplotlib.animation.FuncAnimation`.
         """
         if not axes:
-            axes = plt.gca()
+            axes = self.axes
         anim_fig = axes.get_figure()
 
         if endframe is None:

--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -115,7 +115,11 @@ class BaseFuncAnimator:
         self._set_active_slider(0)
 
         # Set the current axes to the main axes so commands like plt.ylabel() work.
-        plt.sca(self.axes)
+        #
+        # Only do this if figure has a manager, so directly constructed figures
+        # (ie. via matplotlib.figure.Figure()) work.
+        if self.fig.canvas.manager is not None:
+            plt.sca(self.axes)
 
         # Do Plot
         self.im = self.plot_start_image(self.axes)

--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -119,7 +119,7 @@ class BaseFuncAnimator:
         #
         # Only do this if figure has a manager, so directly constructed figures
         # (ie. via matplotlib.figure.Figure()) work.
-        if self.fig.canvas.manager is not None:
+        if hasattr(self.fig.canvas, "manager") and self.fig.canvas.manager is not None:
             plt.sca(self.axes)
 
         # Do Plot

--- a/sunpy/visualization/animator/base.py
+++ b/sunpy/visualization/animator/base.py
@@ -209,7 +209,7 @@ class BaseFuncAnimator:
         self.fig.canvas.mpl_connect('key_press_event', self._key_press)
 
     def _add_colorbar(self, im):
-        self.colorbar = plt.colorbar(im, self.cax)
+        self.colorbar = self.fig.colorbar(im, self.cax)
 
 # =============================================================================
 #   Figure event callback functions

--- a/sunpy/visualization/animator/tests/test_basefuncanimator.py
+++ b/sunpy/visualization/animator/tests/test_basefuncanimator.py
@@ -98,7 +98,7 @@ def test_base_func_init(fig, colorbar, buttons):
     assert tfa.active_slider == 0
 
 
-# Make sure figures created through pyplot and not work
+# Make sure figures created directly and through pyplot work
 @pytest.fixture(params=[plt.figure, mfigure.Figure])
 def funcanimator(request):
     data = np.random.random((3, 10, 10))
@@ -117,6 +117,23 @@ def test_to_anim(funcanimator):
 
 def test_to_axes(funcanimator):
     assert isinstance(funcanimator.axes, maxes.SubplotBase)
+
+
+def test_axes_set():
+    data = np.random.random((3, 10, 10))
+    funcs = [partial(update_plotval, data=data)]
+    ranges = [(0, 3)]
+
+    # Create Figure for animator
+    fig1 = plt.figure()
+    # Create new Figure, Axes, and set current axes
+    fig2, ax = plt.subplots()
+    plt.sca(ax)
+    ani = FuncAnimatorTest(data, funcs, ranges, fig=fig1)
+    # Make sure the animator axes is now the current axes
+    assert plt.gca() is ani.axes
+
+    [plt.close(f) for f in [fig1, fig2]]
 
 
 def test_edges_to_centers_nd():

--- a/sunpy/visualization/animator/tests/test_basefuncanimator.py
+++ b/sunpy/visualization/animator/tests/test_basefuncanimator.py
@@ -4,6 +4,7 @@ import matplotlib.animation as mplanim
 import matplotlib.axes as maxes
 import matplotlib.backend_bases as mback
 import matplotlib.figure as mfigure
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -97,14 +98,16 @@ def test_base_func_init(fig, colorbar, buttons):
     assert tfa.active_slider == 0
 
 
-@pytest.fixture
-def funcanimator():
+# Make sure figures created through pyplot and not work
+@pytest.fixture(params=[plt.figure, mfigure.Figure])
+def funcanimator(request):
     data = np.random.random((3, 10, 10))
     func = partial(update_plotval, data=data)
     funcs = [func]
     ranges = [(0, 3)]
+    fig = request.param()
 
-    return FuncAnimatorTest(data, funcs, ranges)
+    return FuncAnimatorTest(data, funcs, ranges, fig=fig)
 
 
 def test_to_anim(funcanimator):

--- a/sunpy/visualization/animator/tests/test_basefuncanimator.py
+++ b/sunpy/visualization/animator/tests/test_basefuncanimator.py
@@ -3,7 +3,7 @@ from functools import partial
 import matplotlib.animation as mplanim
 import matplotlib.axes as maxes
 import matplotlib.backend_bases as mback
-import matplotlib.pyplot as plt
+import matplotlib.figure as mfigure
 import numpy as np
 import pytest
 
@@ -28,13 +28,10 @@ def button_func1(*args, **kwargs):
     print(*args, **kwargs)
 
 
-@pytest.mark.parametrize('fig, colorbar, buttons', ((None, False, [[], []]),
-                                                    (plt.figure, True, [[button_func1], ["hi"]])))
+@pytest.mark.parametrize('fig, colorbar, buttons',
+                         ((None, False, [[], []]),
+                          (mfigure.Figure(), True, [[button_func1], ["hi"]])))
 def test_base_func_init(fig, colorbar, buttons):
-    # We need to create figures within the test function rather than in parametrize()
-    if callable(fig):
-        fig = fig()
-
     data = np.random.random((3, 10, 10))
     func0 = partial(update_plotval, data=data)
     func1 = partial(update_plotval, data=data*10)
@@ -51,7 +48,7 @@ def test_base_func_init(fig, colorbar, buttons):
     tfa._set_active_slider(1)
     assert tfa.active_slider == 1
 
-    fig = plt.figure()
+    fig = tfa.fig
     event = mback.KeyEvent(name='key_press_event', canvas=fig.canvas, key='down')
     tfa._key_press(event)
     assert tfa.active_slider == 0
@@ -98,10 +95,6 @@ def test_base_func_init(fig, colorbar, buttons):
     event.inaxes = tfa.sliders[0]
     tfa._mouse_click(event)
     assert tfa.active_slider == 0
-
-    # Close the figure if it is a pyplot figure
-    if fig in [plt.figure(i) for i in plt.get_fignums()]:
-        plt.close(fig)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR:
- Allows one to use a directly created figure with `BaseFuncAnimator`
- Updates the test to use a specific figure instance, thus prevent issues like the one fixed in https://github.com/sunpy/sunpy/pull/4963 Unless one specifically wants to test pyplot behaviour, it's good practice to use directly created figures.