### PR TITLE
Use sphinxext-opengraph to fix og tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,9 @@ rst_epilog = """
 """
 
 # -- General configuration -----------------------------------------------------
+# sphinxext-opengraph
+ogp_image = "https://raw.githubusercontent.com/sunpy/sunpy-logo/master/generated/sunpy_logo_word.png"
+
 # Suppress warnings about overriding directives as we overload some of the
 # doctest extensions.
 suppress_warnings = ['app.add_directive', ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,6 +86,11 @@ rst_epilog = """
 # -- General configuration -----------------------------------------------------
 # sphinxext-opengraph
 ogp_image = "https://raw.githubusercontent.com/sunpy/sunpy-logo/master/generated/sunpy_logo_word.png"
+ogp_use_first_image = True
+ogp_description_length = 160
+ogp_custom_meta_tags = [
+    '<meta property="og:ignore_canonical" content="true" />',
+]
 
 # Suppress warnings about overriding directives as we overload some of the
 # doctest extensions.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,11 @@ suppress_warnings = ['app.add_directive', ]
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'matplotlib.sphinxext.plot_directive',
+    'sphinx_automodapi.automodapi',
+    'sphinx_automodapi.smart_resolver',
+    'sphinx_changelog',
+    'sphinx_gallery.gen_gallery',
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
@@ -101,13 +106,9 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
-    'matplotlib.sphinxext.plot_directive',
-    'sphinx_automodapi.automodapi',
-    'sphinx_automodapi.smart_resolver',
-    'sphinx_gallery.gen_gallery',
-    'sphinx_changelog',
     'sunpy.util.sphinx.doctest',
     'sunpy.util.sphinx.generate',
+    "sphinxext.opengraph",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ docs =
   sphinx-automodapi
   sphinx-changelog>=1.1.0rc1 # First to support towncrier 21.3
   sphinx-gallery>=0.9.0 # First to include the defer figures functionality
+  sphinxext-opengraph
   sunpy-sphinx-theme
 
 [options.packages.find]


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5362 

Will need rolling out to each package and the template. 

I tested this on our own discourse and got:
![one](https://user-images.githubusercontent.com/1392107/122619705-f6d1b400-d088-11eb-901f-93aed15ba97c.png)

Issue is that the image on the gallery examples are relative and don't work.
`<meta property="og:image" content="../../../_images/sphx_glr_downloading_lascoC2_001.png">`
Unsure if there is a setting to change with the gallery.
