### PR TITLE
Support observers defined in obsgeo in wcs_utils

### DIFF
--- a/changelog/5315.feature.rst
+++ b/changelog/5315.feature.rst
@@ -1,0 +1,3 @@
+Add support for parsing the observer location from a `~astropy.wcs.WCS` object
+when using the 'OBSGEO' formulation. This is the recommended way to define the
+observer location of a ground based observer.

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 import astropy.units as u
-from astropy.coordinates import ITRS, BaseCoordinateFrame
+from astropy.coordinates import ITRS, BaseCoordinateFrame, SkyCoord
 from astropy.coordinates.earth import EarthLocation
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
@@ -275,7 +275,8 @@ def dkist_location():
     return EarthLocation(*(-5466045.25695494, -2404388.73741278, 2242133.88769004) * u.m)
 
 
-def test_obsgeo_cartesian(dkist_location):
+@pytest.mark.remote_data
+def test_obsgeo_frame_mapping_cartesian(dkist_location, caplog):
 
     obstime = Time("2021-05-21T03:00:00")
     wcs = WCS(naxis=2)
@@ -289,8 +290,11 @@ def test_obsgeo_cartesian(dkist_location):
 
     assert frame.observer == SkyCoord(dkist_location.get_itrs(obstime)).transform_to('heliographic_stonyhurst').frame
 
+    assert not caplog.records
 
-def test_obsgeo_spherical(dkist_location):
+
+@pytest.mark.remote_data
+def test_frame_mapping_obsgeo_spherical(dkist_location, caplog):
 
     obstime = Time("2021-05-21T03:00:00")
     location = dkist_location.get_itrs(obstime)
@@ -305,6 +309,8 @@ def test_obsgeo_spherical(dkist_location):
     assert frame.observer is not None
 
     assert frame.observer == SkyCoord(location).transform_to('heliographic_stonyhurst').frame
+
+    assert not caplog.records
 
 
 # TODO: Remove all these tests after Astropy 5.0 when we can just import obsgeo_to_frame.

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -317,7 +317,8 @@ def test_frame_mapping_obsgeo_spherical(dkist_location, caplog):
 def test_obsgeo_cartesian(dkist_location):
     obstime = Time("2021-05-21T03:00:00")
     wcs = WCS(naxis=2)
-    wcs.wcs.obsgeo = dkist_location.to_value(u.m).tolist() + [0, 0, 0]
+    # tolist() returns a tuple.
+    wcs.wcs.obsgeo = list(dkist_location.to_value(u.m).tolist()) + [0, 0, 0]
     wcs.wcs.dateobs = obstime.isot
 
     frame = obsgeo_to_frame(wcs.wcs.obsgeo, obstime)

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -301,7 +301,7 @@ def test_frame_mapping_obsgeo_spherical(dkist_location, caplog):
     loc_sph = location.spherical
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = ['HPLT', 'HPLN']
-    wcs.wcs.obsgeo = [0, 0, 0] + [loc_sph.lon.value, loc_sph.lat.value, loc_sph.distance.value]
+    wcs.wcs.obsgeo = [0, 0, 0] + [loc_sph.lon.to_value(u.deg), loc_sph.lat.to_value(u.deg), loc_sph.distance.to_value(u.m)]
     wcs.wcs.dateobs = obstime.isot
 
     frame = solar_wcs_frame_mapping(wcs)
@@ -317,7 +317,7 @@ def test_frame_mapping_obsgeo_spherical(dkist_location, caplog):
 def test_obsgeo_cartesian(dkist_location):
     obstime = Time("2021-05-21T03:00:00")
     wcs = WCS(naxis=2)
-    wcs.wcs.obsgeo = list(dkist_location.to_value(u.m).tolist()) + [0, 0, 0]
+    wcs.wcs.obsgeo = dkist_location.to_value(u.m).tolist() + [0, 0, 0]
     wcs.wcs.dateobs = obstime.isot
 
     frame = obsgeo_to_frame(wcs.wcs.obsgeo, obstime)
