### PR TITLE
CompositeMap now uses WCSAxes

### DIFF
--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -370,6 +370,11 @@ class CompositeMap:
         -------
         ret : `list`
             List of axes image or quad contour sets that have been plotted.
+
+        Notes
+        -----
+        If the maps have not been rotated to the same orientation, the plot may
+        have unexpected behavior.
         """
 
         # If axes are not provided, create a WCSAxes based on the first map
@@ -392,7 +397,13 @@ class CompositeMap:
         # Define a list of plotted objects
         ret = []
         # Plot layers of composite map
-        for m in self._maps:
+        for index, m in enumerate(self._maps):
+            # Check if the image is not simply oriented, which is an issue even when using WCSAxes
+            if not np.allclose(m.rotation_matrix, np.identity(2)):
+                warnings.warn(f"The axes of the map at index {index} are not aligned to the pixel "
+                              "grid. Plot axes may be incorrect.",
+                              SunpyUserWarning)
+
             # Parameters for plotting
             params = {
                 "origin": "lower",

--- a/sunpy/map/tests/test_compositemap.py
+++ b/sunpy/map/tests/test_compositemap.py
@@ -17,6 +17,13 @@ pytestmark = [pytest.mark.filterwarnings('ignore:Missing metadata for observer')
 
 @pytest.fixture
 def composite_test_map(aia171_test_map, hmi_test_map):
+    # The test maps both have a rotation angle, which throws off compositing
+    aia171_test_map._data = aia171_test_map.data.astype('float32')
+    aia171_test_map = aia171_test_map.rotate(order=3)
+    hmi_test_map._data = hmi_test_map.data.astype('float32')
+    hmi_test_map = hmi_test_map.rotate(order=3)
+    # The test maps have wildly different observation times, which throws off compositing
+    hmi_test_map.meta['date-obs'] = aia171_test_map.meta['date-obs']
     return sunpy.map.Map(aia171_test_map, hmi_test_map, composite=True)
 
 


### PR DESCRIPTION
`CompositeMap` plotting is currently not WCSAxes-aware.  Trying to provide it a WCSAxes axes creates weird results (e.g., https://github.com/sunpy/sunpy/issues/4492#issuecomment-697082363)  This PR (partially) fixes it by properly figuring out how to place each image on a WCSAxes axes.

The following code:
```python
import matplotlib.pyplot as plt

import astropy.units as u
from astropy.coordinates import SkyCoord

import sunpy.map
from sunpy.data.sample import AIA_171_IMAGE, HMI_LOS_IMAGE

# Use the bottom hemisphere of the AIA image
aia_map = sunpy.map.Map(AIA_171_IMAGE)
aia_submap = aia_map.submap(SkyCoord([-1200, 1200]*u.arcsec, [-1200, 0]*u.arcsec, frame=aia_map.coordinate_frame))

# Use the western hemisphere of the HMI image (but recall that it will be upside down)
hmi_map = sunpy.map.Map(HMI_LOS_IMAGE)
hmi_submap = hmi_map.submap(SkyCoord([0, 1000]*u.arcsec, [-1000, 1000]*u.arcsec, frame=hmi_map.coordinate_frame))

comp_map = sunpy.map.Map(aia_submap, hmi_submap, composite=True)

fig = plt.figure()
ax = fig.add_subplot(111, projection=aia_map)
comp_map.plot(axes=ax)
comp_map.draw_limb(axes=ax, index=0, color='red')
comp_map.draw_grid(axes=ax, index=1, color='magenta')
plt.show()
```
produces
![good](https://user-images.githubusercontent.com/991759/114642670-4b7c3b80-9ca2-11eb-844c-d1963e3831b1.png)

instead of
![bad](https://user-images.githubusercontent.com/991759/114642682-4fa85900-9ca2-11eb-97a5-6daaefb72dc2.png)

Issues:
- This usage of `extent` and `imshow` works only if the maps are oriented the same or upside down (180 degrees rotated).  Edit: There is now a warning for each map that is not simply oriented.
- The internal use of `Helioprojective.assume_spherical_screen` should be discussed.
- ~I haven't bothered to preserve the old, non-WCSAxes behavior.~  Now restored (with fixing some bugs with the previous implementation)
- The grid overlay is below every map but the first one due to the current lack of `zorder` functionality in WCSAxes.