### PR TITLE
More cleanup to HMI synoptic map example

### DIFF
--- a/changelog/5467.bugfix.rst
+++ b/changelog/5467.bugfix.rst
@@ -1,0 +1,1 @@
+The ``.unit`` attribute for HMI synoptic maps has been fixed.

--- a/examples/plotting/hmi_synoptic_maps.py
+++ b/examples/plotting/hmi_synoptic_maps.py
@@ -22,12 +22,6 @@ filename = download_file(
 syn_map = sunpy.map.Map(filename)
 
 ###############################################################################
-# Change colormap and colormap limits
-
-syn_map.plot_settings['cmap'] = 'hmimag'
-syn_map.plot_settings['norm'] = plt.Normalize(-1500, 1500)
-
-###############################################################################
 # Plot the results.
 
 fig = plt.figure(figsize=(12, 5))
@@ -40,11 +34,11 @@ axes.coords[1].set_axislabel("Latitude [deg]")
 axes.coords.grid(color='black', alpha=0.6, linestyle='dotted', linewidth=0.5)
 
 cb = plt.colorbar(im, fraction=0.019, pad=0.1)
-cb.set_label("Radial magnetic field [Gauss]")
+cb.set_label(f"Radial magnetic field [{syn_map.unit}]")
 
 # In order to make the x-axis ticks show, the bottom y-limit has to be adjusted slightly
 axes.set_ylim(bottom=0)
-axes.set_title("{} {}-{}".format(syn_map.meta['content'], syn_map.meta['CAR_ROT'],
-                                 syn_map.meta['CAR_ROT'] + 1))
+axes.set_title(f"{syn_map.meta['content']},\n"
+               f"Carrington rotation {syn_map.meta['CAR_ROT']}")
 
 plt.show()

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -171,6 +171,15 @@ class HMISynopticMap(HMIMap):
         self.plot_settings['cmap'] = 'hmimag'
         self.plot_settings['norm'] = ImageNormalize(vmin=-1.5e3, vmax=1.5e3)
 
+    @property
+    def unit(self):
+        unit_str = self.meta.get('bunit', None)
+        if unit_str == 'Mx/cm^2':
+            # Maxwells aren't in the IAU unit sytle manual, so replace with Gauss
+            return u.Unit('G')
+        else:
+            return super().unit
+
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """

--- a/sunpy/map/sources/tests/test_hmi_synoptic_source.py
+++ b/sunpy/map/sources/tests/test_hmi_synoptic_source.py
@@ -123,7 +123,7 @@ def test_measurement(hmi_synoptic):
 
 
 def test_unit(hmi_synoptic):
-    # Check that the deafult unit of Mx/cm**2 is correctly replaced with a
+    # Check that the default unit of Mx/cm**2 is correctly replaced with a
     # FITS standard unit
     assert hmi_synoptic.unit == u.G
     hmi_synoptic.meta['bunit'] = 'm'

--- a/sunpy/map/sources/tests/test_hmi_synoptic_source.py
+++ b/sunpy/map/sources/tests/test_hmi_synoptic_source.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
+import astropy.units as u
 from astropy.io import fits
 
 from sunpy.map import Map
@@ -119,3 +120,11 @@ def test_observatory(hmi_synoptic):
 def test_measurement(hmi_synoptic):
     """Tests the measurement property of the HMISynopticMap object."""
     assert hmi_synoptic.measurement == "carrington"
+
+
+def test_unit(hmi_synoptic):
+    # Check that the deafult unit of Mx/cm**2 is correctly replaced with a
+    # FITS standard unit
+    assert hmi_synoptic.unit == u.G
+    hmi_synoptic.meta['bunit'] = 'm'
+    assert hmi_synoptic.unit == u.m


### PR DESCRIPTION
- After https://github.com/sunpy/sunpy/pull/5464, no longer need to specify cmap/norm
- Clean up title (a single Carrington rotation is refers to the whole interval of that rotation, so don't do N - N+1 in the title)
- Fix the unit attribute, since Mx isn't in the list of units the IAU guide allows (so astropy doesn't recognise it)