### PR TITLE
Refactored RotatedSunFrame transformations

### DIFF
--- a/changelog/5084.bugfix.rst
+++ b/changelog/5084.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where some `~sunpy.coordinates.metaframes.RotatedSunFrame` transformations could fail with an "observer=None" error.

--- a/changelog/5084.trivial.rst
+++ b/changelog/5084.trivial.rst
@@ -1,0 +1,1 @@
+Refactored `~sunpy.coordinates.metaframes.RotatedSunFrame` transformations for improved performance.


### PR DESCRIPTION
For philosophical reasons, the transformations for `RotatedSunFrame` were written to externally go to/from the corresponding "base" frame, and those transformations would internally go through `HeliocentricInertial` (HCI), which intermediately goes through `HeliographicStonyhurst` (HGS).  Calculating the differential rotation in HGS instead of HCI does not change the result, so the transformation loop HGS->HCI->HGS is unnecessary.  Furthermore, if the overall transformation for `RotatedSunFrame` goes to anything other than the "base" frame, there is an unnecessary transformation detour of going all the way to the "base" frame and then transforming back out of it.

This PR refactors those transformations to externally go to/from HGS.  This strictly reduces the number of transformation legs (i.e., a performance boost) with no change in the calculation result.  It also happens to fix #5082.