### PR TITLE
Adding calc of rsun_obs to make_fitswcs_header

### DIFF
--- a/changelog/5177.bugfix.rst
+++ b/changelog/5177.bugfix.rst
@@ -1,0 +1,1 @@
+Added "rsun_obs" to the output of `sunpy.map.make_fitswcs_header` if "rsun" is in the coordinate argument.

--- a/changelog/5177.bugfix.rst
+++ b/changelog/5177.bugfix.rst
@@ -1,1 +1,1 @@
-Added "rsun_obs" to the output of `sunpy.map.make_fitswcs_header` if "rsun" is in the coordinate argument.
+Added a "rsun_obs" keyword to the output of :func:`sunpy.map.make_fitswcs_header` if the coordinate argument has a "rsun" frame attribute.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -98,6 +98,7 @@ Here's an example of creating a header from some generic data and an `astropy.co
     dsun_obs: 148644585949.49
     hgln_obs: 0.0
     hglt_obs: 4.7711570596394
+    rsun_obs: 965.3829548285768
 
 
 From this we can see now that the function returned a `sunpy.util.MetaDict` that populated
@@ -130,6 +131,7 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
     dsun_obs: 148644585949.49
     hgln_obs: 0.0
     hglt_obs: 4.7711570596394
+    rsun_obs: 965.3829548285768
 
 As we can see, a list of WCS and observer meta information is contained within the generated headers,
 however we may want to include other meta information including the observatory name, the wavelength and

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -161,6 +161,11 @@ def make_fitswcs_header(data, coordinate,
          meta_wcs['PC2_1'], meta_wcs['PC2_2']) = (rotation_matrix[0, 0], rotation_matrix[0, 1],
                                                   rotation_matrix[1, 0], rotation_matrix[1, 1])
 
+    if hasattr(coordinate, 'rsun') and isinstance(coordinate.observer, frames.BaseCoordinateFrame):
+        observer = coordinate.observer.transform_to(frames.HeliographicStonyhurst(obstime=coordinate.observer.obstime))
+        meta_wcs['rsun_obs'] = sun._angular_radius(getattr(coordinate, 'rsun'),
+                                                   observer.radius).to_value(u.arcsec)
+
     meta_dict = MetaDict(meta_wcs)
 
     return meta_dict
@@ -191,41 +196,6 @@ def _get_wcs_meta(coordinate, projection_code):
     cunit1, cunit2 = skycoord_wcs.wcs.cunit
     coord_meta = dict(skycoord_wcs.to_header())
     coord_meta['cunit1'], coord_meta['cunit2'] = cunit1.to_string("fits"), cunit2.to_string("fits")
-
-    return coord_meta
-
-
-@u.quantity_input
-def get_observer_meta(observer, rsun: (u.Mm, None)):
-    """
-    Function to get observer meta from coordinate frame.
-
-    Parameters
-    ----------
-    coordinate : ~`astropy.coordinates.BaseFrame`
-        The coordinate of the observer, must be transformable to Heliographic
-        Stonyhurst.
-    rsun : `astropy.units.Quantity`
-        The radius of the Sun.
-
-    Returns
-    -------
-    `dict`
-        Containing the WCS meta information
-            * hgln_obs, hglt_obs
-            * dsun_obs
-            * rsun_obs
-            * rsun_ref
-    """
-    observer = observer.transform_to(frames.HeliographicStonyhurst(obstime=observer.obstime))
-    coord_meta = {}
-
-    coord_meta['hgln_obs'] = observer.lon.to_value(u.deg)
-    coord_meta['hglt_obs'] = observer.lat.to_value(u.deg)
-    coord_meta['dsun_obs'] = observer.radius.to_value(u.m)
-    if rsun is not None:
-        coord_meta['rsun_ref'] = rsun.to_value(u.m)
-        coord_meta['rsun_obs'] = sun._angular_radius(rsun, observer.radius).to_value(u.arcsec)
 
     return coord_meta
 

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -161,11 +161,9 @@ def make_fitswcs_header(data, coordinate,
                                                   rotation_matrix[1, 0], rotation_matrix[1, 1])
 
     if hasattr(coordinate, 'rsun') and isinstance(coordinate.observer, frames.BaseCoordinateFrame):
