### PR TITLE
[Backport 3.0] Better handling of metadata/properties for Stonyhurst heliographic maps

### DIFF
--- a/changelog/5478.bugfix.rst
+++ b/changelog/5478.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the unintended insertion of (assumed) observer location information when accessing the property `sunpy.map.GenericMap.wcs` for Stonyhurst heliographic maps.

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -94,7 +94,7 @@ def solar_wcs_frame_mapping(wcs):
     if rsun is not None:
         frame_args['rsun'] = rsun
 
-    frame_class = _frame_class_from_ctypes(wcs.wcs.ctype)
+    frame_class = _sunpy_frame_class_from_ctypes(wcs.wcs.ctype)
 
     if frame_class:
         if frame_class == HeliographicStonyhurst:
@@ -105,7 +105,7 @@ def solar_wcs_frame_mapping(wcs):
         return frame_class(**frame_args)
 
 
-def _frame_class_from_ctypes(ctypes):
+def _sunpy_frame_class_from_ctypes(ctypes):
     # Truncate the ctype to the first four letters
     ctypes = {c[:4] for c in ctypes}
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -563,9 +563,9 @@ class GenericMap(NDData):
         if w2.wcs.ctype[1].lower() in ("solar-y", "solar_y"):
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
-        # Set observer coordinate information if appropriate
-        frame_class = sunpy.coordinates.wcs_utils._frame_class_from_ctypes(w2.wcs.ctype)
-        if hasattr(frame_class, 'observer'):
+        # Set observer coordinate information except when we know it is not appropriate (e.g., HGS)
+        sunpy_frame = sunpy.coordinates.wcs_utils._sunpy_frame_class_from_ctypes(w2.wcs.ctype)
+        if sunpy_frame is None or hasattr(sunpy_frame, 'observer'):
             # Clear all the aux information that was set earlier. This is to avoid
             # issues with maps that store multiple observer coordinate keywords.
             # Note that we have to create a new WCS as it's not possible to modify

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -563,9 +563,9 @@ class GenericMap(NDData):
         if w2.wcs.ctype[1].lower() in ("solar-y", "solar_y"):
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
-        if hasattr(astropy.wcs.utils.wcs_to_celestial_frame(w2), 'observer'):
-            # Set observer coordinate information
-            #
+        # Set observer coordinate information if appropriate
+        frame_class = sunpy.coordinates.wcs_utils._frame_class_from_ctypes(w2.wcs.ctype)
+        if hasattr(frame_class, 'observer'):
             # Clear all the aux information that was set earlier. This is to avoid
             # issues with maps that store multiple observer coordinate keywords.
             # Note that we have to create a new WCS as it's not possible to modify

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -32,7 +32,7 @@ import sunpy.coordinates
 import sunpy.io as io
 import sunpy.visualization.colormaps
 from sunpy import config, log
-from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, Helioprojective, get_earth, sun
+from sunpy.coordinates import HeliographicCarrington, Helioprojective, get_earth, sun
 from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.image.resample import resample as sunpy_image_resample
 from sunpy.image.resample import reshape_image_to_4d_superpixel
@@ -563,24 +563,21 @@ class GenericMap(NDData):
         if w2.wcs.ctype[1].lower() in ("solar-y", "solar_y"):
             w2.wcs.ctype[1] = 'HPLT-TAN'
 
-        # Set observer coordinate information
-        #
-        # Clear all the aux information that was set earlier. This is to avoid
-        # issues with maps that store multiple observer coordinate keywords.
-        # Note that we have to create a new WCS as it's not possible to modify
-        # wcs.wcs.aux in place.
-        header = w2.to_header()
-        for kw in ['crln_obs', 'dsun_obs', 'hgln_obs', 'hglt_obs']:
-            header.pop(kw, None)
-        w2 = astropy.wcs.WCS(header)
+        if hasattr(astropy.wcs.utils.wcs_to_celestial_frame(w2), 'observer'):
+            # Set observer coordinate information
+            #
+            # Clear all the aux information that was set earlier. This is to avoid
+            # issues with maps that store multiple observer coordinate keywords.
+            # Note that we have to create a new WCS as it's not possible to modify
+            # wcs.wcs.aux in place.
+            header = w2.to_header()
+            for kw in ['crln_obs', 'dsun_obs', 'hgln_obs', 'hglt_obs']:
+                header.pop(kw, None)
+            w2 = astropy.wcs.WCS(header)
 
