### PR TITLE
Be more lenient when constructing a MetaDict

### DIFF
--- a/changelog/5047.bugfix.rst
+++ b/changelog/5047.bugfix.rst
@@ -1,0 +1,4 @@
+Constructing a `~sunpy.util.MetaDict` is now more lenient, and accepts
+any class that inherits from `collections.abc.Mapping`. This fixes a
+regression where headers read with `astropy.io.fits` raised an error when
+passed to individual `~sunpy.map` sources.

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -24,6 +24,7 @@ import sunpy.data.test
 import sunpy.map
 import sunpy.sun
 from sunpy.coordinates import sun
+from sunpy.map.sources import AIAMap
 from sunpy.time import parse_time
 from sunpy.util import SunpyDeprecationWarning, SunpyUserWarning
 from sunpy.util.exceptions import SunpyMetadataWarning
@@ -32,10 +33,16 @@ testpath = sunpy.data.test.rootdir
 
 
 def test_fits_data_comparison(aia171_test_map):
-    """Make sure the data is the same in pyfits and SunPy"""
+    """Make sure the data is the same when read with astropy.io.fits and sunpy"""
     with pytest.warns(VerifyWarning, match="Invalid 'BLANK' keyword in header."):
         data = fits.open(os.path.join(testpath, 'aia_171_level1.fits'))[0].data
     np.testing.assert_allclose(aia171_test_map.data, data)
+
+
+def test_header_fits_io():
+    with pytest.warns(VerifyWarning, match="Invalid 'BLANK' keyword in header."):
+        with fits.open(os.path.join(testpath, 'aia_171_level1.fits')) as hdu:
+            AIAMap(hdu[0].data, hdu[0].header)
 
 
 def test_get_item(generic_map):

--- a/sunpy/util/metadata.py
+++ b/sunpy/util/metadata.py
@@ -3,6 +3,7 @@ This module provides a generalized dictionary class that deals with header
 parsing, normalization, and maintaining coherence between keys and keycomments.
 """
 from collections import OrderedDict
+from collections.abc import Mapping
 
 __all__ = ['MetaDict']
 
@@ -34,8 +35,11 @@ class MetaDict(OrderedDict):
             adict = args[0]
             if isinstance(adict, list) or isinstance(adict, tuple):
                 items = adict
-            elif isinstance(adict, dict):
-                items = adict.items()
+            elif isinstance(adict, Mapping):
+                # Cast to a dict here, since a Mapping doesn't have to define
+                # a .items() method (but has enough methods to be converted to
+                # a dict)
+                items = dict(adict).items()
             else:
                 raise TypeError(f"Can not create a MetaDict from this input of type {type(adict)}")
 


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5043. Instead of checking explicitly for a `dict`, try `dict(object)` instead, and error if that isn't possible.