### PR TITLE
Transformations now ignore time differences below numerical precision

### DIFF
--- a/changelog/5127.bugfix.rst
+++ b/changelog/5127.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where coordinate frames were considered different due to an unintended time difference during time handling at the level of numerical precision (i.e., tens of picoseconds).
+This resulted in the unexpected use of transformation machinery when transforming a coordinate to its own coordinate frame.

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -41,6 +41,7 @@ from astropy.coordinates.representation import (
 # Import erfa via astropy to make sure we are using the same ERFA library as Astropy
 from astropy.coordinates.sky_coordinate import erfa
 from astropy.coordinates.transformations import FunctionTransform, FunctionTransformWithFiniteDifference
+from astropy.time import Time
 
 from sunpy import log
 from sunpy.sun import constants
@@ -213,7 +214,7 @@ def _observers_are_equal(obs_1, obs_2):
     return np.atleast_1d((u.allclose(obs_1.lat, obs_2.lat) and
                           u.allclose(obs_1.lon, obs_2.lon) and
                           u.allclose(obs_1.radius, obs_2.radius) and
-                          obs_1.obstime == obs_2.obstime)).all()
+                          _times_are_equal(obs_1.obstime, obs_2.obstime))).all()
 
 
 def _check_observer_defined(frame):
@@ -230,6 +231,17 @@ def _check_observer_defined(frame):
                                "but this is valid for only HeliographicCarrington frames.")
 
 
+def _times_are_equal(time_1, time_2):
+    # Checks whether times are equal
+    if isinstance(time_1, Time) and isinstance(time_2, Time):
+        # We explicitly perform the check in TAI to avoid possible numerical precision differences
+        # between a time in UTC and the same time after a UTC->TAI->UTC conversion
+        return np.all(time_1.tai == time_2.tai)
+
+    # We also deem the times equal if they are both None
+    return time_1 is None and time_2 is None
+
+
 # =============================================================================
 # ------------------------- Transformation Framework --------------------------
 # =============================================================================
@@ -242,7 +254,7 @@ def _transform_obstime(frame, obstime):
     If the frame's obstime is None, the frame is copied with the new obstime.
     """
     # If obstime is None or the obstime matches, nothing needs to be done
-    if obstime is None or np.all(frame.obstime == obstime):
+    if obstime is None or _times_are_equal(frame.obstime, obstime):
         return frame
 
     # Transform to the new obstime using the appropriate loopback transformation
@@ -465,7 +477,7 @@ def hpc_to_hpc(from_coo, to_frame):
     It does this by transforming through HGS.
     """
     if _observers_are_equal(from_coo.observer, to_frame.observer) and \
-       np.all(from_coo.obstime == to_frame.obstime):
+       _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
 
     _check_observer_defined(from_coo)
@@ -630,7 +642,7 @@ def hgs_to_hgs(from_coo, to_frame):
     """
     if to_frame.obstime is None:
         return from_coo.replicate()
-    elif np.all(from_coo.obstime == to_frame.obstime):
+    elif _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
         return from_coo.transform_to(HCRS(obstime=from_coo.obstime)).transform_to(to_frame)
@@ -644,7 +656,7 @@ def hgc_to_hgc(from_coo, to_frame):
     Convert between two Heliographic Carrington frames.
     """
     if _observers_are_equal(from_coo.observer, to_frame.observer) and \
-       np.all(from_coo.obstime == to_frame.obstime):
+       _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
 
     _check_observer_defined(from_coo)
@@ -664,7 +676,7 @@ def hcc_to_hcc(from_coo, to_frame):
     Convert between two Heliocentric frames.
     """
     if _observers_are_equal(from_coo.observer, to_frame.observer) and \
-       np.all(from_coo.obstime == to_frame.obstime):
+       _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
 
     _check_observer_defined(from_coo)
@@ -745,7 +757,7 @@ def hee_to_hee(from_coo, to_frame):
     """
     Convert between two Heliocentric Earth Ecliptic frames.
     """
-    if np.all(from_coo.obstime == to_frame.obstime):
+    if _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     elif to_frame.obstime is None:
         return from_coo
@@ -816,7 +828,7 @@ def gse_to_gse(from_coo, to_frame):
     """
     Convert between two Geocentric Solar Ecliptic frames.
     """
-    if np.all(from_coo.obstime == to_frame.obstime):
+    if _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
         heecoord = from_coo.transform_to(HeliocentricEarthEcliptic(obstime=from_coo.obstime))
@@ -892,7 +904,7 @@ def hci_to_hci(from_coo, to_frame):
     """
     Convert between two Heliocentric Inertial frames.
     """
-    if np.all(from_coo.obstime == to_frame.obstime):
+    if _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
         return from_coo.transform_to(HeliographicStonyhurst(obstime=from_coo.obstime)).\
@@ -972,7 +984,8 @@ def gei_to_gei(from_coo, to_frame):
     """
     Convert between two Geocentric Earth Equatorial frames.
     """
-    if np.all((from_coo.equinox == to_frame.equinox) and (from_coo.obstime == to_frame.obstime)):
+    if _times_are_equal(from_coo.equinox, to_frame.equinox) and \
+       _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
         return from_coo.transform_to(HCRS(obstime=from_coo.obstime)).transform_to(to_frame)


### PR DESCRIPTION
#5108 had the consequence that we stopped adding zero seconds to most parsed times.  It turns out that adding zero seconds causes a UTC time to be converted to TAI and then back to UTC, which can result in a delta of tens of picoseconds (see https://github.com/astropy/astropy/issues/8742#issuecomment-494562784).  So, once we stopped doing the unnecessary conversion in `parse_time()`, later manipulation of the `Time` instance could cause it to change by tens of picoseconds.

This is particularly problematic when working with 2D Helioprojective coordinates that are off the limb and transforming the coordinate to its own frame.  When the obstimes (and observer obstimes) are equal, we can bail out and return the same 2D coordinate.  When the obstimes are different, even by only tens of picoseconds, we would run through the whole HPC->HCC->HGS->HCC->HPC chain, so we would convert the coordinate to 3D, and so off-the-limb coordinates turn into NaN.  This is the cause of our current test failures.

~This PR modifies all time-equality checks in `sunpy.coordinates.transformations` to consider a time difference of only tens of picoseconds to be equal.  Once we depend on Astropy 4.2, we can use `Time.isclose()` (see astropy/astropy#10646), but that wouldn't really make the code here much cleaner.~

This PR modifies all time-equality checks in `sunpy.coordinates.transformations` to be performed in TAI.  This is stricter than the above approach of a tolerance.