### PR TITLE
Don't include CROTA when PC present in WCS

### DIFF
--- a/changelog/5166.trivial.rst
+++ b/changelog/5166.trivial.rst
@@ -1,0 +1,3 @@
+The ``CROTA`` keywords are no longer set on `sunpy.map.GenericMap.wcs`, as the
+``PC_ij`` keywords are always set and the FITS standard says that these keywords
+must not co-exist.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -513,6 +513,8 @@ class GenericMap(NDData):
         w2.wcs.crval = u.Quantity([self._reference_longitude, self._reference_latitude])
         w2.wcs.ctype = self.coordinate_system
         w2.wcs.pc = self.rotation_matrix
+        # FITS standard doesn't allow both PC_ij *and* CROTA keywords
+        w2.wcs.crota = (0, 0)
         w2.wcs.cunit = self.spatial_units
         w2.wcs.dateobs = self.date.isot
         w2.wcs.aux.rsun_ref = self.rsun_meters.to_value(u.m)


### PR DESCRIPTION
The FITS standard states (https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf, section 8.1):

> the CROTA2 must not occur with the PCij keywords

This is part of fixing https://github.com/sunpy/sunpy/issues/5165. 