### PR TITLE
Use MapFactory path parsing code in TimeseriesFactory

### DIFF
--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -28,7 +28,7 @@ from sunpy.util.exceptions import NoMapsInFileError, SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.util.metadata import MetaDict
 from sunpy.util.types import DatabaseEntryType
-from sunpy.util.io import parse_path
+from sunpy.util.io import parse_path, possibly_a_path
 
 SUPPORTED_ARRAY_TYPES = (np.ndarray,)
 try:
@@ -233,7 +233,7 @@ class MapFactory(BasicRegistrationFactory):
             elif isinstance(arg, str) and _is_url(arg):
                 # Repalce URL string with a Request object to dispatch on later
                 args[i] = Request(arg)
-            elif _possibly_a_path(arg):
+            elif possibly_a_path(arg):
                 # Repalce path strings with Path objects
                 args[i] = pathlib.Path(arg)
             i += 1
@@ -391,18 +391,6 @@ def _is_url(arg):
     except Exception:
         return False
     return True
-
-
-def _possibly_a_path(arg):
-    """
-    Check if arg can be coerced into a Path object.
-    Does *not* check if the path exists.
-    """
-    try:
-        pathlib.Path(arg)
-        return True
-    except Exception:
-        return False
 
 
 class InvalidMapInput(ValueError):

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -1,9 +1,8 @@
 import os
-import glob
 import pathlib
 import warnings
 from collections import OrderedDict
-from urllib.request import Request, urlopen
+from urllib.request import Request
 
 import numpy as np
 
@@ -26,9 +25,9 @@ from sunpy.util.datatype_factory_base import (
 )
 from sunpy.util.exceptions import NoMapsInFileError, SunpyUserWarning
 from sunpy.util.functools import seconddispatch
+from sunpy.util.io import is_url, parse_path, possibly_a_path
 from sunpy.util.metadata import MetaDict
 from sunpy.util.types import DatabaseEntryType
-from sunpy.util.io import is_url, parse_path, possibly_a_path
 
 SUPPORTED_ARRAY_TYPES = (np.ndarray,)
 try:

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -28,7 +28,7 @@ from sunpy.util.exceptions import NoMapsInFileError, SunpyUserWarning
 from sunpy.util.functools import seconddispatch
 from sunpy.util.metadata import MetaDict
 from sunpy.util.types import DatabaseEntryType
-from sunpy.util.io import parse_path, possibly_a_path
+from sunpy.util.io import is_url, parse_path, possibly_a_path
 
 SUPPORTED_ARRAY_TYPES = (np.ndarray,)
 try:
@@ -230,7 +230,7 @@ class MapFactory(BasicRegistrationFactory):
                 header = args.pop(i)
                 args.insert(i, (data, header))
                 nargs -= 1
-            elif isinstance(arg, str) and _is_url(arg):
+            elif isinstance(arg, str) and is_url(arg):
                 # Repalce URL string with a Request object to dispatch on later
                 args[i] = Request(arg)
             elif possibly_a_path(arg):
@@ -383,14 +383,6 @@ class MapFactory(BasicRegistrationFactory):
         WidgetType = candidate_widget_types[0]
 
         return WidgetType(data, meta, **kwargs)
-
-
-def _is_url(arg):
-    try:
-        urlopen(arg)
-    except Exception:
-        return False
-    return True
 
 
 class InvalidMapInput(ValueError):

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -450,10 +450,10 @@ class TestTimeSeries:
 
     def test_invalid_filepath(self):
         invalid_filepath = os.path.join(filepath, 'invalid_filepath_here')
-        with pytest.raises(NoMatchError):
+        with pytest.raises(ValueError, match='Did not find any files'):
             sunpy.timeseries.TimeSeries(invalid_filepath)
         # Now with silence_errors kwarg set
