### PR TITLE
Add Solar Orbiter EUI colormaps

### DIFF
--- a/changelog/5023.feature.rst
+++ b/changelog/5023.feature.rst
@@ -1,0 +1,2 @@
+Added colormaps for Solar Orbiter EUI images. These are used automatically
+when an EUI image is loaded.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -385,15 +385,7 @@ long as it recognizes the instrument. To see what colormaps are available::
     >>> cm.cmlist.keys()
     dict_keys(['goes-rsuvi94', 'goes-rsuvi131', 'goes-rsuvi171', 'goes-rsuvi195',
     'goes-rsuvi284', 'goes-rsuvi304', 'sdoaia94', 'sdoaia131', 'sdoaia171',
-    'sdoaia193', 'sdoaia211', 'sdoaia304', 'sdoaia335', 'sdoaia1600', 'sdoaia1700',
-    'sdoaia4500', 'sohoeit171', 'sohoeit195', 'sohoeit284', 'sohoeit304', 'soholasco2',
-    'soholasco3', 'sswidlsoholasco2', 'sswidlsoholasco3', 'stereocor1',
-    'stereocor2', 'stereohi1', 'stereohi2', 'yohkohsxtal',
-    'yohkohsxtwh', 'hinodexrt', 'hinodesotintensity', 'trace171', 'trace195',
-    'trace284', 'trace1216', 'trace1550', 'trace1600', 'trace1700', 'traceWL',
-    'hmimag', 'irissji1330', 'irissji1400', 'irissji1600', 'irissji2796',
-    'irissji2832', 'irissji5000', 'irissjiFUV', 'irissjiNUV', 'irissjiSJI_NUV', 'kcor',
-    'rhessi', 'std_gamma_2', 'euvi171', 'euvi195', 'euvi284', 'euvi304'])
+    ...
 
 The SunPy colormaps are registered with matplotlib so you can grab them like
 you would any other colormap::

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -40,6 +40,7 @@ from sunpy.util.decorators import cached_property_based_on, deprecated
 from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyMetadataWarning, SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
+from sunpy.visualization.colormaps import cm as sunpy_cm
 
 TIME_FORMAT = config.get("general", "time_format")
 PixelPair = namedtuple('PixelPair', 'x y')
@@ -221,6 +222,16 @@ class GenericMap(NDData):
                               }
         if plot_settings:
             self.plot_settings.update(plot_settings)
+
+        # Try and set the colormap. This is not always possible if this method
+        # is run before map sources fix some of their metadata, so
+        # just ignore any exceptions raised.
+        try:
+            cmap = self._get_cmap_name()
+            if cmap in sunpy_cm.cmlist:
+                self.plot_settings['cmap'] = cmap
+        except Exception as e:
+            pass
 
     def __getitem__(self, key):
         """ This should allow indexing by physical coordinate """

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -230,7 +230,7 @@ class GenericMap(NDData):
             cmap = self._get_cmap_name()
             if cmap in sunpy_cm.cmlist:
                 self.plot_settings['cmap'] = cmap
-        except Exception as e:
+        except Exception:
             pass
 
     def __getitem__(self, key):

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_403.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_403.json
@@ -52,5 +52,5 @@
   "sunpy.visualization.animator.tests.test_wcs.test_array_animator_wcs_coord_params": "e1678a7b513917e177547b8ee0a93ee2f29a6d3dacff5fa213355ff414e706b1",
   "sunpy.visualization.animator.tests.test_wcs.test_array_animator_wcs_coord_params_no_ticks": "ce35b25eb2c4eb6d2ce56d6a78c8a33b1bfdf8ef00b098c7c2c08feae2a82356",
   "sunpy.visualization.animator.tests.test_wcs.test_array_animator_wcs_coord_params_grid": "4bb5930ec573f8399470df023d4686601728d35a70527c397f7eed39d07ba0e3",
