### PR TITLE
Added a docstring to HMISynopticMap

### DIFF
--- a/changelog/5186.doc.rst
+++ b/changelog/5186.doc.rst
@@ -1,0 +1,1 @@
+Added a documentation string to `~sunpy.map.sources.sdo.HMISynopticMap`.

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -129,7 +129,25 @@ class HMIMap(GenericMap):
 
 
 class HMISynopticMap(HMIMap):
+    """SDO's HMI Synoptic Map.
 
+    Synoptic maps are constructed from HMI 720s line-of-sight Magnetograms
+    collected over a 27-day solar rotation. Near-central-meridian data from
+    20 magnetograms contribute to each point in the final map. Synoptic
+    charts are presented in two projections in each of two sizes.
+    The maps are 3600 points in Carrington longitude by
+    1440 points equally spaced in sine latitude, and 720 points in Carrington
+    longitude by 360 points equally spaced in sine latitude respectively.
+    The map with the lower resolution is produced by applying a boxcar 
+    average to the high-resolution map.
+
+    References
+    ----------
+    * `SDO Mission Page <https://sdo.gsfc.nasa.gov/>`_
+    * `JSOC's page for Synoptic Charts of the Photospheric LOS Magnetic Field HMI <http://jsoc.stanford.edu/HMI/LOS_Synoptic_charts.html>`_
+
+    See docstring for `HMIMap` for more references and information on the HMI instrument
+    """
     def __init__(self, data, header, **kwargs):
         super().__init__(data, header, **kwargs)
 

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -138,7 +138,7 @@ class HMISynopticMap(HMIMap):
     The maps are 3600 points in Carrington longitude by
     1440 points equally spaced in sine latitude, and 720 points in Carrington
     longitude by 360 points equally spaced in sine latitude respectively.
-    The map with the lower resolution is produced by applying a boxcar 
+    The map with the lower resolution is produced by applying a boxcar
     average to the high-resolution map.
 
     References

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -129,24 +129,18 @@ class HMIMap(GenericMap):
 
 
 class HMISynopticMap(HMIMap):
-    """SDO's HMI Synoptic Map.
+    """
+    SDO/HMI Synoptic Map.
 
-    Synoptic maps are constructed from HMI 720s line-of-sight Magnetograms
-    collected over a 27-day solar rotation. Near-central-meridian data from
-    20 magnetograms contribute to each point in the final map. Synoptic
-    charts are presented in two projections in each of two sizes.
-    The maps are 3600 points in Carrington longitude by
-    1440 points equally spaced in sine latitude, and 720 points in Carrington
-    longitude by 360 points equally spaced in sine latitude respectively.
-    The map with the lower resolution is produced by applying a boxcar
-    average to the high-resolution map.
+    Synoptic maps are constructed from HMI 720s line-of-sight magnetograms
+    collected over a 27-day solar rotation.
+
+    See `~sunpy.map.sources.sdo.HMIMap` for information on the HMI instrument.
 
     References
     ----------
-    * `SDO Mission Page <https://sdo.gsfc.nasa.gov/>`_
-    * `JSOC's page for Synoptic Charts of the Photospheric LOS Magnetic Field HMI <http://jsoc.stanford.edu/HMI/LOS_Synoptic_charts.html>`_
-
-    See docstring for `HMIMap` for more references and information on the HMI instrument
+    * `SDO Mission Page <https://sdo.gsfc.nasa.gov/>`__
+    * `JSOC's HMI Synoptic Charts <http://jsoc.stanford.edu/HMI/LOS_Synoptic_charts.html>`__
     """
     def __init__(self, data, header, **kwargs):
         super().__init__(data, header, **kwargs)

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -225,6 +225,10 @@ class MDIMap(GenericMap):
 class MDISynopticMap(MDIMap):
     """
     SOHO MDI synoptic magnetogram Map.
+    
+    The MDISynopticMap class utilises Michelson Doppler Imaging to produce a 
+    magnetogram, which behaves as a sort of a weather map for movement observed 
+    in the Ni 6768 Angstrom solar absorption line.
 
     See the docstring of `MDIMap` for information on the MDI instrument.
     """

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -225,10 +225,6 @@ class MDIMap(GenericMap):
 class MDISynopticMap(MDIMap):
     """
     SOHO MDI synoptic magnetogram Map.
-    
-    The MDISynopticMap class utilises Michelson Doppler Imaging to produce a 
-    magnetogram, which behaves as a sort of a weather map for movement observed 
-    in the Ni 6768 Angstrom solar absorption line.
 
     See the docstring of `MDIMap` for information on the MDI instrument.
     """


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #5128

Added docstring for the missing docstring for HMISynopticMap in sdo.py. I have included a reference, along with referring to the HMIMap class' docstring for more information on the instrument itself.
