### PR TITLE
Removes duplicate test to be skipped for pyinstaller

### DIFF
--- a/.pyinstaller/run_sunpy_tests.py
+++ b/.pyinstaller/run_sunpy_tests.py
@@ -24,7 +24,6 @@ if getattr(sys, 'frozen', False):
         'test_find_dependencies',
         'test_missing_dependencies_by_extra',
         'test_hgc_100',
-        'test_missing_dependencies_by_extra',
         'test_basic',
         'test_data_manager',
         'test_file_tampered',


### PR DESCRIPTION
I made a small mistake and noted the same test to be skipped twice in #5224.
The upstream hook has been added via https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/134 which does not support tests.