### PR TITLE
Add a `_check_axes` helper method to `GenericMap`

### DIFF
--- a/changelog/5223.trivial.rst
+++ b/changelog/5223.trivial.rst
@@ -1,0 +1,3 @@
+`~sunpy.map.GenericMap` plotting methods now have consistent argument
+checking for the ``axes`` argument, and will raise the same warnings
+or errors for similar ``axes`` input.


### PR DESCRIPTION
This gives a consistent way to validate any `axes` input to plotting methods, and makes it easy to extend or modify the validation process (e.g. as done in the draft https://github.com/sunpy/sunpy/pull/5164).