### PR TITLE
Fixed two bugs associated with the `rsun` attribute for `Heliographic*` frames

### DIFF
--- a/changelog/5395.bugfix.1.rst
+++ b/changelog/5395.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fixed a bug where creating a `~sunpy.coordinates.frames.HeliographicStonyhurst` frame or a `~sunpy.coordinates.frames.HeliographicCarrington` frame from WCS information failed to make use of any specified ``rsun_ref`` value.

--- a/changelog/5395.bugfix.2.rst
+++ b/changelog/5395.bugfix.2.rst
@@ -1,0 +1,2 @@
+Fixed a bug where the ``rsun`` frame attribute could be unintentionally reset to the default value during transformation.
+This bug primarily affected the transformation of a `~sunpy.coordinates.frames.Helioprojective` coordinate to a `~sunpy.coordinates.frame.HeliographicStonyhurst` frame.

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -940,3 +940,18 @@ def test_transform_with_sun_center_reset():
     assert_quantity_allclose(result3.lon, result1.lon)
     assert_quantity_allclose(result3.lat, result1.lat)
     assert_quantity_allclose(result3.distance, result1.distance)
+
+
+def test_rsun_preservation():
+    # Check that rsun is preserved when transforming between any two frames with that attribute
+    args_in = {'obstime': '2001-01-01', 'rsun': 690*u.Mm}
+    args_out = {'obstime': '2001-02-01', 'rsun': 700*u.Mm}
+
+    coords_in = [Helioprojective(0*u.deg, 0*u.deg, 1*u.AU, observer='earth', **args_in),
+                 HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU, **args_in),
+                 HeliographicCarrington(0*u.deg, 0*u.deg, 1*u.AU, observer='earth', **args_in)]
+
+    for coord in coords_in:
+        for frame in coords_in:
+            out_coord = coord.transform_to(frame.replicate(**args_out))
+            assert_quantity_allclose(out_coord.rsun, args_out['rsun'])

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -121,7 +121,7 @@ def test_wcs_aux():
 
 
 def test_hpc_frame_to_wcs():
-    frame = Helioprojective(observer="earth", obstime='2013-10-28')
+    frame = Helioprojective(observer="earth", obstime='2013-10-28', rsun=690*u.Mm)
     result_wcs = solar_frame_to_wcs_mapping(frame)
 
     assert isinstance(result_wcs, WCS)
@@ -129,9 +129,9 @@ def test_hpc_frame_to_wcs():
     assert result_wcs.wcs.ctype[0] == 'HPLN-TAN'
     assert result_wcs.wcs.cunit[0] == 'arcsec'
     assert result_wcs.wcs.dateobs == '2013-10-28T00:00:00.000'
+    assert result_wcs.wcs.aux.rsun_ref == frame.rsun.to_value(u.m)
 
     new_frame = solar_wcs_frame_mapping(result_wcs)
-    assert isinstance(new_frame.observer, HeliographicStonyhurst)
     assert new_frame.rsun == frame.rsun
 
     # Test a frame with no obstime and no observer
@@ -150,7 +150,7 @@ def test_hpc_frame_to_wcs():
 
 
 def test_hgs_frame_to_wcs():
-    frame = HeliographicStonyhurst(obstime='2013-10-28')
+    frame = HeliographicStonyhurst(obstime='2013-10-28', rsun=690*u.Mm)
     result_wcs = solar_frame_to_wcs_mapping(frame)
 
     assert isinstance(result_wcs, WCS)
@@ -158,6 +158,10 @@ def test_hgs_frame_to_wcs():
     assert result_wcs.wcs.ctype[0] == 'HGLN-TAN'
     assert result_wcs.wcs.cunit[0] == 'deg'
     assert result_wcs.wcs.dateobs == '2013-10-28T00:00:00.000'
+    assert result_wcs.wcs.aux.rsun_ref == frame.rsun.to_value(u.m)
+
+    new_frame = solar_wcs_frame_mapping(result_wcs)
+    assert new_frame.rsun == frame.rsun
 
     # Test a frame with no obstime
     frame = HeliographicStonyhurst()
