### PR TITLE
Namespace downloaded files with module name

### DIFF
--- a/changelog/5111.feature.rst
+++ b/changelog/5111.feature.rst
@@ -1,0 +1,1 @@
+Added the ability to namespace files downloaded using `sunpy.data.data_manager.manager.DataManager` by prepending the file name with module name.

--- a/sunpy/data/data_manager/cache.py
+++ b/sunpy/data/data_manager/cache.py
@@ -38,7 +38,7 @@ class Cache:
         self._cache_dir = Path(cache_dir)
         self._expiry = expiry if expiry is None else TimeDelta(expiry)
 
-    def download(self, urls, namespace='sunpy.', redownload=False):
+    def download(self, urls, namespace='', redownload=False):
         """
         Downloads the files from the urls.
 
@@ -140,7 +140,7 @@ class Cache:
         details = self._storage.find_by_key('url', url)
         return details
 
-    def _download_and_hash(self, urls, namespace='sunpy.'):
+    def _download_and_hash(self, urls, namespace=''):
         """
         Downloads the file and returns the path, hash and url it used to download.
 

--- a/sunpy/data/data_manager/cache.py
+++ b/sunpy/data/data_manager/cache.py
@@ -38,7 +38,7 @@ class Cache:
         self._cache_dir = Path(cache_dir)
         self._expiry = expiry if expiry is None else TimeDelta(expiry)
 
-    def download(self, urls, namespace, redownload=False):
+    def download(self, urls, namespace='sunpy.', redownload=False):
         """
         Downloads the files from the urls.
 
@@ -140,7 +140,7 @@ class Cache:
         details = self._storage.find_by_key('url', url)
         return details
 
-    def _download_and_hash(self, urls, namespace):
+    def _download_and_hash(self, urls, namespace='sunpy.'):
         """
         Downloads the file and returns the path, hash and url it used to download.
 

--- a/sunpy/data/data_manager/cache.py
+++ b/sunpy/data/data_manager/cache.py
@@ -38,7 +38,7 @@ class Cache:
         self._cache_dir = Path(cache_dir)
         self._expiry = expiry if expiry is None else TimeDelta(expiry)
 
-    def download(self, urls, redownload=False):
+    def download(self, urls, namespace, redownload=False):
         """
         Downloads the files from the urls.
 
@@ -83,7 +83,7 @@ class Cache:
             else:
                 return Path(details['file_path'])
 
-        file_path, file_hash, url = self._download_and_hash(urls)
+        file_path, file_hash, url = self._download_and_hash(urls, namespace)
 
         self._storage.store({
             'file_hash': file_hash,
@@ -140,7 +140,7 @@ class Cache:
         details = self._storage.find_by_key('url', url)
         return details
 
-    def _download_and_hash(self, urls):
+    def _download_and_hash(self, urls, namespace):
         """
         Downloads the file and returns the path, hash and url it used to download.
 
