### PR TITLE
MDI synoptic map does not need crder

### DIFF
--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -241,7 +241,7 @@ class MDISynopticMap(MDIMap):
             header['date-obs'] = header['t_obs']
             header['date-obs'] = parse_time(header['date-obs']).isot
         for i in [1, 2]:
-            if header[f'CRDER{i}'] == 'nan':
+            if header.get(f'CRDER{i}') == 'nan':
                 header.pop(f'CRDER{i}')
         super().__init__(data, header, **kwargs)
 


### PR DESCRIPTION
This allows MDI synoptic maps to not have `CRDER` keywords. I don't know how common this is or if we should be applying a different fix here, but I've been working with some MDI synoptic maps that don't have this and the MDI synoptic source barfs because they're missing `CRDER{1,2}`.