### PR TITLE
Automatically delete unused figures from sunpy-figure-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
       - run: git clone git@github.com:sunpy/sunpy-figure-tests.git --depth 1 -b sunpy-${CIRCLE_BRANCH} ~/sunpy-figure-tests/
       # Generate Reference images
       - run: pip install --user -U tox tox-pypi-filter
+      - run: rm -rf /home/circleci/sunpy-figure-tests/figures/$TOXENV/*
       - run: tox -- --mpl-generate-path=/home/circleci/sunpy-figure-tests/figures/$TOXENV | tee toxlog
       - run: |
           hashlib=$(grep "^figure_hashes.*\.json$" toxlog)

--- a/changelog/5243.feature.rst
+++ b/changelog/5243.feature.rst
@@ -1,1 +1,0 @@
-Figure tests automatically delete the unused figures.

--- a/changelog/5243.feature.rst
+++ b/changelog/5243.feature.rst
@@ -1,2 +1,1 @@
 Figure tests automatically delete the unused figures.
-

--- a/changelog/5243.feature.rst
+++ b/changelog/5243.feature.rst
@@ -1,1 +1,2 @@
 Figure tests automatically delete the unused figures.
+

--- a/changelog/5243.feature.rst
+++ b/changelog/5243.feature.rst
@@ -1,0 +1,1 @@
+Figure tests automatically delete the unused figures.


### PR DESCRIPTION
Fixes #4232 

https://github.com/jeffreypaul15/sunpy/commit/6b83095a06b0f86c6e1d49bb13a3be9cf6ec43eb# Deletes the `test_heliographic_rectangle_top_right` figure test, and then based on the changes at : 
https://github.com/jeffreypaul15/sunpy/blob/master/.circleci/config.yml
The directory is emptied, new figures are generated and merged with `sunpy-figure-test`. The removed figure is deleted and the other figures remain as they are : https://github.com/jeffreypaul15/sunpy-figure-tests/commit/1c11abb011236bbc23e81f9b9c03829ea3254a0b

CI : https://app.circleci.com/pipelines/github/jeffreypaul15/sunpy/10/workflows/08fc4967-5f58-4ae7-890d-ecaa08005701/jobs/37
