### PR TITLE
[Backport 2.0] Relaxed a WCSAxes tolerance to work around disappearing lines in a grid overlay

### DIFF
--- a/changelog/5222.bugfix.rst
+++ b/changelog/5222.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with the visibility of some grid lines when using :meth:`~sunpy.map.GenericMap.draw_grid`.

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -153,6 +153,14 @@ def wcsaxes_heliographic_overlay(axes, grid_spacing: u.deg = 10*u.deg, annotate=
     c1.set_ticks_position('bl')
     c2.set_ticks_position('bl')
 
+    # There is a small inaccuracy with the grid overlay if the axes have a custom solar radius
+    # The actual inaccuracy is small, but round-trip checking causes grid lines to "disappear"
+    # The underlying issue cannot be fully fixed given the API of SunPy 2.x
+    # Instead, for SunPy 2.x, we relax the tolerance in WCSAxes for round-trip checking from its
+    #   default value of 1.
+    if getattr(wcsaxes.grid_paths, 'ROUND_TRIP_RTOL', None) == 1.:
+        wcsaxes.grid_paths.ROUND_TRIP_RTOL = 10.
+
     overlay = axes.get_coords_overlay('heliographic_stonyhurst')
 
     lon = overlay[0]


### PR DESCRIPTION
Backport #5222.

No figure-test hashes are updated because there is no testing against an updated version of Astropy.