### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/dev_guide/contents/remote_data.rst
+++ b/docs/dev_guide/contents/remote_data.rst
@@ -61,7 +61,7 @@ Testing
 =======
 
 A pytest fixture is provided for ease of mocking network requests when using cache.
-The following example demonstates the usage of the fixture.::
+The following example demonstrates the usage of the fixture.::
 
     @pytest.fixture()
     def local_cache(sunpy_cache):

--- a/docs/guide/units-coordinates.rst
+++ b/docs/guide/units-coordinates.rst
@@ -50,7 +50,7 @@ unit systems::
   >>> length.cgs
   <Quantity 1000. cm>
 
-Probably most usefully, `~astropy.units.Quantity` objects will propogate units
+Probably most usefully, `~astropy.units.Quantity` objects will propagate units
 through arithmetic operations when appropriate::
 
   >>> distance_start = 10 * u.mm

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -934,7 +934,7 @@ def test_transform_with_sun_center():
 
 
 def test_transform_with_sun_center_reset():
-    # This test sequence ensures that the context manager resets propoerly
+    # This test sequence ensures that the context manager resets properly
 
     sun_center = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU,
                           frame=HeliographicStonyhurst(obstime="2001-01-01"))

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -606,7 +606,7 @@ class Database:
         db_entries = walker.create(and_(*query), self.session)
 
         # If any of the DatabaseEntry-s lack the sorting attribute, the
-        # sorting key should fall back to 'id', orherwise it fails with
+        # sorting key should fall back to 'id', otherwise it fails with
         # TypeError on py3
         if any([getattr(entry, sortby) is None for entry in db_entries]):
             sortby = 'id'

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1138,7 +1138,7 @@ class GenericMap(NDData):
         This method converts the deprecated CROTA FITS kwargs to the new
         PC rotation matrix.
 
-        This method can be overriden if an instruments header does not use this
+        This method can be overridden if an instruments header does not use this
         conversion.
         """
         lam = self.scale[0] / self.scale[1]

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -963,7 +963,7 @@ def test_more_than_two_dimensions():
     """Checks to see if an appropriate error is raised when a FITS with more than two dimensions is
     loaded.  We need to load a >2-dim dataset with a TELESCOP header"""
 
-    # Data crudely represnts 4 stokes, 4 wavelengths with Y,X of 3 and 5.
+    # Data crudely represents 4 stokes, 4 wavelengths with Y,X of 3 and 5.
     bad_data = np.random.rand(4, 4, 3, 5)
     hdr = fits.Header()
     hdr['TELESCOP'] = 'XXX'


### PR DESCRIPTION
There are small typos in:
- docs/dev_guide/contents/remote_data.rst
- docs/guide/units-coordinates.rst
- sunpy/coordinates/tests/test_transformations.py
- sunpy/database/database.py
- sunpy/map/mapbase.py
- sunpy/map/tests/test_mapbase.py

Fixes:
- Should read `represents` rather than `represnts`.
- Should read `properly` rather than `propoerly`.
- Should read `propagate` rather than `propogate`.
- Should read `overridden` rather than `overriden`.
- Should read `otherwise` rather than `orherwise`.
- Should read `demonstrates` rather than `demonstates`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md