### PR TITLE
update pre-commit to check for all large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,7 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: check-added-large-files
+        args: ['--enforce-all','--maxkb=100']
       - id: end-of-file-fixer
         exclude: ".*(.fits|.fts|.fit|.txt|tca.*)$"
       - id: mixed-line-ending


### PR DESCRIPTION
I had to increase the "maxkb=1256" since we have several files that are 500 kb to 1000 kb in size.

Files that fail:
```
sunpy/data/test/cor1_20090615_000500_s4c1A.fts (535 KB) exceeds 500 KB.
sunpy/data/test/HinodeXRT.fits (527 KB) exceeds 500 KB.
sunpy/data/test/test_ana.fz (846 KB) exceeds 500 KB.
sunpy/data/test/go1520110607.fits (678 KB) exceeds 500 KB.
sunpy/data/test/2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2 (1053 KB) exceeds 500 KB.
sunpy/data/test/annotation_science.db (540 KB) exceeds 500 KB.
sunpy/data/test/waveunit/svsm_e3100_S2_20110625_1856.fts (653 KB) exceeds 500 KB.
```

TODO: Prune the docs from the tarball.
TODO: LOOK AT HEADER ONLY TEST DATA AND WRITE FILES.