### PR TITLE
Update self test

### DIFF
--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -5,7 +5,7 @@ Installation
 Requirements
 ============
 
-sunpy enforces a minimum Python version that you will have to use and currently that is Python 3.7 or higher.
+sunpy requires Python 3.7 or higher.
 
 Installing Scientific Python and sunpy
 ======================================
@@ -47,43 +47,11 @@ You can update to the latest version by running::
 
     conda update sunpy
 
-Testing sunpy
-=============
-
-sunpy provides a method to run the basic test suite that will check that the install has worked correctly.
-
-To do so, use the :func:`sunpy.self_test`::
-
-    import sunpy
-    sunpy.self_test()
-
-You will see something like the following in your terminal::
-
-    Starting sunpy self test...
-    Checking for packages needed to run sunpy:
-    All required and optional sunpy dependencies are installed.
-    Starting the sunpy test suite:
-    ...
-
-The tests will run and will report any fails which you can report at the `sunpy issue tracker <https://github.com/sunpy/sunpy/issues>`__ and we will strive to help.
-
-It is possible to run this command and in a situation where not all packages are installed in order to run the test suite, you will see::
-
-    Starting sunpy self test...
-    Checking for packages needed to run sunpy:
-    The following packages are not installed for the sunpy[database] requirement:
-    * sqlalchemy
-    ...
-    You do not have all the required dependencies installed to run the sunpy test suite.
-    If you want to run the sunpy tests install the 'tests' extra with `pip install sunpy[all,tests]`
-
-This should not appear under a conda install of sunpy but can under a pip install of sunpy.
-This does not mean sunpy is broken, you will need to install the extra packages to ensure a "complete" installation of sunpy.
-
 Installing sunpy on top of an existing scientific Python environment
 --------------------------------------------------------------------
 
-This section assumes you already have everything setup whether that be Conda or a Python virtual environment and that the commands are exceucted within these.
+This section assumes you already have everything setup, whether that be conda or a Python virtual environment.
+These commands are to be executed within these environments.
 
 Conda
 ^^^^^
@@ -128,3 +96,36 @@ If you want to develop sunpy we would strongly recommend reading the `Newcomers'
     This error implies you have an incorrectly configured virtual environment or it is not activated.
 
     If you really do not want to use any virtual environment, you can always do ``pip install --user sunpy``.
+
+Testing sunpy
+=============
+
+sunpy provides a method to run the basic test suite that will check that the install has worked correctly.
+
+To run the basic test suite and ensure that your sunpy install is working correctly, use the :func:`sunpy.self_test`::
+
+    import sunpy
+    sunpy.self_test()
+
+You will see something like the following in your terminal::
+
+    Starting sunpy self test...
+    Checking for packages needed to run sunpy:
+    All required and optional sunpy dependencies are installed.
+    Starting the sunpy test suite:
+    ...
+
+    The tests will run and will report any fails.  You can report these through the `sunpy issue tracker <https://github.com/sunpy/sunpy/issues>`__ and we will strive to help.
+
+It is possible to run this command in a situation where not all packages are installed. If this is the case, you will see the following when you run the test suite::
+
+    Starting sunpy self test...
+    Checking for packages needed to run sunpy:
+    The following packages are not installed for the sunpy[database] requirement:
+    * sqlalchemy
+    ...
+    You do not have all the required dependencies installed to run the sunpy test suite.
+    If you want to run the sunpy tests install the 'tests' extra with `pip install sunpy[all,tests]`
+
+This does not mean sunpy is broken, but you will need to install the extra packages to ensure a "complete" installation of sunpy and run the entire test suite.
+It is quite likely that you will run into not having the tests dependencies installed.

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -5,11 +5,7 @@ Installation
 Requirements
 ============
 
-These are the minimum versions of packages needed to install sunpy:
-
-- python 3.7
-- astropy 4.0.3
-- parfive 1.1
+sunpy enforces a minimum Python version that you will have to use and currently that is Python 3.7 or higher.
 
 Installing Scientific Python and sunpy
 ======================================
