### PR TITLE
Use `interpn` for resampling

### DIFF
--- a/changelog/5476.trivial.rst
+++ b/changelog/5476.trivial.rst
@@ -1,0 +1,3 @@
+Nearest-neighbour and linear
+(the default for :meth:`sunpy.map.GenericMap.resample`)
+resampling have been significantly sped up.


### PR DESCRIPTION
This reduces memory use by a factor of ~8 and running time by a factor of ~3 for me when resampling a 4k image down by a factor of 5, and also drastically improves the code. Perhaps `interpn` didn't exist ~10 years ago, which it looks like is when this code was written.