### PR TITLE
Remove incorrect timesys warning in Map

### DIFF
--- a/changelog/5468.bugfix.rst
+++ b/changelog/5468.bugfix.rst
@@ -1,0 +1,4 @@
+When "TAI" is in the date string, `sunpy.map.GenericMap.date`
+now only raises a warning if the TIMESYS keyword is present
+and different to "TAI". Previously a warning was raised all the
+time when "TAI" was in the date string.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -745,7 +745,7 @@ class GenericMap(NDData):
             # user that it will be ignored.
             timesys = 'TAI'
             timesys_meta = self.meta.get('timesys', '').upper()
-            if timesys_meta != 'TAI':
+            if timesys_meta not in ('', 'TAI'):
                 warn_metadata('Found "TAI" in time string, ignoring TIMESYS keyword '
                               f'which is set to "{timesys_meta}".')
         else:

--- a/sunpy/map/sources/tests/test_hmi_synoptic_source.py
+++ b/sunpy/map/sources/tests/test_hmi_synoptic_source.py
@@ -122,6 +122,11 @@ def test_measurement(hmi_synoptic):
     assert hmi_synoptic.measurement == "carrington"
 
 
+def test_date(hmi_synoptic):
+    """Check that accessing the date doesn't raise a warning."""
+    hmi_synoptic.date
+
+
 def test_unit(hmi_synoptic):
     # Check that the default unit of Mx/cm**2 is correctly replaced with a
     # FITS standard unit


### PR DESCRIPTION
Previously a warning would have been raised if TAI was in the string, regardless of the presence of `TIMESYS`. This is now fixed to only warn if TIMESYS is present too.