### PR TITLE
Only caclulate observer coord for WCS if needed

### DIFF
--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -123,6 +123,20 @@ def _set_wcs_aux_obs_coord(wcs, obs_frame):
     wcs.wcs.aux.dsun_obs = obs_frame.radius.to_value(u.m)
 
 
+def _has_complete_observer_info(wcs):
+    """
+    Return `True` if ``wcs`` has complete observer information in its
+    auxillary information.
+
+    If there is too much information (ie both Carrington longitude and
+    heliographic longitude are present), returns `False`.
+    """
+    return (wcs.wcs.aux.hglt_obs is not None and
+            wcs.wcs.aux.dsun_obs is not None and
+            (wcs.wcs.aux.hgln_obs is not None or
+             wcs.wcs.aux.crln_obs is not None))
+
+
 def solar_frame_to_wcs_mapping(frame, projection='TAN'):
     """
     For a given frame, this function returns the corresponding WCS object.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -527,23 +527,27 @@ class GenericMap(NDData):
         if w2.wcs.ctype[1].lower() in ("solar-y", "solar_y"):
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
-        # Set observer coordinate information
-        #
-        # Clear all the aux information that was set earlier. This is to avoid
-        # issues with maps that store multiple observer coordinate keywords.
-        # Note that we have to create a new WCS as it's not possible to modify
-        # wcs.wcs.aux in place.
-        header = w2.to_header()
-        for kw in ['crln_obs', 'dsun_obs', 'hgln_obs', 'hglt_obs']:
-            header.pop(kw, None)
-        w2 = astropy.wcs.WCS(header)
+        if not sunpy.coordinates.wcs_utils._has_complete_observer_info(w2):
+            # Set observer coordinate information
+            #
+            # Clear all the aux information that was set earlier. This is to avoid
+            # issues with maps that store multiple observer coordinate keywords.
+            # Note that we have to create a new WCS as it's not possible to modify
+            # wcs.wcs.aux in place.
+            #
+            # This can be changed to ``w2.wcs.aux.crln = None`` etc. when we depend
+            # on astropy >= 4.0.5
+            header = w2.to_header()
+            for kw in ['crln_obs', 'dsun_obs', 'hgln_obs', 'hglt_obs']:
+                header.pop(kw, None)
+            w2 = astropy.wcs.WCS(header)
 
-        # Get observer coord, and transform if needed
-        obs_coord = self.observer_coordinate
-        if not isinstance(obs_coord.frame, (HeliographicStonyhurst, HeliographicCarrington)):
-            obs_coord = obs_coord.transform_to(HeliographicStonyhurst(obstime=self.date))
+            # Get observer coord, and transform if needed
+            obs_coord = self.observer_coordinate
+            if not isinstance(obs_coord.frame, (HeliographicStonyhurst, HeliographicCarrington)):
+                obs_coord = obs_coord.transform_to(HeliographicStonyhurst(obstime=self.date))
 
-        sunpy.coordinates.wcs_utils._set_wcs_aux_obs_coord(w2, obs_coord)
+            sunpy.coordinates.wcs_utils._set_wcs_aux_obs_coord(w2, obs_coord)
 
         # Validate the WCS here.
         w2.wcs.set()


### PR DESCRIPTION
This is a minor performance improvement, and also avoids small floating point accuracy changes to the metadata due to round trips in the coordinate transformation machinery.

Part of fixing https://github.com/sunpy/sunpy/issues/5165