### PR TITLE
Bump to support towncrier 21.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ build-backend = 'setuptools.build_meta'
     filename = "CHANGELOG.rst"
     directory = "changelog/"
     issue_format = "`#{issue} <https://github.com/sunpy/sunpy/pull/{issue}>`__"
+    title_format = "{version} ({project_date})"
 
     [[tool.towncrier.type]]
         directory = "breaking"

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ docs =
   ruamel.yaml
   sphinx
   sphinx-automodapi
-  sphinx-changelog>=1.0.0 # First to include the changelog directive
+  sphinx-changelog>=1.1.0rc1 # First to support towncrier 21.3
   sphinx-gallery>=0.9.0 # First to include the defer figures functionality
   sunpy-sphinx-theme
 


### PR DESCRIPTION
This tests the new release of sphinx-changelog which supports the new version of towncrier.

This also means that the changelog is generated without the package name prefix which slightly simplifies our release checklist.