### PR TITLE
Adds a pre-commit hook for prohibiting a string

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,3 +91,8 @@ repos:
         exclude: ".*(.fits|.fts|.fit|.txt|tca.*)$"
       - id: mixed-line-ending
         exclude: ".*(.fits|.fts|.fit|.txt|tca.*)$"
+  - repo: https://github.com/devanshshukla99/pre-commit-hook-prohibit-string
+    rev: v1.2
+    hooks:
+      - id: prohibit-string
+        args: [--prohibit-string, "from warnings import warn,warnings.warn,from astropy import units as u"]


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #5361 

This PR adds a pre-commit hook for banning use of certain strings in the package;

<hr>

Sample terminal output from banning ``from warnings import warn``:

```console
Check for prohibited strings.............................................Failed
- hook id: prohibit-string
- exit code: 1

tools/hektemplate.py:40: Prohibited string (from warnings import warn)
sunpy/net/helio/hec.py:6: Prohibited string (from warnings import warn)
sunpy/data/data_manager/cache.py:4: Prohibited string (from warnings import warn)

```