### PR TITLE
Update wcs when creating animator

### DIFF
--- a/sunpy/visualization/animator/wcs.py
+++ b/sunpy/visualization/animator/wcs.py
@@ -203,6 +203,7 @@ class ArrayAnimatorWCS(ArrayAnimator):
         elif self.plot_dimensionality == 2:
             artist = self.plot_start_image_2d(ax)
 
+        self.axes.reset_wcs(wcs=self.wcs, slices=self.slices_wcsaxes)
         return artist
 
     def update_plot(self, val, artist, slider):


### PR DESCRIPTION
In #4971 adding this line seemed to improve some of the initial images (I think mainly by correctly initialising some of the axes). It might be that the correct solution is to modify `plot_start_image` instead of this heavy handed approach, but I thought it would be good to start here to see if anything does need fixing.