### PR TITLE
Reduce runtimes of some more tests

### DIFF
--- a/sunpy/net/tests/strategies.py
+++ b/sunpy/net/tests/strategies.py
@@ -35,7 +35,6 @@ def TimeDelta(draw):
     abs max is about 10 weeks + 10 days + 10 hours + 10 minutes + a bit
     """
     st.sampled_from(['weeks', 'days', 'hours', 'minutes', 'seconds'])
-    values = st.floats(min_value=1, max_value=10)
     time_dict = {'days': st.floats(min_value=1, max_value=8),
                  'hours': st.floats(min_value=1, max_value=12),
                  'minutes': st.floats(min_value=1, max_value=30),

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -60,7 +60,7 @@ def online_query(draw, instrument=online_instruments()):
 
 
 @no_vso
-@settings(deadline=50000)
+@settings(deadline=50000, max_examples=10)
 @given(offline_query())
 def test_offline_fido(query):
     unifiedresp = Fido.search(query)
@@ -284,7 +284,7 @@ def test_path_read_only(tmp_path):
 
 
 @no_vso
-@settings(deadline=50000)
+@settings(deadline=50000, max_examples=10)
 @given(st.tuples(offline_query(), offline_query()).filter(filter_queries))
 def test_fido_indexing(queries):
     query1, query2 = queries
@@ -357,7 +357,7 @@ def test_fido_indexing(queries):
 
 
 @no_vso
-@settings(deadline=50000)
+@settings(deadline=50000, max_examples=10)
 @given(st.tuples(offline_query(), offline_query()).filter(filter_queries))
 def test_fido_iter(queries):
     query1, query2 = queries
@@ -373,7 +373,7 @@ def test_fido_iter(queries):
 
 
 @no_vso
-@settings(deadline=50000)
+@settings(deadline=50000, max_examples=10)
 @given(offline_query())
 def test_repr2(query):
     res = Fido.search(query)

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -635,11 +635,12 @@ def test_concatenation_different_data_list_error(eve_test_ts, fermi_gbm_test_ts)
 
 
 def test_generic_construction_concatenation():
+    nrows = 10
     # Generate the data and the corrisponding dates
     base = parse_time(datetime.datetime.today())
-    times = base - TimeDelta(np.arange(24 * 60)*u.minute)
-    intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24 * 60))))
-    intensity2 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24 * 60))))
+    times = base - TimeDelta(np.arange(nrows)*u.minute)
+    intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (nrows))))
+    intensity2 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (nrows))))
 
     # Create the data DataFrame, header MetaDict and units OrderedDict
     data = DataFrame(intensity1, index=times, columns=['intensity'])


### PR DESCRIPTION
- The bulk of the time in the `timeseries` test is spent sorting the index, so just reduce the data size
- Reduce the number of examples run in the `Fido` tests from 100 to 10.

Together I think this shaves ~15s off the core tests.