### PR TITLE
Remove runtime use of assert_quantity_allclose

### DIFF
--- a/changelog/5305.bugfix.rst
+++ b/changelog/5305.bugfix.rst
@@ -1,0 +1,2 @@
+Remove runtime use of `astropy.tests.helper.assert_quantity_allclose` which
+introduces a runtime dependancy on `pytest`.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -22,7 +22,6 @@ from astropy.coordinates.builtin_frames.utils import get_jd12
 from astropy.coordinates.representation import CartesianRepresentation, SphericalRepresentation
 # Import erfa via astropy to make sure we are using the same ERFA library as Astropy
 from astropy.coordinates.sky_coordinate import erfa
-from astropy.tests.helper import quantity_allclose
 from astropy.time import Time
 
 from sunpy import log
@@ -132,7 +131,7 @@ def carrington_rotation_time(crot, longitude: u.deg = None):
     """
     crot = crot << u.one
     if longitude is not None:
-        if not quantity_allclose(crot%1, 0):
+        if not u.allclose(crot%1, 0):
             raise ValueError("Carrington rotation number(s) must be integral if `longitude` is provided.")
         if (longitude <= 0*u.deg).any() or (longitude > 360*u.deg).any():
             raise ValueError("Carrington longitude(s) must be > 0 degrees and <= 360 degrees.")


### PR DESCRIPTION
Introduces a runtime dep on pytest, so must be avoided