### PR TITLE
Error on 2D coordinate with observer='self'

### DIFF
--- a/changelog/5358.bugfix.rst
+++ b/changelog/5358.bugfix.rst
@@ -1,0 +1,3 @@
+Constructing a coordinate in the ``'heliographic_carrington'`` frame with ``observer='self'``
+but without specifying ``radius`` now raises an error upon creation. This is because a full
+3D coordinate is needed to fully define the observer.

--- a/changelog/5358.bugfix.rst
+++ b/changelog/5358.bugfix.rst
@@ -1,3 +1,2 @@
-Constructing a coordinate in the ``'heliographic_carrington'`` frame with ``observer='self'``
-but without specifying ``radius`` now raises an error upon creation. This is because a full
-3D coordinate is needed to fully define the observer.
+Constructing a 2D coordinate in the `~sunpy.coordinates.frames.HeliographicCarrington` frame with ``observer='self'`` now raises an error upon creation.
+When specifying ``observer='self'``, the ``radius`` coordinate component serves as the Sun-observer distance that is necessary to fully define the Carrington heliographic coordinates.

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -155,6 +155,11 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
         else:
             return super().__str__()
 
+    @property
+    def _is_2d(self):
+        return (self._data is not None and self._data.norm().unit is u.one
+                and u.allclose(self._data.norm(), 1*u.one))
+
 
 class BaseHeliographic(SunPyBaseCoordinateFrame):
     """
@@ -172,11 +177,6 @@ class BaseHeliographic(SunPyBaseCoordinateFrame):
     }
 
     rsun = QuantityAttribute(default=_RSUN, unit=u.km)
-
-    @property
-    def _is_2d(self):
-        return (self._data is not None and self._data.norm().unit is u.one
-                and u.allclose(self._data.norm(), 1*u.one))
 
     def make_3d(self):
         """
@@ -493,8 +493,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
             now with a third coordinate.
         """
         # Skip if we already are 3D
-        distance = self.spherical.distance
-        if not (distance.unit is u.one and u.allclose(distance, 1*u.one)):
+        if not self._is_2d:
             return self
 
         if not isinstance(self.observer, BaseCoordinateFrame):

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -427,3 +427,9 @@ def test_skycoord_hpc(args, kwargs):
         hgs = sc.transform_to("heliographic_stonyhurst")
 
     assert isinstance(hgs.frame, HeliographicStonyhurst)
+
+
+def test_hpc_incomplete_observer():
+    with pytest.raises(ValueError, match=r'Full 3D coordinate \(including radius\) must be specified'):
+        SkyCoord(0*u.deg, 0*u.deg, frame="heliographic_carrington",
+                 observer='self', obstime="2011-01-01T00:00:00")

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -429,7 +429,7 @@ def test_skycoord_hpc(args, kwargs):
     assert isinstance(hgs.frame, HeliographicStonyhurst)
 
 
-def test_hpc_incomplete_observer():
+def test_hgc_incomplete_observer():
     with pytest.raises(ValueError, match=r'Full 3D coordinate \(including radius\) must be specified'):
         SkyCoord(0*u.deg, 0*u.deg, frame="heliographic_carrington",
                  observer='self', obstime="2011-01-01T00:00:00")


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5356.  This is kind of breaking in that it now errors earlier than it would have done if you're using the faulty coordinate for anything, but is a better error, so I'm not sure where to go re. backports.