### PR TITLE
Fix map source doc when source has no docstring

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -193,7 +193,11 @@ class GenericMap(NDData):
         This is then passed into the Map Factory so we can register them.
         """
         super().__init_subclass__(**kwargs)
+        if cls.__doc__ is None:
+            # Set an empty string, to prevent an error adding None to str in the next line
+            cls.__doc__ = ''
         cls.__doc__ += textwrap.indent(_notes_doc, "    ")
+
         if hasattr(cls, 'is_datasource_for'):
             cls._registry[cls] = cls.is_datasource_for
 


### PR DESCRIPTION
I have a map source in `pfsspy` that has no docstring (yes I know I should really add one...), which raised an error with the new doc tricks we do with map sources. This should fix it.