### PR TITLE
Fix EUI observer coordinate date

### DIFF
--- a/changelog/5462.bugfix.rst
+++ b/changelog/5462.bugfix.rst
@@ -1,0 +1,5 @@
+The date returned by `~sunpy.map.GenericMap.date` for Solar Orbiter/EUI maps
+has been adjusted to be taken from the DATE-AVG keyword
+(the middle of the image acquisition period), instead of the DATE-OBS
+keyword (the beginning of the image acquisition period). This means the observer
+coordinate now has the correct date.

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -8,6 +8,7 @@ from astropy.visualization import ImageNormalize, LinearStretch
 from sunpy.coordinates import HeliocentricInertial
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
+from sunpy.time import parse_time
 
 __all__ = ['EUIMap']
 
@@ -46,6 +47,12 @@ class EUIMap(GenericMap):
     @property
     def exposure_time(self):
         return self.meta.get('xposure', 0.0) * self.timeunit
+
+    @property
+    def date(self):
+        t = self.meta.get('date-avg')
+        timesys = self.meta.get('timesys')
+        return parse_time(t, scale=timesys.lower())
 
     @property
     def _supported_observer_coordinates(self):

--- a/sunpy/map/sources/tests/test_eui_source.py
+++ b/sunpy/map/sources/tests/test_eui_source.py
@@ -242,7 +242,9 @@ def test_is_datasource_for(eui_fsi_map):
 
 
 def test_observer_coordinate(eui_fsi_map):
-    assert isinstance(eui_fsi_map.observer_coordinate, SkyCoord)
+    obs_coord = eui_fsi_map.observer_coordinate
+    assert isinstance(obs_coord, SkyCoord)
+    assert obs_coord.obstime.isot == eui_fsi_map.meta['date-avg']
 
 
 def test_observatory(eui_fsi_map):


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5450. Currently I've just passed a custom value to `.observer_coordinate` property, which means that `.observer_coordinate.obstime != .time`, to avoid changing the return value of `.time`.