### PR TITLE
Save original copy of metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,7 @@ figure_test_images*
 tags
 sunpy_map.asdf
 baseline
+docs/guide/data_types/figure.png
 
 ### Pycharm(?)
 .idea

--- a/changelog/5241.feature.rst
+++ b/changelog/5241.feature.rst
@@ -1,0 +1,11 @@
+`~sunpy.util.MetaDict` now saves a copy of the metadata on creation, which can
+be accessed using the `~sunpy.util.MetaDict.original_meta` property. Three
+new properties have also been added to query any changes that have been made
+to metadata:
+
+- `~sunpy.util.MetaDict.added_items`
+- `~sunpy.util.MetaDict.removed_items`
+- `~sunpy.util.MetaDict.modified_items`
+
+As an example, ``my_map.meta.modified_items`` will return a dictionary mapping
+keys to their original value and current value.

--- a/docs/dev_guide/contents/new_objects.rst
+++ b/docs/dev_guide/contents/new_objects.rst
@@ -8,7 +8,7 @@ Writing a new Instrument Map Class
 ==================================
 
 All instrument Map classes are subclasses of the generic `~sunpy.map.GenericMap` subclass.
-`~sunpy.map.GenericMap` expect to be provided the data array as well as header dictionary and will parse the header metadata to the best of its ability based on common standards.
+`~sunpy.map.GenericMap` expects to be provided the data array and a header dictionary and will parse the header metadata to the best of its ability based on common standards.
 The instrument subclass implements the instrument-specific code to parse the metadata, apply any necessary procedures on the data array, as well as defining other things such what color tables to use.
 
 In practice, the instrument subclass is not directly accessed by users.
@@ -52,7 +52,8 @@ The following example shows how this works and includes a sample doc string that
             # will process the header according to common standards
             super(FutureMap, self).__init__(data, header, **kwargs)
 
-            # Any NextGenerationTelescope Instrument-specific manipulation
+            # Any NextGenerationTelescope Instrument-specific manipulation.
+            # This typically involves editing the `self.meta` attribute.
 
         # used by the Map factory to determine if this subclass should be used
         @classmethod

--- a/examples/map/map_metadata_modification.py
+++ b/examples/map/map_metadata_modification.py
@@ -1,0 +1,40 @@
+"""
+=========================
+Map metadata modification
+=========================
+
+How to query map metadata for changes.
+
+sunpy has a series of map sources that can fix common issues with the original metadata
+stored in FITS files. A copy of the original (unaltered) metadata is stored, so
+any changes that sunpy (or the user) subsequently makes to the metadata can be
+easily queried.
+
+In the example below, we load a HMI sample image, and query the metadata for
+any added, removed, or modified items.
+"""
+import astropy.units as u
+
+import sunpy.map
+from sunpy.data.sample import HMI_LOS_IMAGE
+
+###############################################################################
+# Start by creating a map.
+hmimap = sunpy.map.Map(HMI_LOS_IMAGE)
+
+###############################################################################
+# Now query the ``.meta`` attribute for any changes. We can see that nothing
+# has been added or removed, but the 'bunit' key has been updated from "Gauss"
+# to "G" to make it FITS standard compliant.
+print("Added items:", hmimap.meta.added_items)
+print("Removed items:", hmimap.meta.removed_items)
+print("Modified items:", hmimap.meta.modified_items)
+
+###############################################################################
+# If we modify the map in a way that updates the metadata, these properties
+# allow use to easily see what has changed. As an exmaple, lets rotate the map
+# by 90 degrees, and see what has been updated.
+hmimap = hmimap.rotate(90 * u.deg)
+print("Added items:", hmimap.meta.added_items)
+print("Removed items:", hmimap.meta.removed_items)
+print("Modified items:", hmimap.meta.modified_items)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -22,6 +22,7 @@ import astropy.units as u
 import astropy.wcs
 from astropy.coordinates import Longitude, SkyCoord, UnitSphericalRepresentation
 from astropy.nddata import NDData
+from astropy.utils.metadata import MetaData
 from astropy.visualization import AsymmetricPercentileInterval, HistEqStretch, ImageNormalize
 from astropy.visualization.wcsaxes import WCSAxes
 
@@ -54,6 +55,18 @@ PixelPair = namedtuple('PixelPair', 'x y')
 SpatialPair = namedtuple('SpatialPair', 'axis1 axis2')
 
 _META_FIX_URL = 'https://docs.sunpy.org/en/stable/code_ref/map.html#fixing-map-metadata'
+
+# Manually specify the ``.meta`` docstring. This is assigned to the .meta
+# class attribute in GenericMap.__init__()
+_meta_doc = """
+The map metadata.
+
+This is used to intepret the map data. It may
+have been modified from the original metadata by sunpy. See the
+`~sunpy.util.MetaDict.added_items`, `~sunpy.util.MetaDict.removed_items`
+and `~sunpy.util.MetaDict.modified_items` properties of MetaDict
+to query how the metadata has been modified.
+"""
 
 __all__ = ['GenericMap']
 
@@ -164,6 +177,8 @@ class GenericMap(NDData):
     """
 
     _registry = dict()
+    # This overrides the default doc for the meta attribute
+    meta = MetaData(doc=_meta_doc, copy=False)
 
     def __init_subclass__(cls, **kwargs):
         """

--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -1,6 +1,8 @@
+import copy
+
 import pytest
 
-from sunpy.util.metadata import MetaDict
+from sunpy.util.metadata import MetaDict, ModifiedItem
 
 
 # TODO: Should these be here and not in util?
@@ -512,3 +514,43 @@ def test_key_case_insensitivity(seas_metadict):
     assert seas_metadict['bering'] == 'Russia'
     assert seas_metadict['BeRinG'] == 'Russia'
     assert seas_metadict.get('BERING') == 'Russia'
+
+
+def test_original_copy():
+    md = MetaDict({'foo': 'bar'})
+    assert md.original_meta == md
+
+    # Add a key, make sure original contents doesn't change
+    md['a'] = 'b'
+    assert md.original_meta != md
+    assert list(md.keys()) == ['foo', 'a']
+    assert list(md.original_meta.keys()) == ['foo']
+    assert md.added_items == {'a': 'b'}
+
+    # Check that creating a new MetaDict preserves the original copy
+    md = MetaDict(md)
+    assert list(md.keys()) == ['foo', 'a']
+    assert list(md.original_meta.keys()) == ['foo']
+
+    # Check that creating a copy preserves the original copy
+    md = copy.copy(md)
+    assert list(md.keys()) == ['foo', 'a']
+    assert list(md.original_meta.keys()) == ['foo']
+
+    # Check that creating a deepcopy preserves the original copy
+    md = copy.deepcopy(md)
+    assert list(md.keys()) == ['foo', 'a']
+    assert list(md.original_meta.keys()) == ['foo']
+
+    # Check that creating using .copy() preserves the original copy
+    md = md.copy()
+    assert list(md.keys()) == ['foo', 'a']
+    assert list(md.original_meta.keys()) == ['foo']
+
+    # Check modification of items
+    md['foo'] = 'bar1'
+    assert md.modified_items == {'foo': ModifiedItem('bar', 'bar1')}
+
+    # Check removal of items
+    md.pop('foo')
+    assert md.removed_items == {'foo': 'bar'}


### PR DESCRIPTION
`sunpy.util.MetaDict` now saves a copy of it's initial input metadata. This original copy, along with new helper methods, allows one to query any changes, additions, or removals from the metadata. See the included example for an example.

xref https://github.com/sunpy/sunpy/issues/4194; this goes a little way to making progress on that issue.
