### PR TITLE
`GenericMap.plot()` can now plot to a figure

### DIFF
--- a/changelog/5477.feature.rst
+++ b/changelog/5477.feature.rst
@@ -1,0 +1,2 @@
+It is now possible to explicitly specify the target `~matplotlib.figure.Figure` instance when using :meth:`sunpy.map.GenericMap.plot`, via the ``figure`` keyword argument.
+This is useful when not using the `matplotlib.pyplot` workflow, because there may not be a notion of a "current" figure, and saves having to manually create the `~matplotlib.axes.Axes` in common use cases.

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -52,6 +52,32 @@ def test_plot_aia171(aia171_test_map):
 
 
 @figure_test
+def test_plot_to_empty_figure(aia171_test_map):
+    fig = Figure()
+    aia171_test_map.plot(figure=fig)
+    return fig
+
+
+@figure_test
+def test_plot_to_figure_and_axes(aia171_test_map, hmi_test_map):
+    fig = Figure()
+    ax1 = fig.add_subplot(1, 2, 1, projection=aia171_test_map)
+    ax2 = fig.add_subplot(1, 2, 2, projection=hmi_test_map)
+    aia171_test_map.plot(figure=fig, axes=ax1)
+    hmi_test_map.plot(figure=fig, axes=ax2)
+    return fig
+
+
+def test_plot_to_mismatched_figure_and_axes(aia171_test_map):
+    fig1 = Figure()
+    ax1 = fig1.add_subplot(projection=aia171_test_map)
+    fig2 = Figure()
+    ax2 = fig2.add_subplot(projection=aia171_test_map)
+    with pytest.raises(ValueError):
+        aia171_test_map.plot(figure=fig1, axes=ax2)
+
+
+@figure_test
 def test_plot_rotated_aia171(aia171_test_map):
     # Check that plotting a rotated map and a rectangle works as expected
 

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
@@ -7,6 +7,8 @@
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "a400eef26fdd915ccf12769031bd8dadedbf8f6a93e31cd5982bffe2484702ee",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "1e5435af7bb854d47ebeabf354350f27bf989325aa5d77b930bdcdb043ce25df",
   "sunpy.map.tests.test_plotting.test_plot_aia171": "1e5435af7bb854d47ebeabf354350f27bf989325aa5d77b930bdcdb043ce25df",
+  "sunpy.map.tests.test_plotting.test_plot_to_empty_figure": "1e5435af7bb854d47ebeabf354350f27bf989325aa5d77b930bdcdb043ce25df",
+  "sunpy.map.tests.test_plotting.test_plot_to_figure_and_axes": "3ae7d3a5a4abfb640071f7f6df4bb1f6064cd8afab3342ad6fde2ea3c250e354",
   "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "3d6eb2cf8953cb612fff2c0742e2027fe06f58fef111119508cd55dc75ce1a67",
   "sunpy.map.tests.test_plotting.test_plot_aia171_clip": "241cb73a89ca5d80b9eb673e6e0fda97b842b38be3ea3f25c06e2f8aeb6a4dfc",
   "sunpy.map.tests.test_plotting.test_peek_aia171": "66b8e96ed6c074e87ff328a9154f4dbd32c11cb9d3f83f692c47ddd2946eefe1",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -7,6 +7,8 @@
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "17d50a2992e9b66ede4984376a70cd0aa67dd1434a9a3bc04e23e4e4213cf7a4",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "e4622b1aea9e0aaf076eddf93dbdc06daf5b3472d78aae31ed89a77499d58e0f",
   "sunpy.map.tests.test_plotting.test_plot_aia171": "e4622b1aea9e0aaf076eddf93dbdc06daf5b3472d78aae31ed89a77499d58e0f",
+  "sunpy.map.tests.test_plotting.test_plot_to_empty_figure": "e4622b1aea9e0aaf076eddf93dbdc06daf5b3472d78aae31ed89a77499d58e0f",
+  "sunpy.map.tests.test_plotting.test_plot_to_figure_and_axes": "4c97b8671c8b1982c8c7f1251640d0afbcc81c258b1e95cc881107d5e7bfab2b",
   "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "33d6a3b7b0cc4bc08ef60622795a1777a738dde3e4f161798bb1994c25f23e63",
   "sunpy.map.tests.test_plotting.test_plot_aia171_clip": "c70b809374fe1c3811c30a7df6274b65383f4d46c00edf5550afdb9e29f5367b",
   "sunpy.map.tests.test_plotting.test_peek_aia171": "61a969437ec026fea50a0b0ab158b183c0cb5b0d954634bb97eb2dde4c075758",

--- a/sunpy/visualization/wcsaxes_compat.py
+++ b/sunpy/visualization/wcsaxes_compat.py
@@ -55,9 +55,12 @@ def gca_wcs(wcs, fig=None, slices=None):
     if not fig:
         fig = plt.gcf()
 
-    if not len(fig.get_axes()):
-        ax = plt.axes(projection=wcs, slices=slices)
-    else:
+    naxes = len(fig.get_axes())
+    if naxes == 0:  # Create axes if the figure has none
+        ax = fig.add_subplot(projection=wcs, slices=slices)
+    elif naxes == 1:  # If there exactly one axes, use that
+        ax = fig.get_axes()[0]
+    else:  # Otherwise, use pyplot to determine which axes to use
         ax = plt.gca()
 
     return ax


### PR DESCRIPTION
This PR slightly streamlines the non-pyplot workflow for plotting Maps by removing the need to explicitly create the axes for the usual use case of plotting to the Map's own WCS.

Before this PR:
```python
from matplotlib.figure import Figure

fig = Figure()
ax = fig.add_subplot(projection=aiamap)
aiamap.plot(axes=ax)
```

After this PR:
```python
from matplotlib.figure import Figure

fig = Figure()
aiamap.plot(figure=fig)
```

Earth-shattering, I know.  Thoughts?