### PR TITLE
See what happens when None is returned for .date

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -551,7 +551,8 @@ class GenericMap(NDData):
         # FITS standard doesn't allow both PC_ij *and* CROTA keywords
         w2.wcs.crota = (0, 0)
         w2.wcs.cunit = self.spatial_units
-        w2.wcs.dateobs = self.date.isot
+        if self.date is not None:
+            w2.wcs.dateobs = self.date.isot
         w2.wcs.aux.rsun_ref = self.rsun_meters.to_value(u.m)
 
         # Astropy WCS does not understand the SOHO default of "solar-x" and
@@ -753,12 +754,7 @@ class GenericMap(NDData):
             timesys = self.meta.get('timesys', 'UTC')
 
         if time is None:
-            if self._default_time is None:
-                warn_metadata("Missing metadata for observation time, "
-                              "setting observation time to current time. "
-                              "Set the 'DATE-OBS' FITS keyword to prevent this warning.")
-                self._default_time = parse_time('now')
-            time = self._default_time
+            return
 
         return parse_time(time, scale=timesys.lower())
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -984,10 +984,11 @@ def test_missing_metadata_warnings():
         header['cunit2'] = 'arcsec'
         header['ctype1'] = 'HPLN-TAN'
         header['ctype2'] = 'HPLT-TAN'
+        header['date-obs'] = parse_time('2020-01-01').isot
         array_map = sunpy.map.Map(np.random.rand(20, 15), header)
         array_map.peek()
-    # There should be 2 warnings for missing metadata (obstime and observer location)
-    assert len([w for w in record if w.category in (SunpyMetadataWarning, SunpyUserWarning)]) == 2
+    # There should be 1 warning for missing metadata (observer location)
+    assert len([w for w in record if w.category in (SunpyMetadataWarning, SunpyUserWarning)]) == 1
 
 
 def test_fits_header(aia171_test_map):


### PR DESCRIPTION
**DON'T MERGE**

I thought we should see how much of our docs/tests breaks if we do return `None` instead of defaulting to 'now' for `.date`. xref https://github.com/sunpy/sunpy/issues/5454