### PR TITLE
Shortcut adding zero timedelta in parse_time()

### DIFF
--- a/changelog/5108.trivial.rst
+++ b/changelog/5108.trivial.rst
@@ -1,0 +1,3 @@
+Significantly sped up calls to :func:`~sunpy.time.parse_time` for string
+arguments. This will have knock on effects, including improved performance of
+querying the VSO.

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import astropy.time
 import astropy.units as u
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
 
 # This is not called but imported to register it
 from sunpy.time.utime import TimeUTime  # NOQA
@@ -64,6 +64,8 @@ TIME_FORMAT_LIST = [
     "%Y/%m/%dT%H:%M",  # Example 2007/05/04T21:08
 ]
 
+_ONE_DAY_TIMEDELTA = TimeDelta(1 * u.day)
+
 
 def is_time_equal(t1, t2):
     """
@@ -101,15 +103,15 @@ def _regex_parse_time(inp, format):
     try:
         hour = match.group("hour")
     except IndexError:
-        return inp, astropy.time.TimeDelta(0 * u.day)
+        return inp, False
     if hour == "24":
         if not all(
                 _n_or_eq(_group_or_none(match, g, int), 00)
                 for g in ["minute", "second", "microsecond"]):
             raise ValueError
         from_, to = match.span("hour")
-        return inp[:from_] + "00" + inp[to:], astropy.time.TimeDelta(1 * u.day)
-    return inp, astropy.time.TimeDelta(0 * u.day)
+        return inp[:from_] + "00" + inp[to:], True
+    return inp, False
 
 
 def find_time(string, format):
@@ -222,12 +224,15 @@ def convert_time_str(time_string, **kwargs):
     for time_format in TIME_FORMAT_LIST:
         try:
             try:
-                ts, time_delta = _regex_parse_time(time_string, time_format)
+                ts, add_one_day = _regex_parse_time(time_string, time_format)
             except TypeError:
                 break
             if ts is None:
                 continue
-            return Time.strptime(ts, time_format, **kwargs) + time_delta
+            t = Time.strptime(ts, time_format, **kwargs)
+            if add_one_day:
+                t += _ONE_DAY_TIMEDELTA
+            return t
         except ValueError:
             pass
 


### PR DESCRIPTION
xref https://github.com/sunpy/sunpy/issues/5107 - there is a non-trival performance overhead in adding a zero timedelta, when instead one can just check for zero and not add the timedelta. This should possibly go upstream to astropy too?