### PR TITLE
added source='xrs' keyword

### DIFF
--- a/changelog/5080.doc.rst
+++ b/changelog/5080.doc.rst
@@ -1,0 +1,1 @@
+Updated the `goes_xrs_example` with correct keywords to handle netcdf files.

--- a/examples/acquiring_data/goes_xrs_example.py
+++ b/examples/acquiring_data/goes_xrs_example.py
@@ -69,7 +69,7 @@ file_goes15 = Fido.fetch(result_goes15)
 #############################################################
 # Lets now load this data into a `~sunpy.timeseries.TimeSeries`,
 # and inspect the data using `~sunpy.timeseries.GenericTimeSeries.peek()`
-goes_15 = ts.TimeSeries(file_goes15)
+goes_15 = ts.TimeSeries(file_goes15, source='xrs')
 goes_15.peek()
 
 ###############################################################
@@ -125,5 +125,5 @@ print(results_16)
 files = Fido.fetch(results_16)
 # We use the `concatenate=True` keyword argument in TimeSeries, as
 # we have two files and want to create one timeseries from them.
-goes_16 = ts.TimeSeries(files, concatenate=True)
+goes_16 = ts.TimeSeries(files, concatenate=True, source='xrs')
 goes_16.peek()


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #5076 
As per #4592 the `source='xrs'` keyword should be specified when working with `netcdf` files.
This updates the examples to produce the results.
