### PR TITLE
Re-ordered keyword-only arguments of draw_rectangle

### DIFF
--- a/changelog/5091.trivial.rst
+++ b/changelog/5091.trivial.rst
@@ -1,0 +1,1 @@
+Re-ordered keyword-only arguments of :meth:`sunpy.map.GenericMap.draw_rectangle` to match :meth:`sunpy.map.GenericMap.submap`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2055,8 +2055,8 @@ class GenericMap(NDData):
         return quad
 
     @u.quantity_input
-    def draw_rectangle(self, bottom_left, *, width: u.deg = None, height: u.deg = None,
-                       axes=None, top_right=None, **kwargs):
+    def draw_rectangle(self, bottom_left, *,top_right=None, width: u.deg = None, height: u.deg = None,
+                       axes=None,  **kwargs):
         """
         Draw a rectangle defined in world coordinates on the plot.
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2055,8 +2055,8 @@ class GenericMap(NDData):
         return quad
 
     @u.quantity_input
-    def draw_rectangle(self, bottom_left, *,top_right=None, width: u.deg = None, height: u.deg = None,
-                       axes=None,  **kwargs):
+    def draw_rectangle(self, bottom_left, *, top_right=None, width: u.deg = None, height: u.deg = None,
+                       axes=None, **kwargs):
         """
         Draw a rectangle defined in world coordinates on the plot.
 


### PR DESCRIPTION
@Cadair as mentioned in the issue summary, I have re-ordered the positional arguments of draw_rectangle. Though, it is to be noted the modification of the decorator and re-ordering of the sub_map was already done. As mentioned  https://github.com/sunpy/sunpy/pull/3677#discussion_r409606416 

<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #4025 
