### PR TITLE
Add "keyword-only" to nitpick exceptions

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -33,6 +33,7 @@ py:class prop
 # These come from astropy.coordinates.baseframe.represent_as
 py:class data
 py:class keyword only
+py:class keyword-only
 py:class string
 py:class subclass of BaseRepresentation
 


### PR DESCRIPTION
Part of fixing https://github.com/sunpy/sunpy/issues/5488