### PR TITLE
Bump minimum required Matplotlib version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ dask =
 database =
   sqlalchemy
 instr =
-  matplotlib>=2.2.2
+  matplotlib>=3.1.1
   pandas>=0.24.0
   scipy>=1.2.0
 image =
@@ -55,7 +55,7 @@ image =
 jpeg2000 =
   glymur!=0.9.0
 map =
-  matplotlib>=2.2.2
+  matplotlib>=3.1.1
   scipy>=1.2.0
 net =
   beautifulsoup4
@@ -66,10 +66,10 @@ net =
   zeep
 timeseries =
   h5netcdf>=0.8.1
-  matplotlib>=2.2.2
+  matplotlib>=3.1.1
   pandas>=0.24.0
 visualization =
-  matplotlib>=2.2.2
+  matplotlib>=3.1.1
 tests =
   pytest-astropy >= 0.8  # 0.8 is the first release to include filter-subpackage
   pytest-doctestplus >= 0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     # Oldest deps we pin against.
     oldestdeps: astropy<4.1
     oldestdeps: numpy<1.17.0
-    oldestdeps: matplotlib<3.0
+    oldestdeps: matplotlib<3.2
     oldestdeps: scipy<1.3
     oldestdeps: parfive<1.2
     oldestdeps: pandas<0.25


### PR DESCRIPTION
xref https://github.com/sunpy/sunpy/pull/4968#issuecomment-774237195. Matplotlib 3.1.0 was released in April 2019, so will be >24mo old by the time sunpy 3.0 comes out.