### PR TITLE
save method for MapSequence

### DIFF
--- a/changelog/5145.feature.rst
+++ b/changelog/5145.feature.rst
@@ -1,0 +1,2 @@
+Added a :meth:`~sunpy.map.MapSequence.save` method to `sunpy.map.MapSequence`
+that saves each map of the sequence.

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -537,7 +537,7 @@ class MapSequence:
         >>> smap = Map(sunpy.data.sample.HMI_LOS_IMAGE,
         ...            sunpy.data.sample.AIA_1600_IMAGE,
         ...            sequence=True)  # doctest: +REMOTE_DATA
-        >>> smap.save('map_{index:03}.fits')  # doctest: +REMOTE_DATA
+        >>> smap.save('map_{index:03}.fits')  # doctest: +SKIP
 
         """
         if filepath.format(index=0) == filepath:

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -513,7 +513,8 @@ class MapSequence:
         return [m.meta for m in self.maps]
 
     def save(self, filepath, filetype='auto', **kwargs):
-        """Saves the SunPy Map Sequence object to a file.
+        """
+        Saves the SunPy Map Sequence object to a file.
 
         Currently SunPy can only save files in the FITS format.
 

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -532,15 +532,11 @@ class MapSequence:
         Notes
         -----
         The individual maps are saved as with the specified
-        `filepath` followed by an `_` with a sequence number.
-        If an extension isn't specified it is defaulted to `fits`.
+        `filepath` based on {index} specified by the user.
         """
-        filepath_ = Path(filepath)
         for index, map_seq in enumerate(self.maps):
-            extension = filepath_.suffix
-            path = (filepath_.parent / filepath_.stem).as_posix()
-            if extension == '':
-                path = f"{path}_{index:03}.fits"
+            filepath_ = filepath.format(index=index)
+            if filepath_ == filepath:
+                raise ValueError("{index} must be specified")
             else:
-                path = f"{path}_{index:03}{extension}"
-            map_seq.save(path, filetype, **kwargs)
+                map_seq.save(filepath_, filetype, **kwargs)

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -5,8 +5,8 @@ import textwrap
 import warnings
 import webbrowser
 from copy import deepcopy
-from tempfile import NamedTemporaryFile
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 import matplotlib.animation
 import numpy as np

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -5,6 +5,7 @@ import textwrap
 import warnings
 import webbrowser
 from copy import deepcopy
+from tempfile import NamedTemporaryFile
 from pathlib import Path
 
 import matplotlib.animation

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -515,8 +515,7 @@ class MapSequence:
     def save(self, filepath, filetype='auto', **kwargs):
         """Saves the SunPy Map Sequence object to a file.
 
-        Currently SunPy can only save files in the FITS format. In the future
-        support will be added for saving to other formats.
+        Currently SunPy can only save files in the FITS format.
 
         Parameters
         ----------
@@ -532,7 +531,7 @@ class MapSequence:
         Notes
         -----
         The individual maps are saved as with the specified
-        filepath followed by an `_` with the sequence number.
+        `filepath` followed by an `_` with a sequence number.
         If an extension isn't specified it is defaulted to `fits`.
         """
         filepath_ = Path(filepath)

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -5,7 +5,7 @@ import textwrap
 import warnings
 import webbrowser
 from copy import deepcopy
-from tempfile import NamedTemporaryFile
+from pathlib import Path
 
 import matplotlib.animation
 import numpy as np
@@ -513,7 +513,7 @@ class MapSequence:
         return [m.meta for m in self.maps]
 
     def save(self, filepath, filetype='auto', **kwargs):
-        """Saves the SunPy Map object to a file.
+        """Saves the SunPy Map Sequence object to a file.
 
         Currently SunPy can only save files in the FITS format. In the future
         support will be added for saving to other formats.
@@ -528,7 +528,19 @@ class MapSequence:
         kwargs :
             Any additional keyword arguments are passed to
             `~sunpy.io.write_file`.
