### PR TITLE
GenericMap now passes docstrings to its subclasses

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -189,6 +189,7 @@ class GenericMap(NDData):
         `is_datasource_for` attribute.
         This is then passed into the Map Factory so we can register them.
         """
+        cls.__doc__ = cls.__doc__ + '\n' + GenericMap.__doc__.split("data array")[1].split("Examples")[0]
         super().__init_subclass__(**kwargs)
         if hasattr(cls, 'is_datasource_for'):
             cls._registry[cls] = cls.is_datasource_for

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -68,6 +68,52 @@ and `~sunpy.util.MetaDict.modified_items` properties of MetaDict
 to query how the metadata has been modified.
 """
 
+# The notes live here so we can reuse it in the source maps
+_notes_doc = """
+
+Notes
+-----
+
+A number of the properties of this class are returned as two-value named
+tuples that can either be indexed by position ([0] or [1]) or be accessed
+by the names (.x and .y) or (.axis1 and .axis2). Things that refer to pixel
+axes use the ``.x``, ``.y`` convention, where x and y refer to the FITS
+axes (x for columns y for rows). Spatial axes use ``.axis1`` and ``.axis2``
+which correspond to the first and second axes in the header. ``axis1``
+corresponds to the coordinate axis for ``x`` and ``axis2`` corresponds to
+``y``.
+
+This class makes some assumptions about the WCS information contained in
+the meta data. The first and most extensive assumption is that it is
+FITS-like WCS information as defined in the FITS WCS papers.
+
+Within this scope it also makes some other assumptions.
+
+* In the case of APIS convention headers where the CROTAi/j arguments are
+    provided it assumes that these can be converted to the standard PCi_j
+    notation using equations 32 in Thompson (2006).
+
+* If a CDi_j matrix is provided it is assumed that it can be converted to a
+    PCi_j matrix and CDELT keywords as described in
+    `Greisen & Calabretta (2002) <https://doi.org/10.1051/0004-6361:20021327>`_
+
+* The 'standard' FITS keywords that are used by this class are the PCi_j
+    matrix and CDELT, along with the other keywords specified in the WCS
+    papers. All subclasses of this class must convert their header
+    information to this formalism. The CROTA to PCi_j conversion is done in
+    this class.
+
+.. warning::
+    This class currently assumes that a header with the CDi_j matrix
+    information also includes the CDELT keywords, without these keywords
+    this class will not process the WCS.
+    Also the rotation_matrix does not work if the CDELT1 and CDELT2
+    keywords are exactly equal.
+    Also, if a file with more than two dimensions is feed into the class,
+    only the first two dimensions (NAXIS1, NAXIS2) will be loaded and the
+    rest will be discarded.
+"""
+
 __all__ = ['GenericMap']
 
 
@@ -132,50 +178,7 @@ class GenericMap(NDData):
     >>> aia.spatial_units   # doctest: +REMOTE_DATA
     SpatialPair(axis1=Unit("arcsec"), axis2=Unit("arcsec"))
     >>> aia.peek()   # doctest: +SKIP
-
-    Notes
-    -----
-
-    A number of the properties of this class are returned as two-value named
-    tuples that can either be indexed by position ([0] or [1]) or be accessed
-    by the names (.x and .y) or (.axis1 and .axis2). Things that refer to pixel
-    axes use the ``.x``, ``.y`` convention, where x and y refer to the FITS
-    axes (x for columns y for rows). Spatial axes use ``.axis1`` and ``.axis2``
-    which correspond to the first and second axes in the header. ``axis1``
-    corresponds to the coordinate axis for ``x`` and ``axis2`` corresponds to
-    ``y``.
-
-    This class makes some assumptions about the WCS information contained in
-    the meta data. The first and most extensive assumption is that it is
-    FITS-like WCS information as defined in the FITS WCS papers.
-
-    Within this scope it also makes some other assumptions.
-
-    * In the case of APIS convention headers where the CROTAi/j arguments are
-      provided it assumes that these can be converted to the standard PCi_j
-      notation using equations 32 in Thompson (2006).
-
-    * If a CDi_j matrix is provided it is assumed that it can be converted to a
-      PCi_j matrix and CDELT keywords as described in
-      `Greisen & Calabretta (2002) <https://doi.org/10.1051/0004-6361:20021327>`_
-
-    * The 'standard' FITS keywords that are used by this class are the PCi_j
-      matrix and CDELT, along with the other keywords specified in the WCS
-      papers. All subclasses of this class must convert their header
-      information to this formalism. The CROTA to PCi_j conversion is done in
-      this class.
-
-    .. warning::
-        This class currently assumes that a header with the CDi_j matrix
-        information also includes the CDELT keywords, without these keywords
-        this class will not process the WCS.
-        Also the rotation_matrix does not work if the CDELT1 and CDELT2
-        keywords are exactly equal.
-        Also, if a file with more than two dimensions is feed into the class,
-        only the first two dimensions (NAXIS1, NAXIS2) will be loaded and the
-        rest will be discarded.
     """
-
     _registry = dict()
     # This overrides the default doc for the meta attribute
     meta = MetaData(doc=_meta_doc, copy=False)
@@ -189,8 +192,8 @@ class GenericMap(NDData):
         `is_datasource_for` attribute.
         This is then passed into the Map Factory so we can register them.
         """
-        cls.__doc__ = cls.__doc__ + '\n' + GenericMap.__doc__.split("data array")[1].split("Examples")[0]
         super().__init_subclass__(**kwargs)
+        cls.__doc__ += textwrap.indent(_notes_doc, "    ")
         if hasattr(cls, 'is_datasource_for'):
             cls._registry[cls] = cls.is_datasource_for
 
@@ -2565,6 +2568,9 @@ class GenericMap(NDData):
                           SunpyUserWarning)
 
         return axes
+
+
+GenericMap.__doc__ += textwrap.indent(_notes_doc, "    ")
 
 
 class InvalidHeaderInformation(ValueError):


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
Helps GenericMap to pass its docstring to its subclasses.
Fixes #3716 
