### PR TITLE
Overhaul `GenericMap.draw_limb()` for transformations and to show visibility

### DIFF
--- a/changelog/5237.feature.rst
+++ b/changelog/5237.feature.rst
@@ -1,0 +1,2 @@
+Enhanced :meth:`sunpy.map.GenericMap.draw_limb` so that the solar limb can be plotted on axes that correspond to a different map (e.g., with a different observer).
+The part of the limb that is not visible to the axes's observer because it is on the far side of the Sun is shown as dotted rather than solid.

--- a/examples/map_transformations/reprojection_different_observers.py
+++ b/examples/map_transformations/reprojection_different_observers.py
@@ -63,11 +63,24 @@ out_shape = (512, 512)
 map_aia = map_aia.resample(out_shape * u.pix)
 map_euvi = map_euvi.resample(out_shape * u.pix)
 
+######################################################################
+# Plot the two maps, with the solar limb as seen by each observatory
+# overlaid on both plots.
+
 fig = plt.figure()
+
 ax1 = fig.add_subplot(1, 2, 1, projection=map_aia)
 map_aia.plot(axes=ax1)
+map_aia.draw_limb(axes=ax1, color='white')
+map_euvi.draw_limb(axes=ax1, color='red')
+
 ax2 = fig.add_subplot(1, 2, 2, projection=map_euvi)
 map_euvi.plot(axes=ax2)
+limb_aia = map_aia.draw_limb(axes=ax2, color='white')
+limb_euvi = map_euvi.draw_limb(axes=ax2, color='red')
+
+plt.legend([limb_aia[0], limb_euvi[0]],
+           ['Limb as seen by AIA', 'Limb as seen by EUVI A'])
 
 ######################################################################
 # We now need to construct an output WCS. We build a custom header using

--- a/examples/units_and_coordinates/AIA_limb_STEREO.py
+++ b/examples/units_and_coordinates/AIA_limb_STEREO.py
@@ -8,7 +8,6 @@ overplot the limb as seen by AIA on an EUVI-B image. Then we overplot the AIA
 coordinate grid on the STEREO image.
 """
 import matplotlib.pyplot as plt
-import numpy as np
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
@@ -48,20 +47,11 @@ maps = {m.detector: m.submap(SkyCoord([-1100, 1100], [-1100, 1100],
                                       unit=u.arcsec, frame=m.coordinate_frame))
         for m in sunpy.map.Map(downloaded_files)}
 
-##############################################################################
-# Next, let's calculate points on the limb in the AIA image for the half that
-# can be seen from STEREO's point of view.
-
-r = maps['AIA'].rsun_obs - 1 * u.arcsec  # remove one arcsec so it's on disk.
-# Adjust the following range if you only want to plot on STEREO_A
-th = np.linspace(-180 * u.deg, 0 * u.deg)
-x = r * np.sin(th)
-y = r * np.cos(th)
-coords = SkyCoord(x, y, frame=maps['AIA'].coordinate_frame)
-
 
 ##############################################################################
-# Now, let's plot both maps
+# Now, let's plot both maps, and we draw the limb as seen by AIA onto the
+# EUVI image.  We remove the part of the limb that is hidden because it is on
+# the far side of the Sun from STEREO's point of view.
 
 fig = plt.figure(figsize=(10, 4))
 ax1 = fig.add_subplot(1, 2, 1, projection=maps['AIA'])
@@ -70,7 +60,8 @@ maps['AIA'].draw_limb()
 
 ax2 = fig.add_subplot(1, 2, 2, projection=maps['EUVI'])
 maps['EUVI'].plot(axes=ax2)
-ax2.plot_coord(coords, color='w')
+visible, hidden = maps['AIA'].draw_limb()
+hidden.remove()
 
 
 ##############################################################################

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2079,7 +2079,7 @@ class GenericMap(NDData):
             is_visible = limb_in_axes.spherical.distance <= reference_distance
         else:
             # If the axes has no observer, the entire limb is considered visible
-            is_visible = np.ones_like(limb_in_axes.spherical.distance, np.bool)
+            is_visible = np.ones_like(limb_in_axes.spherical.distance, bool, subok=False)
 
         # Create the Polygon for the near side of the Sun (using a solid line)
         if 'linestyle' not in kwargs:

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2013,7 +2013,9 @@ class GenericMap(NDData):
 
         To avoid triggering Matplotlib auto-scaling, these patches are added as
         artists instead of patches.  One consequence is that the plot legend is not
-        populated automatically when the limb is specified with a text label.
+        populated automatically when the limb is specified with a text label.  See
+        :ref:`sphx_glr_gallery_text_labels_and_annotations_custom_legends.py` in
+        the Matplotlib documentation for examples of creating a custom legend.
         """
         # Put import here to reduce sunpy.map import time
         from matplotlib import patches

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -31,7 +31,7 @@ import sunpy.coordinates
 import sunpy.io as io
 import sunpy.visualization.colormaps
 from sunpy import config, log
