### PR TITLE
Revert "Added `reindex` method in ``GenericTimeSeries``"

### DIFF
--- a/changelog/5373.feature.rst
+++ b/changelog/5373.feature.rst
@@ -1,1 +1,0 @@
-Added :meth:`sunpy.timeseries.GenericTimeSeries.reindex` in `sunpy.timeseries.GenericTimeSeries` as a wrapper for `~pandas.DataFrame.reindex`.

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -967,18 +967,6 @@ def test_lyra_plot(lyra_test_ts):
         np.testing.assert_array_equal(ax.lines[0].get_ydata(), lyra_test_ts.to_array().T[i])
 
 
-def test_ts_reindex(generic_ts):
-    dates = generic_ts.time_range.start + TimeDelta(np.arange(60)*u.minute)
-    new_index = dates.isot.astype('datetime64')
-    # Test for pandas.DatetimeIndex as index
-    generic_ts_reindexed_1 = generic_ts.reindex(new_index, method="nearest")
-    df_selected = generic_ts.to_dataframe().loc[new_index]
-    assert generic_ts_reindexed_1.to_dataframe().equals(df_selected)
-    # Test for sunpy.timeseries.TimeSeries as index
-    generic_ts_reindexed_2 = generic_ts.reindex(generic_ts_reindexed_1, method="nearest")
-    assert generic_ts_reindexed_2.to_dataframe().equals(generic_ts_reindexed_1.to_dataframe())
-
-
 # TODO:
 # _validate_units
 # _validate_meta

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -444,41 +444,6 @@ class GenericTimeSeries:
         object._sanitize_units()
         return object
 
-    def reindex(self, index, method="nearest", **kwargs):
-        """
-        Returns a new time series with a new index.
-
-        By default values on the new time series are filled using a
-        nearest valid observation method. See `~pandas.DataFrame.reindex`
-        for the different re-indexing options available.
-
-        Parameters
-        ----------
-        index : `~sunpy.timeseries.TimeSeries` or `~pandas.DatetimeIndex`
-            Another `~sunpy.timeseries.TimeSeries` or a valid index column.
-        method : `str`, optional
-            Method to use for filling holes in reindexed time series.
-            Defaults to "nearest".
-
-        Returns
-        -------
-        `~sunpy.timeseries.TimeSeries`
-            A `~sunpy.timeseries.TimeSeries` with new index.
-
-        Notes
-        -----
-        This method is a wrapper around `pandas.DataFrame.reindex`; all additional
-        keyword arguments are passed to this method.
-        """
-        if isinstance(index, GenericTimeSeries):
-            index = index.index
-        object = GenericTimeSeries(self._data.reindex(index, method=method, **kwargs),
-                                   meta=TimeSeriesMetaData(copy.copy(self.meta.metadata)),
-                                   units=copy.copy(self.units))
-        object._sanitize_metadata()
-        object._sanitize_units()
-        return object
-
 # #### Plotting Methods #### #
 
     def plot(self, axes=None, **plot_args):


### PR DESCRIPTION
Reverts sunpy/sunpy#5373. As discussed at the developer meeting, we do not want this to go in before we re-implement `TimeSeries` using astropy underneath instead of pandas.