### PR TITLE
Fix scraper issue with Windows and URL path separation 

### DIFF
--- a/changelog/5022.bugfix.rst
+++ b/changelog/5022.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug in `sunpy.until.scraper.Scraper` which caused URL patterns containing backslashes to be incorrectly parsed on Windows.

--- a/sunpy/util/scraper.py
+++ b/sunpy/util/scraper.py
@@ -116,8 +116,8 @@ class Scraper:
             Notice that these directories may not exist in the archive.
         """
         # find directory structure - without file names
-        directorypattern = os.path.dirname(self.pattern) + '/'
-        # TODO what if there's not slashes?
+        if '/' in self.pattern:
+            directorypattern = '/'.join(self.pattern.split('/')[:-1]) + '/'
         timestep = self._smallerPattern(directorypattern)
         if timestep is None:
             return [directorypattern]

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -45,6 +45,14 @@ def testDirectoryRange():
     assert s.range(timerange) == directory_list
 
 
+def testDirectoryRegex():
+    s = Scraper('https://spdf.gsfc.nasa.gov/pub/data/psp/fields/l2/rfs_lfr/2019/'
+                'psp_fld_l2_(\\w){7}_(\\d){8}_v(\\d){2}.cdf', regex=True)
+    timerange = TimeRange('2019-02-01', '2019-02-03')
+    directory = s.range(timerange)
+    assert directory == ['https://spdf.gsfc.nasa.gov/pub/data/psp/fields/l2/rfs_lfr/2019/']
+
+
 def testDirectoryRangeFalse():
     s = Scraper('%Y%m%d/%Y%m%d_%H.fit.gz')
     directory_list = ['20091230/', '20091231/', '20100101/',

--- a/sunpy/util/tests/test_scraper.py
+++ b/sunpy/util/tests/test_scraper.py
@@ -46,11 +46,11 @@ def testDirectoryRange():
 
 
 def testDirectoryRegex():
-    s = Scraper('https://spdf.gsfc.nasa.gov/pub/data/psp/fields/l2/rfs_lfr/2019/'
-                'psp_fld_l2_(\\w){7}_(\\d){8}_v(\\d){2}.cdf', regex=True)
+    # Test for Windows where '\' is a path separator and not part of the regex
+    s = Scraper('scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext', regex=True)
     timerange = TimeRange('2019-02-01', '2019-02-03')
     directory = s.range(timerange)
-    assert directory == ['https://spdf.gsfc.nasa.gov/pub/data/psp/fields/l2/rfs_lfr/2019/']
+    assert directory == ['scheme://a.url.with/a/few/forward/slashes/']
 
 
 def testDirectoryRangeFalse():


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Scraper subtly broken on windows when using regex patterns. In the `scraper.range` call `os.path.dirname` is used to obtain the base directory from the pattern e.g. `http://a.server.dom/some/path/afile(\d){3}.ext`. On windows `os.path.dirname` correctly interprets backslashes in the url pattern as path separators.  So a **URL** like above which should become `http://a.server.dom/some/path` instead becomes `http://a.server.dom/some/path/afile`.

I replaced `os.path.dirname` which assumes it is working with a path with code used the fact the pattern is a url and not a path. I looked at using `urllib` `parserurl` but that didn't seem to work with the regex patterns either.