### PR TITLE
Fixed bug where ``GenericMap`` breaks with keyword-arguments

### DIFF
--- a/changelog/5392.bugfix.rst
+++ b/changelog/5392.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where `~sunpy.map.GenericMap` used to break with keyword arguments.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -3,6 +3,7 @@ Map is a generic Map class from which all other Map classes inherit from.
 """
 import copy
 import html
+import inspect
 import numbers
 import textwrap
 import webbrowser
@@ -215,7 +216,9 @@ class GenericMap(NDData):
             warn_user("This file contains more than 2 dimensions. "
                       "Data will be truncated to the first two dimensions.")
 
-        super().__init__(data, meta=MetaDict(header), **kwargs)
+        params = list(inspect.signature(NDData).parameters)
+        nddata_kwargs = {x: kwargs.pop(x) for x in params & kwargs.keys()}
+        super().__init__(data, meta=MetaDict(header), **nddata_kwargs)
 
         # Correct possibly missing meta keywords
         self._fix_date()

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -60,6 +60,11 @@ class TestMap:
         sequence = sunpy.map.Map(a_list_of_many, sequence=True)
         assert isinstance(sequence, sunpy.map.MapSequence)
 
+    def test_mapsequence_sortby(self):
+        # Test making a MapSequence with sortby kwarg
+        sequence = sunpy.map.Map(a_list_of_many, sequence=True, sortby=None)
+        assert isinstance(sequence, sunpy.map.MapSequence)
+
     def test_composite(self):
         # Test making a CompositeMap
         comp = sunpy.map.Map(AIA_171_IMAGE, RHESSI_IMAGE, composite=True)


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #4170 

The parent class of `GenericMap`, `NDData` doesn't support keyword-arguments; that's why an exception was raised with `sortby` kwarg.