### PR TITLE
Fixed the definition of `lonpole` by the FITS WCS header helper

### DIFF
--- a/changelog/5448.bugfix.rst
+++ b/changelog/5448.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the incorrect value for the FITS WCS ``LONPOLE`` keyword when using :func:`~sunpy.map.make_fitswcs_header` for certain combinations of WCS projection and reference coordinate.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -175,6 +175,12 @@ def _set_transform_params(meta_wcs, coordinate, reference_pixel, scale, shape):
     meta_wcs['crval1'], meta_wcs['crval2'] = (coordinate.spherical.lon.to_value(meta_wcs['cunit1']),
                                               coordinate.spherical.lat.to_value(meta_wcs['cunit2']))
 
+    # When the native latitude of the fiducial point is 0 degrees, which is typical for cylindrical
+    # projections, the correct value of `lonpole` depends on whether the world latitude of the
+    # fiducial point is greater than or less than its native latitude.
+    meta_wcs['LONPOLE'] = 180. if meta_wcs['crval2'] < meta_wcs['theta0'] else 0.
+    del meta_wcs['theta0']  # remove the native latitude of the fiducial point
+
     # Add 1 to go from input 0-based indexing to FITS 1-based indexing
     meta_wcs['crpix1'], meta_wcs['crpix2'] = (reference_pixel[0].to_value(u.pixel) + 1,
                                               reference_pixel[1].to_value(u.pixel) + 1)
@@ -210,6 +216,7 @@ def _get_wcs_meta(coordinate, projection_code):
     cunit1, cunit2 = skycoord_wcs.wcs.cunit
     coord_meta = dict(skycoord_wcs.to_header())
     coord_meta['cunit1'], coord_meta['cunit2'] = cunit1.to_string("fits"), cunit2.to_string("fits")
+    coord_meta['theta0'] = skycoord_wcs.wcs.theta0  # add the native latitude of the fiducial point
 
     return coord_meta
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -546,6 +546,7 @@ class GenericMap(NDData):
         # array with sequence error.
         w2.wcs.cdelt = u.Quantity(self.scale)
         w2.wcs.crval = u.Quantity([self._reference_longitude, self._reference_latitude])
+        w2.wcs.lonpole = 180. if w2.wcs.crval[1] < w2.wcs.theta0 else 0.
         w2.wcs.ctype = self.coordinate_system
         w2.wcs.pc = self.rotation_matrix
         # FITS standard doesn't allow both PC_ij *and* CROTA keywords

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -546,7 +546,6 @@ class GenericMap(NDData):
         # array with sequence error.
         w2.wcs.cdelt = u.Quantity(self.scale)
         w2.wcs.crval = u.Quantity([self._reference_longitude, self._reference_latitude])
-        w2.wcs.lonpole = 180. if w2.wcs.crval[1] < w2.wcs.theta0 else 0.
         w2.wcs.ctype = self.coordinate_system
         w2.wcs.pc = self.rotation_matrix
         # FITS standard doesn't allow both PC_ij *and* CROTA keywords

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -7,40 +7,56 @@ from astropy.wcs import WCS
 
 import sunpy.map
 from sunpy.coordinates import frames, sun
+from sunpy.map import make_fitswcs_header
 from sunpy.util.metadata import MetaDict
 
 
 @pytest.fixture
 def map_data():
-    return np.random.rand(10, 10)
+    return np.random.rand(20, 10)
 
 
 @pytest.fixture
