### PR TITLE
ignore gallery warnings on release version of docs only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,7 @@ tags
 sunpy_map.asdf
 baseline
 docs/guide/data_types/figure.png
+october_M1_flares.csv
 
 ### Pycharm(?)
 .idea

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,11 @@ release = __version__
 sunpy_version = Version(__version__)
 is_release = not(sunpy_version.is_prerelease or sunpy_version.is_devrelease)
 
+# We want to ignore all warnings in a release version.
+if is_release:
+    import warnings
+    warnings.simplefilter("ignore")
+
 # -- SunPy Sample Data and Config ----------------------------------------------
 
 # We set the logger to debug so that we can see any sample data download errors

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,19 +1,15 @@
 """
 Configuration file for the Sphinx documentation builder.
-
-isort:skip_file
 """
-# flake8: NOQA: E402
-
 # -- stdlib imports ------------------------------------------------------------
 import os
 import sys
 import datetime
+import warnings
 from pkg_resources import get_distribution
 from packaging.version import Version
 
 # -- Check for dependencies ----------------------------------------------------
-
 doc_requires = get_distribution("sunpy").requires(extras=("docs",))
 missing_requirements = []
 for requirement in doc_requires:
@@ -29,7 +25,6 @@ if missing_requirements:
     sys.exit(1)
 
 # -- Read the Docs Specific Configuration --------------------------------------
-
 # This needs to be done before sunpy is imported
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
@@ -40,16 +35,15 @@ if on_rtd:
     os.environ['HIDE_PARFIVE_PROGESS'] = 'True'
 
 # -- Non stdlib imports --------------------------------------------------------
-
 import ruamel.yaml as yaml  # NOQA
 from sphinx_gallery.sorting import ExplicitOrder  # NOQA
 from sphinx_gallery.sorting import ExampleTitleSortKey  # NOQA
 
 import sunpy  # NOQA
 from sunpy import __version__  # NOQA
+from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyPendingDeprecationWarning  # NOQA
 
 # -- Project information -------------------------------------------------------
-
 project = 'SunPy'
 author = 'The SunPy Community'
 copyright = '{}, {}'.format(datetime.datetime.now().year, author)
@@ -61,11 +55,14 @@ is_release = not(sunpy_version.is_prerelease or sunpy_version.is_devrelease)
 
 # We want to ignore all warnings in a release version.
 if is_release:
-    import warnings
     warnings.simplefilter("ignore")
-
+warnings.filterwarnings("error", category=SunpyDeprecationWarning)
+warnings.filterwarnings("error", category=SunpyPendingDeprecationWarning)
+# TODO: Remove this when we remove instr in sunpy 3.1
+warnings.filterwarnings(
+    "ignore", message="sunpy.instr is deprecated and will be removed in sunpy 3.1.", category=SunpyDeprecationWarning
+)
 # -- SunPy Sample Data and Config ----------------------------------------------
-
 # We set the logger to debug so that we can see any sample data download errors
 # in the CI, especially RTD.
 ori_level = sunpy.log.level
@@ -90,7 +87,6 @@ rst_epilog = """
 """
 
 # -- General configuration -----------------------------------------------------
-
 # Suppress warnings about overriding directives as we overload some of the
 # doctest extensions.
 suppress_warnings = ['app.add_directive', ]
@@ -152,7 +148,6 @@ napoleon_use_rtype = False
 napoleon_google_docstring = False
 
 # -- Options for intersphinx extension -----------------------------------------
-
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": (
@@ -183,7 +178,6 @@ intersphinx_mapping = {
 }
 
 # -- Options for HTML output ---------------------------------------------------
-
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
@@ -207,7 +201,8 @@ graphviz_dot_args = [
 ]
 
 # -- Sphinx Gallery ------------------------------------------------------------