@@ -155,7 +155,7 @@ class Cache:
             Path, hash and URL of the file.
         """
         def download(url):
-            path = self._cache_dir / get_filename(urlopen(url), url)
+            path = self._cache_dir / (namespace + get_filename(urlopen(url), url))
             # replacement_filename returns a string and we want a Path object
             path = Path(replacement_filename(str(path)))
             self._downloader.download(url, path)

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -64,7 +64,8 @@ class DataManager:
                         file_hash = hash_file(file_path)
                     else:
                         file_path, file_hash, _ = self._cache._download_and_hash(
-                                                    [replace['uri']], self._namespace)
+                            [replace['uri']], self._namespace
+                        )
                     if replace['hash'] and file_hash != replace['hash']:
                         # if hash provided to replace function doesn't match the hash of the file
                         # raise error

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -1,3 +1,4 @@
+import inspect
 import pathlib
 import warnings
 import functools
@@ -26,6 +27,7 @@ class DataManager:
 
         self._file_cache = {}
 
+        self._namespace = None
         self._skip_hash_check = False
         self._skip_file: Dict[str, str] = {}
 
@@ -49,6 +51,12 @@ class DataManager:
         def decorator(func):
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
+                self._namespace = func.__module__.lstrip('.').split('.')[0]
+                if self._namespace == '__main__':
+                    self._namespace = ''
+                else:
+                    self._namespace += '.'
+
                 replace = self._skip_file.get(name, None)
                 if replace:
                     uri_parse = urlparse(replace['uri'])
@@ -61,14 +69,14 @@ class DataManager:
                         file_path = uri_parse.netloc + uri_parse.path
                         file_hash = hash_file(file_path)
                     else:
-                        file_path, file_hash, _ = self._cache._download_and_hash([replace['uri']])
+                        file_path, file_hash, _ = self._cache._download_and_hash([replace['uri']], self._namespace)
                     if replace['hash'] and file_hash != replace['hash']:
                         # if hash provided to replace function doesn't match the hash of the file
                         # raise error
                         raise ValueError(
                             "Hash provided to override_file does not match hash of the file.")
                 elif self._skip_hash_check:
-                    file_path = self._cache.download(urls, redownload=True)
+                    file_path = self._cache.download(urls, self._namespace, redownload=True)
                 else:
                     details = self._cache.get_by_hash(sha_hash)
                     if not details:
@@ -80,7 +88,7 @@ class DataManager:
                             # in the database
                             raise ValueError(f"{urls} has already been downloaded, but no file "
                                              f"matching the hash {sha_hash} can be found.")
-                        file_path = self._cache.download(urls)
+                        file_path = self._cache.download(urls, self._namespace)
                         file_hash = hash_file(file_path)
                         if file_hash != sha_hash:
                             # the hash of the file downloaded does not match provided hash
@@ -96,7 +104,7 @@ class DataManager:
                         if hash_file(details['file_path']) != details['file_hash']:
                             warnings.warn("Hashes do not match, the file will be redownloaded (could be be tampered/corrupted)",
                                           SunpyUserWarning)
-                            file_path = self._cache.download(urls, redownload=True)
+                            file_path = self._cache.download(urls, self._namespace, redownload=True)
                             # Recheck the hash again, if this fails, we will exit.
                             if hash_file(file_path) != details['file_hash']:
                                 raise RuntimeError("Redownloaded file also has the incorrect hash."
@@ -104,8 +112,13 @@ class DataManager:
                         else:
                             file_path = details['file_path']
 
-                self._file_cache[name] = file_path
-                return func(*args, **kwargs)
+                if name not in self._file_cache:
+                    self._file_cache[name] = {}
+                self._file_cache[name][self._namespace] = file_path
+
+                result = func(*args, **kwargs)
+                self._namespace = None
+                return result
             return wrapper
 
         return decorator
@@ -172,7 +185,7 @@ class DataManager:
         `KeyError`
             If ``name`` is not in the cache.
         """
-        return pathlib.Path(self._file_cache[name])
+        return pathlib.Path(self._file_cache[name][self._namespace])
 
     def _cache_has_file(self, urls):
         for url in urls:

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -69,7 +69,8 @@ class DataManager:
                         file_path = uri_parse.netloc + uri_parse.path
                         file_hash = hash_file(file_path)
                     else:
-                        file_path, file_hash, _ = self._cache._download_and_hash([replace['uri']], self._namespace)
+                        file_path, file_hash, _ = self._cache._download_and_hash(
+                                                    [replace['uri']], self._namespace)
                     if replace['hash'] and file_hash != replace['hash']:
                         # if hash provided to replace function doesn't match the hash of the file
                         # raise error

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -190,7 +190,20 @@ class DataManager:
         return False
 
     def _get_module(self, func):
-        # Made into a separate function for the ability to patch in tests
+        """
+        Returns the name of the module (appended with a dot) that a function belongs to.
+        This is made into a separate function for the ability to patch in tests.
+
+        Parameters
+        ----------
+        func : `function`
+            A function who's module is to be found.
+
+        Returns
+        -------
+        `module`:
+            A `str` that represents the module name appended with a dot.
+        """
         module = func.__module__.lstrip('.').split('.')[0] + '.'
         if module == '__main__.':
             module = ''

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -111,7 +111,6 @@ class DataManager:
                 if name not in self._file_cache:
                     self._file_cache[name] = {}
                 self._file_cache[name][self._namespace] = file_path
