### PR TITLE
Context manager to handle differential rotation automatically in transformations

### DIFF
--- a/changelog/5281.feature.rst
+++ b/changelog/5281.feature.rst
@@ -1,0 +1,1 @@
+Added the :func:`~sunpy.coordinates.propagate_with_solar_surface` context manager for transformations, which will automatically apply solar differential rotation when transforming a coordinate between frames with a change in time (``obstime``).

--- a/docs/code_ref/coordinates/rotatedsunframe.rst
+++ b/docs/code_ref/coordinates/rotatedsunframe.rst
@@ -34,7 +34,7 @@ Multiple models for differential rotation are supported (see :func:`~sunpy.physi
 
 .. note::
    `~sunpy.coordinates.metaframes.RotatedSunFrame` is a powerful metaframe, but can be tricky to use correctly.
-   We recommend users to first check if the simpler :func:`~sunpy.coordinates.propagate_with_solar_surface` context manager is sufficient.
+   We recommend users to first check if the simpler :func:`~sunpy.coordinates.propagate_with_solar_surface` context manager is sufficient for their needs.
 
 In addition, one may want to account for the translational motion of the Sun as well, and that can be achieved by also using the context manager :func:`~sunpy.coordinates.transform_with_sun_center` for desired coordinate transformations.
 

--- a/docs/code_ref/coordinates/rotatedsunframe.rst
+++ b/docs/code_ref/coordinates/rotatedsunframe.rst
@@ -32,6 +32,10 @@ To evolve a coordinate in time such that it accounts for the rotational motion o
 This machinery will take into account the latitude-dependent rotation rate of the solar surface, also known as differential rotation.
 Multiple models for differential rotation are supported (see :func:`~sunpy.physics.differential_rotation.diff_rot` for details).
 
+.. note::
+   `~sunpy.coordinates.metaframes.RotatedSunFrame` is a powerful metaframe, but can be tricky to use correctly.
+   We recommend users to first check if the simpler :func:`~sunpy.coordinates.propagate_with_solar_surface` context manager is sufficient.
+
 In addition, one may want to account for the translational motion of the Sun as well, and that can be achieved by also using the context manager :func:`~sunpy.coordinates.transform_with_sun_center` for desired coordinate transformations.
 
 Basics of the RotatedSunFrame class

--- a/docs/whatsnew/3.1.rst
+++ b/docs/whatsnew/3.1.rst
@@ -13,6 +13,7 @@ The SunPy project is pleased to announce the 3.1 release of the sunpy package.
 On this page, you can read about some of the big changes in this release:
 
 * :ref:`whatsnew-3.1-python`
+* :ref:`whatsnew-3.1-diffrot-context`
 
 SunPy 3.1 also includes a large number of smaller improvements and bug fixes, which are described in the :ref:`changelog`.
 
@@ -80,6 +81,18 @@ are not written to provide valid results for times before 1972-01-01.
 
 This format is equivalent to `~astropy.time.TimeUnixTai`, except that the epoch
 is 12 years earlier.
+
+.. _whatsnew-3.1-diffrot-context:
+
+Propagating solar-surface coordinates in time
+=============================================
+
+There is now an easy-to-use context manager (:func:`~sunpy.coordinates.propagate_with_solar_surface`) to enable coordinate transformations to take solar rotation into account.
+Normally, a coordinate refers to a point in inertial space, so transforming it to a different observation time does not move the point at all.
+Under this context manager, a coordinate will be treated as if it were referring to a point on the solar surface.
+Coordinate transformations with a change in observation time will automatically rotate the point in heliographic longitude for the time difference, with the amount of rotation depending on the specified differential-rotation model.
+
+.. minigallery:: sunpy.coordinates.propagate_with_solar_surface
 
 Contributors to this Release
 ============================

--- a/docs/whatsnew/3.1.rst
+++ b/docs/whatsnew/3.1.rst
@@ -13,6 +13,7 @@ The SunPy project is pleased to announce the 3.1 release of the sunpy package.
 On this page, you can read about some of the big changes in this release:
 
 * :ref:`whatsnew-3.1-python`
+* :ref:`whatsnew-3.1-map-datetime`
 * :ref:`whatsnew-3.1-diffrot-context`
 
 SunPy 3.1 also includes a large number of smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -36,7 +37,7 @@ We have bumped the minimum version of several packages we depend on; these are t
 - astropy >= 4.2
 - numpy >= 1.17.0
 
-.. _whatsnew-3.1-contributors:
+.. _whatsnew-3.1-map-datetime:
 
 Changes to map date/time handling
 =================================
@@ -93,6 +94,8 @@ Under this context manager, a coordinate will be treated as if it were referring
 Coordinate transformations with a change in observation time will automatically rotate the point in heliographic longitude for the time difference, with the amount of rotation depending on the specified differential-rotation model.
 
 .. minigallery:: sunpy.coordinates.propagate_with_solar_surface
+
+.. _whatsnew-3.1-contributors:
 
 Contributors to this Release
 ============================

--- a/examples/differential_rotation/reprojected_map.py
+++ b/examples/differential_rotation/reprojected_map.py
@@ -5,11 +5,6 @@ Differentially rotating a map
 
 How to apply differential rotation to a Map.
 
-The example uses the `~sunpy.coordinates.metaframes.RotatedSunFrame` coordinate
-metaframe in `sunpy.coordinates` to apply differential rotation to a
-Map.  See :ref:`sunpy-coordinates-rotatedsunframe` for more details on
-using `~sunpy.coordinates.metaframes.RotatedSunFrame`.
-
 .. note::
    This example requires `reproject` 0.6 or later to be installed.
 
@@ -22,7 +17,7 @@ from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
 import sunpy.map
-from sunpy.coordinates import Helioprojective, RotatedSunFrame, transform_with_sun_center
+from sunpy.coordinates import Helioprojective, propagate_with_solar_surface
 from sunpy.data.sample import AIA_171_IMAGE
 
 ##############################################################################
@@ -37,32 +32,14 @@ in_time = aiamap.date
 # to the location of AIA in the original observation).
 
 out_time = in_time + 5*u.day
-out_frame = Helioprojective(observer='earth', obstime=out_time, rsun=aiamap.coordinate_frame.rsun)
+out_frame = Helioprojective(observer='earth', obstime=out_time,
+                            rsun=aiamap.coordinate_frame.rsun)
 
 ##############################################################################
-# For the reprojection, the definition of the target frame can be
-# counter-intuitive. Reprojection should be performed between two frames that
-# point to inertial locations at the same time, but ``out_frame`` is not at
-# the same time as the original frame (``out_time`` versus ``in_time``).
-# The `~sunpy.coordinates.metaframes.RotatedSunFrame` metaframe allows one to
-# specify coordinates in a coordinate frame at one time (here, ``out_frame``)
-# to refer to inertial locations at a different time (here, ``in_time``,
-# which is supplied through the keyword argument ``rotated_time``).
-# `~sunpy.coordinates.metaframes.RotatedSunFrame` will account for the
-# appropriate amount of solar (differential) rotation for the time
-# difference between ``out_time`` and ``in_time``.
-
-rot_frame = RotatedSunFrame(base=out_frame, rotated_time=in_time)
-print(rot_frame)
-
-##############################################################################
-# Construct a WCS object for the output map with the target
-# ``RotatedSunHelioprojective`` frame specified instead of the regular
-# `~sunpy.coordinates.frames.Helioprojective` frame.
-# If one has an actual ``Map`` object at the desired output
-# time (e.g., the actual AIA observation at the output time), one can use the
-# WCS object from that ``Map`` object (e.g., ``mymap.wcs``) instead of
-# constructing a custom WCS.
+# Construct a WCS object for the output map.  If one has an actual ``Map``
+# object at the desired output time (e.g., the actual AIA observation at the
+# output time), one can use the WCS object from that ``Map`` object (e.g.,
+# ``mymap.wcs``) instead of constructing a custom WCS.
 
 out_shape = aiamap.data.shape
 out_center = SkyCoord(0*u.arcsec, 0*u.arcsec, frame=out_frame)
@@ -70,22 +47,21 @@ header = sunpy.map.make_fitswcs_header(out_shape,
                                        out_center,
                                        scale=u.Quantity(aiamap.scale))
 out_wcs = WCS(header)
-out_wcs.coordinate_frame = rot_frame
 
 ##############################################################################
 # Reproject the map from the input frame to the output frame.  We use the
-# :func:`~sunpy.coordinates.transform_with_sun_center` context manager so that
-# the coordinates stay defined relative to Sun center as the Sun moves slowly
-# over time.
+# :func:`~sunpy.coordinates.propagate_with_solar_surface` context manager so
+# that coordinates are treated as points that evolve in time with the
+# rotation of the solar surface rather than as inertial points in space.
 
-with transform_with_sun_center():
+with propagate_with_solar_surface():
     arr, _ = reproject_interp(aiamap, out_wcs, out_shape)
 
 ##############################################################################
 # Finally, we create the output map and preserve the original map's plot
 # settings.
 
-out_warp = sunpy.map.Map(arr, out_wcs)
+out_warp = sunpy.map.Map(arr, header)
 out_warp.plot_settings = aiamap.plot_settings
 
 ##############################################################################

--- a/examples/differential_rotation/reprojected_map.py
+++ b/examples/differential_rotation/reprojected_map.py
@@ -8,6 +8,9 @@ How to apply differential rotation to a Map.
 .. note::
    This example requires `reproject` 0.6 or later to be installed.
 
+The example uses the :func:`~sunpy.coordinates.propagate_with_solar_surface`
+context manager to apply differential rotation during coordinate
+transformations.
 """
 import matplotlib.pyplot as plt
 from reproject import reproject_interp

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -22,7 +22,7 @@ from . import sun
 from .ephemeris import *
 from .frames import *
 from .metaframes import *
-from .transformations import _make_sunpy_graph, transform_with_sun_center
+from .transformations import _make_sunpy_graph, propagate_with_solar_surface, transform_with_sun_center
 from .wcs_utils import *
 
 __doc__ += _make_sunpy_graph()

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -21,6 +21,7 @@ from astropy.coordinates.representation import (
 )
 from astropy.time import Time
 
+from sunpy import log
 from sunpy.sun.constants import radius as _RSUN
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
@@ -282,6 +283,19 @@ class HeliographicStonyhurst(BaseHeliographic):
     (90., 2.54480438, 45.04442252)>
     """
     name = "heliographic_stonyhurst"
+
+    def _apply_diffrot(self, duration, rotation_model):
+        oldrepr = self.spherical
+
+        from sunpy.physics.differential_rotation import diff_rot
+        log.debug(f"Applying {duration} of solar rotation")
+        newlon = oldrepr.lon + diff_rot(duration,
+                                        oldrepr.lat,
+                                        rot_type=rotation_model,
+                                        frame_time='sidereal')
+        newrepr = SphericalRepresentation(newlon, oldrepr.lat, oldrepr.distance)
+
+        return self.realize_frame(newrepr)
 
 
 @add_common_docstring(**_frame_parameters())

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -126,7 +126,7 @@ class RotatedSunFrame(SunPyBaseCoordinateFrame):
         The time to rotate the Sun to.  If provided, ``duration`` will be set to the difference
         between this time and the observation time in ``base``.
     rotation_model : `str`
-        Accepted model names are ``'howard'`` (default), ``'snodgrass'``, and ``'allen'``.
+        Accepted model names are ``'howard'`` (default), ``'snodgrass'``, ``'allen'``, and ``'rigid'``.
         See the documentation for :func:`~sunpy.physics.differential_rotation.diff_rot` for differences
         between these models.
 

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -135,7 +135,7 @@ def transform_with_sun_center():
         old_ignore_sun_motion = _ignore_sun_motion  # nominally False
 
         if not old_ignore_sun_motion:
-            log.debug("Ignore the motion of the center of the Sun for transformations")
+            log.debug("Ignoring the motion of the center of the Sun for transformations")
         _ignore_sun_motion = True
         yield
     finally:
@@ -215,13 +215,13 @@ def propagate_with_solar_surface(rotation_model='howard'):
 
             old_autoapply_diffrot = _autoapply_diffrot  # nominally False
 
-            log.debug("Enable automatic solar differential rotation "
+            log.debug("Enabling automatic solar differential rotation "
                       f"('{rotation_model}') for any changes in obstime")
             _autoapply_diffrot = rotation_model
             yield
         finally:
             if not old_autoapply_diffrot:
-                log.debug("Disable automatic solar differential rotation "
+                log.debug("Disabling automatic solar differential rotation "
                           "for any changes in obstime")
             _autoapply_diffrot = old_autoapply_diffrot
 

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -96,6 +96,20 @@ def transform_with_sun_center():
     "follow" the translational motion of the center of Sun, thus maintaining the position of the
     coordinate relative to the center of the Sun.
 
+    Notes
+    -----
+    This context manager accounts only for the motion of the center of the Sun, i.e.,
+    translational motion.  The motion of solar features due to any rotation of the Sun about its
+    rotational axis is not accounted for.
+
+    Due to the implementation approach, this context manager modifies transformations between only
+    these five coordinate frames:
+    `~sunpy.coordinates.frames.HeliographicStonyhurst`,
+    `~sunpy.coordinates.frames.HeliographicCarrington`,
+    `~sunpy.coordinates.frames.HeliocentricInertial`,
+    `~sunpy.coordinates.frames.Heliocentric`, and
+    `~sunpy.coordinates.frames.Helioprojective`.
+
     Examples
     --------
     >>> from astropy.coordinates import SkyCoord
@@ -114,20 +128,6 @@ def transform_with_sun_center():
     ...     sun_center.transform_to(end_frame)  # now following Sun center
     <SkyCoord (HeliographicStonyhurst: obstime=2001-02-01T00:00:00.000, rsun=695700.0 km): (lon, lat, radius) in (deg, deg, AU)
         (0., 0., 0.)>
-
-    Notes
-    -----
-    This context manager accounts only for the motion of the center of the Sun, i.e.,
-    translational motion.  The motion of solar features due to any rotation of the Sun about its
-    rotational axis is not accounted for.
-
-    Due to the implementation approach, this context manager modifies transformations between only
-    these five coordinate frames:
-    `~sunpy.coordinates.frames.HeliographicStonyhurst`,
-    `~sunpy.coordinates.frames.HeliographicCarrington`,
-    `~sunpy.coordinates.frames.HeliocentricInertial`,
-    `~sunpy.coordinates.frames.Heliocentric`, and
-    `~sunpy.coordinates.frames.Helioprojective`.
     """
     try:
         global _ignore_sun_motion
@@ -148,20 +148,66 @@ def transform_with_sun_center():
 def propagate_with_solar_surface(rotation_model='howard'):
     """
     Context manager for coordinate transformations to automatically apply solar
-    differential rotation for any change in obstime.
+    differential rotation for any change in observation time.
 
-    This context manager also ignores the motion of the center of the Sun (see
-    :func:`~sunpy.coordinates.transformations.transform_with_sun_center`).
+    Normally, coordinates refer to a point in inertial space (relative to the
+    barycenter of the solar system).  Transforming to a different observation time
+    does not move the point at all, but rather only updates the coordinate
+    representation as needed for the origin and axis orientations at the new
+    observation time.
+
+    Under this context manager, transformations will instead treat the coordinate
+    as if it were referring to a point on the solar surface instead of a point in
+    inertial space.  If a transformation has a change in observation time, the
+    heliographic longitude of the point will be updated according to the specified
+    rotation model.
+
+    Parameters
+    ----------
+    rotation_model : `str`
+        Accepted model names are ``'howard'`` (default), ``'snodgrass'``,
+        ``'allen'``, and ``'rigid'``.  See the documentation for
+        :func:`~sunpy.physics.differential_rotation.diff_rot` for the differences
+        between these models.
 
     Notes
     -----
-    Due to the implementation approach, this context manager modifies transformations
-    between only these five coordinate frames:
+    This context manager also ignores the motion of the center of the Sun (see
+    :func:`~sunpy.coordinates.transformations.transform_with_sun_center`).
+
+    Due to the implementation approach, this context manager modifies
+    transformations between only these five coordinate frames:
     `~sunpy.coordinates.frames.HeliographicStonyhurst`,
     `~sunpy.coordinates.frames.HeliographicCarrington`,
     `~sunpy.coordinates.frames.HeliocentricInertial`,
     `~sunpy.coordinates.frames.Heliocentric`, and
     `~sunpy.coordinates.frames.Helioprojective`.
+
+    Examples
+    --------
+
+    .. minigallery:: sunpy.coordinates.propagate_with_solar_surface
+
+    >>> import astropy.units as u
+    >>> from astropy.coordinates import SkyCoord
+    >>> from sunpy.coordinates import HeliocentricInertial, propagate_with_solar_surface
+    >>> meridian = SkyCoord(0*u.deg, [-60, -30, 0, 30, 60]*u.deg, 1*u.AU,
+    ...                     frame=HeliocentricInertial, obstime='2021-09-15')
+    >>> out_frame = HeliocentricInertial(obstime='2021-09-21')
+    >>> with propagate_with_solar_surface():
+    ...     print(meridian.transform_to(out_frame))
+    <SkyCoord (HeliocentricInertial: obstime=2021-09-21T00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
+        [(70.24182965, -60., 1.),
+         (82.09298036, -30., 1.),
+         (85.9579703 ,   0., 1.),
+         (82.09298036,  30., 1.),
+         (70.24182965,  60., 1.)]>
+    >>> with propagate_with_solar_surface(rotation_model='rigid'):
+    ...     print(meridian.transform_to(out_frame))
+    <SkyCoord (HeliocentricInertial: obstime=2021-09-21T00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
+        [(85.1064, -60., 1.), (85.1064, -30., 1.),
+         (85.1064,   0., 1.), (85.1064,  30., 1.),
+         (85.1064,  60., 1.)]>
     """
     with transform_with_sun_center():
         try:


### PR DESCRIPTION
Working with `RotatedSunFrame` is sometimes confusing – even for me!  This PR provides a context manager such that "all" transformations with a change in `obstime` will automatically apply solar differential rotation for the difference in time.

```python
>>> import astropy.units as u
>>> from astropy.coordinates import SkyCoord

>>> import sunpy.map
>>> from sunpy.coordinates import Helioprojective, propagate_with_solar_surface
>>> from sunpy.data.sample import AIA_171_IMAGE

>>> aiamap = sunpy.map.Map(AIA_171_IMAGE)

# HPC frame and disk center for 4 days in the past for an Earth observer

>>> past_frame = Helioprojective(observer='earth', obstime=aiamap.date - 4*u.day)
>>> disk_center = SkyCoord(0*u.arcsec, 0*u.arcsec, frame=past_frame)

# Without the context manager, the past disk center is slightly to the east at the present time
# because its position is changed due only to the observer having moved in heliographic longitude

>>> print(disk_center.transform_to(aiamap.coordinate_frame))
<SkyCoord (Helioprojective: obstime=2011-06-07T06:33:02.770, rsun=696000.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.770, rsun=696000.0 km): (lon, lat, radius) in (deg, deg, m)
    (-0.00406308, 0.04787238, 1.51846026e+11)>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
    (-59.8859642, -7.85599737, 1.01036752)>

# With the context manager, the disk center has moved to the west after 4 days of solar rotation

>>> with propagate_with_solar_surface():
...     print(disk_center.transform_to(aiamap.coordinate_frame))
<SkyCoord (Helioprojective: obstime=2011-06-07T06:33:02.770, rsun=696000.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.770, rsun=696000.0 km): (lon, lat, radius) in (deg, deg, m)
    (-0.00406308, 0.04787238, 1.51846026e+11)>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
    (761.80116918, -7.86144802, 1.01226939)>
```

This context manager can also be used to achieve all of the plotting stuff in #5081 with an equally clean API, but now without having to hack WCSAxes.

## To do
- [x] Add test(s)
- [x] Add example(s)