### PR TITLE
Improve error message when trying to parse an unkonwn file with tseries

### DIFF
--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -471,11 +471,11 @@ class TestTimeSeries:
 
     def test_invalid_file(self):
         invalid_filepath = os.path.join(filepath, 'annotation_ppt.db')
-        with pytest.raises(TypeError):
+        with pytest.raises(NoMatchError):
             sunpy.timeseries.TimeSeries(invalid_filepath)
         # Now with silence_errors kwarg set
-        with pytest.raises(TypeError):
-            sunpy.timeseries.TimeSeries(invalid_filepath, silence_errors=True)
+        ts = sunpy.timeseries.TimeSeries(invalid_filepath, silence_errors=True)
+        assert ts == []
 
     def test_validate_units(self):
         valid_units = OrderedDict(

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -16,6 +16,7 @@ from astropy.table import Column, Table
 from sunpy import config
 from sunpy.time import TimeRange
 from sunpy.timeseries import TimeSeriesMetaData
+from sunpy.util.datatype_factory_base import NoMatchError
 from sunpy.util.exceptions import SunpyUserWarning
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
@@ -698,4 +699,4 @@ class GenericTimeSeries:
         filepath : `str`
             The path to the file you want to parse.
         """
-        return NotImplemented
+        raise NoMatchError(f'Could not find any timeseries sources to parse {filepath}')


### PR DESCRIPTION
I think this seems to be the nicest way to tell a user that we don't have any sources for their file.

Before:
```python
Traceback (most recent call last):
  File "/Users/dstansby/github/sunpy/tseries_test.py", line 3, in <module>
    TimeSeries('/Users/dstansby/Downloads/before.png')
  File "/Users/dstansby/github/sunpy/sunpy/timeseries/timeseries_factory.py", line 406, in __call__
    new_ts = self._check_registered_widgets(filepath=filepath, **kwargs)
  File "/Users/dstansby/github/sunpy/sunpy/timeseries/timeseries_factory.py", line 530, in _check_registered_widgets
    data, meta, units = WidgetType._parse_file(filepath)
```

After:
```python
Traceback (most recent call last):
  File "/Users/dstansby/github/sunpy/tseries_test.py", line 3, in <module>
    TimeSeries('/Users/dstansby/Downloads/before.png')
  File "/Users/dstansby/github/sunpy/sunpy/timeseries/timeseries_factory.py", line 406, in __call__
    new_ts = self._check_registered_widgets(filepath=filepath, **kwargs)
  File "/Users/dstansby/github/sunpy/sunpy/timeseries/timeseries_factory.py", line 530, in _check_registered_widgets
    data, meta, units = WidgetType._parse_file(filepath)
  File "/Users/dstansby/github/sunpy/sunpy/timeseries/timeseriesbase.py", line 701, in _parse_file
    raise RuntimeError(f'Could not find any timeseries sources to parse {filepath}')
RuntimeError: Could not find any timeseries sources to parse /Users/dstansby/Downloads/before.png
```