### PR TITLE
Add info urls to client results

### DIFF
--- a/changelog/5431.feature.rst
+++ b/changelog/5431.feature.rst
@@ -1,0 +1,6 @@
+Printing the response from a `~sunpy.net.Fido` query now includes the URL where
+the data files are sourced from.
+
+If you develop a third-party `~sunpy.net.Fido` client, support for this can
+be automatically enabled by adding a ``info_url`` property to your
+`~sunpy.net.base_client.BaseClient` that returns a URL as a string.

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -103,6 +103,8 @@ To see a summary of the results of our query, simply type the name of the variab
     Results from 1 Provider:
     <BLANKLINE>
     3 Results from the LYRAClient:
+    Source: http://proba2.oma.be/lyra/data/bsd
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Provider Level
     ----------------------- ----------------------- ---------- ... -------- -----
     2012-03-04 00:00:00.000 2012-03-04 23:59:59.999       LYRA ...      ESA     2
@@ -121,6 +123,8 @@ Specific passbands can be searched for by supplying an `~astropy.units.Quantity`
     Results from 1 Provider:
     <BLANKLINE>
     3 Results from the NoRHClient:
+    Source: https://solar.nro.nao.ac.jp/norh/doc/manuale/node1.html
+    <BLANKLINE>
            Start Time               End Time        ... Provider Wavelength
                                                     ...             GHz
     ----------------------- ----------------------- ... -------- ----------