-
                 result = func(*args, **kwargs)
                 self._namespace = None
                 return result

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -191,7 +191,6 @@ class DataManager:
     def _get_module(self, func):
         """
         Returns the name of the module (appended with a dot) that a function belongs to.
-        This is made into a separate function for the ability to patch in tests.
 
         Parameters
         ----------

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -1,4 +1,3 @@
-import inspect
 import pathlib
 import warnings
 import functools
@@ -51,12 +50,7 @@ class DataManager:
         def decorator(func):
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
-                self._namespace = func.__module__.lstrip('.').split('.')[0]
-                if self._namespace == '__main__':
-                    self._namespace = ''
-                else:
-                    self._namespace += '.'
-
+                self._namespace = self._get_module(func)
                 replace = self._skip_file.get(name, None)
                 if replace:
                     uri_parse = urlparse(replace['uri'])
@@ -193,3 +187,10 @@ class DataManager:
             if self._cache._get_by_url(url):
                 return True
         return False
+
+    def _get_module(self, func):
+        # Made into a separate function for the ability to patch in tests
+        module = func.__module__.lstrip('.').split('.')[0] + '.'
+        if module == '__main__.':
+            module = ''
+        return module

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -196,8 +196,8 @@ class DataManager:
 
         Parameters
         ----------
-        func : `function`
-            A function who's module is to be found.
+        func : function
+            A function whose module is to be found.
 
         Returns
         -------

--- a/sunpy/data/data_manager/manager.py
+++ b/sunpy/data/data_manager/manager.py
@@ -201,8 +201,7 @@ class DataManager:
 
         Returns
         -------
-        `module`:
-            A `str` that represents the module name appended with a dot.
+        A `str` that represents the module name appended with a dot.
         """
         module = func.__module__.lstrip('.').split('.')[0] + '.'
         if module == '__main__.':

--- a/sunpy/data/data_manager/tests/conftest.py
+++ b/sunpy/data/data_manager/tests/conftest.py
@@ -72,3 +72,26 @@ def data_function(manager):
         manager_tester(manager)
 
     return foo
+
+
+@pytest.fixture
+def module_patched_manager(tmp_path, downloader, storage, mocker):
+    def _get_module(func):
+        return 'fake_module.'
+
+    module_patched_manager = DataManager(Cache(downloader, storage, tmp_path))
+    module_patched_manager._tempdir = str(tmp_path)
+    module_patched_manager._get_module = _get_module
+    m = mock.Mock()
+    m.headers = {'Content-Disposition': 'test_file'}
+    mocker.patch('sunpy.data.data_manager.cache.urlopen', return_value=m)
+    yield module_patched_manager
+
+
+@pytest.fixture
+def data_function_from_fake_module(module_patched_manager):
+    @module_patched_manager.require('test_file', ['http://www.example.com/test_file'], mocks.MOCK_HASH)
+    def foo(manager_tester=lambda x: 1):
+        manager_tester(module_patched_manager)
+
+    return foo

--- a/sunpy/data/data_manager/tests/conftest.py
+++ b/sunpy/data/data_manager/tests/conftest.py
@@ -90,7 +90,8 @@ def module_patched_manager(tmp_path, downloader, storage, mocker):
 
 @pytest.fixture
 def data_function_from_fake_module(module_patched_manager):
-    @module_patched_manager.require('test_file', ['http://www.example.com/test_file'], mocks.MOCK_HASH)
+    @module_patched_manager.require(
+        'test_file', ['http://www.example.com/test_file'], mocks.MOCK_HASH)
     def foo(manager_tester=lambda x: 1):
         manager_tester(module_patched_manager)
 

--- a/sunpy/data/data_manager/tests/test_cache.py
+++ b/sunpy/data/data_manager/tests/test_cache.py
@@ -2,41 +2,41 @@ from .mocks import MOCK_HASH
 
 
 def test_cache_basic(cache):
-    cache.download('http://example.com', 'sunpy')
+    cache.download('http://example.com')
     assert cache._downloader.times_called == 1
 
 
 def test_cache_caching(cache):
