### PR TITLE
Properly specify `rsun` in the output header when reprojecting an AIA map

### DIFF
--- a/examples/differential_rotation/reprojected_map.py
+++ b/examples/differential_rotation/reprojected_map.py
@@ -37,7 +37,7 @@ in_time = aiamap.date
 # to the location of AIA in the original observation).
 
 out_time = in_time + 5*u.day
-out_frame = Helioprojective(observer='earth', obstime=out_time)
+out_frame = Helioprojective(observer='earth', obstime=out_time, rsun=aiamap.coordinate_frame.rsun)
 
 ##############################################################################
 # For the reprojection, the definition of the target frame can be

--- a/examples/map_transformations/reprojection_different_observers.py
+++ b/examples/map_transformations/reprojection_different_observers.py
@@ -89,7 +89,7 @@ plt.legend([limb_aia[0], limb_euvi[0]],
 
 out_header = sunpy.map.make_fitswcs_header(
     out_shape,
-    map_aia.reference_coordinate,
+    map_aia.reference_coordinate.replicate(rsun=map_euvi.reference_coordinate.rsun),
     scale=u.Quantity(map_aia.scale),
     instrument="EUVI",
     observatory="AIA Observer",
@@ -123,8 +123,8 @@ ax2 = fig.add_subplot(1, 2, 2, projection=outmap)
 outmap.plot(axes=ax2, title='EUVI image as seen from SDO')
 
 # Set the HPC grid color to black as the background is white
-ax2.coords[0].grid_lines_kwargs['color'] = 'k'
-ax2.coords[1].grid_lines_kwargs['color'] = 'k'
+ax2.coords[0].grid_lines_kwargs['edgecolor'] = 'k'
+ax2.coords[1].grid_lines_kwargs['edgecolor'] = 'k'
 
 ######################################################################
 # AIA as Seen from Mars
@@ -145,6 +145,7 @@ mars_ref_coord = SkyCoord(map_aia.reference_coordinate.Tx,
                           map_aia.reference_coordinate.Ty,
                           obstime=map_aia.reference_coordinate.obstime,
                           observer=mars,
+                          rsun=map_aia.reference_coordinate.rsun,
                           frame="helioprojective")
 
 ######################################################################

--- a/examples/map_transformations/reprojection_spherical_screen.py
+++ b/examples/map_transformations/reprojection_spherical_screen.py
@@ -49,7 +49,8 @@ new_observer = SkyCoord(70*u.deg, 20*u.deg, 1*u.AU, obstime=aia_map.date,
 out_shape = aia_map.data.shape
 
 out_ref_coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime=new_observer.obstime,
-                         frame='helioprojective', observer=new_observer)
+                         frame='helioprojective', observer=new_observer,
+                         rsun=aia_map.coordinate_frame.rsun)
 out_header = sunpy.map.make_fitswcs_header(
     out_shape,
     out_ref_coord,


### PR DESCRIPTION
Some of the slightly odd results when reprojecting an AIA map (to another HPC frame) is because we need to create a target WCS header that has the correct `rsun_ref`.  We can do that by specifying the `rsun` frame attribute on the reference coordinate provided to `make_fitswcs_header()`.