+
+        Notes
+        -----
+        The individual maps are saved as with the specified
+        filepath followed by an `_` with the sequence number.
+        If an extension isn't specified it is defaulted to `fits`.
         """
+        filepath_ = Path(filepath)
         for index, map_seq in enumerate(self.maps):
-            _filepath = filepath + "_{}".format(index)
-            map_seq.save(_filepath, filetype, **kwargs)
+            extension = filepath_.suffix
+            path = (filepath_.parent / filepath_.stem).as_posix()
+            if extension == '':
+                path = f"{path}_{index:03}.fits"
+            else:
+                path = f"{path}_{index:03}{extension}"
+            map_seq.save(path, filetype, **kwargs)

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -535,7 +535,7 @@ class MapSequence:
         --------
         >>> from sunpy.map import Map
         >>> import sunpy.data.sample # doctest: +REMOTE_DATA
-        >>> smap = Map(sunpy.data.sample.AIA_171_IMAGE, sunpy.data.sample.AIA_193_IMAGE, sequence=True) # doctest: +REMOTE_DATA
+        >>> smap = Map(sunpy.data.sample.HMI_LOS_IMAGE, sunpy.data.sample.AIA_1600_IMAGE, sequence=True) # doctest: +REMOTE_DATA
         >>> smap.save('map_{index:03}.fits') # doctest: +REMOTE_DATA
 
         """

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -5,7 +5,6 @@ import textwrap
 import warnings
 import webbrowser
 from copy import deepcopy
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import matplotlib.animation

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -530,5 +530,5 @@ class MapSequence:
             `~sunpy.io.write_file`.
         """
         for index, map_seq in enumerate(self.maps):
-            _filepath = filepath+"_{}".format(index)
+            _filepath = filepath + "_{}".format(index)
             map_seq.save(_filepath, filetype, **kwargs)

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -511,3 +511,24 @@ class MapSequence:
         Return all the meta objects as a list.
         """
         return [m.meta for m in self.maps]
+
+    def save(self, filepath, filetype='auto', **kwargs):
+        """Saves the SunPy Map object to a file.
+
+        Currently SunPy can only save files in the FITS format. In the future
+        support will be added for saving to other formats.
+
+        Parameters
+        ----------
+        filepath : str
+            Location to save file to. 
+            Each map from the sequence will be saved separately.
+        filetype : str
+            'auto' or any supported file extension.
+        kwargs :
+            Any additional keyword arguments are passed to
+            `~sunpy.io.write_file`.
+        """
+        for index, map_seq in enumerate(self.maps):
+            _filepath = filepath+"_{}".format(index)
+            map_seq.save(_filepath, filetype, **kwargs)

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -522,16 +522,21 @@ class MapSequence:
         filepath : str
             Location to save file to.
             Each map from the sequence will be saved separately.
+            The individual maps are saved based on {index} specified
+            by the user.
         filetype : str
             'auto' or any supported file extension.
         kwargs :
             Any additional keyword arguments are passed to
             `~sunpy.io.write_file`.
 
-        Notes
-        -----
-        The individual maps are saved as with the specified
-        `filepath` based on {index} specified by the user.
+        Examples
+        --------
+        >>> from sunpy.map import Map
+        >>> import sunpy.data.sample
+        >>> smap = Map(sunpy.data.sample.AIA_171_IMAGE, sunpy.data.sample.AIA_193_IMAGE, sequence=True)
+        >>> smap.save('map_{index:03}.fits')
+
         """
         for index, map_seq in enumerate(self.maps):
             filepath_ = filepath.format(index=index)

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -521,7 +521,7 @@ class MapSequence:
         Parameters
         ----------
         filepath : str
-            Location to save file to. 
+            Location to save file to.
             Each map from the sequence will be saved separately.
         filetype : str
             'auto' or any supported file extension.

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -534,9 +534,9 @@ class MapSequence:
         Examples
         --------
         >>> from sunpy.map import Map
-        >>> import sunpy.data.sample
-        >>> smap = Map(sunpy.data.sample.AIA_171_IMAGE, sunpy.data.sample.AIA_193_IMAGE, sequence=True)
-        >>> smap.save('map_{index:03}.fits')
+        >>> import sunpy.data.sample # doctest: +REMOTE_DATA
+        >>> smap = Map(sunpy.data.sample.AIA_171_IMAGE, sunpy.data.sample.AIA_193_IMAGE, sequence=True) # doctest: +REMOTE_DATA
+        >>> smap.save('map_{index:03}.fits') # doctest: +REMOTE_DATA
 
         """
         for index, map_seq in enumerate(self.maps):

