### PR TITLE
Unused arguments passed to test methods in GenericMap

### DIFF
--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -359,7 +359,7 @@ def test_swapped_ctypes(simple_map):
     assert u.allclose(simple_map.top_right_coord.Ty, 1 * u.arcsec)
 
 
-def test_save(aia171_test_map, generic_map):
+def test_save(aia171_test_map):
     """Tests the map save function"""
     aiamap = aia171_test_map
     afilename = tempfile.NamedTemporaryFile(suffix='fits').name
@@ -373,7 +373,7 @@ def test_save(aia171_test_map, generic_map):
     assert_quantity_allclose(loaded_save.data, aiamap.data)
 
 
-def test_save_compressed(aia171_test_map, generic_map):
+def test_save_compressed(aia171_test_map):
     """Tests the map save function"""
     aiamap = aia171_test_map
     afilename = tempfile.NamedTemporaryFile(suffix='fits').name


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
While writing tests for `MapSequence` I noticed that `generic_map` was passed as arguments to these 2 tests and they weren't being used in this method.
