### PR TITLE
Re-enable the JPL HORIZONS consistency unit test

### DIFF
--- a/changelog/5314.trivial.rst
+++ b/changelog/5314.trivial.rst
@@ -1,0 +1,1 @@
+Re-enabled the unit test to check for coordinates consistency with JPL HORIZONS when the matching ephemeris can be specified.

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ visualization =
 tests =
   jplephem  # For some coordinates tests
   pytest-astropy>=0.8  # 0.8 is the first release to include filter-subpackage
+  hypothesis>=6.0.0  # Included in pytest-astropy. 6.0 is the first version to support disabling function-scoped fixture warning
   pytest-doctestplus>=0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
   pytest-mock
   pytest-mpl>=0.12 # First version to support our figure tests

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -1,6 +1,6 @@
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 
 import astropy.units as u
 from astropy.constants import c as speed_of_light
@@ -131,37 +131,35 @@ def test_get_horizons_coord_dict_time():
     assert_quantity_allclose(e.radius, e_ref.radius)
 
 
+@pytest.fixture
 @pytest.mark.remote_data
-class TestUsingDE440s:
-    # This class is for test functions that need the Astropy ephemeris to be set to DE440s
-
-    # get_horizons_coord() depends on astroquery
+def use_DE440s():
+    # This class is for test functions that need the Astropy ephemeris to be set to DE432s
     pytest.importorskip("astroquery")
 
-    @classmethod
-    def setup_class(cls):
-        cls.old_ephemeris = solar_system_ephemeris.get()
-        try:
-            solar_system_ephemeris.set('de440s')
-        except ValueError:
-            pytest.skip("The installed version of Astropy cannot set the ephemeris to DE440s")
+    old_ephemeris = solar_system_ephemeris.get()
+    try:
+        solar_system_ephemeris.set('de440s')
+    except ValueError:
+        pytest.skip("The installed version of Astropy cannot set the ephemeris to DE440s")
 
-    @classmethod
-    def teardown_class(cls):
-        solar_system_ephemeris.set(cls.old_ephemeris)
+    yield
 
-    @given(obstime=times())
-    @settings(deadline=5000, max_examples=10)
-    def test_consistency_with_horizons(self, obstime):
-        # Check that the high-accuracy Astropy ephemeris has been set
-        assert solar_system_ephemeris.get() == 'de440s'
+    solar_system_ephemeris.set(old_ephemeris)
 
-        # Check whether the location of Earth is the same between Astropy and JPL HORIZONS
-        e1 = get_earth(obstime)
-        e2 = get_horizons_coord('Geocenter', obstime)
-        assert_quantity_allclose(e2.separation_3d(e1), 0*u.km, atol=50*u.m)
 
-        # Check whether the location of Mars is the same between Astropy and JPL HORIZONS
-        e1 = get_body_heliographic_stonyhurst('mars', obstime)
-        e2 = get_horizons_coord('Mars barycenter', obstime)
-        assert_quantity_allclose(e2.separation_3d(e1), 0*u.km, atol=500*u.m)
+@given(obstime=times())
+@settings(deadline=5000, max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_consistency_with_horizons(use_DE440s, obstime):
+    # Check that the high-accuracy Astropy ephemeris has been set
+    assert solar_system_ephemeris.get() == 'de440s'
+
+    # Check whether the location of Earth is the same between Astropy and JPL HORIZONS
+    e1 = get_earth(obstime)
+    e2 = get_horizons_coord('Geocenter', obstime)
+    assert_quantity_allclose(e2.separation_3d(e1), 0*u.km, atol=50*u.m)
+
+    # Check whether the location of Mars is the same between Astropy and JPL HORIZONS
+    e1 = get_body_heliographic_stonyhurst('mars', obstime)
+    e2 = get_horizons_coord('Mars barycenter', obstime)
+    assert_quantity_allclose(e2.separation_3d(e1), 0*u.km, atol=500*u.m)

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -132,7 +132,6 @@ def test_get_horizons_coord_dict_time():
 
 
 @pytest.fixture
-@pytest.mark.remote_data
 def use_DE440s():
     # This class is for test functions that need the Astropy ephemeris to be set to DE432s
     pytest.importorskip("astroquery")
@@ -148,6 +147,7 @@ def use_DE440s():
     solar_system_ephemeris.set(old_ephemeris)
 
 
+@pytest.mark.remote_data
 @given(obstime=times())
 @settings(deadline=5000, max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_consistency_with_horizons(use_DE440s, obstime):

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -132,8 +132,8 @@ def test_get_horizons_coord_dict_time():
 
 
 @pytest.mark.remote_data
-class TestUsingDE432s:
-    # This class is for test functions that need the Astropy ephemeris to be set to DE432s
+class TestUsingDE440s:
+    # This class is for test functions that need the Astropy ephemeris to be set to DE440s
 
     # get_horizons_coord() depends on astroquery
     pytest.importorskip("astroquery")
@@ -141,19 +141,20 @@ class TestUsingDE432s:
     @classmethod
     def setup_class(cls):
         cls.old_ephemeris = solar_system_ephemeris.get()
-        solar_system_ephemeris.set('de432s')
+        try:
+            solar_system_ephemeris.set('de440s')
+        except ValueError:
+            pytest.skip("The installed version of Astropy cannot set the ephemeris to DE440s")
 
     @classmethod
     def teardown_class(cls):
         solar_system_ephemeris.set(cls.old_ephemeris)
 
-    @pytest.mark.xfail(reason="JPL HORIZONS is using a newer ephemeris (DE441) than the latest "
-                              "available through Astropy (DE430/DE432s)")
     @given(obstime=times())
     @settings(deadline=5000, max_examples=10)
     def test_consistency_with_horizons(self, obstime):
         # Check that the high-accuracy Astropy ephemeris has been set
-        assert solar_system_ephemeris.get() == 'de432s'
+        assert solar_system_ephemeris.get() == 'de440s'
 
         # Check whether the location of Earth is the same between Astropy and JPL HORIZONS
         e1 = get_earth(obstime)


### PR DESCRIPTION
Now that astropy/astropy#11601 has made the JPL DE440s ephemeris available, we can re-enable the JPL HORIZONS consistency unit test that was disabled in #5203.  The test will be skipped if the installed version of Astropy is not aware of DE440s.