### PR TITLE
Deprecate 'neighbor' as a resample method

### DIFF
--- a/changelog/5480.deprecation.rst
+++ b/changelog/5480.deprecation.rst
@@ -1,0 +1,3 @@
+Using "neighbour" as a resampling method in
+:func:`sunpy.image.resample.resample` is deprecated. Use "nearest" instead,
+which has the same effect.

--- a/sunpy/image/resample.py
+++ b/sunpy/image/resample.py
@@ -5,6 +5,8 @@ import numpy as np
 import scipy.interpolate
 import scipy.ndimage
 
+from sunpy.util.exceptions import warn_deprecated
+
 __all__ = ['resample', 'reshape_image_to_4d_superpixel']
 
 
@@ -28,7 +30,6 @@ def resample(orig, dimensions, method='linear', center=False, minusone=False):
         Dimensions that new `numpy.ndarray` should have.
     method : {``"neighbor"``, ``"nearest"``, ``"linear"``, ``"spline"``}, optional
         Method to use for resampling interpolation.
-            * neighbor - Closest value from original data
             * nearest and linear - Uses "n x 1D" interpolations calculated by
               `scipy.interpolate.interp1d`.
             * spline - Uses `scipy.ndimage.map_coordinates`
@@ -66,6 +67,8 @@ def resample(orig, dimensions, method='linear', center=False, minusone=False):
 
     # Resample data
     if method == 'neighbor':
+        warn_deprecated('Using "neighbor" as a method for resampling is deprecated. '
+                        'Use "nearest" instead.')
         data = _resample_neighbor(orig, dimensions, offset, m1)
     elif method in ['nearest', 'linear']:
         data = _resample_nearest_linear(orig, dimensions, method,
@@ -131,6 +134,7 @@ def _resample_neighbor(orig, dimensions, offset, m1):
     """
     Resample Map using closest-value interpolation.
     """
+    # This can be deleted once the deprecation above in resample is expired
     dimlist = []
     dimensions = np.asarray(dimensions, dtype=int)
 

--- a/sunpy/image/tests/test_resample.py
+++ b/sunpy/image/tests/test_resample.py
@@ -8,6 +8,7 @@ import astropy.units as u
 import sunpy.data.test
 import sunpy.map
 from sunpy.image.resample import reshape_image_to_4d_superpixel
+from sunpy.util.exceptions import SunpyDeprecationWarning
 
 
 @pytest.fixture
@@ -22,7 +23,7 @@ def shape(aia171_test_map):
 
 
 def resample_meta(aia171_test_map, dimensions, method, center, minusone):
-    map_resampled = aia171_test_map.resample(dimensions)
+    map_resampled = aia171_test_map.resample(dimensions, method=method)
     return tuple(map_resampled.data.shape)
 
 
@@ -39,7 +40,9 @@ def resample_method(aia171_test_map, method):
 
 
 def test_resample_neighbor(aia171_test_map):
-    resample_method(aia171_test_map, 'neighbor')
+    with pytest.warns(SunpyDeprecationWarning,
+                      match='Using "neighbor" as a method for resampling is deprecated.'):
+        resample_method(aia171_test_map, 'neighbor')
 
 
 def test_resample_nearest(aia171_test_map):


### PR DESCRIPTION
As far as I can tell this is just the same as "nearest", and we don't need to roll our own code since scipy handles this fine?