@@ -334,7 +334,7 @@ def test_obsgeo_spherical(dkist_location):
     loc_sph = dkist_location.spherical
 
     wcs = WCS(naxis=2)
-    wcs.wcs.obsgeo = [0, 0, 0] + [loc_sph.lon.value, loc_sph.lat.value, loc_sph.distance.value]
+    wcs.wcs.obsgeo = [0, 0, 0] + [loc_sph.lon.to_value(u.deg), loc_sph.lat.to_value(u.deg), loc_sph.distance.to_value(u.m)]
     wcs.wcs.dateobs = obstime.isot
 
     frame = obsgeo_to_frame(wcs.wcs.obsgeo, obstime)
@@ -345,7 +345,7 @@ def test_obsgeo_spherical(dkist_location):
     assert u.allclose(frame.z, dkist_location.z)
 
 
-def test_obsgeo_infinite(dkist_location):
+def test_obsgeo_nonfinite(dkist_location):
     obstime = Time("2021-05-21T03:00:00")
     dkist_location = dkist_location.get_itrs(obstime)
     loc_sph = dkist_location.spherical

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -269,6 +269,7 @@ def test_self_observer():
     assert u.allclose(wcs.wcs.aux.dsun_obs, frame.radius.to_value(u.m))
 
 
+@pytest.mark.remote_data
 def test_obsgeo_cartesian():
 
     obstime = Time("2021-05-21T03:00:00")
@@ -285,6 +286,7 @@ def test_obsgeo_cartesian():
     assert frame.observer == SkyCoord(location.get_itrs(obstime)).transform_to('heliographic_stonyhurst').frame
 
 
+@pytest.mark.remote_data
 def test_obsgeo_spherical():
 
     obstime = Time("2021-05-21T03:00:00")

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 import astropy.units as u
-from astropy.coordinates import BaseCoordinateFrame, SkyCoord
+from astropy.coordinates import ITRS, BaseCoordinateFrame
 from astropy.coordinates.earth import EarthLocation
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
@@ -18,6 +18,7 @@ from sunpy.coordinates.frames import (
 )
 from sunpy.coordinates.wcs_utils import (
     _set_wcs_aux_obs_coord,
+    obsgeo_to_frame,
     solar_frame_to_wcs_mapping,
     solar_wcs_frame_mapping,
 )
@@ -269,45 +270,63 @@ def test_self_observer():
     assert u.allclose(wcs.wcs.aux.dsun_obs, frame.radius.to_value(u.m))
 
 
-@pytest.mark.remote_data
-def test_obsgeo_cartesian():
+# TODO: Remove all these tests after Astropy 5.0 when we can just import obsgeo_to_frame.
+@pytest.fixture
+def dkist_location():
+    return EarthLocation(*(-5466045.25695494, -2404388.73741278, 2242133.88769004) * u.m)
 
+
+def test_obsgeo_cartesian(dkist_location):
     obstime = Time("2021-05-21T03:00:00")
-    location = EarthLocation.of_site("DKIST")
     wcs = WCS(naxis=2)
-    wcs.wcs.ctype = ['HPLT', 'HPLN']
-    wcs.wcs.obsgeo = list(location.to_value(u.m).tolist()) + [0, 0, 0]
+    wcs.wcs.obsgeo = list(dkist_location.to_value(u.m).tolist()) + [0, 0, 0]
     wcs.wcs.dateobs = obstime.isot
 
-    frame = solar_wcs_frame_mapping(wcs)
+    frame = obsgeo_to_frame(wcs.wcs.obsgeo, obstime)
 
-    assert frame.observer is not None
+    assert isinstance(frame, ITRS)
+    assert frame.x == dkist_location.x
+    assert frame.y == dkist_location.y
+    assert frame.z == dkist_location.z
 