-        # Get observer coord, and transform if needed
-        obs_coord = self.observer_coordinate
-        if not isinstance(obs_coord.frame, (HeliographicStonyhurst, HeliographicCarrington)):
-            obs_coord = obs_coord.transform_to(HeliographicStonyhurst(obstime=self.date,
-                                                                      rsun=self.rsun_meters))
-
-        sunpy.coordinates.wcs_utils._set_wcs_aux_obs_coord(w2, obs_coord)
+            # Get observer coord, and set the aux information
+            obs_coord = self.observer_coordinate
+            sunpy.coordinates.wcs_utils._set_wcs_aux_obs_coord(w2, obs_coord)
 
         # Validate the WCS here.
         w2.wcs.set()

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -24,7 +24,7 @@ import sunpy.coordinates
 import sunpy.data.test
 import sunpy.map
 import sunpy.sun
-from sunpy.coordinates import sun
+from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, sun
 from sunpy.map.sources import AIAMap
 from sunpy.time import parse_time
 from sunpy.util import SunpyDeprecationWarning, SunpyUserWarning
@@ -1256,3 +1256,27 @@ def test_meta_modifications(aia171_test_map):
     assert set(aiamap_rot.meta.added_items.keys()) == set(['bunit', 'pc1_1', 'pc1_2', 'pc2_1', 'pc2_2'])
     assert set(aiamap_rot.meta.removed_items.keys()) == set(['crota2'])
     assert set(aiamap_rot.meta.modified_items) == set(['cdelt1', 'crpix1', 'crpix2', 'crval1'])
+
+
+
+def test_no_wcs_observer_info(heliographic_test_map):
+    # Check that HeliographicCarrington WCS has observer info set
+    assert isinstance(heliographic_test_map.coordinate_frame, HeliographicCarrington)
+    wcs_aux = heliographic_test_map.wcs.wcs.aux
+    assert wcs_aux.hgln_obs is not None
+    assert wcs_aux.hglt_obs is not None
+    assert wcs_aux.dsun_obs is not None
+
+    # Remove observer information, and change coordinate system to HeliographicStonyhurst
+    heliographic_test_map.meta.pop('HGLN_OBS')
+    heliographic_test_map.meta.pop('HGLT_OBS')
+    heliographic_test_map.meta.pop('DSUN_OBS')
+    heliographic_test_map.meta['CTYPE1'] = 'HGLN-CAR'
+    heliographic_test_map.meta['CTYPE2'] = 'HGLT-CAR'
+    assert isinstance(heliographic_test_map.coordinate_frame, HeliographicStonyhurst)
+
+    # Check that GenericMap.wcs doesn't set an observer
+    wcs_aux = heliographic_test_map.wcs.wcs.aux
+    assert wcs_aux.hgln_obs is None
+    assert wcs_aux.hglt_obs is None
+    assert wcs_aux.dsun_obs is None

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1258,7 +1258,6 @@ def test_meta_modifications(aia171_test_map):
     assert set(aiamap_rot.meta.modified_items) == set(['cdelt1', 'crpix1', 'crpix2', 'crval1'])
 
 
-
 def test_no_wcs_observer_info(heliographic_test_map):
     # Check that HeliographicCarrington WCS has observer info set
     assert isinstance(heliographic_test_map.coordinate_frame, HeliographicCarrington)
@@ -1280,3 +1279,22 @@ def test_no_wcs_observer_info(heliographic_test_map):
     assert wcs_aux.hgln_obs is None
     assert wcs_aux.hglt_obs is None
     assert wcs_aux.dsun_obs is None
+
+
+def test_rsun_meters_no_warning_for_hgs(heliographic_test_map):
+    # Make sure that Stonyhurst heliographic maps do not emit a warning about assuming an
+    # Earth-based observer when returning the physical radius of the Sun, because such an
+    # assumption is not necessary
+
+    # Convert the heliographic test map to Stonyhurst heliographic coordinates
+    heliographic_test_map.meta.pop('HGLN_OBS')
+    heliographic_test_map.meta.pop('HGLT_OBS')
+    heliographic_test_map.meta.pop('DSUN_OBS')
+    heliographic_test_map.meta['CTYPE1'] = 'HGLN-CAR'
+    heliographic_test_map.meta['CTYPE2'] = 'HGLT-CAR'
+
+    # Add a custom physical radius for the Sun
+    heliographic_test_map.meta['rsun_ref'] = 1.1 * sunpy.sun.constants.radius.to_value(u.m)
+
+    assert_quantity_allclose(heliographic_test_map.rsun_meters,
+                             heliographic_test_map.meta['rsun_ref'] << u.m)


### PR DESCRIPTION
Backport #5478.

The second bug is not actually present in 3.0 because it was introduced in #5416.  So, there was nothing to backport from that commit on the implementation side, but I retained the test to be safe.