-        observer = coordinate.observer.transform_to(
-            frames.HeliographicStonyhurst(obstime=coordinate.observer.obstime)
-        )
-        meta_wcs['rsun_obs'] = sun._angular_radius(getattr(coordinate, 'rsun'),
-                                                   observer.radius).to_value(u.arcsec)
+        meta_wcs['rsun_obs'] = sun._angular_radius(
+            coordinate.rsun, coordinate.observer.radius
+        ).to_value(u.arcsec)
 
     meta_dict = MetaDict(meta_wcs)
 

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -6,7 +6,7 @@ from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
 import sunpy.map
-from sunpy.coordinates import frames
+from sunpy.coordinates import frames, sun
 from sunpy.util.metadata import MetaDict
 
 
@@ -88,19 +88,21 @@ def test_make_fits_header(map_data, hpc_test_header, hgc_test_header,
     assert header['crpix1'] == 5.5
     assert header['ctype1'] == 'HPLN-TAN'
     assert u.allclose(header['dsun_obs'], hpc_test_header.frame.observer.radius.to_value(u.m))
-    assert header.get('rsun_obs') is not None
+    assert u.allclose(header['rsun_ref'] * u.m, hpc_test_header.frame.rsun)
+    assert u.allclose(header['rsun_obs'] * u.arcsec,
+                      sun._angular_radius(header['rsun_ref'] * u.m, header['dsun_obs'] * u.m))
     assert isinstance(WCS(header), WCS)
 
     # Check no observer info for HGS
     header = sunpy.map.make_fitswcs_header(map_data, hgs_test_header)
-    assert header.get('dsun_obs') is None
-    assert header.get('rsun_obs') is None
+    assert 'dsun_obs' not in header
+    assert 'rsun_obs' not in header
     assert isinstance(WCS(header), WCS)
 
     # Check for observer info for HGC
     header = sunpy.map.make_fitswcs_header(map_data, hgc_test_header)
     assert u.allclose(header['dsun_obs'], hgc_test_header.frame.observer.radius.to_value(u.m))
-    assert header.get('rsun_obs') is None
+    assert 'rsun_obs' not in header
     assert isinstance(WCS(header), WCS)
 
     # Check arguments not given as astropy Quantities

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -10,7 +10,6 @@ from sunpy.coordinates import frames
 from sunpy.util.metadata import MetaDict
 
 
-# test setups
 @pytest.fixture
 def map_data():
     return np.random.rand(10, 10)
@@ -45,7 +44,6 @@ def hpc_test_header_notime():
     return SkyCoord(0*u.arcsec, 0*u.arcsec, frame=frames.Helioprojective)
 
 
-# tests
 def test_metakeywords():
     meta = sunpy.map.meta_keywords()
     assert isinstance(meta, dict)
@@ -90,16 +88,19 @@ def test_make_fits_header(map_data, hpc_test_header, hgc_test_header,
     assert header['crpix1'] == 5.5
     assert header['ctype1'] == 'HPLN-TAN'
     assert u.allclose(header['dsun_obs'], hpc_test_header.frame.observer.radius.to_value(u.m))
+    assert header.get('rsun_obs') is not None
     assert isinstance(WCS(header), WCS)
 
     # Check no observer info for HGS
     header = sunpy.map.make_fitswcs_header(map_data, hgs_test_header)
     assert header.get('dsun_obs') is None
+    assert header.get('rsun_obs') is None
     assert isinstance(WCS(header), WCS)
 
     # Check for observer info for HGC
     header = sunpy.map.make_fitswcs_header(map_data, hgc_test_header)
     assert u.allclose(header['dsun_obs'], hgc_test_header.frame.observer.radius.to_value(u.m))
+    assert header.get('rsun_obs') is None
     assert isinstance(WCS(header), WCS)
 
     # Check arguments not given as astropy Quantities


### PR DESCRIPTION
### Description

This comes from #5171  - it adds back in the trig calc for the `rsun_obs` keyword, and removes a redundant function that's no longer used following #4620 

Thoughts on this - I'm in favour, but also could be persuaded. Also is there ever a case that someone would want to pass their own `rsun_obs`? 