@@ -139,6 +143,8 @@ To search for data at a given cadence use the `a.Sample <sunpy.net.attrs.Sample>
     Results from 1 Provider:
     <BLANKLINE>
     289 Results from the VSOClient:
+    Source: http://vso.stanford.edu/cgi-bin/search
+    <BLANKLINE>
            Start Time       ...
                             ...
     ----------------------- ...
@@ -176,17 +182,23 @@ This joins queries together just as the logical ``OR`` operator would::
     Results from 3 Providers:
     <BLANKLINE>
     2 Results from the LYRAClient:
+    Source: http://proba2.oma.be/lyra/data/bsd
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Provider Level
     ----------------------- ----------------------- ---------- ... -------- -----
     2012-03-04 00:00:00.000 2012-03-04 23:59:59.999       LYRA ...      ESA     2
     2012-03-04 00:00:00.000 2012-03-04 23:59:59.999       LYRA ...      ESA     3
     <BLANKLINE>
     1 Results from the RHESSIClient:
+    Source: https://hesperia.gsfc.nasa.gov/hessidata
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Source Provider
     ----------------------- ----------------------- ---------- ... ------ --------
     2012-03-04 00:00:00.000 2012-03-04 23:59:59.999     RHESSI ... RHESSI     NASA
     <BLANKLINE>
     3 Results from the VSOClient:
+    Source: http://vso.stanford.edu/cgi-bin/search
+    <BLANKLINE>
            Start Time               End Time        ...   Size        Info
                                                     ...  Mibyte
     ----------------------- ----------------------- ... -------- --------------
@@ -215,12 +227,16 @@ For example, the following code returns a response containing LYRA data from the
     Results from 2 Providers:
     <BLANKLINE>
     2 Results from the LYRAClient:
+    Source: http://proba2.oma.be/lyra/data/bsd
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Provider Level
     ----------------------- ----------------------- ---------- ... -------- -----
     2012-01-01 00:00:00.000 2012-01-01 23:59:59.999       LYRA ...      ESA     2
     2012-01-02 00:00:00.000 2012-01-02 23:59:59.999       LYRA ...      ESA     2
     <BLANKLINE>
     50 Results from the VSOClient:
+    Source: http://vso.stanford.edu/cgi-bin/search
+    <BLANKLINE>
            Start Time               End Time        ...   Size         Info
                                                     ...  Mibyte
     ----------------------- ----------------------- ... -------- ----------------
@@ -274,6 +290,8 @@ For example if we did a query for some AIA and HMI data::
     Results from 2 Providers:
     <BLANKLINE>
     402 Results from the VSOClient:
+    Source: http://vso.stanford.edu/cgi-bin/search
+    <BLANKLINE>
            Start Time       ...
                             ...
     ----------------------- ...
@@ -301,6 +319,8 @@ For example if we did a query for some AIA and HMI data::
     Length = 402 rows
     <BLANKLINE>
     42 Results from the VSOClient:
+    Source: http://vso.stanford.edu/cgi-bin/search
+    <BLANKLINE>
            Start Time               End Time        Source ...   Size   Wavetype
                                                            ...  Mibyte
     ----------------------- ----------------------- ------ ... -------- --------
@@ -342,6 +362,8 @@ And then we can pick which ones to see with the :meth:`~.UnifiedResponse.show` m
     Results from 2 Providers:
     <BLANKLINE>
     402 Results from the VSOClient:
+    Source: http://vso.stanford.edu/cgi-bin/search
+    <BLANKLINE>
            Start Time       Instrument  Physobs   Wavelength [2]
                                                      Angstrom
     ----------------------- ---------- --------- ----------------
@@ -369,6 +391,8 @@ And then we can pick which ones to see with the :meth:`~.UnifiedResponse.show` m
     Length = 402 rows
     <BLANKLINE>
     42 Results from the VSOClient:
+    Source: http://vso.stanford.edu/cgi-bin/search
+    <BLANKLINE>
            Start Time       Instrument        Physobs         Wavelength [2]
                                                                  Angstrom
     ----------------------- ---------- --------------------- ----------------

--- a/docs/guide/acquiring_data/jsoc.rst
+++ b/docs/guide/acquiring_data/jsoc.rst
@@ -77,6 +77,8 @@ variable set to the Fido search, in this case, res::
     Results from 1 Provider:
     <BLANKLINE>
     81 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
              T_REC          TELESCOP  INSTRUME  WAVELNTH CAR_ROT
     ----------------------- -------- ---------- -------- -------
     2014.01.01_00:00:45_TAI  SDO/HMI HMI_FRONT2   6173.0    2145
@@ -194,6 +196,8 @@ If you want to get a manual set of keywords in the response object, you can pass
     Results from 1 Provider:
     <BLANKLINE>
     81 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
     TELESCOP  INSTRUME           T_OBS
     -------- ---------- -----------------------
      SDO/HMI HMI_FRONT2 2014.01.01_00:00:37_TAI
@@ -232,6 +236,8 @@ To display all of the columns, we can use ``show()`` without passing any argumen
     Results from 1 Provider:
     <BLANKLINE>
     81 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
             DATE                DATE__OBS        ... CALVER64
     -------------------- ----------------------- ... --------
     2014-01-05T17:46:02Z 2013-12-31T23:59:39.20Z ...     4370
@@ -301,6 +307,8 @@ To get files for more than 1 segment at the same time, chain ``a.jsoc.Segment()`
     Results from 1 Provider:
     <BLANKLINE>
     61 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
              T_REC          TELESCOP  INSTRUME WAVELNTH CAR_ROT
     ----------------------- -------- --------- -------- -------
     2014.01.01_00:00:00_TAI  SDO/HMI HMI_SIDE1   6173.0    2145
@@ -342,6 +350,8 @@ between January 1st from 00:00 to 01:00, 2014, every 10 minutes, you can do::
     Results from 1 Provider:
     <BLANKLINE>
     7 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
              T_REC          TELESCOP  INSTRUME  WAVELNTH CAR_ROT
     ----------------------- -------- ---------- -------- -------
     2014.01.01_00:00:45_TAI  SDO/HMI HMI_FRONT2   6173.0    2145
@@ -370,6 +380,8 @@ Let's look for 2 different series data at the same time::
     Results from 2 Providers:
     <BLANKLINE>
     81 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
              T_REC          TELESCOP  INSTRUME  WAVELNTH CAR_ROT
     ----------------------- -------- ---------- -------- -------
     2014.01.01_00:00:45_TAI  SDO/HMI HMI_FRONT2   6173.0    2145
