### PR TITLE
Only set WCS observer if map frame has observer attribute

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -552,24 +552,21 @@ class GenericMap(NDData):
         if w2.wcs.ctype[1].lower() in ("solar-y", "solar_y"):
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
-        # Set observer coordinate information
-        #
-        # Clear all the aux information that was set earlier. This is to avoid
-        # issues with maps that store multiple observer coordinate keywords.
-        # Note that we have to create a new WCS as it's not possible to modify
-        # wcs.wcs.aux in place.
-        header = w2.to_header()
-        for kw in ['crln_obs', 'dsun_obs', 'hgln_obs', 'hglt_obs']:
-            header.pop(kw, None)
-        w2 = astropy.wcs.WCS(header)
+        if hasattr(astropy.wcs.utils.wcs_to_celestial_frame(w2), 'observer'):
+            # Set observer coordinate information
+            #
+            # Clear all the aux information that was set earlier. This is to avoid
+            # issues with maps that store multiple observer coordinate keywords.
+            # Note that we have to create a new WCS as it's not possible to modify
+            # wcs.wcs.aux in place.
+            header = w2.to_header()
+            for kw in ['crln_obs', 'dsun_obs', 'hgln_obs', 'hglt_obs']:
+                header.pop(kw, None)
+            w2 = astropy.wcs.WCS(header)
 
-        # Get observer coord, and transform if needed
-        obs_coord = self.observer_coordinate
-        if not isinstance(obs_coord.frame, (HeliographicStonyhurst, HeliographicCarrington)):
-            obs_coord = obs_coord.transform_to(HeliographicStonyhurst(obstime=self.date,
-                                                                      rsun=self.rsun_meters))
-
-        sunpy.coordinates.wcs_utils._set_wcs_aux_obs_coord(w2, obs_coord)
+            # Get observer coord, and set the aux information
+            obs_coord = self.observer_coordinate
+            sunpy.coordinates.wcs_utils._set_wcs_aux_obs_coord(w2, obs_coord)
 
         # Validate the WCS here.
         w2.wcs.set()

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -25,7 +25,7 @@ import sunpy.coordinates
 import sunpy.data.test
 import sunpy.map
 import sunpy.sun
-from sunpy.coordinates import sun
+from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, sun
 from sunpy.map.sources import AIAMap
 from sunpy.time import parse_time
 from sunpy.util import SunpyDeprecationWarning, SunpyUserWarning
@@ -1201,3 +1201,27 @@ def test_meta_modifications(aia171_test_map):
     assert set(aiamap_rot.meta.added_items.keys()) == set(['bunit', 'pc1_1', 'pc1_2', 'pc2_1', 'pc2_2'])
     assert set(aiamap_rot.meta.removed_items.keys()) == set(['crota2'])
     assert set(aiamap_rot.meta.modified_items) == set(['cdelt1', 'crpix1', 'crpix2', 'crval1'])
+
+
+
+def test_no_wcs_observer_info(heliographic_test_map):
+    # Check that HeliographicCarrington WCS has observer info set
+    assert isinstance(heliographic_test_map.coordinate_frame, HeliographicCarrington)
+    wcs_aux = heliographic_test_map.wcs.wcs.aux
+    assert wcs_aux.hgln_obs is not None
+    assert wcs_aux.hglt_obs is not None
+    assert wcs_aux.dsun_obs is not None
+
+    # Remove observer information, and change coordinate system to HeliographicStonyhurst
+    heliographic_test_map.meta.pop('HGLN_OBS')
+    heliographic_test_map.meta.pop('HGLT_OBS')
+    heliographic_test_map.meta.pop('DSUN_OBS')
+    heliographic_test_map.meta['CTYPE1'] = 'HGLN-CAR'
+    heliographic_test_map.meta['CTYPE2'] = 'HGLT-CAR'
+    assert isinstance(heliographic_test_map.coordinate_frame, HeliographicStonyhurst)
+
+    # Check that GenericMap.wcs doesn't set an observer
+    wcs_aux = heliographic_test_map.wcs.wcs.aux
+    assert wcs_aux.hgln_obs is None
+    assert wcs_aux.hglt_obs is None
+    assert wcs_aux.dsun_obs is None


### PR DESCRIPTION
TL;DR: I think for a Stonyhurst frame, observer information shouldn't be set on a WCS.

Story time!

As part of https://github.com/sunpy/sunpy/pull/5244, warnings will be raised if plotting when `map.wcs != axes.wcs`. More precisely, this comparison is done with the line `axes.wcs.wcs.compare(self.wcs.wcs, tolerance=0.01)`. This will compare every WCS keyword, and evaluate true iff all keywords are identical to within an absolute tolerance of 0.01.

In the `reprojection_aia_euvi_mosaic.py` example, the following happens:

1. Create a FITS header in a Stonyhurst frame using `header_helper`. Because the Stonyhurst frame does (in general) not have an observer property, no observer keywords are set in the header. I shall call the WCS from this `wcs_header`.
2. Using `reproject`, create new maps from this header. I shall call the WCS from this `wcs_map`.
3. Create an axes with `wcs_header`
4. Plot the map on this axes

However, `map.wcs` sees there is no observer information in the header, and falls back to assuming the observer is the Earth, and sets the observer keywords in `wcs_map`. This leads to `wcs_header.compare(map_wcs, tolerance=0.01)` failing.

I *think* the solution to this is to only set the observer information in `GenericMap.wcs` if the coordinate frame of the map has an observer attribute. @ayshih should check this.