-  "sunpy.visualization.colormaps.tests.test_cm.test_cmap_visual": "a2a4885b1bcdef40626bef1e8e9be1b7469530beae47a8c75f25aa697a708b4f"
+  "sunpy.visualization.colormaps.tests.test_cm.test_cmap_visual": "5a84e72f109d35eb09bcdd197e2e76d8d0204ea9bbcf7b4376bdd3e9a9edcd80"
 }

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -52,5 +52,5 @@
   "sunpy.visualization.animator.tests.test_wcs.test_array_animator_wcs_coord_params": "e1678a7b513917e177547b8ee0a93ee2f29a6d3dacff5fa213355ff414e706b1",
   "sunpy.visualization.animator.tests.test_wcs.test_array_animator_wcs_coord_params_no_ticks": "ce35b25eb2c4eb6d2ce56d6a78c8a33b1bfdf8ef00b098c7c2c08feae2a82356",
   "sunpy.visualization.animator.tests.test_wcs.test_array_animator_wcs_coord_params_grid": "4bb5930ec573f8399470df023d4686601728d35a70527c397f7eed39d07ba0e3",
-  "sunpy.visualization.colormaps.tests.test_cm.test_cmap_visual": "a2a4885b1bcdef40626bef1e8e9be1b7469530beae47a8c75f25aa697a708b4f"
+  "sunpy.visualization.colormaps.tests.test_cm.test_cmap_visual": "5a84e72f109d35eb09bcdd197e2e76d8d0204ea9bbcf7b4376bdd3e9a9edcd80"
 }

--- a/sunpy/visualization/colormaps/cm.py
+++ b/sunpy/visualization/colormaps/cm.py
@@ -29,6 +29,19 @@ sohoeit195 = ct.eit_color_table(195*u.angstrom)
 sohoeit284 = ct.eit_color_table(284*u.angstrom)
 sohoeit304 = ct.eit_color_table(304*u.angstrom)
 
+# Solar Orbiter EUI
+# These are deliberately the same as AIA
+solohri_euv174 = ct.aia_color_table(171*u.angstrom)
+solohri_euv174.name = 'SolO EUI HRI 174 angstrom'
+solofsi174 = ct.aia_color_table(171*u.angstrom)
+solofsi174.name = 'SolO EUI FSI 174 angstrom'
+solofsi304 = ct.aia_color_table(304*u.angstrom)
+solofsi304.name = 'SolO EUI FSI 304 angstrom'
+# Lyman alpha is a modified IDL red color table
+solohri_lya1216 = ct.idl_3
+solohri_lya1216[:, 2] = solohri_lya1216[:, 0] * np.linspace(0, 1, 256)
+solohri_lya1216 = ct._cmap_from_rgb(*solohri_lya1216.T, 'SolO EUI HRI Lyman Alpha')
+
 goesrsuvi94 = ct.suvi_color_table(94*u.angstrom)
 goesrsuvi131 = ct.suvi_color_table(131*u.angstrom)
 goesrsuvi171 = ct.suvi_color_table(171*u.angstrom)
@@ -142,6 +155,10 @@ cmlist = {
     'euvi195': euvi195,
     'euvi284': euvi284,
     'euvi304': euvi304,
+    'solar orbiterfsi174': solofsi174,
+    'solar orbiterfsi304': solofsi304,
+    'solar orbiterhri_euv174': solohri_euv174,
+    'solar orbiterhri_lya1216': solohri_lya1216,
 }
 
 # Register the colormaps with matplotlib so plt.get_cmap('sdoaia171') works

--- a/sunpy/visualization/colormaps/color_tables.py
+++ b/sunpy/visualization/colormaps/color_tables.py
@@ -303,8 +303,10 @@ def suvi_color_table(wavelength: u.angstrom):
 def rhessi_color_table():
     return cmap_from_rgb_file("rhessi", "rhessi.csv")
 
+
 def std_gamma_2():
     return cmap_from_rgb_file("std_gamma_2", "std_gamma_2.csv")
+
 
 def euvi_color_table(wavelength: u.angstrom):
 
@@ -315,6 +317,7 @@ def euvi_color_table(wavelength: u.angstrom):
             "Invalid EUVI wavelength. Valid values are "
             "171, 195, 284, 304."
         )
+
 
 def cmap_from_rgb_file(name, fname):
     """


### PR DESCRIPTION
Pulled out of https://github.com/sunpy/sunpy/pull/4712. I think this is worth a backport, so users don't have to wait 6 months to have these colormaps used automatically for EUI images.