-from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, get_earth, sun
+from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, Helioprojective, get_earth, sun
 from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.image.resample import resample as sunpy_image_resample
 from sunpy.image.resample import reshape_image_to_4d_superpixel
@@ -2043,8 +2043,10 @@ class GenericMap(NDData):
         # transform is always passed on as a keyword argument
         c_kw.setdefault('transform', transform)
 
-        # If not WCSAxes or if the map's frame matches the axes's frame, we can use Circle
-        if not is_wcsaxes or self.coordinate_frame == axes._transform_pixel2world.frame_out:
+        # If not WCSAxes or if the map's frame matches the axes's frame and is Helioprojective,
+        # we can use Circle
+        if not is_wcsaxes or (self.coordinate_frame == axes._transform_pixel2world.frame_out
+                              and isinstance(self.coordinate_frame, Helioprojective)):
             c_kw.setdefault('radius', radius)
 
             circ = patches.Circle([0, 0], **c_kw)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1997,10 +1997,10 @@ class GenericMap(NDData):
 
         Returns
         -------
-        visible : `~matplotlib.patches.Polygon`
+        visible : `~matplotlib.patches.Polygon` or `~matplotlib.patches.Circle`
             The patch added to the axes for the visible part of the limb (i.e., the
             "near" side of the Sun).
