### PR TITLE
Better handling of metadata/properties for Stonyhurst heliographic maps

### DIFF
--- a/changelog/5478.bugfix.1.rst
+++ b/changelog/5478.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fixed the unintended insertion of (assumed) observer location information when accessing the property `sunpy.map.GenericMap.wcs` for Stonyhurst heliographic maps.

--- a/changelog/5478.bugfix.2.rst
+++ b/changelog/5478.bugfix.2.rst
@@ -1,0 +1,2 @@
+Fixed a bug where the property `sunpy.map.GenericMap.rsun_meters` would always internally determine the observer location, even when it is not needed, particularly for Stonyhurst heliographic maps, which have no notion of an observer.
+Thus, when working with a Stonyhurst heliographic map, a user could get an irrelevant warning message about having to assume an observer location (Earth center).

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -153,7 +153,7 @@ def solar_wcs_frame_mapping(wcs):
     if rsun is not None:
         frame_args['rsun'] = rsun
 
-    frame_class = _frame_class_from_ctypes(wcs.wcs.ctype)
+    frame_class = _sunpy_frame_class_from_ctypes(wcs.wcs.ctype)
 
     if frame_class:
         if frame_class == HeliographicStonyhurst:
@@ -164,7 +164,7 @@ def solar_wcs_frame_mapping(wcs):
         return frame_class(**frame_args)
 
 
-def _frame_class_from_ctypes(ctypes):
+def _sunpy_frame_class_from_ctypes(ctypes):
     # Truncate the ctype to the first four letters
     ctypes = {c[:4] for c in ctypes}
 

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -153,22 +153,31 @@ def solar_wcs_frame_mapping(wcs):
     if rsun is not None:
         frame_args['rsun'] = rsun
 
+    frame_class = _frame_class_from_ctypes(wcs.wcs.ctype)
+
+    if frame_class:
+        if frame_class == HeliographicStonyhurst:
+            frame_args.pop('observer', None)
+        if frame_class == Heliocentric:
+            frame_args.pop('rsun', None)
+
+        return frame_class(**frame_args)
+
+
+def _frame_class_from_ctypes(ctypes):
     # Truncate the ctype to the first four letters
-    ctypes = {c[:4] for c in wcs.wcs.ctype}
+    ctypes = {c[:4] for c in ctypes}
 
-    if {'HPLN', 'HPLT'} <= ctypes:
-        return Helioprojective(**frame_args)
+    mapping = {
+        Helioprojective: {'HPLN', 'HPLT'},
+        HeliographicStonyhurst: {'HGLN', 'HGLT'},
+        HeliographicCarrington: {'CRLN', 'CRLT'},
+        Heliocentric: {'SOLX', 'SOLY'},
+    }
 
-    if {'HGLN', 'HGLT'} <= ctypes:
-        frame_args.pop('observer', None)
-        return HeliographicStonyhurst(**frame_args)
-
-    if {'CRLN', 'CRLT'} <= ctypes:
-        return HeliographicCarrington(**frame_args)
-
-    if {'SOLX', 'SOLY'} <= ctypes:
-        frame_args.pop('rsun', None)
-        return Heliocentric(**frame_args)
+    for frame_class, ctype_pair in mapping.items():
+        if ctype_pair <= ctypes:
+            return frame_class
 
 
 def _set_wcs_aux_obs_coord(wcs, obs_frame):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -564,9 +564,9 @@ class GenericMap(NDData):
         if w2.wcs.ctype[1].lower() in ("solar-y", "solar_y"):
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
-        # Set observer coordinate information if appropriate
-        frame_class = sunpy.coordinates.wcs_utils._frame_class_from_ctypes(w2.wcs.ctype)
-        if hasattr(frame_class, 'observer'):
+        # Set observer coordinate information except when we know it is not appropriate (e.g., HGS)
+        sunpy_frame = sunpy.coordinates.wcs_utils._sunpy_frame_class_from_ctypes(w2.wcs.ctype)
+        if sunpy_frame is None or hasattr(sunpy_frame, 'observer'):
             # Clear all the aux information that was set earlier. This is to avoid
             # issues with maps that store multiple observer coordinate keywords.
             # Note that we have to create a new WCS as it's not possible to modify

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -915,7 +915,7 @@ class GenericMap(NDData):
 
         return new_map
 
-    def _rsun_meters(self, dsun):
+    def _rsun_meters(self, dsun=None):
         """
         This property exists to avoid circular logic in constructing the
         observer coordinate, by allowing a custom 'dsun' to be specified,
@@ -925,6 +925,8 @@ class GenericMap(NDData):
         if rsun is not None:
             return rsun * u.m
         elif self._rsun_obs_no_default is not None:
+            if dsun is None:
+                dsun = self.dsun
             return sun._radius_from_angular_radius(self.rsun_obs, dsun)
         else:
             log.info("Missing metadata for solar radius: assuming "
@@ -934,15 +936,15 @@ class GenericMap(NDData):
     @property
     def rsun_meters(self):
         """
-        Assumed radius of observed emmision from the Sun center.
+        Assumed radius of observed emission from the Sun center.
 
-        This is taken from the RSUN_REF FTIS keyword, if present.
-        If not, and angular radius metadata is present it is calculated from
+        This is taken from the RSUN_REF FITS keyword, if present.
+        If not, and angular radius metadata is present, it is calculated from
         `~sunpy.map.GenericMap.rsun_obs` and `~sunpy.map.GenericMap.dsun`.