--- a/sunpy/map/tests/conftest.py
+++ b/sunpy/map/tests/conftest.py
@@ -27,6 +27,7 @@ def hmi_test_map():
     (data, header), = sunpy.io.read_file(os.path.join(testpath, 'resampled_hmi.fits'))
 
     # Get rid of the blank keyword to prevent some astropy fits fixing warnings
+    header.pop('BLANK')
     header.pop('CRDER2')
     header.pop('CRDER1')
     return sunpy.map.Map((data, header))

--- a/sunpy/map/tests/conftest.py
+++ b/sunpy/map/tests/conftest.py
@@ -27,7 +27,6 @@ def hmi_test_map():
     (data, header), = sunpy.io.read_file(os.path.join(testpath, 'resampled_hmi.fits'))
 
     # Get rid of the blank keyword to prevent some astropy fits fixing warnings
-    header.pop('BLANK')
     header.pop('CRDER2')
     header.pop('CRDER1')
     return sunpy.map.Map((data, header))

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -1,12 +1,14 @@
 """
 Test mapsequence functionality
 """
+import tempfile
 from unittest import mock
 
 import numpy as np
 import pytest
 
 import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 import sunpy
 import sunpy.data.test
@@ -196,3 +198,23 @@ def test_norm_animator(hmi_test_map):
 def test_map_sequence_plot(aia171_test_map, hmi_test_map):
     seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
     seq.plot()
+
+
+def test_save(aia171_test_map, hmi_test_map):
+    """Tests the map save function"""
+    seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
+    afilename = tempfile.NamedTemporaryFile(suffix='fits').name
+    seq.save(afilename, filetype='fits', overwrite=True)
+    test_seq = sunpy.map.Map(afilename+"_0", afilename+"_1", sequence=True)
+    assert isinstance(test_seq.maps[0], sunpy.map.sources.sdo.AIAMap)
+    assert isinstance(test_seq.maps[1], sunpy.map.sources.sdo.HMIMap)
+
+    assert test_seq.maps[0].meta.keys() == seq.maps[0].meta.keys()
+    for k in seq.maps[0].meta:
+        assert test_seq.maps[0].meta[k] == seq.maps[0].meta[k]
+    assert_quantity_allclose(test_seq.maps[0].data, seq.maps[0].data)
+
+    assert test_seq.maps[1].meta.keys() == seq.maps[1].meta.keys()
+    for k in seq.maps[1].meta:
+        assert test_seq.maps[1].meta[k] == seq.maps[1].meta[k]
+    assert_quantity_allclose(test_seq.maps[1].data, seq.maps[1].data)

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -200,9 +200,9 @@ def test_map_sequence_plot(aia171_test_map, hmi_test_map):
     seq.plot()
 
 
-def test_save(aia171_test_map, hmi_test_map):
+def test_save(aia171_test_map):
     """Tests the map save function"""
-    seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
+    seq = sunpy.map.Map([aia171_test_map, aia171_test_map], sequence=True)
     afilename = tempfile.NamedTemporaryFile(suffix='fits').name
     seq.save(afilename, filetype='fits', overwrite=True)
     test_seq = sunpy.map.Map(afilename + "_0", afilename + "_1", sequence=True)

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -200,12 +200,15 @@ def test_map_sequence_plot(aia171_test_map, hmi_test_map):
     seq.plot()
 
 
