### PR TITLE
Fixed bugged behavior of `all_corner_coords_from_map()` for non-square maps

### DIFF
--- a/changelog/5419.bugfix.rst
+++ b/changelog/5419.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed incorrect return values from :func:`~sunpy.map.maputils.all_corner_coords_from_map` if a rectangular map was provided.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -34,7 +34,8 @@ def all_pixel_indices_from_map(smap):
         A `numpy.array` with the all the pixel indices built from the
         dimensions of the map.
     """
-    return np.meshgrid(*[np.arange(v.value) for v in smap.dimensions]) * u.pix
+    y, x = np.indices(smap.data.shape)
+    return [x, y] * u.pix
 
 
 def all_coordinates_from_map(smap):
@@ -60,11 +61,9 @@ def all_corner_coords_from_map(smap):
     """
     Returns the coordinates of the pixel corners in a map.
     """
-    nx, ny = smap.data.shape
-    xpix = np.arange(0, nx + 1, 1) - 0.5
-    ypix = np.arange(0, ny + 1, 1) - 0.5
-    xpix, ypix = np.meshgrid(xpix, ypix, indexing='ij') * u.pix
-    return smap.pixel_to_world(xpix, ypix)
+    ny, nx = smap.data.shape
+    y, x = np.indices((ny + 1, nx + 1))
+    return smap.pixel_to_world((x - 0.5) * u.pix, (y - 0.5) * u.pix)
 
 
 def map_edges(smap):

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -3,6 +3,7 @@ import pytest
 
 import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
 
 import sunpy.map
 from sunpy.coordinates import HeliographicStonyhurst
@@ -93,6 +94,14 @@ def test_all_coordinates_from_map(sub_smap):
     assert isinstance(coordinates.frame, BaseCoordinateFrame)
     assert coordinates.frame.name == sub_smap.coordinate_frame.name
 
+    xpix, ypix = sub_smap.world_to_pixel(coordinates[0, 0])
+    assert_quantity_allclose(xpix, 0*u.pix, atol=1e-7*u.pix)
+    assert_quantity_allclose(ypix, 0*u.pix, atol=1e-7*u.pix)
+
+    xpix, ypix = sub_smap.world_to_pixel(coordinates[-1, -1])
+    assert_quantity_allclose(xpix, sub_smap.dimensions[0] - 1*u.pix)
+    assert_quantity_allclose(ypix, sub_smap.dimensions[1] - 1*u.pix)
+
 
 def test_all_corner_coordinates_from_map(sub_smap):
     coordinates = all_corner_coords_from_map(sub_smap)
@@ -101,6 +110,14 @@ def test_all_corner_coordinates_from_map(sub_smap):
     assert isinstance(coordinates, SkyCoord)
     assert isinstance(coordinates.frame, BaseCoordinateFrame)
     assert coordinates.frame.name == sub_smap.coordinate_frame.name
+
+    xpix, ypix = sub_smap.world_to_pixel(coordinates[0, 0])
+    assert_quantity_allclose(xpix, -0.5*u.pix)
+    assert_quantity_allclose(ypix, -0.5*u.pix)
+
+    xpix, ypix = sub_smap.world_to_pixel(coordinates[-1, -1])
+    assert_quantity_allclose(xpix, sub_smap.dimensions[0] - 0.5*u.pix)
+    assert_quantity_allclose(ypix, sub_smap.dimensions[1] - 0.5*u.pix)
 
 
 def test_map_edges(all_off_disk_map):


### PR DESCRIPTION
#4776 introduced `all_corner_coords_from_map()`, but that function returns incorrect values for non-square maps.  The existing unit test uses a non-square map, but doesn't actually check any of the return values.