### PR TITLE
Fixed a units issue when determining the proper value for ``lonpole``

### DIFF
--- a/changelog/5490.bugfix.rst
+++ b/changelog/5490.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an incorrect value for the FITS WCS ``LONPOLE`` keyword when using :func:`~sunpy.map.make_fitswcs_header` for `~sunpy.coordinates.frames.Helioprojective` maps with certain values of latitude for the reference coordinate.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -178,7 +178,10 @@ def _set_transform_params(meta_wcs, coordinate, reference_pixel, scale, shape):
     # When the native latitude of the fiducial point is 0 degrees, which is typical for cylindrical
     # projections, the correct value of `lonpole` depends on whether the world latitude of the
     # fiducial point is greater than or less than its native latitude.
-    meta_wcs['LONPOLE'] = 180. if meta_wcs['crval2'] < meta_wcs['theta0'] else 0.
+    if coordinate.spherical.lat.to_value(u.deg) < meta_wcs['theta0']:
+        meta_wcs['LONPOLE'] = 180.
+    else:
+        meta_wcs['LONPOLE'] = 0.
     del meta_wcs['theta0']  # remove the native latitude of the fiducial point
 
     # Add 1 to go from input 0-based indexing to FITS 1-based indexing

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -18,7 +18,7 @@ def map_data():
 
 @pytest.fixture
 def hpc_coord():
-    return SkyCoord(0*u.arcsec, 0*u.arcsec, observer='earth', rsun=7.1e8*u.m,
+    return SkyCoord(0*u.arcsec, 100*u.arcsec, observer='earth', rsun=7.1e8*u.m,
                     obstime='2013-10-28 00:00', frame=frames.Helioprojective)
 
 
@@ -85,7 +85,7 @@ def test_hpc_header(hpc_header, hpc_coord):
     assert hpc_header['crval1'] == 0
     assert hpc_header['crpix1'] == 5.5
     assert hpc_header['ctype1'] == 'HPLN-TAN'
-    assert hpc_header['crval2'] == 0
+    assert hpc_header['crval2'] == 100.
     assert hpc_header['crpix2'] == 10.5
     assert hpc_header['ctype2'] == 'HPLT-TAN'
 


### PR DESCRIPTION
There's a bug in #5448 where I didn't make sure that I was comparing degrees to degrees when determining the proper value for ``lonpole``.  This affects `Helioprojective` maps when the reference coordinate's latitude is greater than 90 arcseconds.

Ping @wtbarnes 