### PR TITLE
Safer handling of pyplot figures by tests

### DIFF
--- a/changelog/4969.trivial.rst
+++ b/changelog/4969.trivial.rst
@@ -1,0 +1,1 @@
+The testing suite now raises a warning if the `~matplotlib.pyplot` figure stack is not empty prior to running a test, and it closes all open figures after finishing each test.


### PR DESCRIPTION
This PR is a broader version of what @dstansby first toyed with in #4961.

- Raise a `SunpyUserWarning` (nominally converted to an error) if the pyplot figure stack is not empty prior to running a test.
- After a running a test, clear any pyplot figures that are still open, with an associated info message.  To see these messages, you can provide `-o log_cli=true` as a command-line argument for pytest.