### PR TITLE
Add method for common unit string fixes

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -28,7 +28,7 @@ from astropy.visualization.wcsaxes import WCSAxes
 import sunpy.coordinates
 import sunpy.io as io
 import sunpy.visualization.colormaps
-from sunpy import config
+from sunpy import config, log
 from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, get_earth, sun
 from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.image.resample import resample as sunpy_image_resample
@@ -190,6 +190,7 @@ class GenericMap(NDData):
         # Correct possibly missing meta keywords
         self._fix_date()
         self._fix_naxis()
+        self._fix_unit()
 
         # Setup some attributes
         self._nickname = None
@@ -1132,6 +1133,20 @@ class GenericMap(NDData):
         if 'bitpix' not in self.meta:
             float_fac = -1 if self.dtype.kind == "f" else 1
             self.meta['bitpix'] = float_fac * 8 * self.dtype.itemsize
+
+    def _fix_unit(self):
+        """
+        Fix some common unit strings that aren't technically FITS standard
+        compliant, but obvious enough that we can covert them into something
+        that's standards compliant.
+        """
+        unit = self.meta.get('bunit', None)
+        replacements = {'Gauss': 'G',
+                        'DN': 'ct',
+                        'DN/s': 'ct/s'}
+        if unit in replacements:
+            log.debug(f'Changing BUNIT from "{unit}" to "{replacements[unit]}"')
+            self.meta['bunit'] = replacements[unit]
 
     def _get_cmap_name(self):
         """Build the default color map name."""

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -45,22 +45,18 @@ class AIAMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        if 'bunit' not in header and 'pixlunit' in header:
+            # PIXLUNIT is not a FITS standard keyword
+            header['bunit'] = header['pixlunit']
+
         super().__init__(data, header, **kwargs)
 
         # Fill in some missing info
         self.meta['detector'] = self.meta.get('detector', "AIA")
-        if 'bunit' not in self.meta and 'pixlunit' in self.meta:
-            # PIXLUNIT is not a FITS standard keyword
-            self.meta['bunit'] = self.meta['pixlunit']
         self._nickname = self.detector
         self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, AsinhStretch(0.01)), clip=False)
-        # DN is not a FITS standard unit, so convert to counts
-        if self.meta.get('bunit', None) == 'DN':
-            self.meta['bunit'] = 'ct'
-        if self.meta.get('bunit', None) == 'DN/s':
-            self.meta['bunit'] = 'ct/s'
 
     @property
     def _supported_observer_coordinates(self):


### PR DESCRIPTION
Fixing 'Gauss` came up in https://github.com/sunpy/sunpy/pull/4875, and we already do a similar fix for AIA maps, so I thought it would be worth having a single method where we apply obvious and simple unit fixes like these.