### PR TITLE
Context manager to handle differential rotation automatically in WCSAxes

### DIFF
--- a/examples/map_transformations/reprojection_different_observers.py
+++ b/examples/map_transformations/reprojection_different_observers.py
@@ -63,11 +63,24 @@ out_shape = (512, 512)
 map_aia = map_aia.resample(out_shape * u.pix)
 map_euvi = map_euvi.resample(out_shape * u.pix)
 
+######################################################################
+# Plot the two maps, with the solar limb as seen by each observatory
+# overlaid on both plots.
+
 fig = plt.figure()
+
 ax1 = fig.add_subplot(1, 2, 1, projection=map_aia)
 map_aia.plot(axes=ax1)
+map_aia.draw_limb(axes=ax1, color='white')
+map_euvi.draw_limb(axes=ax1, color='red')
+
 ax2 = fig.add_subplot(1, 2, 2, projection=map_euvi)
 map_euvi.plot(axes=ax2)
+limb_aia = map_aia.draw_limb(axes=ax2, color='white')
+limb_euvi = map_euvi.draw_limb(axes=ax2, color='red')
+
+plt.legend([limb_aia[0], limb_euvi[0]],
+           ['Limb as seen by AIA', 'Limb as seen by EUVI A'])
 
 ######################################################################
 # We now need to construct an output WCS. We build a custom header using

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -29,7 +29,7 @@ import sunpy.coordinates
 import sunpy.io as io
 import sunpy.visualization.colormaps
 from sunpy import config, log
-from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, get_earth, sun
+from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, Helioprojective, get_earth, sun
 from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.image.resample import resample as sunpy_image_resample
 from sunpy.image.resample import reshape_image_to_4d_superpixel
@@ -1939,48 +1939,120 @@ class GenericMap(NDData):
                                                            obstime=self.date,
                                                            **kwargs)
 
-    def draw_limb(self, axes=None, **kwargs):
+    def draw_limb(self, axes=None, *, resolution=1000, **kwargs):
         """
-        Draws a circle representing the solar limb
+        Draws the solar limb as seen by the map's observer.
+
+        The limb is a circle for only the simplest plots.  If the coordinate frame of
+        the limb is different from the coordinate frame of the plot axes, not only
+        may the limb not be a true circle, a portion of the limb may be hidden from
+        the observer.  In that case, the circle is divided into visible and hidden
+        segments, represented by solid and dotted lines, respectively.
 
         Parameters
         ----------
-        axes: `~matplotlib.axes` or None
-            Axes to plot limb on or None to use current axes.
+        axes : `~matplotlib.axes` or ``None``
+            Axes to plot limb on or ``None`` to use current axes.
+        resolution : `int`
+            The number of points to use to represent the limb.
 
         Returns
         -------
-        circ: list
-            A list containing the `~matplotlib.patches.Circle` object that
-            has been added to the axes.
+        visible : `~matplotlib.patches.Polygon`
+            The patch added to the axes for the visible part of the limb (i.e., the
+            "near" side of the Sun).
+        hidden : `~matplotlib.patches.Polygon`
+            The patch added to the axes for the hidden part of the limb (i.e., the
+            "far" side of the Sun).
 
         Notes
         -----
-        Keyword arguments are passed onto `matplotlib.patches.Circle`.
+        Keyword arguments are passed onto the patches.
+
+        If the limb is a true circle, ``visible`` will instead be
+        `~matplotlib.patches.Circle` and ``hidden`` will be ``None``.
+
+        To avoid trigger Matplotlib auto-scaling, these patches are added as generic
+        artists instead of patches.  One consequence is that the plot legend is not
+        populated automatically when the limb is specified with a text label.
         """
         # Put import here to reduce sunpy.map import time
         from matplotlib import patches
+        from matplotlib.path import Path
 
         if not axes:
             axes = wcsaxes_compat.gca_wcs(self.wcs)
+        is_wcsaxes = wcsaxes_compat.is_wcsaxes(axes)
 
-        transform = wcsaxes_compat.get_world_transform(axes)
-        if wcsaxes_compat.is_wcsaxes(axes):
-            radius = self.rsun_obs.to(u.deg).value
-        else:
-            radius = self.rsun_obs.value
-        c_kw = {'radius': radius,
-                'fill': False,
+        c_kw = {'fill': False,
                 'color': 'white',
-                'zorder': 100,
-                'transform': transform
-                }
+                'zorder': 100}
         c_kw.update(kwargs)
 