-        hidden : `~matplotlib.patches.Polygon`
+        hidden : `~matplotlib.patches.Polygon` or None
             The patch added to the axes for the hidden part of the limb (i.e., the
             "far" side of the Sun).
 

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -2,6 +2,7 @@
 Test Generic Map
 """
 import os
+import copy
 
 import matplotlib.colors as mcolor
 import matplotlib.pyplot as plt
@@ -262,3 +263,17 @@ def test_different_wcs_plot_warning(aia171_test_map, hmi_test_map):
                       match=(r'The map world coordinate system \(WCS\) is different '
                              'from the axes WCS')):
         hmi_test_map.plot(axes=plt.gca())
+
+
+@figure_test
+def test_draw_limb_different_observer(aia171_test_map):
+    # Create a new map from the test map with a different observer location
+    new_map = copy.deepcopy(aia171_test_map)
+    del new_map.meta['haex_obs']
+    del new_map.meta['haey_obs']
+    del new_map.meta['haez_obs']
+    new_map.meta['hgln_obs'] = 45
+    new_map.meta['hglt_obs'] = 10
+
+    aia171_test_map.plot()
+    new_map.draw_limb(color='red')

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -12,6 +12,7 @@ from matplotlib.figure import Figure
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from astropy.wcs import WCS
 
 import sunpy
 import sunpy.coordinates
@@ -277,3 +278,31 @@ def test_draw_limb_different_observer(aia171_test_map):
 
     aia171_test_map.plot()
     new_map.draw_limb(color='red')
+
+
+@figure_test
+def test_draw_limb_heliographic_stonyhurst(aia171_test_map):
+    # Create the WCS header for HGS axes
+    header = {
+        'date-obs': aia171_test_map.date.utc.isot,
+        'naxis': 2,
+        'naxis1': 360,
+        'naxis2': 180,
+        'ctype1': 'HGLN-CAR',
+        'ctype2': 'HGLT-CAR',
+        'cdelt1': 1,
+        'cdelt2': 1,
+        'cunit1': 'deg',
+        'cunit2': 'deg',
+        'crpix1': 180.5,
+        'crpix2': 90.5,
+        'crval1': 0,
+        'crval2': 0,
+        'lonpole': 0,
+    }
+    fig = Figure()
+    ax = fig.add_subplot(projection=WCS(header))
+    aia171_test_map.draw_limb(axes=ax, color='red')
+    ax.set_xlim(0, 360)
+    ax.set_ylim(0, 180)
+    return fig

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
@@ -34,7 +34,7 @@
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_top_right": "40591e49e6b32ec3a27b6fc50b9e2fdfcaa9665eca70b6a515dfb9dc7c0b1724",
   "sunpy.map.tests.test_plotting.test_heliographic_grid_annotations": "c7c08b2b6dae1b96c303345b04682060da97a1b304e7f25bcfd40b2154751465",
   "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "d85fc7e939ac813274bdf7886c646fdab2fca61659f18009c8f5f2b760c4bb57",
-  "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "083e833accf928a8c2679f7d1ed1eae8c80af90c5dd71ec451041aeaffbbe116",
+  "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "2f7cf5251db91da34a86b3a72610acc9b257e4c586f2dcf6f10381bd7c3ea186",
   "sunpy.net.tests.test_helioviewer.test_download_jp2_map": "438fdcccc6f879491c876ce24a591843bb60d724e354d1c8124678a356ff3426",
   "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
@@ -33,7 +33,7 @@
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_width_height": "a52dca9100f3f96644e924f283c7ba9bd26db115be3a8e19b91898406d06f9ba",
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_top_right": "40591e49e6b32ec3a27b6fc50b9e2fdfcaa9665eca70b6a515dfb9dc7c0b1724",
   "sunpy.map.tests.test_plotting.test_heliographic_grid_annotations": "c7c08b2b6dae1b96c303345b04682060da97a1b304e7f25bcfd40b2154751465",
-  "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "4ee92ca6097b55ab6842076b42b08bd384ae6bd86a2c18dddbd40b15f0e5297d",
+  "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "d85fc7e939ac813274bdf7886c646fdab2fca61659f18009c8f5f2b760c4bb57",
   "sunpy.net.tests.test_helioviewer.test_download_jp2_map": "438fdcccc6f879491c876ce24a591843bb60d724e354d1c8124678a356ff3426",
   "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
@@ -33,6 +33,7 @@
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_width_height": "a52dca9100f3f96644e924f283c7ba9bd26db115be3a8e19b91898406d06f9ba",
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_top_right": "40591e49e6b32ec3a27b6fc50b9e2fdfcaa9665eca70b6a515dfb9dc7c0b1724",
   "sunpy.map.tests.test_plotting.test_heliographic_grid_annotations": "c7c08b2b6dae1b96c303345b04682060da97a1b304e7f25bcfd40b2154751465",
+  "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "4ee92ca6097b55ab6842076b42b08bd384ae6bd86a2c18dddbd40b15f0e5297d",
   "sunpy.net.tests.test_helioviewer.test_download_jp2_map": "438fdcccc6f879491c876ce24a591843bb60d724e354d1c8124678a356ff3426",
   "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
@@ -34,6 +34,7 @@
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_top_right": "40591e49e6b32ec3a27b6fc50b9e2fdfcaa9665eca70b6a515dfb9dc7c0b1724",
   "sunpy.map.tests.test_plotting.test_heliographic_grid_annotations": "c7c08b2b6dae1b96c303345b04682060da97a1b304e7f25bcfd40b2154751465",
   "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "d85fc7e939ac813274bdf7886c646fdab2fca61659f18009c8f5f2b760c4bb57",
+  "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "083e833accf928a8c2679f7d1ed1eae8c80af90c5dd71ec451041aeaffbbe116",
   "sunpy.net.tests.test_helioviewer.test_download_jp2_map": "438fdcccc6f879491c876ce24a591843bb60d724e354d1c8124678a356ff3426",
   "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -34,7 +34,7 @@
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_top_right": "40591e49e6b32ec3a27b6fc50b9e2fdfcaa9665eca70b6a515dfb9dc7c0b1724",
   "sunpy.map.tests.test_plotting.test_heliographic_grid_annotations": "c7c08b2b6dae1b96c303345b04682060da97a1b304e7f25bcfd40b2154751465",
   "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "d85fc7e939ac813274bdf7886c646fdab2fca61659f18009c8f5f2b760c4bb57",
-  "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "083e833accf928a8c2679f7d1ed1eae8c80af90c5dd71ec451041aeaffbbe116",
+  "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "2f7cf5251db91da34a86b3a72610acc9b257e4c586f2dcf6f10381bd7c3ea186",
   "sunpy.net.tests.test_helioviewer.test_download_jp2_map": "438fdcccc6f879491c876ce24a591843bb60d724e354d1c8124678a356ff3426",
   "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -33,7 +33,7 @@
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_width_height": "a52dca9100f3f96644e924f283c7ba9bd26db115be3a8e19b91898406d06f9ba",
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_top_right": "40591e49e6b32ec3a27b6fc50b9e2fdfcaa9665eca70b6a515dfb9dc7c0b1724",
   "sunpy.map.tests.test_plotting.test_heliographic_grid_annotations": "c7c08b2b6dae1b96c303345b04682060da97a1b304e7f25bcfd40b2154751465",
-  "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "4ee92ca6097b55ab6842076b42b08bd384ae6bd86a2c18dddbd40b15f0e5297d",
+  "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "d85fc7e939ac813274bdf7886c646fdab2fca61659f18009c8f5f2b760c4bb57",
   "sunpy.net.tests.test_helioviewer.test_download_jp2_map": "438fdcccc6f879491c876ce24a591843bb60d724e354d1c8124678a356ff3426",
   "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -33,6 +33,7 @@
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_width_height": "a52dca9100f3f96644e924f283c7ba9bd26db115be3a8e19b91898406d06f9ba",
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_top_right": "40591e49e6b32ec3a27b6fc50b9e2fdfcaa9665eca70b6a515dfb9dc7c0b1724",
   "sunpy.map.tests.test_plotting.test_heliographic_grid_annotations": "c7c08b2b6dae1b96c303345b04682060da97a1b304e7f25bcfd40b2154751465",
+  "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "4ee92ca6097b55ab6842076b42b08bd384ae6bd86a2c18dddbd40b15f0e5297d",
   "sunpy.net.tests.test_helioviewer.test_download_jp2_map": "438fdcccc6f879491c876ce24a591843bb60d724e354d1c8124678a356ff3426",
   "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -34,6 +34,7 @@
   "sunpy.map.tests.test_plotting.test_heliographic_quadrangle_top_right": "40591e49e6b32ec3a27b6fc50b9e2fdfcaa9665eca70b6a515dfb9dc7c0b1724",
   "sunpy.map.tests.test_plotting.test_heliographic_grid_annotations": "c7c08b2b6dae1b96c303345b04682060da97a1b304e7f25bcfd40b2154751465",
   "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "d85fc7e939ac813274bdf7886c646fdab2fca61659f18009c8f5f2b760c4bb57",
+  "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "083e833accf928a8c2679f7d1ed1eae8c80af90c5dd71ec451041aeaffbbe116",
   "sunpy.net.tests.test_helioviewer.test_download_jp2_map": "438fdcccc6f879491c876ce24a591843bb60d724e354d1c8124678a356ff3426",
   "sunpy.timeseries.tests.test_timeseriesbase.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.tests.test_timeseriesbase.test_esp_peek": "d069eee419c45875cffe9a10c3262f83b3d28ccf7f13ee66ca1b99fe557f09b8",


### PR DESCRIPTION
(pulled out of #5081)

This PR enhances `GenericMap.draw_limb()` so that the solar limb can be drawn correctly on a WCSAxes based on a different WCS (e.g., plot the EUVI limb on an AIA map).  The limb will not necessarily be a circle, and the non-visible part of the limb is dotted rather than solid.

The PR includes a figure test that generates the following plot:
![Figure_1](https://user-images.githubusercontent.com/991759/115614495-c86b6e80-a2bb-11eb-8780-3bac3c7c6c17.png)