### PR TITLE
xfail the consistency test with JPL HORIZONS

### DIFF
--- a/changelog/5203.trivial.rst
+++ b/changelog/5203.trivial.rst
@@ -1,0 +1,1 @@
+Temporarily disabled the unit test to check for coordinates consistency with JPL HORIZONS due to the inability to choose a matching ephemeris.

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -131,6 +131,8 @@ class TestUsingDE432s:
     def teardown_class(cls):
         solar_system_ephemeris.set(cls.old_ephemeris)
 
+    @pytest.mark.xfail(reason="JPL HORIZONS is using a newer ephemeris (DE441) than the latest "
+                              "available through Astropy (DE430/DE432s)")
     @given(obstime=times())
     @settings(deadline=5000, max_examples=10)
     def test_consistency_with_horizons(self, obstime):


### PR DESCRIPTION
JPL HORIZONS has been updated to use a newer ephemeris (DE441) than the latest currently available through Astropy (DE430/DE432s).  This breaks our unit test that checks for consistency with JPL HORIZONS.  I created an Astropy issue (astropy/astropy#11544).  I'd prefer not to expand the tolerances, so I'm xfailing the test for now.