### PR TITLE
Manually inherit class docstring for QueryResponseTable

### DIFF
--- a/sunpy/net/base_client.py
+++ b/sunpy/net/base_client.py
@@ -164,6 +164,8 @@ class QueryResponseColumn(Column):
 
 
 class QueryResponseTable(QTable):
+    __doc__ = QTable.__doc__
+
     Row = QueryResponseRow
     Column = QueryResponseColumn
 


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
This sets the docstring of the `sunpy.net.base_client.QueryResponseTable` class manually to the docstring of its parent (`astropy.table.QTable`) class.
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #5137 
