### PR TITLE
Minor `superpixel()` fixes

### DIFF
--- a/changelog/5301.bugfix.1.rst
+++ b/changelog/5301.bugfix.1.rst
@@ -1,0 +1,3 @@
+Inputs to the ``dimensions`` and ``offset`` arguments to
+:meth:`sunpy.map.GenericMap.superpixel` in units other than ``u.pix``
+(e.g. ```u.kpix``) are now handled correctly.

--- a/changelog/5301.bugfix.rst
+++ b/changelog/5301.bugfix.rst
@@ -1,0 +1,4 @@
+Fractional inputs to the ``dimensions`` and ``offset`` arguments to
+:meth:`sunpy.map.GenericMap.superpixel` were previously rounded using :func:`int`
+in the superpixel algorithm, but not assigned integer values in the new meatadata.
+This has now been changed so the rounding is correctly reflected in the meatadata.

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -699,6 +699,25 @@ def test_superpixel(aia171_test_map, aia171_test_map_with_mask):
         int((aia171_test_map.dimensions[1] / dimensions[1]).value) * u.pix - 1 * u.pix)
 
 
+def test_superpixel_units(generic_map):
+    new_dims = (2, 2) * u.pix
+    super1 = generic_map.superpixel(new_dims)
+    super2 = generic_map.superpixel(new_dims.to(u.kpix))
+    assert super1.meta == super2.meta
+
+    offset = (1, 2) * u.pix
+    super1 = generic_map.superpixel(new_dims, offset=offset)
+    super2 = generic_map.superpixel(new_dims, offset=offset.to(u.kpix))
+    assert super1.meta == super2.meta
+
+
+def test_superpixel_fractional_inputs(generic_map):
+    super1 = generic_map.superpixel((2, 3) * u.pix)
+    super2 = generic_map.superpixel((2.2, 3.2) * u.pix)
+    assert np.all(super1.data == super2.data)
+    assert super1.meta == super2.meta
+
+
 def test_superpixel_err(generic_map):
     with pytest.raises(ValueError, match="Offset is strictly non-negative."):
         generic_map.superpixel((2, 2) * u.pix, offset=(-2, 2) * u.pix)


### PR DESCRIPTION
1. `reshape_image_to_4d_superpixel()` internally uses `int()` to round `dimensions` and `offset`, but this rounding wasn't applied to the actual values given to `superpixel()`, which could result in fractional values in metadata. Now the rounding is done explicitly in `superpixel()`, and mentioned in the docstring.
2. Change some `.value` calls to `.to_value()`, to make different units (e.g. milli-pixels) work properly.

This is pulled out of https://github.com/sunpy/sunpy/pull/5295 for easier review.