-        circ = patches.Circle([0, 0], **c_kw)
-        axes.add_artist(circ)
+        # Obtain the solar radius and the world->pixel transform
+        if not is_wcsaxes:
+            radius = self.rsun_obs.value
+            transform = axes.transData
+        else:
+            radius = self.rsun_obs.to_value(u.deg)
 
-        return [circ]
+            if isinstance(self.coordinate_frame, Helioprojective):
+                frame = self.coordinate_frame
+            else:
+                frame = Helioprojective(observer=self.observer_coordinate,
+                                        obstime=self.date, rsun=self.rsun_meters)
+            transform = axes.get_transform(frame)
+
+        # transform is always passed on as a keyword argument
+        c_kw.setdefault('transform', transform)
+
+        # If not WCSAxes or if the map's frame matches the axes's frame, we can use Circle
+        if not is_wcsaxes or frame == axes._transform_pixel2world.frame_out:
+            c_kw.setdefault('radius', radius)
+
+            circ = patches.Circle([0, 0], **c_kw)
+            axes.add_artist(circ)
+
+            return circ, None
+
+        # Otherwise, we use Polygon to be able to distort the limb
+
+        theta = np.linspace(0, 2*np.pi, resolution+1)[:-1] << u.rad
+        # Use the Cartesian approximation of helioprojective coordinates because the Sun is small
+        Tx, Ty = radius * np.cos(theta), radius * np.sin(theta)
+
+        # Perform the round-trip transformation world->pixel->world
+        true_vertices = np.array([Tx, Ty]).T
+        apparent_vertices = transform.inverted().transform(transform.transform(true_vertices))
+
+        # Points that move by less than 1 arcmin are intepreted to be on the "near" side of the Sun
+        diff_Tx = Longitude((true_vertices[:, 0] - apparent_vertices[:, 0]) << u.deg,
+                            wrap_angle=180*u.deg)
+        diff_Ty = (true_vertices[:, 1] - apparent_vertices[:, 1]) << u.deg
+        discrepancy = np.sqrt(diff_Tx ** 2 + diff_Ty ** 2)
+        near = discrepancy < 10*u.arcsec
+
+        # Create the Polygon for the near side of the Sun (using a solid line)
+        if 'linestyle' not in kwargs:
+            c_kw['linestyle'] = '-'
+        visible = patches.Polygon(true_vertices, **c_kw)
+        visible_codes = visible.get_path().codes
+        visible_codes[:-1][~near] = Path.MOVETO
+        visible_codes[-1] = Path.MOVETO if not near[0] else Path.LINETO
+
+        # Create the Polygon for the far side of the Sun (using a dotted line)
+        if 'linestyle' not in kwargs:
+            c_kw['linestyle'] = ':'
+        hidden = patches.Polygon(true_vertices, **c_kw)
+        hidden_codes = hidden.get_path().codes
+        hidden_codes[:-1][near] = Path.MOVETO
+        hidden_codes[-1] = Path.MOVETO if near[0] else Path.LINETO
+
+        # Add both patches as artists rather than patches to avoid triggering auto-scaling
+        axes.add_artist(visible)
+        axes.add_artist(hidden)
+
+        return visible, hidden
 
     @u.quantity_input
     def draw_quadrangle(self, bottom_left, *, width: u.deg = None, height: u.deg = None,

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1936,6 +1936,7 @@ class GenericMap(NDData):
         return wcsaxes_compat.wcsaxes_heliographic_overlay(axes,
                                                            grid_spacing=grid_spacing,
                                                            annotate=annotate,
+                                                           obstime=self.date,
                                                            **kwargs)
 
     def draw_limb(self, axes=None, **kwargs):

--- a/sunpy/visualization/visualization.py
+++ b/sunpy/visualization/visualization.py
@@ -2,10 +2,16 @@
 This module provides plotting support in iPython.
 """
 from functools import wraps
+from contextlib import contextmanager
 
 import matplotlib.pyplot as plt
 
-__all__ = ['peek_show', "axis_labels_from_ctype"]
+from astropy.coordinates import BaseCoordinateFrame, SkyCoord
+
+from sunpy.coordinates import RotatedSunFrame
+from .wcsaxes_compat import is_wcsaxes
+
+__all__ = ['peek_show', "axis_labels_from_ctype", 'diffrot_axes']
 
 
 def peek_show(func):
@@ -53,3 +59,81 @@ def axis_labels_from_ctype(ctype, unit):
               'SOLY': f'Heliocentric Y [{unit}]'}
 
     return labels.get(ctype_short, f"{ctype} [{unit}]")
+
+
+@contextmanager
+def diffrot_axes(axes=None):
+    """
+    Context manager that enables a WCSAxes instance to automatically account for
+    solar differential rotation.
+
+    Coordinates and coordinate frames supplied to WCSAxes methods (e.g.,
+    :meth:`~astropy.visualization.wcsaxes.WCSAxes.plot_coord`,
+    :meth:`~astropy.visualization.wcsaxes.WCSAxes.get_coords_overlay`,
+    :meth:`~astropy.visualization.wcsaxes.WCSAxes.get_transform`) account for the
+    differential rotation between their ``obstime`` and the ``obstime`` of the
+    WCSAxes's coordinate frame.
+
+    Parameters
+    ----------
+    axes : `~astropy.visualization.wcsaxes.WCSAxes`
+         The axes to modify.  If ``None``, the current `matplotlib.pyplot` axes are
+         used.
+
+    Notes
+    -----
+    Since this context manager modifies WCSAxes methods, it may not function as
+    intended if the WCSAxes implementation changes.
+
+    This context manager uses `~sunpy.coordinates.metaframes.RotatedSunFrame`
+    internally.
+    """
+    try:
+        if axes is None:
+            axes = plt.gca()
+
+        if not is_wcsaxes(axes):
+            raise TypeError("The axes need to be an instance of WCSAxes. You may have neglected "
+                            "to use `projection=` when creating the axes.")
+
+        # Monkey patch the instance's private method used by get_transform()
+        old_get_transform = axes._get_transform_no_transdata
+
+        def new_get_transform(self, frame):
+            transform = old_get_transform(frame)
+            if getattr(transform, '_a', None) is axes._transform_pixel2world:
+                step = transform._b
+                if step.output_system.obstime is None:
+                    raise ValueError(f"The {step.output_system.__class__.__name__} instance "
+                                     f"must have a defined `obstime`.")
+                new_input_system = RotatedSunFrame(base=step.input_system,
+                                                   rotated_time=step.output_system.obstime)
+                transform._b = step.__class__(new_input_system, step.output_system)
+            return transform
+
+        axes._get_transform_no_transdata = new_get_transform.__get__(axes, type(axes))
+
+        # Monkey patch the instance's plot_coord()
+        # This is necessary because plot_coord() first transforms the coordinate prior to calling
+        #   get_transform()
+        old_plot_coord = axes.plot_coord
+
+        def new_plot_coord(self, *args, **kwargs):
+            if isinstance(args[0], (SkyCoord, BaseCoordinateFrame)):
+                frame = args[0].frame if hasattr(args[0], 'frame') else args[0]
+                if frame.obstime is None:
+                    raise ValueError(f"The {frame.__class__.__name__} instance "
+                                     f"must have a defined `obstime`.")
+                rsf_frame = RotatedSunFrame(base=axes._transform_pixel2world.frame_out,
+                                            rotated_time=frame.obstime)
+                args = (frame.transform_to(rsf_frame).as_base(),) + args[1:]
+            return old_plot_coord(*args, **kwargs)
+
+        axes.plot_coord = new_plot_coord.__get__(axes, type(axes))
+
+        yield
+
+    finally:
+        # Reverse the monkey patches
+        axes._get_transform_no_transdata = old_get_transform
+        axes.plot_coord = old_plot_coord

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -6,6 +6,8 @@ import matplotlib.pyplot as plt
 import astropy.units as u
 from astropy.visualization import wcsaxes
 
+from sunpy.coordinates import HeliographicStonyhurst
+
 __all__ = ["is_wcsaxes", "gca_wcs", "get_world_transform",
            "default_wcs_grid", "wcsaxes_heliographic_overlay"]
 
@@ -104,7 +106,8 @@ def default_wcs_grid(axes):
 
 
 @u.quantity_input
-def wcsaxes_heliographic_overlay(axes, grid_spacing: u.deg = 10*u.deg, annotate=True, **kwargs):
+def wcsaxes_heliographic_overlay(axes, grid_spacing: u.deg = 10*u.deg, annotate=True,
+                                 obstime=None, **kwargs):
     """
     Create a heliographic overlay using
     `~astropy.visualization.wcsaxes.WCSAxes`.
@@ -119,6 +122,8 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing: u.deg = 10*u.deg, annotate=
         Spacing for longitude and latitude grid in degrees.
     annotate : `bool`
         Passing `False` disables the axes labels and the ticks on the top and right axes.
+    obstime : `~astropy.time.Time`
+        The `obstime` to use for the `~sunpy.coordinates.HeliographicStonyhurst` grid.
 
     Returns
     -------
@@ -143,7 +148,7 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing: u.deg = 10*u.deg, annotate=
     c1.set_ticks_position('bl')
     c2.set_ticks_position('bl')
 
-    overlay = axes.get_coords_overlay('heliographic_stonyhurst')
+    overlay = axes.get_coords_overlay(HeliographicStonyhurst(obstime=obstime))
 
     lon = overlay[0]
     lat = overlay[1]


### PR DESCRIPTION
Working with `RotatedSunFrame` is sometimes confusing – even for me! – and plotting exactly what you want with WCSAxes methods can be tricky or, in some cases, impossible.  This PR provides a context manager that enables a WCSAxes instance to automatically account for solar differential rotation, based on the difference between the `obstime` of supplied coordinates or coordinate frames and the `obstime` of the WCSAxes's coordinate frame.  All use of `RotatedSunFrame` is hidden from the user.

To do:
- [x] Fix `GenericMap.draw_grid()`
- [x] Fix `GenericMap.draw_limb()`
- [ ] Add tests
- [ ] Add examples
- [ ] Figure out what changes in WCSAxes would make this code less hacky

## plot_coord()
Here, I create a coordinate for disk center four days before an AIA image.  When I don't use the context manager, `plot_coord()` plots the coordinate as seen from the change in observer location (i.e., Earth's motion along its orbit).  When I use the context manager, four days of differential rotation are automatically accounted for, in addition to change in observer location.
```python
import matplotlib.pyplot as plt
import astropy.units as u

import sunpy.map
from sunpy.coordinates import Helioprojective, transform_with_sun_center
from sunpy.data.sample import AIA_171_IMAGE
from sunpy.visualization import diffrot_axes

aiamap = sunpy.map.Map(AIA_171_IMAGE)
old_disk_center = Helioprojective(0*u.arcsec, 0*u.arcsec, observer='earth', obstime=aiamap.date - 4*u.day)

fig = plt.figure()
ax = plt.subplot(projection=aiamap)
aiamap.plot(clip_interval=(1., 99.95)*u.percent)

ax.plot_coord(old_disk_center, 'bx', label="Without diffrot_axes")

with transform_with_sun_center(), diffrot_axes(ax):
    ax.plot_coord(old_disk_center, 'g+', label="With diffrot_axes")

plt.legend()

plt.show()
```
![Figure_1](https://user-images.githubusercontent.com/991759/110987343-ef3d9900-833c-11eb-9dc4-c57c1d13c7ea.png)

## get_transform()
Same here, but for `get_transform()`, here used for patches.
```python
from astropy.visualization.wcsaxes import Quadrangle

old_hpc = old_disk_center.replicate_without_data()

fig = plt.figure()
ax = plt.subplot(projection=aiamap)
aiamap.plot(clip_interval=(1., 99.95)*u.percent)

q1 = Quadrangle((0, 0)*u.arcsec, 100*u.arcsec, 500*u.arcsec,
               edgecolor='blue', facecolor='none', ls=':', linewidth=2, label='Without diffrot_axes',
               transform=ax.get_transform(old_hpc))

with diffrot_axes(ax):
    q2 = Quadrangle((0, 0)*u.arcsec, 100*u.arcsec, 500*u.arcsec,
                   edgecolor='green', facecolor='none', ls='-', linewidth=2, label='With diffrot_axes',
                   transform=ax.get_transform(old_hpc))

ax.add_patch(q1)
ax.add_patch(q2)

plt.legend()

with transform_with_sun_center():
    plt.show()
```
![Figure_2](https://user-images.githubusercontent.com/991759/110987838-b05c1300-833d-11eb-832e-b53244c30145.png)

## get_coords_overlay()
Same here, but for `get_coords_overlay()` to plot grid lines.
```python
fig = plt.figure()
ax = plt.subplot(projection=aiamap)
aiamap.plot(clip_interval=(1., 99.95)*u.percent)

overlay1 = ax.get_coords_overlay(old_hpc)
overlay1[0].set_ticks(spacing=3*u.arcmin)
overlay1[1].set_ticks(spacing=3*u.arcmin)
overlay1.grid(ls=':', color='blue', linewidth=2)

with diffrot_axes(ax):
    overlay2 = ax.get_coords_overlay(old_hpc)
    overlay2[0].set_ticks(spacing=3*u.arcmin)
    overlay2[1].set_ticks(spacing=3*u.arcmin)
    overlay2.grid(ls='-', color='green', linewidth=2)

with transform_with_sun_center():
    plt.show()
```
![Figure_3](https://user-images.githubusercontent.com/991759/110987315-e6e55e00-833c-11eb-9d44-03570c9ca084.png)