### PR TITLE
Added rigid rotation model to `diff_rot()`

### DIFF
--- a/changelog/5132.feature.rst
+++ b/changelog/5132.feature.rst
@@ -1,1 +1,1 @@
-Added Rigid Rotation Model to :func:`~sunpy.physics.differential_rotation.diff_rot`, which can be used by passing `rot_type` as `"rigid"`.
+Added Rigid Rotation Model to :func:`~sunpy.physics.differential_rotation.diff_rot`, which can be used by passing ``rot_type`` as "rigid".

--- a/changelog/5132.feature.rst
+++ b/changelog/5132.feature.rst
@@ -1,0 +1,1 @@
+Added Rigid Rotation Model to :func:`~sunpy.physics.differential_rotation.diff_rot`, which can be used by passing `rot_type` as `"rigid"`.

--- a/changelog/5132.feature.rst
+++ b/changelog/5132.feature.rst
@@ -1,1 +1,1 @@
-Added Rigid Rotation Model to :func:`~sunpy.physics.differential_rotation.diff_rot`, which can be used by passing ``rot_type`` as "rigid".
+Added a rigid rotation model to :func:`~sunpy.physics.differential_rotation.diff_rot` via ``rot_type=rigid``, where the rotation rate does not vary with latitude.

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -18,8 +18,9 @@ from sunpy.map import (
     on_disk_bounding_coordinates,
 )
 from sunpy.map.header_helper import get_observer_meta
+from sunpy.sun.constants import sidereal_rotation_rate
 from sunpy.time import parse_time
-from sunpy.util import expand_list
+from sunpy.util import expand_list 
 
 __all__ = ['diff_rot', 'solar_rotate_coordinate', 'differential_rotate']
 
@@ -43,6 +44,7 @@ def diff_rot(duration: u.s, latitude: u.deg, rot_type='howard', frame_time='side
         | ``howard`` : Use values from Howard et al. (1990)
         | ``snodgrass`` : Use values from Snodgrass et. al. (1983)
         | ``allen`` : Use values from Allen's Astrophysical Quantities, and simpler equation.
+        | ``rigid`` : Use values from `~sunpy.sun.constants.sidereal_rotation_rate`.
 
     frame_time : `str`
         One of : ``'sidereal'`` or  ``'synodic'``. Choose 'type of day' time reference frame.
@@ -62,13 +64,14 @@ def diff_rot(duration: u.s, latitude: u.deg, rot_type='howard', frame_time='side
 
     where :math:`A, B, C` are constants that depend on the model:
 
-    ========= ===== ====== ====== ==========
-    Model     A     B      C      Unit
-    ========= ===== ====== ====== ==========
-    howard    2.894 -0.428 -0.370 microrad/s
-    snodgrass 2.851 -0.343 -0.474 microrad/s
-    allen     14.44 -3.0   0      deg/day
-    ========= ===== ====== ====== ==========
+    ========= ======= ====== ====== ==========
+    Model     A       B      C      Unit
+    ========= ======= ====== ====== ==========
+    howard    2.894   -0.428 -0.370 microrad/s
+    snodgrass 2.851   -0.343 -0.474 microrad/s
+    allen     14.44   -3.0   0      deg/day
+    rigid     14.1844 0      0      deg/day
+    ========= ======= ====== ====== ==========
 
     1 microrad/s is approximately 4.95 deg/day.
 
@@ -115,10 +118,11 @@ def diff_rot(duration: u.s, latitude: u.deg, rot_type='howard', frame_time='side
 
     rot_params = {'howard': [2.894, -0.428, -0.370] * u.urad / u.second,
                   'snodgrass': [2.851, -0.343, -0.474] * u.urad / u.second,
-                  'allen': [14.44, -3.0, 0] * u.deg / u.day
+                  'allen': [14.44, -3.0, 0] * u.deg / u.day,
+                  'rigid': [sidereal_rotation_rate.value, 0, 0] * u.deg / u.day
                   }
 
-    if rot_type not in ['howard', 'allen', 'snodgrass']:
+    if rot_type not in ['howard', 'allen', 'snodgrass', 'rigid']:
         raise ValueError("rot_type must equal one of "
                          "{{ {} }}".format(" | ".join(rot_params.keys())))
 

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -119,7 +119,7 @@ def diff_rot(duration: u.s, latitude: u.deg, rot_type='howard', frame_time='side
     rot_params = {'howard': [2.894, -0.428, -0.370] * u.urad / u.second,
                   'snodgrass': [2.851, -0.343, -0.474] * u.urad / u.second,
                   'allen': [14.44, -3.0, 0] * u.deg / u.day,
-                  'rigid': [sidereal_rotation_rate.value, 0, 0] * u.deg / u.day
+                  'rigid': sidereal_rotation_rate * [1, 0, 0]
                   }
 
     if rot_type not in ['howard', 'allen', 'snodgrass', 'rigid']:

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -20,7 +20,7 @@ from sunpy.map import (
 from sunpy.map.header_helper import get_observer_meta
 from sunpy.sun.constants import sidereal_rotation_rate
 from sunpy.time import parse_time
-from sunpy.util import expand_list 
+from sunpy.util import expand_list
 
 __all__ = ['diff_rot', 'solar_rotate_coordinate', 'differential_rotate']
 

--- a/sunpy/physics/tests/test_differential_rotation.py
+++ b/sunpy/physics/tests/test_differential_rotation.py
@@ -130,6 +130,11 @@ def test_snodgrass(seconds_per_day):
     assert_quantity_allclose(rot, 135.4232 * u.deg, rtol=1e-3)
 
 
+def test_rigid(seconds_per_day):
+    rot = diff_rot(10 * seconds_per_day, 30 * u.deg, rot_type='rigid')
+    assert_quantity_allclose(rot, 141.844 * u.deg, rtol=1e-3)
+
+
 def test_fail(seconds_per_day):
     with pytest.raises(ValueError):
         rot = diff_rot(10 * seconds_per_day, 30 * u.deg, rot_type='garbage')

--- a/sunpy/physics/tests/test_differential_rotation.py
+++ b/sunpy/physics/tests/test_differential_rotation.py
@@ -131,8 +131,8 @@ def test_snodgrass(seconds_per_day):
 
 
 def test_rigid(seconds_per_day):
-    rot = diff_rot(10 * seconds_per_day, 30 * u.deg, rot_type='rigid')
-    assert_quantity_allclose(rot, 141.844 * u.deg, rtol=1e-3)
+    rot = diff_rot(10 * seconds_per_day, [0, 30, 60] * u.deg, rot_type='rigid')
+    assert_quantity_allclose(rot, [141.844 * u.deg] * 3, rtol=1e-3)
 
 
 def test_fail(seconds_per_day):


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
Added a new parameter `"rigid"` to rot_params, which calculates longitude by assuming sun as a rigid body.
Fixes #5123 