-        If neither peices of metadata are present defaults to the standard
+        If neither pieces of metadata are present, defaults to the standard
         photospheric radius.
         """
-        return self._rsun_meters(self.dsun)
+        return self._rsun_meters()
 
     @property
     def _rsun_obs_no_default(self):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -564,9 +564,9 @@ class GenericMap(NDData):
         if w2.wcs.ctype[1].lower() in ("solar-y", "solar_y"):
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
-        if hasattr(astropy.wcs.utils.wcs_to_celestial_frame(w2), 'observer'):
-            # Set observer coordinate information
-            #
+        # Set observer coordinate information if appropriate
+        frame_class = sunpy.coordinates.wcs_utils._frame_class_from_ctypes(w2.wcs.ctype)
+        if hasattr(frame_class, 'observer'):
             # Clear all the aux information that was set earlier. This is to avoid
             # issues with maps that store multiple observer coordinate keywords.
             # Note that we have to create a new WCS as it's not possible to modify

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1261,7 +1261,6 @@ def test_meta_modifications(aia171_test_map):
     assert set(aiamap_rot.meta.modified_items) == set(['cdelt1', 'crpix1', 'crpix2', 'crval1'])
 
 
-
 def test_no_wcs_observer_info(heliographic_test_map):
     # Check that HeliographicCarrington WCS has observer info set
     assert isinstance(heliographic_test_map.coordinate_frame, HeliographicCarrington)
@@ -1283,3 +1282,22 @@ def test_no_wcs_observer_info(heliographic_test_map):
     assert wcs_aux.hgln_obs is None
     assert wcs_aux.hglt_obs is None
     assert wcs_aux.dsun_obs is None
+
+
+def test_rsun_meters_no_warning_for_hgs(heliographic_test_map):
+    # Make sure that Stonyhurst heliographic maps do not emit a warning about assuming an
+    # Earth-based observer when returning the physical radius of the Sun, because such an
+    # assumption is not necessary
+
+    # Convert the heliographic test map to Stonyhurst heliographic coordinates
+    heliographic_test_map.meta.pop('HGLN_OBS')
+    heliographic_test_map.meta.pop('HGLT_OBS')
+    heliographic_test_map.meta.pop('DSUN_OBS')
+    heliographic_test_map.meta['CTYPE1'] = 'HGLN-CAR'
+    heliographic_test_map.meta['CTYPE2'] = 'HGLT-CAR'
+
+    # Add a custom physical radius for the Sun
+    heliographic_test_map.meta['rsun_ref'] = 1.1 * sunpy.sun.constants.radius.to_value(u.m)
+
+    assert_quantity_allclose(heliographic_test_map.rsun_meters,
+                             heliographic_test_map.meta['rsun_ref'] << u.m)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -24,7 +24,7 @@ import sunpy.coordinates
 import sunpy.data.test
 import sunpy.map
 import sunpy.sun
-from sunpy.coordinates import sun
+from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, sun
 from sunpy.map.sources import AIAMap
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
@@ -1259,3 +1259,27 @@ def test_meta_modifications(aia171_test_map):
     assert set(aiamap_rot.meta.added_items.keys()) == set(['bunit', 'pc1_1', 'pc1_2', 'pc2_1', 'pc2_2'])
     assert set(aiamap_rot.meta.removed_items.keys()) == set(['crota2'])
     assert set(aiamap_rot.meta.modified_items) == set(['cdelt1', 'crpix1', 'crpix2', 'crval1'])
+
+
+
+def test_no_wcs_observer_info(heliographic_test_map):
+    # Check that HeliographicCarrington WCS has observer info set
+    assert isinstance(heliographic_test_map.coordinate_frame, HeliographicCarrington)
+    wcs_aux = heliographic_test_map.wcs.wcs.aux
+    assert wcs_aux.hgln_obs is not None
+    assert wcs_aux.hglt_obs is not None
+    assert wcs_aux.dsun_obs is not None
+
+    # Remove observer information, and change coordinate system to HeliographicStonyhurst
+    heliographic_test_map.meta.pop('HGLN_OBS')
+    heliographic_test_map.meta.pop('HGLT_OBS')
+    heliographic_test_map.meta.pop('DSUN_OBS')
+    heliographic_test_map.meta['CTYPE1'] = 'HGLN-CAR'
+    heliographic_test_map.meta['CTYPE2'] = 'HGLT-CAR'
+    assert isinstance(heliographic_test_map.coordinate_frame, HeliographicStonyhurst)
+
+    # Check that GenericMap.wcs doesn't set an observer
+    wcs_aux = heliographic_test_map.wcs.wcs.aux
+    assert wcs_aux.hgln_obs is None
+    assert wcs_aux.hglt_obs is None
+    assert wcs_aux.dsun_obs is None


### PR DESCRIPTION
- Copied from #5246: Don't set observer information for the WCS returned for Stonyhurst heliographic maps
- Disrupt the "vicious cycle" for our implementation of `.observer_coordinate` and `.wcs` (see https://github.com/sunpy/sunpy/pull/5246#issuecomment-828575070) by defining a private function to determine the frame class from `CTYPEi` rather than having to build the entire frame instance from `.wcs`.
- Fixed the `.rsun_meters` property so that it does not use `.dsun` unless it needs to, because `.dsun` will use `.observer_coordinate`.  For Stonyhurst heliographic maps without observer information, that will emit a irrelevant warning that an Earth-based observer is being assumed.