### PR TITLE
Rename CROTA to CROTA2 for EUI maps

### DIFF
--- a/changelog/5493.bugfix.rst
+++ b/changelog/5493.bugfix.rst
@@ -1,0 +1,1 @@
+A non-standard ``CROTA`` keyword included in a `sunpy.map.sources.EUIMap` FITS header is now renamed to the recommended ``CROTA2`` so a warning is no longer raised.

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -5,6 +5,7 @@ import astropy.units as u
 from astropy.coordinates import CartesianRepresentation
 from astropy.visualization import ImageNormalize, LinearStretch
 
+from sunpy import log
 from sunpy.coordinates import HeliocentricInertial
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
@@ -37,6 +38,10 @@ class EUIMap(GenericMap):
         self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, LinearStretch()), clip=False)
+
+        if 'CROTA' in self.meta and 'CROTA2' not in self.meta:
+            log.debug("Renaming 'CROTA' to 'CROTA2'")
+            self.meta['CROTA2'] = self.meta.pop('CROTA')
 
     @property
     def processing_level(self):


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
Renames `CROTA` to `CROTA2` in EUI headers (if `CROTA2` not already defined). This is the same code as:
https://github.com/sunpy/sunpy/blob/112dab490ef9a43078872583208210de7940d1c3/sunpy/map/sources/rhessi.py#L65-L67
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #5274 
