### PR TITLE
Show the inherited attributes/methods in the docs for Map subclasses

### DIFF
--- a/changelog/5142.doc.rst
+++ b/changelog/5142.doc.rst
@@ -1,0 +1,1 @@
+For the various subclasses of `~sunpy.map.GenericMap` (e.g., `~sunpy.map.sources.AIAMap`), the online documentation now shows all of the inherited attributes and methods.

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -85,6 +85,7 @@ which data and metadata pairs match its instrument.
 
 .. automodapi:: sunpy.map.sources
     :no-main-docstr:
+    :inherited-members:
 
 
 Writing a new Instrument Map Class


### PR DESCRIPTION
I don't know why this wasn't done before.  For example, https://docs.sunpy.org/en/stable/api/sunpy.map.sources.AIAMap.html doesn't show nearly any of the attributes/methods that a user would actually want to use.