@@ -396,6 +408,8 @@ Let's look for 2 different series data at the same time::
     Length = 81 rows
     <BLANKLINE>
     2107 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
            T_REC         TELESCOP INSTRUME WAVELNTH CAR_ROT
     -------------------- -------- -------- -------- -------
     2014-01-01T00:00:01Z  SDO/AIA    AIA_4       94    2145
@@ -435,6 +449,8 @@ of conditions which get passed to the JSOC.  Let's say you want all the
     Results from 2 Providers:
     <BLANKLINE>
     81 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
              T_REC          TELESCOP  INSTRUME  WAVELNTH CAR_ROT
     ----------------------- -------- ---------- -------- -------
     2014.01.01_00:00:45_TAI  SDO/HMI HMI_FRONT2   6173.0    2145
@@ -461,6 +477,8 @@ of conditions which get passed to the JSOC.  Let's say you want all the
     Length = 81 rows
     <BLANKLINE>
     81 Results from the JSOCClient:
+    Source: http://jsoc.stanford.edu
+    <BLANKLINE>
              T_REC          TELESCOP  INSTRUME  WAVELNTH CAR_ROT
     ----------------------- -------- ---------- -------- -------
     2014.01.02_00:00:45_TAI  SDO/HMI HMI_FRONT2   6173.0    2145

--- a/sunpy/net/base_client.py
+++ b/sunpy/net/base_client.py
@@ -458,6 +458,13 @@ class BaseClient(ABC):
         using the incorrect client.
         """
 
+    @property
+    def info_url(self):
+        """
+        This should return a string that is a URL to the data server or
+        documentation on the data being served.
+        """
+
     @staticmethod
     def check_attr_types_in_query(query, required_attrs={}, optional_attrs={}):
         """

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -25,6 +25,8 @@ class EVEClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the EVEClient:
+    Source: https://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Provider Level
     ----------------------- ----------------------- ---------- ... -------- -----
     2016-01-01 00:00:00.000 2016-01-01 23:59:59.999        EVE ...     LASP     0