-        with pytest.raises(NoMatchError):
+        with pytest.raises(ValueError, match='Did not find any files'):
             sunpy.timeseries.TimeSeries(invalid_filepath, silence_errors=True)
 
     def test_invalid_file(self):

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -2,11 +2,9 @@
 This module provies the `~sunpy.timeseries.TimeSeriesFactory` class.
 """
 import os
-import pathlib
 import copy
-import glob
+import pathlib
 from collections import OrderedDict
-from urllib.request import urlopen
 
 import numpy as np
 import pandas as pd
@@ -30,9 +28,9 @@ from sunpy.util.datatype_factory_base import (
     NoMatchError,
     ValidationFunctionError,
 )
+from sunpy.util.io import is_url, parse_path, possibly_a_path
 from sunpy.util.metadata import MetaDict
 from sunpy.util.net import download_file
-from sunpy.util.io import is_url, parse_path, possibly_a_path
 
 __all__ = ['TimeSeries', 'TimeSeriesFactory', 'NoTimeSeriesFound',
            'InvalidTimeSeriesInput', 'InvalidTimeSeriesType']

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -302,6 +302,17 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                 # Add a 3-tuple for this TimeSeries.
                 data_header_unit_tuples.append((data, meta, units))
 
+            # URL
+            elif isinstance(arg, str) and is_url(arg):
+                url = arg
+                path = download_file(url, get_and_create_download_dir())
+                results = parse_path(pathlib.Path(path), self._read_file)
+                for r in results:
+                    if isinstance(r, pathlib.Path):
+                        filepaths.append(r)
+                    else:
+                        data_header_pairs.append(r)
+
             # Filepath
             elif possibly_a_path(arg):
                 # Repalce path strings with Path objects
@@ -316,17 +327,6 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             # Already a TimeSeries
             elif isinstance(arg, GenericTimeSeries):
                 already_timeseries.append(arg)
-
-            # A URL
-            elif isinstance(arg, str) and is_url(arg):
-                url = arg
-                path = download_file(url, get_and_create_download_dir())
-                results = parse_path(path, self._read_file)
-                for r in results:
-                    if isinstance(r, pathlib.Path):
-                        filepaths.append(r)
-                    else:
-                        data_header_pairs.append(r)
 
             else:
                 raise NoMatchError("File not found or invalid input")

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -32,7 +32,7 @@ from sunpy.util.datatype_factory_base import (
 )
 from sunpy.util.metadata import MetaDict
 from sunpy.util.net import download_file
-from sunpy.util.io import parse_path, possibly_a_path
+from sunpy.util.io import is_url, parse_path, possibly_a_path
 
 __all__ = ['TimeSeries', 'TimeSeriesFactory', 'NoTimeSeriesFound',
            'InvalidTimeSeriesInput', 'InvalidTimeSeriesType']
@@ -320,8 +320,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                 already_timeseries.append(arg)
 
             # A URL
-            elif (isinstance(arg, str) and
-                  _is_url(arg)):
+            elif isinstance(arg, str) and is_url(arg):
                 url = arg
                 path = download_file(url, get_and_create_download_dir())
                 results = parse_path(path, self._read_file)
@@ -505,14 +504,6 @@ def _apply_result(data_header_pairs, filepaths, result):
         filepaths.append(result)
 
     return data_header_pairs, filepaths
-
-
-def _is_url(arg):
-    try:
-        urlopen(arg)
-    except Exception:
-        return False
-    return True
 
 
 class InvalidTimeSeriesInput(ValueError):

--- a/sunpy/util/io.py
+++ b/sunpy/util/io.py
@@ -33,6 +33,7 @@ def parse_path(path, f, **kwargs):
     elif glob.glob(str(path)):
         read_files = []
         for afile in sorted(glob.glob(str(path))):
+            afile = pathlib.Path(afile)
             read_files += f(afile, **kwargs)
         return read_files
     else:

--- a/sunpy/util/io.py
+++ b/sunpy/util/io.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import pathlib
+import urllib.request
 
 
 def parse_path(path, f, **kwargs):
@@ -68,3 +69,11 @@ def possibly_a_path(obj):
         return True
     except Exception:
         return False
+
+
+def is_url(obj):
+    try:
+        urllib.request.urlopen(obj)
+    except Exception:
+        return False
+    return True

--- a/sunpy/util/io.py
+++ b/sunpy/util/io.py
@@ -1,0 +1,56 @@
+import glob
+import os
+
+
+def parse_path(path, f, **kwargs):
+    """
+    Read in a series of files at *path* using the function *f*.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+    f : callable
+        Must return a list of read-in data.
+    kwargs :
+        Additional keyword arguments are handed to ``f``.
+
+    Returns
+    -------
+    list
+        List of files read in by ``f``.
+    """
+    if not isinstance(path, os.PathLike):
+        raise ValueError('path must be a pathlib.Path object')
+    path = path.expanduser()
+    if is_file(path):
+        return f(path, **kwargs)
+    elif is_dir(path):
+        read_files = []
+        for afile in sorted(path.glob('*')):
+            read_files += f(afile, **kwargs)
+        return read_files
+    elif glob.glob(str(path)):
+        read_files = []
+        for afile in sorted(glob.glob(str(path))):
+            read_files += f(afile, **kwargs)
+        return read_files
+    else:
+        raise ValueError(f'Did not find any files at {path}')
+
+
+# In python<3.8 paths with un-representable chars (ie. '*' on windows)
+# raise an error, so make our own version that returns False instead of
+# erroring. These can be removed when we support python >= 3.8
+# https://docs.python.org/3/library/pathlib.html#methods
+def is_file(path):
+    try:
+        return path.is_file()
+    except Exception:
+        return False
+
+
+def is_dir(path):
+    try:
+        return path.is_dir()
+    except Exception:
+        return False

--- a/sunpy/util/io.py
+++ b/sunpy/util/io.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import pathlib
 
 
 def parse_path(path, f, **kwargs):
@@ -52,5 +53,17 @@ def is_file(path):
 def is_dir(path):
     try:
         return path.is_dir()
+    except Exception:
+        return False
+
+
+def possibly_a_path(obj):
+    """
+    Check if ``obj`` can be coerced into a pathlib.Path object.
+    Does *not* check if the path exists.
+    """
+    try:
+        pathlib.Path(obj)
+        return True
     except Exception:
         return False

--- a/sunpy/util/io.py
+++ b/sunpy/util/io.py
@@ -1,5 +1,5 @@
-import glob
 import os
+import glob
 import pathlib
 import urllib.request
 


### PR DESCRIPTION
This extracts a lot of generic path parsing logic from the `MapFactory`, and uses it in the `TimeSeriesFactory`. Part of my attempts to overhaul the `TimeseriesFactory`, with the end goal of making it possible to plug in file readers (CDF files is my use case). But for now this is just refactoring that makes the code better.