-def hpc_test_header():
-    return SkyCoord(0*u.arcsec, 0*u.arcsec, observer='earth',
+def hpc_coord():
+    return SkyCoord(0*u.arcsec, 0*u.arcsec, observer='earth', rsun=7.1e8*u.m,
                     obstime='2013-10-28 00:00', frame=frames.Helioprojective)
 
 
 @pytest.fixture
-def hgc_test_header():
-    return SkyCoord(70*u.deg, -30*u.deg, observer='earth',
+def hgc_coord():
+    return SkyCoord(70*u.deg, -30*u.deg, 1.5*u.AU, observer='self', rsun=7.2e8*u.m,
                     obstime='2013-10-28 00:00', frame=frames.HeliographicCarrington)
 
 
 @pytest.fixture
-def hgs_test_header():
-    return SkyCoord(-50*u.deg, 50*u.deg, observer='earth',
+def hgs_coord():
+    return SkyCoord(-50*u.deg, 50*u.deg, rsun=7.3e8*u.m,
                     obstime='2013-10-28 00:00', frame=frames.HeliographicStonyhurst)
 
 
 @pytest.fixture
-def hcc_test_header():
-    return SkyCoord(-72241*u.km, 361206.1*u.km, 589951.4*u.km,
+def hcc_coord():
+    return SkyCoord(-72241*u.km, 361206.1*u.km, 589951.4*u.km, observer='earth',
                     obstime='2013-10-28 00:00', frame=frames.Heliocentric)
 
 
 @pytest.fixture
-def hpc_test_header_notime():
+def hpc_header(map_data, hpc_coord):
+    return make_fitswcs_header(map_data, hpc_coord)
+
+
+@pytest.fixture
+def hgc_header(map_data, hgc_coord):
+    return make_fitswcs_header(map_data, hgc_coord, projection_code='CAR')
+
+
+@pytest.fixture
+def hgs_header(map_data, hgs_coord):
+    return make_fitswcs_header(map_data, hgs_coord, projection_code='CAR')
+
+
+@pytest.fixture
+def hpc_coord_notime():
     return SkyCoord(0*u.arcsec, 0*u.arcsec, frame=frames.Helioprojective)
 
 
@@ -49,78 +65,94 @@ def test_metakeywords():
     assert isinstance(meta, dict)
 
 
-def test_rotation_angle(map_data, hpc_test_header):
-    header = sunpy.map.make_fitswcs_header(map_data, hpc_test_header,
-                                           rotation_angle=90*u.deg)
+def test_rotation_angle(map_data, hpc_coord):
+    header = make_fitswcs_header(map_data, hpc_coord,
+                                 rotation_angle=90*u.deg)
     wcs = WCS(header)
     np.testing.assert_allclose(wcs.wcs.pc, [[0, -1], [1, 0]], atol=1e-5)
 
 
-def test_rotation_matrix(map_data, hpc_test_header):
-    header = sunpy.map.make_fitswcs_header(map_data, hpc_test_header,
-                                           rotation_matrix=np.array([[1, 0], [0, 1]]))
+def test_rotation_matrix(map_data, hpc_coord):
+    header = make_fitswcs_header(map_data, hpc_coord,
+                                 rotation_matrix=np.array([[1, 0], [0, 1]]))
     wcs = WCS(header)
     np.testing.assert_allclose(wcs.wcs.pc, [[1, 0], [0, 1]], atol=1e-5)
 
 
-def test_make_fits_header(map_data, hpc_test_header, hgc_test_header,
-                          hgs_test_header, hcc_test_header, hpc_test_header_notime):
+def test_hpc_header(hpc_header, hpc_coord):
+    assert isinstance(hpc_header, MetaDict)
 
-    # Check that different coordinate frames return header MetaDict or not in the case of HCC
-    assert isinstance(sunpy.map.make_fitswcs_header(map_data, hpc_test_header), MetaDict)
-    assert isinstance(sunpy.map.make_fitswcs_header(map_data, hgc_test_header), MetaDict)
-    assert isinstance(sunpy.map.make_fitswcs_header(map_data, hgs_test_header), MetaDict)
-    # Raise the HCC error
-    with pytest.raises(ValueError):
-        sunpy.map.make_fitswcs_header(map_data, hcc_test_header)
+    assert hpc_header['crval1'] == 0
+    assert hpc_header['crpix1'] == 5.5
+    assert hpc_header['ctype1'] == 'HPLN-TAN'
+    assert hpc_header['crval2'] == 0
+    assert hpc_header['crpix2'] == 10.5
+    assert hpc_header['ctype2'] == 'HPLT-TAN'
 
-    # Check for when coordinate argument isn't given as an `astropy.coordinate.SkyCoord`
-    with pytest.raises(ValueError):
-        sunpy.map.make_fitswcs_header(map_data, map_data)
+    assert hpc_header['lonpole'] == 180.
+    assert u.allclose(hpc_header['rsun_ref'] * u.m, hpc_coord.rsun)
 
-    # Check for when an observation time isn't given
-    with pytest.raises(ValueError):
-        sunpy.map.make_fitswcs_header(map_data, hpc_test_header_notime)
+    # Check for observer info for HPC
+    assert u.allclose(hpc_header['hgln_obs'] * u.deg, hpc_coord.observer.lon)
+    assert u.allclose(hpc_header['hglt_obs'] * u.deg, hpc_coord.observer.lat)
+    assert u.allclose(hpc_header['dsun_obs'] * u.m, hpc_coord.observer.radius)
+    assert u.allclose(hpc_header['rsun_obs'] * u.arcsec,
+                      sun._angular_radius(hpc_coord.rsun, hpc_coord.observer.radius))
 
-    # Check that correct information is in header MetaDict including observer for HPC
-    header = sunpy.map.make_fitswcs_header(map_data, hpc_test_header)
-    assert header['crval1'] == 0
-    assert header['crpix1'] == 5.5
-    assert header['ctype1'] == 'HPLN-TAN'
-    assert u.allclose(header['dsun_obs'], hpc_test_header.frame.observer.radius.to_value(u.m))
-    assert u.allclose(header['rsun_ref'] * u.m, hpc_test_header.frame.rsun)
-    assert u.allclose(header['rsun_obs'] * u.arcsec,
-                      sun._angular_radius(header['rsun_ref'] * u.m, header['dsun_obs'] * u.m))
-    assert u.allclose(header['hgln_obs'] * u.deg, hpc_test_header.frame.observer.lon)
-    assert u.allclose(header['hglt_obs'] * u.deg, hpc_test_header.frame.observer.lat)
-    assert isinstance(WCS(header), WCS)
+    assert isinstance(WCS(hpc_header), WCS)
+
+
+def test_hgc_header(hgc_header, hgc_coord):
+    assert isinstance(hgc_header, MetaDict)
+
+    assert hgc_header['crval1'] == 70
+    assert hgc_header['crpix1'] == 5.5
+    assert hgc_header['ctype1'] == "CRLN-CAR"
+    assert hgc_header['crval2'] == -30
+    assert hgc_header['crpix2'] == 10.5
+    assert hgc_header['ctype2'] == "CRLT-CAR"
+    assert hgc_header['cunit1'] == "deg"
+    assert hgc_header['cunit2'] == "deg"
+
+    assert hgc_header['lonpole'] == 180.  # for negative reference latitude in a CAR projection
+    assert u.allclose(hgc_header['rsun_ref'] * u.m, hgc_coord.rsun)
+
+    # Check for observer info for HGC (which is set to "self")
+    assert u.allclose(hgc_header['crln_obs'] * u.deg, hgc_coord.lon)
+    assert u.allclose(hgc_header['crlt_obs'] * u.deg, hgc_coord.lat)
+    assert u.allclose(hgc_header['dsun_obs'] * u.m, hgc_coord.radius)
+    assert u.allclose(hgc_header['rsun_obs'] * u.arcsec,
+                      sun._angular_radius(hgc_coord.rsun, hgc_coord.radius))
+
+    assert isinstance(WCS(hgc_header), WCS)
+
+
+def test_hgs_header(hgs_header, hgs_coord):
+    assert isinstance(hgs_header, MetaDict)
+
+    assert hgs_header['crval1'] == -50
+    assert hgs_header['crpix1'] == 5.5
+    assert hgs_header['ctype1'] == "HGLN-CAR"
+    assert hgs_header['crval2'] == 50
+    assert hgs_header['crpix2'] == 10.5
+    assert hgs_header['ctype2'] == "HGLT-CAR"
+    assert hgs_header['cunit1'] == "deg"
+    assert hgs_header['cunit2'] == "deg"
+
+    assert hgs_header['lonpole'] == 0.  # for positive reference latitude in a CAR projection
+    assert u.allclose(hgs_header['rsun_ref'] * u.m, hgs_coord.rsun)
 
     # Check no observer info for HGS
-    header = sunpy.map.make_fitswcs_header(map_data, hgs_test_header)
-    assert 'dsun_obs' not in header
-    assert 'rsun_obs' not in header
-    assert isinstance(WCS(header), WCS)
+    assert "hgln_obs" not in hgs_header
+    assert "hglt_obs" not in hgs_header
+    assert 'dsun_obs' not in hgs_header
+    assert 'rsun_obs' not in hgs_header
 
-    # Check for observer info for HGC
-    header = sunpy.map.make_fitswcs_header(map_data, hgc_test_header)
-    assert u.allclose(header['dsun_obs'], hgc_test_header.frame.observer.radius.to_value(u.m))
-    assert isinstance(WCS(header), WCS)
+    assert isinstance(WCS(hgs_header), WCS)
 
-    # Check arguments not given as astropy Quantities
-    with pytest.raises(TypeError):
-        header = sunpy.map.make_fitswcs_header(map_data, hpc_test_header, reference_pixel=[0, 0])
-        header = sunpy.map.make_fitswcs_header(map_data, hpc_test_header, scale=[0, 0])
 
-    # Check arguments of reference_pixel and scale have to be given in astropy units of pix, and arcsec/pix
-    with pytest.raises(u.UnitsError):
-        header = sunpy.map.make_fitswcs_header(
-            map_data, hpc_test_header, reference_pixel=u.Quantity([0, 0]))
-        header = sunpy.map.make_fitswcs_header(map_data, hpc_test_header, scale=u.Quantity([0, 0]))
-        header = sunpy.map.make_fitswcs_header(
-            map_data, hpc_test_header, scale=u.Quantity([0, 0]*u.arcsec))
-
-    # Check keyword helper arguments
-    header = sunpy.map.make_fitswcs_header(map_data, hpc_test_header, instrument='test name')
+def test_instrument_keyword(map_data, hpc_coord):
+    header = make_fitswcs_header(map_data, hpc_coord, instrument='test name')
     assert header['instrume'] == 'test name'
 
     # Check returned MetaDict will make a `sunpy.map.Map`
@@ -128,51 +160,26 @@ def test_make_fits_header(map_data, hpc_test_header, hgc_test_header,
     assert isinstance(map_test, sunpy.map.mapbase.GenericMap)
 
 
-def test_HGS_CAR_header():
-    # This tests both non-HPC and non-TAN header generation.
-    new_data = np.empty((72, 144))
-    new_frame = SkyCoord(0*u.deg, 0*u.deg, obstime="2019-06-16", frame="heliographic_stonyhurst")
-    new_header = sunpy.map.make_fitswcs_header(new_data, new_frame,
-                                               scale=[2.5, 2.5]*u.deg/u.pix,
-                                               projection_code="CAR")
+def test_invalid_inputs(map_data, hcc_coord, hpc_coord_notime, hpc_coord):
+    # Raise the HCC error
+    with pytest.raises(ValueError):
+        make_fitswcs_header(map_data, hcc_coord)
 
-    assert new_header['ctype1'] == "HGLN-CAR"
-    assert new_header['ctype2'] == "HGLT-CAR"
-    assert new_header['cunit1'] == "deg"
-    assert new_header['cunit2'] == "deg"
+    # Check for when coordinate argument isn't given as an `astropy.coordinate.SkyCoord`
+    with pytest.raises(ValueError):
+        make_fitswcs_header(map_data, map_data)
 
-    assert "hgln_obs" not in new_header
-    assert "hglt_obs" not in new_header
-    assert "dsun_obs" not in new_header
+    # Check for when an observation time isn't given
+    with pytest.raises(ValueError):
+        make_fitswcs_header(map_data, hpc_coord_notime)
 
-    wcs = WCS(new_header)
-    pix_coords = np.mgrid[0:new_data.shape[1], 0:new_data.shape[0]]
-    world_coords = wcs.pixel_to_world(*pix_coords)
+    # Check arguments not given as astropy Quantities
+    with pytest.raises(TypeError):
+        header = make_fitswcs_header(map_data, hpc_coord, reference_pixel=[0, 0])
+        header = make_fitswcs_header(map_data, hpc_coord, scale=[0, 0])
 
-    # In this projection the coordinate system is symmetric around the
-    # reference pixel. because the reference pixel should be in the center of
-    # the array it means the array should be symmetric apart from the sign
-    # flip. This is therefore testing that the reference pixel is correctly in
-    # the center of the array.
-    assert u.allclose(world_coords.lon, world_coords.lon[::-1, ::-1]*-1)
-    assert u.allclose(world_coords.lat, world_coords.lat[::-1, ::-1]*-1)
-
-
-def test_latlon_order():
-    # This tests that CRVAL1, CRVAL2 (i.e. lon,lat) correspond to CTYPE1, CTYPE2 (i.e. HGLN, HGLT)
-    data = np.zeros((100, 100))
-    coord = SkyCoord(20*u.arcsec, -10*u.arcsec, obstime='2013-10-28', frame=frames.Helioprojective)
-    header = sunpy.map.make_fitswcs_header(data, coord)
-    # check LON
-    assert ('LN' in header['ctype1']) and header['crval1'] == coord.spherical.lon.to_value()
-    # check LAT
-    assert 'LT' in header['ctype2'] and header['crval2'] == coord.spherical.lat.to_value()
-
-
-def test_carrington_self_observer():
-    coord = SkyCoord(70*u.deg, -30*u.deg, 1*u.au, observer='self',
-                     obstime='2013-10-28 00:00', frame=frames.HeliographicCarrington)
-    header = sunpy.map.make_fitswcs_header(np.zeros((10, 10)), coord)
-    assert header['rsun_obs'] == sun._angular_radius(coord.rsun,
-                                                     coord.radius).to_value(u.arcsec)
-    assert header['dsun_obs'] == coord.radius.to_value(u.m)
+    # Check arguments of reference_pixel and scale have to be given in astropy units of pix, and arcsec/pix
+    with pytest.raises(u.UnitsError):
+        header = make_fitswcs_header(map_data, hpc_coord, reference_pixel=u.Quantity([0, 0]))
+        header = make_fitswcs_header(map_data, hpc_coord, scale=u.Quantity([0, 0]))
+        header = make_fitswcs_header(map_data, hpc_coord, scale=u.Quantity([0, 0]*u.arcsec))


### PR DESCRIPTION
~I believe this fixes the handling of FITS WCS `lonpole`.  In short, the `lonpole` is set in `WCS` headers based on the default reference coordinate, but if we change the latitude of the reference coordinate (`crval2`), `lonpole` may need to be changed at the same time.~

This PR fixes the definition of `lonpole` by the FITS WCS header helper

This PR also overhauls the suite of unit tests for the header helper because they were a bit of a mess