-    cache.download('http://example.com', 'sunpy')
-    cache.download('http://example.com', 'sunpy')
+    cache.download('http://example.com')
+    cache.download('http://example.com')
     assert cache._downloader.times_called == 1
 
 
 def test_cache_redownload(cache):
-    cache.download('http://example.com', 'sunpy')
-    cache.download('http://example.com', 'sunpy', redownload=True)
+    cache.download('http://example.com')
+    cache.download('http://example.com', redownload=True)
     assert cache._downloader.times_called == 2
 
 
 def test_get_by_url(cache):
-    cache.download('http://example.com/file_name', 'sunpy')
+    cache.download('http://example.com/file_name')
     details = cache._get_by_url('http://example.com/file_name')
     assert details['file_path'].endswith('file_name')
 
 
 def test_get_by_url_fail(cache):
-    cache.download('http://example.com/file_name', 'sunpy')
+    cache.download('http://example.com/file_name')
     details = cache._get_by_url('http://example.com/file')
     assert details is None
 
 
 def test_get_by_hash(cache):
-    cache.download('http://example.com/file_name', 'sunpy')
+    cache.download('http://example.com/file_name')
     details = cache.get_by_hash(MOCK_HASH)
     assert details['file_path'].endswith('file_name')
 
 
 def test_get_by_hash_fail(cache):
-    cache.download('http://example.com/file_name', 'sunpy')
+    cache.download('http://example.com/file_name')
     details = cache.get_by_hash('wrong_hash')
     assert details is None

--- a/sunpy/data/data_manager/tests/test_cache.py
+++ b/sunpy/data/data_manager/tests/test_cache.py
@@ -2,41 +2,41 @@ from .mocks import MOCK_HASH
 
 
 def test_cache_basic(cache):
-    cache.download('http://example.com')
+    cache.download('http://example.com', 'sunpy')
     assert cache._downloader.times_called == 1
 
 
 def test_cache_caching(cache):
-    cache.download('http://example.com')
-    cache.download('http://example.com')
+    cache.download('http://example.com', 'sunpy')
+    cache.download('http://example.com', 'sunpy')
     assert cache._downloader.times_called == 1
 
 
 def test_cache_redownload(cache):
-    cache.download('http://example.com')
-    cache.download('http://example.com', redownload=True)
+    cache.download('http://example.com', 'sunpy')
+    cache.download('http://example.com', 'sunpy', redownload=True)
     assert cache._downloader.times_called == 2
 
 
 def test_get_by_url(cache):
-    cache.download('http://example.com/file_name')
+    cache.download('http://example.com/file_name', 'sunpy')
     details = cache._get_by_url('http://example.com/file_name')
     assert details['file_path'].endswith('file_name')
 
 
 def test_get_by_url_fail(cache):
-    cache.download('http://example.com/file_name')
+    cache.download('http://example.com/file_name', 'sunpy')
     details = cache._get_by_url('http://example.com/file')
     assert details is None
 
 
 def test_get_by_hash(cache):
-    cache.download('http://example.com/file_name')
+    cache.download('http://example.com/file_name', 'sunpy')
     details = cache.get_by_hash(MOCK_HASH)
     assert details['file_path'].endswith('file_name')
 
 
 def test_get_by_hash_fail(cache):
-    cache.download('http://example.com/file_name')
+    cache.download('http://example.com/file_name', 'sunpy')
     details = cache.get_by_hash('wrong_hash')
     assert details is None

--- a/sunpy/data/data_manager/tests/test_manager.py
+++ b/sunpy/data/data_manager/tests/test_manager.py
@@ -162,7 +162,8 @@ def test_delete_db(sqlmanager, sqlstorage):
     test_function()
 
 
-def test_same_file_id_different_module(downloader, storage, data_function, data_function_from_fake_module):
+def test_same_file_id_different_module(
+        downloader, storage, data_function, data_function_from_fake_module):
     # Uses name 'test_file' to refer to the file
     data_function()
 

