### PR TITLE
Add function to get limb coordinates

### DIFF
--- a/changelog/5417.feature.rst
+++ b/changelog/5417.feature.rst
@@ -1,0 +1,2 @@
+Added :func:`sunpy.coordinates.utils.get_limb_coordinates` to get the solar
+limb coordinates as seen from a given observer.

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -7,9 +7,10 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 
-from sunpy.coordinates import Heliocentric, get_body_heliographic_stonyhurst
+from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, get_body_heliographic_stonyhurst
+from sunpy.sun import constants
 
-__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency']
+__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates']
 
 
 class GreatArc:
@@ -436,3 +437,36 @@ def solar_angle_equivalency(observer):
               lambda x: np.arctan(x/sun_observer_distance))]
 
     return equiv
+
+
+@u.quantity_input
+def get_limb_coordinates(observer, rsun=constants.radius, resolution=1000):
+    """
+    Get coordinates for the solar limb as viewed by a specified observer.
+
+    Parameters
+    ----------
+    observer : `~astropy.coordinates.SkyCoord`
+        Observer coordinate.
+    rsun : `~astropy.units.Quantity`
+        Physical radius of the limb from Sun center. Defaults to the standard
+        photospheric radius.
+    resolution : int
+        Number of coordinates to return. The coordinates are equally spaced
+        around the limb as seen from the observer.
+    """
+    observer = observer.transform_to(
+        HeliographicStonyhurst(obstime=observer.obstime))
+    dsun = observer.radius
+    if dsun <= rsun:
+        raise ValueError('Observer distance must be greater than rsun')
+    # Create the limb coordinate array using Heliocentric Radial
+    limb_radial_distance = np.sqrt(dsun**2 - rsun**2)
+    limb_hcr_rho = limb_radial_distance * rsun / dsun
+    limb_hcr_z = dsun - np.sqrt(limb_radial_distance**2 - limb_hcr_rho**2)
+    limb_hcr_psi = np.linspace(0, 2*np.pi, resolution+1)[:-1] << u.rad
+    limb = SkyCoord(limb_hcr_rho, limb_hcr_psi, limb_hcr_z,
+                    representation_type='cylindrical',
+                    frame='heliocentric',
+                    observer=observer, obstime=observer.obstime)
+    return limb

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -440,7 +440,7 @@ def solar_angle_equivalency(observer):
 
 
 @u.quantity_input
-def get_limb_coordinates(observer, rsun=constants.radius, resolution=1000):
+def get_limb_coordinates(observer, rsun: u.m = constants.radius, resolution=1000):
     """
     Get coordinates for the solar limb as viewed by a specified observer.
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -32,7 +32,7 @@ import sunpy.io as io
 import sunpy.visualization.colormaps
 from sunpy import config, log
 from sunpy.coordinates import HeliographicCarrington, Helioprojective, get_earth, sun
-from sunpy.coordinates.utils import get_rectangle_coordinates
+from sunpy.coordinates.utils import get_limb_coordinates, get_rectangle_coordinates
 from sunpy.image.resample import resample as sunpy_image_resample
 from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.sun import constants
@@ -2100,14 +2100,9 @@ class GenericMap(NDData):
 
         # Otherwise, we use Polygon to be able to distort the limb
 
-        # Create the limb coordinate array using Heliocentric Radial
-        limb_radial_distance = self.observer_coordinate.radius * np.cos(self.rsun_obs)
-        limb_hcr_rho = limb_radial_distance * np.sin(self.rsun_obs)
-        limb_hcr_z = self.observer_coordinate.radius - limb_radial_distance * np.cos(self.rsun_obs)
-        limb_hcr_psi = np.linspace(0, 2*np.pi, resolution+1)[:-1] << u.rad
-        limb = SkyCoord(limb_hcr_rho, limb_hcr_psi, limb_hcr_z, representation_type='cylindrical',
-                        frame='heliocentric', observer=self.observer_coordinate, obstime=self.date)
-
+        # Get the limb coordinates
+        limb = get_limb_coordinates(self.observer_coordinate, self.rsun_meters,
+                                    resolution=resolution)
         # Transform the limb to the axes frame and get the 2D vertices
         axes_frame = axes._transform_pixel2world.frame_out
         limb_in_axes = limb.transform_to(axes_frame)


### PR DESCRIPTION
This pulls out the code for calculating limb coordinates from `draw_limb`. The motivation for this is drawing the limb in `sunkit-pyvista`, so we want the coordinates without calling `draw_limb`.

I chose to use `rsun` (physical distance) instead of `rsun_obs`, as the latter can vary for a varying observer-sun distance, whereas (for a similar observation) `rsun` will not depend on observer-sun distance. As such the logic has changed, but I think I got the trigonometry right.

This relies on https://github.com/sunpy/sunpy/pull/5416 to make sure `dsun` has a fallback on `rsun_obs`.