@@ -21,11 +17,10 @@ If you do not currently have a working scientific Python distribution this guide
 
 To install the Miniconda Python distribution follow the instructions at
 `here <https://docs.conda.io/en/latest/miniconda.html>`__.
-Although Miniconda makes it simple to switch between Python versions, we recommend that new users install
-the latest Python 3.x version of Miniconda as SunPy only supports Python 3.7+.
+Although Miniconda makes it simple to switch between Python versions, we recommend that new users install the latest Python 3.x version of Miniconda.
 
 The reason we choose Miniconda over Anaconda, is mainly due to the size as Anaconda comes with a full install of packages you probably do not need and this way you have more direct control over what has been installed into your Python virtual environment.
-Furthermore, you bypass the need for the conda resolver to sort out your root environment which should make "conda" faster to use.
+Furthermore, you bypass the need for the conda resolver to sort out your root environment which should make conda faster to use.
 
 Installing sunpy using Miniconda
 --------------------------------
@@ -52,8 +47,43 @@ You can update to the latest version by running::
 
     conda update sunpy
 
+Testing sunpy
+=============
+
+sunpy provides a method to run the basic test suite that will check that the install has worked correctly.
+
+To do so, use the :func:`sunpy.self_test`::
+
+    import sunpy
+    sunpy.self_test()
+
+You will see something like the following in your terminal::
+
+    Starting sunpy self test...
+    Checking for packages needed to run sunpy:
+    All required and optional sunpy dependencies are installed.
+    Starting the sunpy test suite:
+    ...
+
+The tests will run and will report any fails which you can report at the `sunpy issue tracker <https://github.com/sunpy/sunpy/issues>`__ and we will strive to help.
+
+It is possible to run this command and in a situation where not all packages are installed in order to run the test suite, you will see::
+
+    Starting sunpy self test...
+    Checking for packages needed to run sunpy:
+    The following packages are not installed for the sunpy[database] requirement:
+    * sqlalchemy
+    ...
+    You do not have all the required dependencies installed to run the sunpy test suite.
+    If you want to run the sunpy tests install the 'tests' extra with `pip install sunpy[all,tests]`
+
+This should not appear under a conda install of sunpy but can under a pip install of sunpy.
+This does not mean sunpy is broken, you will need to install the extra packages to ensure a "complete" installation of sunpy.
+
 Installing sunpy on top of an existing scientific Python environment
 --------------------------------------------------------------------
+
+This section assumes you already have everything setup whether that be Conda or a Python virtual environment and that the commands are exceucted within these.
 
 Conda
 ^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,6 @@ tests =
   pytest-mock
   pytest-mpl>=0.12 # First version to support our figure tests
   pytest-intercept-remote>=1.2
-  tox
 docs =
   astroquery
   jplephem

--- a/sunpy/tests/self_test.py
+++ b/sunpy/tests/self_test.py
@@ -52,8 +52,9 @@ def self_test(*, package=None, online=False, online_only=False, figure_only=Fals
         print("All required and optional sunpy dependencies are installed.")
     if test_missing:
         print("You do not have all the required dependencies installed to run the sunpy test suite.")
-        print(
-            "If you want to run the sunpy tests install the 'tests' extra with `pip install sunpy[all,tests]`")
+        print(list(test_missing.keys()))
+        print("If are using conda, you will want to run `conda install <package name>`")
+        print("Otherwise you will want run `pip install sunpy[all,tests]`")
         return
     import pytest
     print("Starting the sunpy test suite:")


### PR DESCRIPTION
Added back the self test text removed from #4586
Fixes #3284 (tho the work was in another PR)

This is how it now appears on conda if you do a fresh install of sunpy (plus this patch):
```python
>>> import sunpy
>>> sunpy.self_test()



Starting sunpy self test...
Checking for packages needed to run sunpy:
All required and optional sunpy dependencies are installed.
You do not have all the required dependencies installed to run the sunpy test suite.
['jplephem', 'pytest-mpl', 'hypothesis', 'pytest-mock', 'pytest-astropy', 'pytest-doctestplus']
If are using conda, you will want to run `conda install <package name>`
Otherwise you will want run `pip install sunpy[all,tests]`
```