-    assert frame.observer == SkyCoord(location.get_itrs(obstime)).transform_to('heliographic_stonyhurst').frame
 
-
-@pytest.mark.remote_data
-def test_obsgeo_spherical():
-
+def test_obsgeo_spherical(dkist_location):
     obstime = Time("2021-05-21T03:00:00")
-    location = EarthLocation.of_site("DKIST").get_itrs(obstime)
-    loc_sph = location.spherical
+    dkist_location = dkist_location.get_itrs(obstime)
+    loc_sph = dkist_location.spherical
+
     wcs = WCS(naxis=2)
-    wcs.wcs.ctype = ['HPLT', 'HPLN']
     wcs.wcs.obsgeo = [0, 0, 0] + [loc_sph.lon.value, loc_sph.lat.value, loc_sph.distance.value]
     wcs.wcs.dateobs = obstime.isot
 
-    frame = solar_wcs_frame_mapping(wcs)
+    frame = obsgeo_to_frame(wcs.wcs.obsgeo, obstime)
 
-    assert frame.observer is not None
+    assert isinstance(frame, ITRS)
+    assert u.allclose(frame.x, dkist_location.x)
+    assert u.allclose(frame.y, dkist_location.y)
+    assert u.allclose(frame.z, dkist_location.z)
 
-    assert frame.observer == SkyCoord(location).transform_to('heliographic_stonyhurst').frame
 
+def test_obsgeo_infinite(dkist_location):
+    obstime = Time("2021-05-21T03:00:00")
+    dkist_location = dkist_location.get_itrs(obstime)
+    loc_sph = dkist_location.spherical
 
-def test_obsgeo_invalid():
     wcs = WCS(naxis=2)
-    wcs.wcs.ctype = ['HPLT', 'HPLN']
-    wcs.wcs.obsgeo = [0, 2, 0, 0, 2, 0]
+    wcs.wcs.obsgeo = [1, 1, np.nan] + [loc_sph.lon.value, loc_sph.lat.value, loc_sph.distance.value]
+    wcs.wcs.dateobs = obstime.isot
+    wcs.wcs.set()
 
-    with pytest.raises(SunpyUserWarning):
-        solar_wcs_frame_mapping(wcs)
+    frame = obsgeo_to_frame(wcs.wcs.obsgeo, obstime)
+
+    assert isinstance(frame, ITRS)
+    assert u.allclose(frame.x, dkist_location.x)
+    assert u.allclose(frame.y, dkist_location.y)
+    assert u.allclose(frame.z, dkist_location.z)
+
+
+@pytest.mark.parametrize("obsgeo", ([np.nan] * 6, None, [0] * 6, [54] * 5))
+def test_obsgeo_invalid(obsgeo):
+
+    with pytest.raises(ValueError):
+        obsgeo_to_frame(obsgeo, None)

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -83,7 +83,10 @@ def solar_wcs_frame_mapping(wcs):
                              **kwargs)
 
     # Read the observer out of obsgeo for ground based observers
-    if observer is None and wcs.wcs.obsgeo is not None and not np.all(wcs.wcs.obsgeo == 0):
+    if observer is None and (
+            wcs.wcs.obsgeo is not None
+            and not np.all(wcs.wcs.obsgeo == 0)
+            and not np.all(~np.isfinite(wcs.wcs.obsgeo))):
         data = None
 
         # If the spherical coords are zero then use the cartesian ones
@@ -96,7 +99,7 @@ def solar_wcs_frame_mapping(wcs):
 
         # Anything else is undefined
         else:
-            warnings.warn("Can not parse the obsgeo observer information in this header. "
+            warnings.warn(f"Can not parse the obsgeo observer information in this header. ({wcs.wcs.obsgeo})"
                           "obsgeo must only be sepecifed in Cartesian or spherical coordinates.",
                           SunpyUserWarning)
 


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

Adds support for reading observer locations out of obsgeo for ground based observers.
