### PR TITLE
Don't modify the header in the constructor of `GenericMap` subclasses

### DIFF
--- a/sunpy/map/sources/mlso.py
+++ b/sunpy/map/sources/mlso.py
@@ -29,17 +29,8 @@ class KCorMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
         super().__init__(data, header, **kwargs)
 
-        # Fill in some missing info
-        self.meta['observatory'] = 'MLSO'
-        self.meta['detector'] = 'KCor'
-        self.meta['waveunit'] = self.meta.get('waveunit', 'nm')
-        # Since KCor is on Earth, no need to raise the warning in mapbase
-        self.meta['dsun_obs'] = self.meta.get('dsun_obs',
-                                              sun.earth_distance(self.date).to(u.m).value)
-        self.meta['hgln_obs'] = self.meta.get('hgln_obs', 0.0)
         self._nickname = self.detector
 
         self.plot_settings['cmap'] = self._get_cmap_name()
@@ -56,10 +47,26 @@ class KCorMap(GenericMap):
 
     @property
     def observatory(self):
-        """
-        Returns the observatory.
-        """
-        return self.meta['observatory']
+        return "MLSO"
+
+    @property
+    def detector(self):
+        return "KCor"
+
+    @property
+    def waveunit(self):
+        unit = self.meta.get("waveunit", "nm")
+        return u.Unit(unit)
+
+    @property
+    def _supported_observer_coordinates(self):
+        # Override missing metadata in the observer coordinate
+        dsun_obs = self.meta.get('dsun_obs', sun.earth_distance(self.date).to_value(u.m))
+        return [(('hgln_obs', 'hglt_obs', 'dsun_obs'), {'lon': self.meta.get('hgln_obs', 0.0),
+                                                        'lat': self.meta.get('hglt_obs'),
+                                                        'radius': self.meta.get('dsun_obs', dsun_obs),
+                                                        'unit': (u.deg, u.deg, u.m),
+                                                        'frame': "heliographic_stonyhurst"})]
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/proba2.py
+++ b/sunpy/map/sources/proba2.py
@@ -26,17 +26,18 @@ class SWAPMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
-        GenericMap.__init__(self, data, header, **kwargs)
-
-        # It needs to be verified that these must actually be set and
-        # are not already in the header.
-        self.meta['detector'] = "SWAP"
-#        self.meta['instrme'] = "SWAP"
-        self.meta['obsrvtry'] = "PROBA2"
+        super().__init__(data, header, **kwargs)
 
         self._nickname = self.detector
         self.plot_settings['cmap'] = 'sdoaia171'
+
+    @property
+    def observatory(self):
+        return "PROBA2"
+
+    @property
+    def detector(self):
+        return "SWAP"
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -78,6 +78,11 @@ class AIAMap(GenericMap):
         unit_str = self.meta.get('bunit', self.meta.get('pixlunit'))
         if unit_str is None:
             return
+
+        # AIA Uses a non-standard unit for counts
+        if unit_str == "DN":
+            unit_str = "ct"
+
         return self._parse_fits_unit(unit_str)
 
     @classmethod

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -127,7 +127,7 @@ class LASCOMap(GenericMap):
             return date
 
         time=self.meta.get('time-obs', self.meta.get('time_obs'))
-        return f"{date}T{time}"
+        return self._parse_fits_date(f"{date}T{time}")
 
     @property
     def measurement(self):

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -31,22 +31,28 @@ class EUVIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        super().__init__(data, header, **kwargs)
 
-        GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'euvi{wl:d}'.format(wl=int(self.wavelength.value))
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
-        self.meta['waveunit'] = self.meta.get('waveunit', 'Angstrom')
 
-        # Try to identify when the FITS meta data does not have the correct
-        # date FITS keyword
-        if ('date_obs' in self.meta) and not('date-obs' in self.meta):
-            self.meta['date-obs'] = self.meta['date_obs']
-        # fix CROTA to CROTAn
+        # fix CROTA to CROTA2
+        # This has to be done here or else rotate will not modify it correctly
         if "crota" in self.meta and "crota2" not in self.meta:
             log.debug("EUVIMap: Changing the CROTA keyword to CROTA2")
             self.meta["crota2"] = self.meta.pop("crota")
+
+    @property
+    def date(self):
+        date = self.meta.get('date-obs', self.meta.get('date_obs'))
+        return self._parse_fits_date(date)
+
+    @property
+    def waveunit(self):
+        unit = self.meta.get("waveunit", "Angstrom")
+        return u.Unit(unit)
 
     @property
     def rsun_arcseconds(self):
@@ -101,18 +107,17 @@ class CORMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'stereocor{det!s}'.format(det=self.detector[-1])
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
 
-        # Try to identify when the FITS meta data does not have the correct
-        # date FITS keyword
-        if ('date_obs' in self.meta) and not('date-obs' in self.meta):
-            self.meta['date-obs'] = self.meta['date_obs']
+    @property
+    def date(self):
+        date = self.meta.get('date-obs', self.meta.get('date_obs'))
+        return self._parse_fits_date(date)
 
     @property
     def measurement(self):
