### PR TITLE
Consistently use super() in map sources

### DIFF
--- a/sunpy/map/sources/hinode.py
+++ b/sunpy/map/sources/hinode.py
@@ -43,7 +43,7 @@ class XRTMap(GenericMap):
 
     def __init__(self, data, header, **kwargs):
 
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         # converting data array to masked array
         # self.data = ma.masked_where(self.data > SATURATION_LIMIT, self.data)
@@ -110,7 +110,7 @@ class SOTMap(GenericMap):
                         'FG shutterless Stokes', 'SP IQUV 4D array']
 
     def __init__(self, data, header, **kwargs):
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         self.meta['detector'] = "SOT"
         self.meta['telescop'] = "Hinode"

--- a/sunpy/map/sources/proba2.py
+++ b/sunpy/map/sources/proba2.py
@@ -26,8 +26,7 @@ class SWAPMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         # It needs to be verified that these must actually be set and
         # are not already in the header.

--- a/sunpy/map/sources/stereo.py
+++ b/sunpy/map/sources/stereo.py
@@ -31,8 +31,8 @@ class EUVIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        super().__init__(data, header, **kwargs)
 
-        GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'euvi{wl:d}'.format(wl=int(self.wavelength.value))
         self.plot_settings['norm'] = ImageNormalize(
@@ -101,8 +101,7 @@ class CORMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'stereocor{det!s}'.format(det=self.detector[-1])
@@ -148,8 +147,8 @@ class HIMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
+        super().__init__(data, header, **kwargs)
 
-        GenericMap.__init__(self, data, header, **kwargs)
         self._nickname = "{}-{}".format(self.detector, self.observatory[-1])
         self.plot_settings['cmap'] = 'stereohi{det!s}'.format(det=self.detector[-1])
         self.plot_settings['norm'] = ImageNormalize(

--- a/sunpy/map/sources/trace.py
+++ b/sunpy/map/sources/trace.py
@@ -49,8 +49,7 @@ class TRACEMap(GenericMap):
         # Assume pixel units are arcesc if not given
         header['cunit1'] = header.get('cunit1', 'arcsec')
         header['cunit2'] = header.get('cunit2', 'arcsec')
-
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         # It needs to be verified that these must actually be set and are not
         # already in the header.

--- a/sunpy/map/sources/yohkoh.py
+++ b/sunpy/map/sources/yohkoh.py
@@ -40,8 +40,7 @@ class SXTMap(GenericMap):
     """
 
     def __init__(self, data, header, **kwargs):
-
-        GenericMap.__init__(self, data, header, **kwargs)
+        super().__init__(data, header, **kwargs)
 
         self.meta['detector'] = "SXT"
         self.meta['telescop'] = "Yohkoh"


### PR DESCRIPTION
Minor change to make `super().__init__()` consistent across all the map sources.