### PR TITLE
pin importlib_metadata in test deps

### DIFF
--- a/.test_package_pins.txt
+++ b/.test_package_pins.txt
@@ -1,0 +1,3 @@
+# Avoid DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
+# Ignore in setup.cfg seems to not work 100% of the time.
+importlib-metadata<3.9.0


### PR DESCRIPTION
Attempt to bypass the warning issue with py37.

Setting the ignore text seems to not work at all.

https://github.com/python/importlib_metadata/blob/main/CHANGES.rst#v390