--- a/sunpy/data/data_manager/tests/test_manager.py
+++ b/sunpy/data/data_manager/tests/test_manager.py
@@ -162,8 +162,8 @@ def test_delete_db(sqlmanager, sqlstorage):
     test_function()
 
 
-def test_same_file_id_different_module(
-        downloader, storage, data_function, data_function_from_fake_module):
+def test_same_file_id_different_module(downloader, storage,
+                                       data_function, data_function_from_fake_module):
     # Uses name 'test_file' to refer to the file
     data_function()
 
@@ -182,8 +182,8 @@ def test_same_file_id_different_module(
     assert Path(storage._store[1]['file_path']).name == 'fake_module.test_file'
 
 
-def test_namespacing_with_manager_override_file(
-        module_patched_manager, downloader, storage, data_function_from_fake_module):
+def test_namespacing_with_manager_override_file(module_patched_manager, downloader,
+                                                storage, data_function_from_fake_module):
     # Download a file using manager.require()
     data_function_from_fake_module()
 

--- a/sunpy/data/data_manager/tests/test_manager.py
+++ b/sunpy/data/data_manager/tests/test_manager.py
@@ -12,7 +12,7 @@ def test_basic(storage, downloader, data_function):
 
     assert downloader.times_called == 1
     assert len(storage._store) == 1
-    assert Path(storage._store[0]['file_path']).name == ('test_file')
+    assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
 def test_cache(manager, storage, downloader, data_function):
@@ -24,7 +24,7 @@ def test_cache(manager, storage, downloader, data_function):
 
     assert downloader.times_called == 1
     assert len(storage._store) == 1
-    assert Path(storage._store[0]['file_path']).name == ('test_file')
+    assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
 def test_file_tampered(manager, storage, downloader, data_function):
@@ -32,13 +32,13 @@ def test_file_tampered(manager, storage, downloader, data_function):
     Test calling function multiple times does not redownload.
     """
     data_function()
-    write_to_test_file(manager._tempdir + '/test_file', 'b')
+    write_to_test_file(manager._tempdir + '/sunpy.test_file', 'b')
     with pytest.warns(SunpyUserWarning):
         data_function()
 
     assert downloader.times_called == 2
     assert len(storage._store) == 1
-    assert Path(storage._store[0]['file_path']).name == ('test_file')
+    assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
 def test_wrong_hash_provided(manager):
@@ -60,7 +60,7 @@ def test_skip_all(manager, storage, downloader, data_function):
 
     assert downloader.times_called == 2
     assert len(storage._store) == 1
-    assert Path(storage._store[0]['file_path']).name == ('test_file')
+    assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
 def test_override_file(manager, storage, downloader, data_function, tmpdir):
@@ -72,7 +72,7 @@ def test_override_file(manager, storage, downloader, data_function, tmpdir):
         """
         Function to test whether the file name is test_file.
         """
-        assert manager.get('test_file').name == ('test_file')
+        assert manager.get('test_file').name == ('sunpy.test_file')
 
     def override_file_tester(manager):
         """

--- a/sunpy/data/data_manager/tests/test_manager.py
+++ b/sunpy/data/data_manager/tests/test_manager.py
@@ -160,3 +160,22 @@ def test_delete_db(sqlmanager, sqlstorage):
 
     # SQLite should not throw an error
     test_function()
+
+
+def test_same_file_id_different_module(downloader, storage, data_function, data_function_from_fake_module):
+    # Uses name 'test_file' to refer to the file
+    data_function()
+
+    # Change hash of the above file to allow MockDownloader to download another file
+    # Otherwise it will skip the download because a file with the same hash already exists
+    storage._store[0]['file_hash'] = 'abc'
+
+    # This function from a different module uses same name 'test_file' to refer to a different file
+    data_function_from_fake_module()
+
+    assert len(storage._store) == 2
+    assert downloader.times_called == 2
+
+    # Check if the files are namespaced correctly
+    assert Path(storage._store[0]['file_path']).name == 'sunpy.test_file'
+    assert Path(storage._store[1]['file_path']).name == 'fake_module.test_file'


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
Added namespaces for files downloaded using `DataManager`, by prepending the file name with module name. 

Closes #3908.