@@ -36,6 +38,10 @@ class EVEClient(GenericClient):
     baseurl = (r'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
                r'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
     pattern = '{}/SpWx/{:4d}/{year:4d}{month:2d}{day:2d}_EVE_L{Level:1d}{}'
+
+    @property
+    def info_url(self):
+        return 'https://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/'
 
     @classmethod
     def register_values(cls):

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -37,6 +37,8 @@ class GBMClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     3 Results from the GBMClient:
+    Source: https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily
+    <BLANKLINE>
            Start Time               End Time        ... Resolution Detector
     ----------------------- ----------------------- ... ---------- --------
     2015-06-21 00:00:00.000 2015-06-21 23:59:59.999 ...      ctime       n3
@@ -48,6 +50,10 @@ class GBMClient(GenericClient):
     """
     baseurl = r'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/%Y/%m/%d/current/glg_(\w){5}_(\w){2}_%y%m%d_v00.pha'
     pattern = '{}/daily/{year:4d}/{month:2d}/{day:2d}/current/glg_{Resolution:5}_{Detector:2}_{:6d}{}'
+
+    @property
+    def info_url(self):
+        return 'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily'
 
     @classmethod
     def register_values(cls):

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -51,6 +51,8 @@ class XRSClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     4 Results from the XRSClient:
+    Source: https://umbra.nascom.nasa.gov/goes/fits
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Source Provider
     ----------------------- ----------------------- ---------- ... ------ --------
     2016-01-01 00:00:00.000 2016-01-01 23:59:59.999        XRS ...   GOES     NOAA
@@ -76,6 +78,10 @@ class XRSClient(GenericClient):
                  r"/l2/data/xrsf-l2-flx1s_science/%Y/%m/sci_xrsf-l2-flx1s_g{SatelliteNumber}_d%Y%m%d_.*\.nc")
     pattern_r = ("{}/goes/goes{SatelliteNumber:02d}/l2/data/xrsf-l2-flx1s_science/{year:4d}/"
                  "{month:2d}/sci_xrsf-l2-flx1s_g{SatelliteNumber:02d}_d{year:4d}{month:2d}{day:2d}_{}.nc")
+
+    @property
+    def info_url(self):
+        return 'https://umbra.nascom.nasa.gov/goes/fits'
 
     def post_search_hook(self, i, matchdict):
         tr = get_timerange_from_exdict(i)
@@ -196,6 +202,8 @@ class SUVIClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     3 Results from the SUVIClient:
+    Source: https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Level Wavelength
                                                                ...        Angstrom
     ----------------------- ----------------------- ---------- ... ----- ----------
@@ -216,6 +224,10 @@ class SUVIClient(GenericClient):
     pattern2 = ('{}/goes/goes{SatelliteNumber:2d}/{}/dr_suvi-l{Level}-ci{Wavelength:03d}_g{SatelliteNumber:2d}_s'
                 '{year:4d}{month:2d}{day:2d}T{hour:2d}{minute:2d}{second:2d}Z_e'
                 '{eyear:4d}{emonth:2d}{eday:2d}T{ehour:2d}{eminute:2d}{esecond:2d}Z_{}')
+
+    @property
+    def info_url(self):
+        return 'https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes'
 
     def post_search_hook(self, i, matchdict):
 

--- a/sunpy/net/dataretriever/sources/gong.py
+++ b/sunpy/net/dataretriever/sources/gong.py
@@ -19,6 +19,8 @@ class GONGClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     5 Results from the GONGClient:
+    Source: https://gong2.nso.edu/oQR/zqs
+    <BLANKLINE>
            Start Time               End Time        ... Provider ExtentType
     ----------------------- ----------------------- ... -------- ----------
     2019-12-31 22:14:00.000 2019-12-31 22:14:59.999 ...      NSO   SYNOPTIC
@@ -32,6 +34,10 @@ class GONGClient(GenericClient):
     baseurl = (r'https://gong2.nso.edu/oQR/zqs/%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc'
                r'(\d){4}_(\d){3}\.fits.gz')
     pattern = '{}/zqs/{year:4d}{month:2d}/mrzqs{:4d}{day:2d}/mrzqs{:6d}t{hour:2d}{minute:2d}c{}'
+
+    @property
+    def info_url(self):
+        return 'https://gong2.nso.edu/oQR/zqs'
 
     @classmethod
     def register_values(cls):

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -23,6 +23,8 @@ class LYRAClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     4 Results from the LYRAClient:
+    Source: http://proba2.oma.be/lyra/data/bsd
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Provider Level
     ----------------------- ----------------------- ---------- ... -------- -----
     2016-01-01 00:00:00.000 2016-01-01 23:59:59.999       LYRA ...      ESA     2
@@ -36,6 +38,10 @@ class LYRAClient(GenericClient):
     baseurl = (r'http://proba2.oma.be/lyra/data/bsd/%Y/%m/%d/'
                r'lyra_(\d){8}-000000_lev(\d){1}_std.fits')
     pattern = '{}/bsd/{year:4d}/{month:2d}/{day:2d}/{}_lev{Level:1d}_std.fits'
+
+    @property
+    def info_url(self):
+        return 'http://proba2.oma.be/lyra/data/bsd'
 
     @classmethod
     def register_values(cls):

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -27,6 +27,8 @@ class NOAAIndicesClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     1 Results from the NOAAIndicesClient:
+    Source: https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json
+    <BLANKLINE>
      Instrument     Physobs     Source Provider
     ------------ -------------- ------ --------
     NOAA-Indices sunspot number   SIDC     SWPC
@@ -35,6 +37,10 @@ class NOAAIndicesClient(GenericClient):
 
     """
     required = {a.Instrument}
+
+    @property
+    def info_url(self):
+        return 'https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json'
 
     def search(self, *args, **kwargs):
         rowdict = self._get_match_dict(*args, **kwargs)
@@ -82,6 +88,8 @@ class NOAAPredictClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     1 Results from the NOAAPredictClient:
+    Source: https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json
+    <BLANKLINE>
      Instrument     Physobs     Source Provider
     ------------ -------------- ------ --------
     NOAA-Predict sunspot number   ISES     SWPC
@@ -90,6 +98,10 @@ class NOAAPredictClient(GenericClient):
 
     """
     required = {a.Instrument}
+
+    @property
+    def info_url(self):
+        return 'https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json'
 
     def search(self, *args, **kwargs):
         rowdict = self._get_match_dict(*args, **kwargs)

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -31,6 +31,8 @@ class NoRHClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the NoRHClient:
+    Source: https://solar.nro.nao.ac.jp/norh/doc/manuale/node1.html
+    <BLANKLINE>
            Start Time               End Time        ... Provider Wavelength
                                                     ...             GHz
     ----------------------- ----------------------- ... -------- ----------
@@ -42,6 +44,10 @@ class NoRHClient(GenericClient):
     """
     baseurl = r'ftp://solar-pub.nao.ac.jp/pub/nsro/norh/data/tcx/%Y/%m/(\w){3}%y%m%d'
     pattern = '{}/tcx/{year:4d}/{month:2d}/{Wavelength:3l}{:4d}{day:2d}'
+
+    @property
+    def info_url(self):
+        return 'https://solar.nro.nao.ac.jp/norh/doc/manuale/node1.html'
 
     @classmethod
     def pre_search_hook(cls, *args, **kwargs):

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -112,6 +112,8 @@ class RHESSIClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the RHESSIClient:
+    Source: https://hesperia.gsfc.nasa.gov/hessidata
+    <BLANKLINE>
            Start Time               End Time        Instrument ... Source Provider
     ----------------------- ----------------------- ---------- ... ------ --------
     2016-01-01 00:00:00.000 2016-01-01 23:59:59.999     RHESSI ... RHESSI     NASA
@@ -121,6 +123,10 @@ class RHESSIClient(GenericClient):
 
     """
     pattern = '{}/catalog/hsi_obssumm_{year:4d}{month:2d}{day:2d}_{}'
+
+    @property
+    def info_url(self):
+        return 'https://hesperia.gsfc.nasa.gov/hessidata'
 
     def get_observing_summary_filename(self, time_range):
         """

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -181,7 +181,9 @@ class UnifiedResponse(Sequence):
         else:
             ret = 'Results from {} Providers:\n\n'.format(len(self))
         for block in self:
-            ret += "{} Results from the {}:\n".format(len(block), block.client.__class__.__name__)
+            ret += f"{len(block)} Results from the {block.client.__class__.__name__}:\n"
+            if block.client.info_url is not None:
+                ret += f'Source: {block.client.info_url}\n\n'
             lines = repr(block).split('\n')
             ret += '\n'.join(lines[1:])
             ret += '\n\n'

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -190,6 +190,10 @@ class JSOCClient(BaseClient):
     # Default number of max connections that the Downloader opens
     default_max_conn = 2
 
+    @property
+    def info_url(self):
+        return 'http://jsoc.stanford.edu'
+
     def search(self, *query, **kwargs):
         """
         Build a JSOC query and submit it to JSOC for processing.

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -221,8 +221,8 @@ def test_repr():
 
     rep = repr(results)
     rep = rep.split('\n')
-    # 6 header lines, the results table and two blank lines at the end
-    assert len(rep) == 6 + len(list(results)[0]) + 2
+    # 8 header lines, the results table and two blank lines at the end
+    assert len(rep) == 8 + len(list(results)[0]) + 2
 
 
 def filter_queries(queries):

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -666,3 +666,7 @@ class VSOClient(BaseClient):
 
         with open(os.path.join(here, 'data', 'attrs.json'), 'w') as attrs_file:
             json.dump(attrs, attrs_file, indent=2)
+
+    @property
+    def info_url(self):
+        return 'http://vso.stanford.edu/cgi-bin/search'


### PR DESCRIPTION
I think we should enforce this as an `abstractproperty`, but this would be a breaking change for now. So, thoughts on making this compulsory somehow eventually?

Still needs:

- [x] Docs
- [ ] Changelog
- [x] Tests (this will just be fixing current doctests)