### PR TITLE
Use DATE-BEG/DATE-END/XPOSURE FITS keywords

### DIFF
--- a/changelog/5394.feature.1.rst
+++ b/changelog/5394.feature.1.rst
@@ -1,0 +1,2 @@
+`sunpy.map.GenericMap.date` now reads from the 'DATE-BEG' FITS keyword if
+present, and if not falls back on the 'DATE-OBS' keyword.

--- a/changelog/5394.feature.2.rst
+++ b/changelog/5394.feature.2.rst
@@ -1,0 +1,3 @@
+The `sunpy.map.GenericMap.exposure_time` property now defaults to using the
+'XPOSURE' FITS keyword if present, falling back on the 'EXPTIME' keyword
+otherwise.

--- a/changelog/5394.feature.rst
+++ b/changelog/5394.feature.rst
@@ -1,0 +1,2 @@
+Added `sunpy.map.GenericMap.date_end` that returns the end date/time of the
+observation (if present in the map metadata).

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -804,9 +804,13 @@ class GenericMap(NDData):
         """
         Exposure time of the image in seconds.
 
-        This is taken from the 'EXPTIME' FITS keyword.
+        This is taken from the 'XPOSURE' FITS keyword if present, otherwise
+        the 'EXPTIME' FITS keyword if present, and returns `None` if neither
+        are present.
         """
-        if 'exptime' in self.meta:
+        if 'xposure' in self.meta:
+            return self.meta['xposure'] * self.timeunit
+        elif 'exptime' in self.meta:
             return self.meta['exptime'] * self.timeunit
 
     @property

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -44,10 +44,6 @@ class EUIMap(GenericMap):
             return int(self.meta.get('level')[1:])
 
     @property
-    def exposure_time(self):
-        return self.meta.get('xposure', 0.0) * self.timeunit
-
-    @property
     def _supported_observer_coordinates(self):
         return [(('hcix_obs', 'hciy_obs', 'hciz_obs'),
                  {'x': self.meta.get('hcix_obs'),

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -16,7 +16,6 @@ from astropy.coordinates import Latitude, SkyCoord
 from astropy.io import fits
 from astropy.io.fits.verify import VerifyWarning
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.time import Time
 from astropy.visualization import wcsaxes
 
 import sunpy

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -136,7 +136,17 @@ def test_nickname_set(generic_map):
 
 
 def test_date(generic_map):
-    assert isinstance(generic_map.date, Time)
+    generic_map.meta['date-obs'] = parse_time('2020-01-01').isot
+    generic_map.meta['date-beg'] = parse_time('2021-02-02').isot
+    assert generic_map.date == parse_time('2021-02-02')
+
+    generic_map.meta.pop('date-beg')
+    assert generic_map.date == parse_time('2020-01-01')
+
+
+def test_date_end(generic_map):
+    generic_map.meta['date-end'] = parse_time('2021-02-02').isot
+    assert generic_map.date_end == parse_time('2021-02-02')
 
 
 def test_date_scale(generic_map):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -161,6 +161,18 @@ def test_date_aia(aia171_test_map):
     assert aia171_test_map.date == parse_time('2011-02-15T00:00:00.34')
 
 
+def test_exposure(generic_map):
+    generic_map.meta['xposure'] = 1
+    generic_map.meta['exptime'] = 2
+    assert generic_map.exposure_time == 1 * u.s
+
+    generic_map.meta.pop('xposure')
+    assert generic_map.exposure_time == 2 * u.s
+
+    generic_map.meta.pop('exptime')
+    assert generic_map.exposure_time is None
+
+
 def test_detector(generic_map):
     assert generic_map.detector == 'bar'
 


### PR DESCRIPTION
This is the recommended way to access image observation time and exposure time in FITS 4. As far as I can tell reading the time part of the FITS 4 standard this now brings `sunpy` up to speed with FITS 4.

TODO:
- [x] Decide whether to backport this 
- [x] Add tests
- [x] Add changelog