### PR TITLE
Remove pandas from net dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ map =
 net =
   beautifulsoup4>=4.8.0
   drms>=0.6.1
-  pandas>=0.24.0
   python-dateutil>=2.8.0
   tqdm>=4.32.1
   zeep>=3.4.0


### PR DESCRIPTION
This appeared via. https://github.com/sunpy/sunpy/commit/e2cc09bcf799e1798e75c9dbd8a6dc0a80edbb29 (by @nabobalis ), but I think was a mistake? `grep sunpy/net 'pandas'` doesn't suggest we need `pandas` for `net`.