@@ -171,7 +175,7 @@ def test_hgs_frame_to_wcs():
 
 
 def test_hgc_frame_to_wcs():
-    frame = HeliographicCarrington(obstime='2013-10-28')
+    frame = HeliographicCarrington(obstime='2013-10-28', rsun=690*u.Mm)
     result_wcs = solar_frame_to_wcs_mapping(frame)
 
     assert isinstance(result_wcs, WCS)
@@ -179,6 +183,10 @@ def test_hgc_frame_to_wcs():
     assert result_wcs.wcs.ctype[0] == 'CRLN-TAN'
     assert result_wcs.wcs.cunit[0] == 'deg'
     assert result_wcs.wcs.dateobs == '2013-10-28T00:00:00.000'
+    assert result_wcs.wcs.aux.rsun_ref == frame.rsun.to_value(u.m)
+
+    new_frame = solar_wcs_frame_mapping(result_wcs)
+    assert new_frame.rsun == frame.rsun
 
     # Test a frame with no obstime
     frame = HeliographicCarrington()

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -444,6 +444,10 @@ def hcc_to_hgs(helioccoord, heliogframe):
     newrepr = helioccoord.cartesian.transform(total_matrix)
     int_coord = HeliographicStonyhurst(newrepr, obstime=hcc_observer_at_hcc_obstime.obstime)
 
+    # For historical reasons, we support HCC with no obstime transforming to HGS with an obstime
+    if int_coord.obstime is None and heliogframe.obstime is not None:
+        int_coord = int_coord.replicate(obstime=heliogframe.obstime)
+
     # Loopback transform HGS as needed
     return int_coord.transform_to(heliogframe)
 

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -444,8 +444,8 @@ def hcc_to_hgs(helioccoord, heliogframe):
     newrepr = helioccoord.cartesian.transform(total_matrix)
     int_coord = HeliographicStonyhurst(newrepr, obstime=hcc_observer_at_hcc_obstime.obstime)
 
-    # Loopback transform HGS if there is a change in obstime
-    return _transform_obstime(int_coord, heliogframe.obstime)
+    # Loopback transform HGS as needed
+    return int_coord.transform_to(heliogframe)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -168,20 +168,29 @@ def solar_wcs_frame_mapping(wcs):
             warnings.warn('Observer information present in WCS auxillary information, ignoring '
                           '.heliographic_observer', SunpyUserWarning)
 
+    # Collect all of the possible frame attributes, although some may be removed later
+    frame_args = {'obstime': dateobs}
+    if observer is not None:
+        frame_args['observer'] = observer
+    if rsun is not None:
+        frame_args['rsun'] = rsun
+
     # Truncate the ctype to the first four letters
     ctypes = {c[:4] for c in wcs.wcs.ctype}
 
     if {'HPLN', 'HPLT'} <= ctypes:
-        return Helioprojective(obstime=dateobs, observer=observer, rsun=rsun)
+        return Helioprojective(**frame_args)
 
     if {'HGLN', 'HGLT'} <= ctypes:
-        return HeliographicStonyhurst(obstime=dateobs)
+        frame_args.pop('observer', None)
+        return HeliographicStonyhurst(**frame_args)
 
     if {'CRLN', 'CRLT'} <= ctypes:
-        return HeliographicCarrington(obstime=dateobs, observer=observer)
+        return HeliographicCarrington(**frame_args)
 
     if {'SOLX', 'SOLY'} <= ctypes:
-        return Heliocentric(obstime=dateobs, observer=observer)
+        frame_args.pop('rsun', None)
+        return Heliocentric(**frame_args)
 
 
 def _set_wcs_aux_obs_coord(wcs, obs_frame):


### PR DESCRIPTION
#5211 added the `rsun` frame attribute to `Heliographic*` frames.  This PR:

- Properly sets that frame attribute when instantiating a frame from a WCS that has `rsun_ref` set.
- Fixed a bug in the HCC->HGS transformation where the returned HGS frame would fall back to the default `rsun` value regardless of the definition in the target frame.  This bug is most apparent when transforming a SkyCoord from HPC to HGS, which normally tries to propagate the `rsun` value, but instead sees the `rsun` value reset to the default.