### PR TITLE
`GenericMap.rsun_obs` now uses `rsun_ref` if it is in the header

### DIFF
--- a/changelog/5172.bugfix.rst
+++ b/changelog/5172.bugfix.rst
@@ -1,0 +1,1 @@
+If the property `sunpy.map.GenericMap.rsun_obs` needs to calculate the solar angular radius from header information, it now properly uses the ``rsun_ref`` keyword if it is present and does not emit any warning.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -914,8 +914,11 @@ class GenericMap(NDData):
         Notes
         -----
         This value is taken the ``'rsun_obs'``, ``'solar_r'``, or ``radius``
-        FITS keywords. If none of these keys are present the photospheric limb
-        as seen from the observer coordinate is returned.
+        FITS keywords. If none of these keys are present, the angular radius
+        will be calculated from the radius of the Sun (taken from the
+        ``rsun_ref`` FITS keyword) and the observer distance.  If the
+        ``rsun_ref`` key is not present, the standard radius of the photosphere
+        will be assumed.
         """
         rsun_arcseconds = self.meta.get('rsun_obs',
                                         self.meta.get('solar_r',
@@ -923,11 +926,11 @@ class GenericMap(NDData):
                                                                     None)))
 
         if rsun_arcseconds is None:
-            warnings.warn("Missing metadata for solar angular radius: assuming photospheric limb "
-                          "as seen from observer coordinate.",
-                          SunpyUserWarning)
-            dsun = self.dsun
-            rsun = sun._angular_radius(constants.radius, dsun)
+            if 'rsun_ref' not in self.meta:
+                warnings.warn("Missing metadata for solar angular radius: assuming the standard "
+                              "radius of the photosphere as seen from the observer distance.",
+                              SunpyUserWarning)
+            rsun = sun._angular_radius(self.rsun_meters, self.dsun)
         else:
             rsun = rsun_arcseconds * u.arcsec
         return rsun

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -173,11 +173,17 @@ def test_rsun_meters(generic_map):
     assert generic_map.rsun_meters == sunpy.sun.constants.radius
 
 
-def test_rsun_obs(generic_map):
+def test_rsun_obs_without_rsun_ref(generic_map):
     with pytest.warns(SunpyUserWarning,
-                      match='Missing metadata for solar angular radius: assuming '
-                      'photospheric limb as seen from observer coordinate.'):
+                      match='assuming the standard radius of the photosphere '
+                            'as seen from the observer distance'):
         assert_quantity_allclose(generic_map.rsun_obs, sun.angular_radius(generic_map.date))
+
+
+def test_rsun_obs_with_rsun_ref(generic_map):
+    generic_map.meta['rsun_ref'] = sunpy.sun.constants.radius
+    # The following should not raise a warning because we can calculate it exactly
+    assert_quantity_allclose(generic_map.rsun_obs, sun.angular_radius(generic_map.date))
 
 
 def test_coordinate_system(generic_map):


### PR DESCRIPTION
Related to #5171 

When the property `GenericMap.rsun_obs` (used by `.draw_limb()`) doesn't find any information for the solar angular radius, it falls back to using the solar physical radius at the observer distance.  However, it doesn't make use of the `rsun_ref` keyword if it is present.  In that case, it doesn't need to raise a warning, because no assumption is being made.