@@ -148,17 +153,17 @@ class HIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        super().__init__(data, header, **kwargs)
 
-        GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'stereohi{det!s}'.format(det=self.detector[-1])
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, PowerStretch(0.25)), clip=False)
 
-        # Try to identify when the FITS meta data does not have the correct
-        # date FITS keyword
-        if ('date_obs' in self.meta) and not('date-obs' in self.meta):
-            self.meta['date-obs'] = self.meta['date_obs']
+    @property
+    def date(self):
+        date = self.meta.get('date-obs', self.meta.get('date_obs'))
+        return self._parse_fits_date(date)
 
     @property
     def measurement(self):

--- a/sunpy/map/sources/suvi.py
+++ b/sunpy/map/sources/suvi.py
@@ -70,12 +70,8 @@ class SUVIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
         super().__init__(data, header, **kwargs)
 
-        # Fill in some missing info
-        self.meta["detector"] = "SUVI"
-        self.meta["telescop"] = "GOES-R"
         self._nickname = self.detector
         self.plot_settings["cmap"] = self._get_cmap_name()
         self.plot_settings["norm"] = ImageNormalize(
@@ -94,10 +90,11 @@ class SUVIMap(GenericMap):
 
     @property
     def observatory(self):
-        """
-        Returns the observatory.
-        """
-        return self.meta["telescop"].split("/")[0]
+        return "GOES-R"
+
+    @property
+    def detector(self):
+        return "SUVI"
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -50,17 +50,21 @@ class TRACEMap(GenericMap):
         header['cunit1'] = header.get('cunit1', 'arcsec')
         header['cunit2'] = header.get('cunit2', 'arcsec')
 
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
-        # It needs to be verified that these must actually be set and are not
-        # already in the header.
-        self.meta['detector'] = "TRACE"
-        self.meta['obsrvtry'] = "TRACE"
         self._nickname = self.detector
         # Colour maps
         self.plot_settings['cmap'] = 'trace' + str(self.meta['WAVE_LEN'])
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, LogStretch()), clip=False)
+
+    @property
+    def observatory(self):
+        return "TRACE"
+
+    @property
+    def detector(self):
+        return "TRACE"
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/yohkoh.py
+++ b/sunpy/map/sources/yohkoh.py
@@ -40,14 +40,26 @@ class SXTMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        super().__init__(data, header, **kwargs)
 
-        GenericMap.__init__(self, data, header, **kwargs)
-
-        self.meta['detector'] = "SXT"
-        self.meta['telescop'] = "Yohkoh"
         self.plot_settings['cmap'] = 'yohkohsxt' + self.measurement[0:2].lower()
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, PowerStretch(0.5)), clip=False)
+
+    @property
+    def observatory(self):
+        return "Yohkoh"
+
+    @property
+    def detector(self):
+        return "SXT"
+
+    @property
+    def dsun(self):
+        """
+        For Yohkoh Maps, dsun_obs is not always defined.
+        Uses approximation defined above if it is not defined.
+        """
 
         # 2012/12/19 - the SXT headers do not have a value of the distance from
         # the spacecraft to the center of the Sun.  The FITS keyword 'DSUN_OBS'
@@ -56,15 +68,12 @@ class SXTMap(GenericMap):
         # use simple trigonometry to calculate the distance of the center of
         # the Sun from the spacecraft.  Note that the small angle approximation
         # is used, and the solar radius stored in SXT FITS files is in arcseconds.
-        self.meta['dsun_apparent'] = self.meta.get('dsun_apparent', constants.au)
-        if 'solar_r' in self.meta:
-            self.meta['dsun_apparent'] = constants.radius/(np.deg2rad(self.meta['solar_r']/3600.0))
 
-    @property
-    def dsun(self):
-        """ For Yohkoh Maps, dsun_obs is not always defined. Uses approximation
-        defined above it is not defined."""
-        return self.meta.get('dsun_obs', self.meta['dsun_apparent'])
+        if 'solar_r' in self.meta:
+            dsun = constants.radius/(np.deg2rad(self.meta['solar_r']/3600.0))
+        else:
+            dsun = constants.au
+        return self.meta.get('dsun_obs', dsun)
 
     @property
     def measurement(self):


### PR DESCRIPTION
I am not entirely sure how I let this one get away from me this much, but here goes.

The objective of the map sources system is to provide a standard API to access the metadata from a disparate set of headers. This is done via the use of properties which abstract where a bit of information comes from so other places in map can use it (i.e. WCS).

We seem to have forgotten this however, and have widely (for a large number of years) taken to editing the header directly in the constructor of the map source. This PR moves all header modification (with a couple of exceptions) into properties and leaves the actual headers the user gives us alone.

This is relying quite heavily on the sources tests, which I don't have a huge amount of faith in. Also I am taking this as an opportunity to fix issues with defaults if people want to pick on them