### PR TITLE
Reduce number of rotatedsun test examples

### DIFF
--- a/sunpy/coordinates/tests/test_metaframes.py
+++ b/sunpy/coordinates/tests/test_metaframes.py
@@ -192,7 +192,7 @@ def test_alternate_rotation_model():
                                    f.HeliocentricInertial])
 @given(lon=longitudes(), lat=latitudes(),
        obstime=times(), rotated_time1=times(), rotated_time2=times())
-@settings(deadline=None)
+@settings(deadline=None, max_examples=10)
 def test_rotatedsun_transforms(frame, lon, lat, obstime, rotated_time1, rotated_time2):
     # Tests the transformations (to, from, and loopback) for consistency with `diff_rot` output
 


### PR DESCRIPTION
I had a look at what the slowest tests in the test suite are, and locally I got:
```
======================================================== slowest durations ========================================================
22.62s call     sunpy/coordinates/tests/test_metaframes.py::test_rotatedsun_transforms[HeliographicCarrington]
11.81s call     sunpy/image/tests/test_transform.py::test_reproducible_matrix_multiplication
8.33s call     sunpy/coordinates/tests/test_metaframes.py::test_rotatedsun_transforms[HeliographicStonyhurst]
7.33s call     sunpy/timeseries/tests/test_timeseries_factory.py::TestTimeSeries::test_generic_construction_concatenation
3.86s call     sunpy/net/tests/test_fido.py::test_fido_indexing
```

`test_rotatedsun_transforms` is a `hypothesis` test, so the duration should scale linearly with the number of examples. Reducing from the default of 100 to 10 should therefore save ~20s per test run, which over the 6 jobs it is run on saves 2 minutes per PR, which is not large, but also not insignificant.