### PR TITLE
updated vso example with a more complex double query

### DIFF
--- a/examples/acquiring_data/searching_vso.py
+++ b/examples/acquiring_data/searching_vso.py
@@ -41,3 +41,15 @@ result = Fido.search(a.Time('2020/03/04 00:00', '2020/03/04 00:02'),
                      a.Instrument.aia,
                      a.Wavelength(171*u.angstrom) | a.Wavelength(94*u.angstrom))
 print(result)
+
+###############################################################################
+# We can even combine entire queries in this manner.
+# Here we will define two searches for the AIA and HMI data.
+# But unlike other examples, we have to ``&`` the individual queries.
+
+search_aia = (a.Time('2020/03/04 00:00', '2020/03/04 00:01') & a.Instrument.aia)
+search_hmi = (a.Time('2020/03/04 00:00', '2020/03/04 00:01')
+              & a.Instrument.hmi & a.Physobs.los_magnetic_field)
+
+result = Fido.search(search_aia | search_hmi)
+print(result)


### PR DESCRIPTION
Fixes #1441

Output from the new section of the example.

```python
Results from 2 Providers:

41 Results from the VSOClient:
       Start Time               End Time        Source Instrument  Wavelength [2]  Provider  Physobs  Wavetype Extent Width Extent Length Extent Type   Size                              Info                          
                                                                      Angstrom                                                                         Mibyte                                                           
----------------------- ----------------------- ------ ---------- ---------------- -------- --------- -------- ------------ ------------- ----------- -------- ---------------------------------------------------------
2020-03-04 00:00:00.000 2020-03-04 00:00:01.000    SDO        AIA   335.0 .. 335.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.901 exposure] [100.00 percentd]
2020-03-04 00:00:04.000 2020-03-04 00:00:05.000    SDO        AIA   193.0 .. 193.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.000 exposure] [100.00 percentd]
2020-03-04 00:00:05.000 2020-03-04 00:00:06.000    SDO        AIA   304.0 .. 304.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.902 exposure] [100.00 percentd]
2020-03-04 00:00:05.000 2020-03-04 00:00:06.000    SDO        AIA 4500.0 .. 4500.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [0.300 exposure] [100.00 percentd]
2020-03-04 00:00:06.000 2020-03-04 00:00:07.000    SDO        AIA   131.0 .. 131.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.901 exposure] [100.00 percentd]
2020-03-04 00:00:09.000 2020-03-04 00:00:10.000    SDO        AIA   171.0 .. 171.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.000 exposure] [100.00 percentd]
2020-03-04 00:00:09.000 2020-03-04 00:00:10.000    SDO        AIA   211.0 .. 211.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.901 exposure] [100.00 percentd]
2020-03-04 00:00:11.000 2020-03-04 00:00:12.000    SDO        AIA     94.0 .. 94.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.901 exposure] [100.00 percentd]
                    ...                     ...    ...        ...              ...      ...       ...      ...          ...           ...         ...      ...                                                       ...
2020-03-04 00:00:52.000 2020-03-04 00:00:53.000    SDO        AIA 1700.0 .. 1700.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [1.000 exposure] [100.00 percentd]
2020-03-04 00:00:52.000 2020-03-04 00:00:53.000    SDO        AIA   193.0 .. 193.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.000 exposure] [100.00 percentd]
2020-03-04 00:00:53.000 2020-03-04 00:00:54.000    SDO        AIA   304.0 .. 304.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.902 exposure] [100.00 percentd]
2020-03-04 00:00:54.000 2020-03-04 00:00:55.000    SDO        AIA   131.0 .. 131.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.901 exposure] [100.00 percentd]
2020-03-04 00:00:57.000 2020-03-04 00:00:58.000    SDO        AIA   171.0 .. 171.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.000 exposure] [100.00 percentd]
2020-03-04 00:00:57.000 2020-03-04 00:00:58.000    SDO        AIA   211.0 .. 211.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.901 exposure] [100.00 percentd]
2020-03-04 00:00:59.000 2020-03-04 00:01:00.000    SDO        AIA     94.0 .. 94.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.901 exposure] [100.00 percentd]
2020-03-04 00:01:00.000 2020-03-04 00:01:01.000    SDO        AIA   335.0 .. 335.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844 AIA level 1, 4096x4096 [2.901 exposure] [100.00 percentd]
Length = 41 rows

1 Results from the VSOClient:
       Start Time               End Time        Source Instrument  Wavelength [2]  Provider      Physobs       Wavetype Extent Width Extent Length Extent Type   Size          Info       
                                                                      Angstrom                                                                                  Mibyte                    
----------------------- ----------------------- ------ ---------- ---------------- -------- ------------------ -------- ------------ ------------- ----------- -------- ------------------
2020-03-04 00:00:26.000 2020-03-04 00:00:27.000    SDO        HMI 6173.0 .. 6174.0     JSOC LOS_magnetic_field   NARROW         4096          4096    FULLDISK -0.00098 45sec. Magnetogram
```