-
+# JSOC email os env
+os.environ["JSOC_EMAIL"] = "jsoc@cadair.com"
 sphinx_gallery_conf = {
     'backreferences_dir': os.path.join('generated', 'modules'),
     'filename_pattern': '^((?!skip_).)*$',
@@ -236,7 +231,6 @@ sphinx_gallery_conf = {
 }
 
 # -- Stability Page ------------------------------------------------------------
-
 with open('./code_ref/sunpy_stability.yaml', 'r') as estability:
     sunpy_modules = yaml.load(estability.read(), Loader=yaml.Loader)
 
@@ -262,12 +256,7 @@ def rstjinja(app, docname, source):
         source[0] = rendered
 
 
-# JSOC email os env
-os.environ["JSOC_EMAIL"] = "jsoc@cadair.com"
-
 # -- Sphinx setup --------------------------------------------------------------
-
-
 def setup(app):
     # Generate the stability page
     app.connect("source-read", rstjinja)

--- a/docs/guide/plotting.rst
+++ b/docs/guide/plotting.rst
@@ -200,6 +200,9 @@ then used to modify the plot:
     plt.colorbar()
     plt.show()
 
+It is possible to create the same plot, explicitly not using `~astropy.visualization.wcsaxes`, however, this will not have the features of `~astropy.visualization.wcsaxes` which include correct representation of rotation and plotting in different coordinate systems.
+Please see this example :ref:`sphx_glr_generated_gallery_map_plot_frameless_image.py`.
+
 .. _wcsaxes-plotting:
 
 Plotting Maps with wcsaxes

--- a/docs/guide/plotting.rst
+++ b/docs/guide/plotting.rst
@@ -200,41 +200,6 @@ then used to modify the plot:
     plt.colorbar()
     plt.show()
 
-It is possible to create the same plot, explicitly not using
-`~astropy.visualization.wcsaxes`, however, this will not have the features of
-`~astropy.visualization.wcsaxes` which include correct representation of
-rotation and plotting in different coordinate systems.
-
-.. plot::
-    :include-source:
-
-    import matplotlib.pyplot as plt
-    import astropy.units as u
-
-    import sunpy.map
-    import sunpy.data.sample
-
-    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-
-    fig, ax = plt.subplots()
-
-    im = smap.plot()
-
-    # Prevent the image from being re-scaled while overplotting.
-    ax.set_autoscale_on(False)
-
-    xc = [0,100,1000] * u.arcsec
-    yc = [0,100,1000] * u.arcsec
-
-    p = plt.plot(xc, yc, 'o')
-
-    # Set title.
-    ax.set_title('Custom plot without WCSAxes')
-
-    plt.colorbar()
-    plt.show()
-
-
 .. _wcsaxes-plotting:
 
 Plotting Maps with wcsaxes

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -6,6 +6,7 @@ Release History
    :maxdepth: 1
 
    changelog
+   3.1
    3.0
    2.1
    2.0

--- a/examples/map/composite_map_AIA_HMI.py
+++ b/examples/map/composite_map_AIA_HMI.py
@@ -30,7 +30,6 @@ aia_smap = aia_map.submap(SkyCoord(*bottom_left, frame=aia_map.coordinate_frame)
 hmi_smap = hmi_map.submap(SkyCoord(*bottom_left, frame=hmi_map.coordinate_frame),
                           top_right=SkyCoord(*top_right, frame=hmi_map.coordinate_frame))
 
-
 ##############################################################################
 # Let's create a `~sunpy.map.CompositeMap` which includes both maps.
 

--- a/examples/plotting/plotting_blank_map.py
+++ b/examples/plotting/plotting_blank_map.py
@@ -56,8 +56,6 @@ yc = [0, 100, 400] * u.arcsec
 ################################################################################
 # Place and mark coordinates on the plot.
 
-# sphinx_gallery_defer_figures
-
 coords = SkyCoord(xc, yc, frame=blank_map.coordinate_frame)
 p = ax.plot_coord(coords, 'o')
 # Set title.

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -450,9 +450,7 @@ def test_add_entry_from_hek_qr(database):
         hek.attrs.EventType('FL'))
     assert len(database) == 0
     database.add_from_hek_query_result(hek_res)
-    # This number loves to change, so we are just going to test that it's added
-    # *something*
-    assert len(database) > 1
+    assert len(database) == 90
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/dataretriever/sources/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/sources/tests/test_noaa.py
@@ -167,10 +167,10 @@ def test_srs_unpack():
 @pytest.mark.remote_data
 def test_srs_midyear():
     qr = Fido.search(a.Instrument("soon") & a.Time("2011/06/07", "2011/06/08T23:59:29"))
-    res = Fido.fetch(qr)
+    res = sorted(Fido.fetch(qr))
     assert len(res) == 2
-    assert res.data[0].endswith("20110607SRS.txt")
-    assert res.data[-1].endswith("20110608SRS.txt")
+    assert res[0].endswith("20110607SRS.txt")
+    assert res[-1].endswith("20110608SRS.txt")
 
 
 @no_vso


### PR DESCRIPTION
On release versions, tagged basically, we will hide all warnings in the gallery. On master or any dev version they will be there and we can still fix them.

Fixes #4255
Fixes #1917 by restoring the check.