### PR TITLE
Fixed the "Creating a Heliographic Map" example to use `rsun`

### DIFF
--- a/examples/map_transformations/reprojection_heliographic_stonyhurst.py
+++ b/examples/map_transformations/reprojection_heliographic_stonyhurst.py
@@ -40,7 +40,8 @@ aia_map.plot(ax)
 shape_out = [720, 1440]
 frame_out = SkyCoord(0, 0, unit=u.deg,
                      frame="heliographic_stonyhurst",
-                     obstime=aia_map.date)
+                     obstime=aia_map.date,
+                     rsun=aia_map.coordinate_frame.rsun)
 header = sunpy.map.make_fitswcs_header(shape_out,
                                        frame_out,
                                        scale=[360 / shape_out[1],
@@ -65,8 +66,6 @@ outmap.plot_settings = aia_map.plot_settings
 fig = plt.figure()
 ax = plt.subplot(projection=outmap)
 outmap.plot(ax)
-
-ax.set_xlim(0, shape_out[1])
-ax.set_ylim(0, shape_out[0])
+outmap.draw_limb(color='blue')
 
 plt.show()


### PR DESCRIPTION
This can be considered an extension of #5391.

The ["Creating a Heliographic Map" example](https://docs.sunpy.org/en/v3.0.1/generated/gallery/map_transformations/reprojection_heliographic_stonyhurst.html) did not account for AIA's non-default `rsun` value, which results in the loss of a bunch of data near the limb:
![before](https://user-images.githubusercontent.com/991759/126053942-44bc6365-ede0-4631-af97-51ca23e77a1a.png)

After this PR:
![after](https://user-images.githubusercontent.com/991759/126053957-07833720-e6c4-4fd1-b356-db575a39e018.png)