### PR TITLE
Wrap the `psi` component of Heliocentric Radial at 360 deg

### DIFF
--- a/changelog/5242.bugfix.rst
+++ b/changelog/5242.bugfix.rst
@@ -1,0 +1,1 @@
+When using the cylindrical representation of `Heliocentric` to work in the Heliocentric Radial coordinate frame, the ``psi`` component now goes from 0 to 360 degrees instead of -180 to 180 degrees.

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -373,6 +373,18 @@ def test_hcc_default_observer():
     assert not hcc.is_frame_attr_default('observer')
 
 
+@pytest.mark.parametrize('x, y, psi', [(0*u.km, -1*u.km, 270*u.deg),
+                                       (0*u.km, 1*u.km, 90*u.deg),
+                                       (-1*u.km, 0*u.km, 180*u.deg)])
+def test_heliocentric_radial_psi(x, y, psi):
+    # The cylindrical representation of HCC is Heliocentric Radial
+    # Test that the `psi` component is represented as desired
+    # The definition is shifted by 90 degrees relative to Thompson (2006)
+    hcc = Heliocentric(CartesianRepresentation(x, y, 0*u.km), representation_type='cylindrical')
+
+    assert_quantity_allclose(hcc.psi, psi)
+
+
 # ==============================================================================
 # SkyCoord Tests
 # ==============================================================================


### PR DESCRIPTION
Closes #5240

We implement Heliocentric Radial through the cylindrical representation of our `Heliocentric` coordinate frame.  We're stuck with a 90-degree offset in the definition of the `psi` component, but at least we can have `psi` go from 0 deg to 360 deg (as requested by #5240).