-def test_save(aia171_test_map, hmi_test_map):
-    """Tests the map save function"""
+def test_save(aia171_test_map, hmi_test_map, tmp_path):
+    """Tests the MapSequence save function"""
     seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
-    afilename = tempfile.NamedTemporaryFile(suffix='fits').name
-    seq.save(afilename, filetype='fits', overwrite=True)
-    test_seq = sunpy.map.Map(afilename + "_0", afilename + "_1", sequence=True)
+
+    seq.save(tmp_path.as_posix(), filetype='fits', overwrite=True)
+
+    test_seq = sunpy.map.Map(f"{tmp_path.as_posix()}_000.fits",
+                             f"{tmp_path.as_posix()}_001.fits", sequence=True)
+
     assert isinstance(test_seq.maps[0], sunpy.map.sources.sdo.AIAMap)
     assert isinstance(test_seq.maps[1], sunpy.map.sources.sdo.HMIMap)
 

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -1,7 +1,6 @@
 """
 Test mapsequence functionality
 """
-import tempfile
 from unittest import mock
 
 import numpy as np

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -200,9 +200,9 @@ def test_map_sequence_plot(aia171_test_map, hmi_test_map):
     seq.plot()
 
 
-def test_save(aia171_test_map):
+def test_save(aia171_test_map, hmi_test_map):
     """Tests the map save function"""
-    seq = sunpy.map.Map([aia171_test_map, aia171_test_map], sequence=True)
+    seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
     afilename = tempfile.NamedTemporaryFile(suffix='fits').name
     seq.save(afilename, filetype='fits', overwrite=True)
     test_seq = sunpy.map.Map(afilename + "_0", afilename + "_1", sequence=True)

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -200,7 +200,9 @@ def test_map_sequence_plot(aia171_test_map, hmi_test_map):
 
 
 def test_save(aia171_test_map, hmi_test_map, tmp_path):
-    """Tests the MapSequence save function"""
+    """
+    Tests the MapSequence save function
+    """
     seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
 
     with pytest.raises(ValueError, match="{index} must be specified"):

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -205,7 +205,7 @@ def test_save(aia171_test_map, hmi_test_map):
     seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
     afilename = tempfile.NamedTemporaryFile(suffix='fits').name
     seq.save(afilename, filetype='fits', overwrite=True)
-    test_seq = sunpy.map.Map(afilename+"_0", afilename+"_1", sequence=True)
+    test_seq = sunpy.map.Map(afilename + "_0", afilename + "_1", sequence=True)
     assert isinstance(test_seq.maps[0], sunpy.map.sources.sdo.AIAMap)
     assert isinstance(test_seq.maps[1], sunpy.map.sources.sdo.HMIMap)
 

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -203,7 +203,9 @@ def test_save(aia171_test_map, hmi_test_map, tmp_path):
     """Tests the MapSequence save function"""
     seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
 
-    seq.save(tmp_path.as_posix(), filetype='fits', overwrite=True)
+    with pytest.raises(ValueError, match="{index} must be specified"):
+        seq.save(f"{tmp_path.as_posix()}_index:03", filetype='fits', overwrite=True)
+    seq.save(f"{tmp_path.as_posix()}_{{index:03}}.fits", filetype='auto', overwrite=True)
 
     test_seq = sunpy.map.Map(f"{tmp_path.as_posix()}_000.fits",
                              f"{tmp_path.as_posix()}_001.fits", sequence=True)

--- a/sunpy/net/attr.py
+++ b/sunpy/net/attr.py
@@ -546,8 +546,8 @@ class AttrWalker:
         creators = list(self.createmm.registry.keys())
         appliers = list(self.applymm.registry.keys())
         return f"""{super().__repr__()}
-Registered creators: {creators}
-Registered appliers: {appliers}"""
+Registered creators:\n {creators}\n
+Registered appliers:\n {appliers}"""
 
     @staticmethod
     def _unknown_type(*args, **kwargs):


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #2301
Adds a save method to `MapSequence` where it saves each map from the sequence with `_{map_index_number}` as the suffix.
Does this have to be tested?
