### PR TITLE
Use disk center as the reference coordinate for the Mars observer

### DIFF
--- a/examples/map_transformations/reprojection_different_observers.py
+++ b/examples/map_transformations/reprojection_different_observers.py
@@ -141,8 +141,7 @@ mars = get_body_heliographic_stonyhurst('mars', map_aia.date)
 # coordinate, which is similar to the one for AIA, except now with
 # the observer at Mars.
 
-mars_ref_coord = SkyCoord(map_aia.reference_coordinate.Tx,
-                          map_aia.reference_coordinate.Ty,
+mars_ref_coord = SkyCoord(0*u.arcsec, 0*u.arcsec,
                           obstime=map_aia.reference_coordinate.obstime,
                           observer=mars,
                           rsun=map_aia.reference_coordinate.rsun,


### PR DESCRIPTION
For the gallery example where an AIA image is reprojected to a Mars observer, it's better for the reference coordinate for the reprojected map be at disk center (i.e., (0, 0) in helioprojective coordinates).  That is, we are saying that the hypothetical imager at Mars is pointed at disk center.  There's no compelling reason to say that is slightly offset from disk center with the same offsets as the AIA image.