### PR TITLE
Add some basic logging to HEK

### DIFF
--- a/changelog/5020.trivial.rst
+++ b/changelog/5020.trivial.rst
@@ -1,0 +1,1 @@
+Added some basic logging to HEK searches, at the 'debug' logging level.

--- a/sunpy/net/hek/hek.py
+++ b/sunpy/net/hek/hek.py
@@ -12,6 +12,7 @@ from astropy.table import Row
 from astropy.time import Time
 
 import sunpy.net._attrs as core_attrs
+from sunpy import log
 from sunpy.net import attr
 from sunpy.net.base_client import BaseClient, QueryResponseTable
 from sunpy.net.hek import attrs
@@ -61,7 +62,9 @@ class HEKClient(BaseClient):
 
         while True:
             data['page'] = page
-            fd = urllib.request.urlopen(self.url+urllib.parse.urlencode(data))
+            url = self.url + urllib.parse.urlencode(data)
+            log.debug(f'Opening {url}')
+            fd = urllib.request.urlopen(url)
             try:
                 result = codecs.decode(fd.read(), encoding='utf-8', errors='replace')
                 result = json.loads(result)


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5005. Not sure if there's a way to test for this (or if it's even worth it)? Because HEK results are by default 100 per page, this will log something for every 100 results, which locally for me is every few seconds, which solves my request for some feedback on something happening.