### PR TITLE
Add some WCS smoke tests for map sources

### DIFF
--- a/sunpy/map/sources/tests/test_aia_source.py
+++ b/sunpy/map/sources/tests/test_aia_source.py
@@ -7,6 +7,8 @@ import glob
 
 import pytest
 
+import astropy.units as u
+
 import sunpy.data.test
 from sunpy.map import Map
 from sunpy.map.sources.sdo import AIAMap
@@ -59,3 +61,8 @@ def test_measurement(createAIAMap):
 def test_norm_clip(createAIAMap):
     # Tests that the default normalizer has clipping disabled
     assert not createAIAMap.plot_settings['norm'].clip
+
+
+def test_wcs(createAIAMap):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    createAIAMap.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_cor_source.py
+++ b/sunpy/map/sources/tests/test_cor_source.py
@@ -6,6 +6,8 @@ This particular test file pertains to CORMap.
 import os
 import glob
 
+import astropy.units as u
+
 import sunpy.data.test
 from sunpy.map import Map
 from sunpy.map.sources.stereo import CORMap
@@ -42,3 +44,8 @@ def test_observatory():
 def test_norm_clip():
     # Tests that the default normalizer has clipping disabled
     assert not cor.plot_settings['norm'].clip
+
+
+def test_wcs():
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    cor.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_eit_source.py
+++ b/sunpy/map/sources/tests/test_eit_source.py
@@ -55,3 +55,8 @@ def test_rsun(createEIT):
 def test_norm_clip(createEIT):
     # Tests that the default normalizer has clipping disabled
     assert not createEIT.plot_settings['norm'].clip
+
+
+def test_wcs(createEIT):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    createEIT.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_eui_source.py
+++ b/sunpy/map/sources/tests/test_eui_source.py
@@ -270,3 +270,8 @@ def test_unit(eui_fsi_map):
 def test_norm_clip(eui_fsi_map):
     # Tests that the default normalizer has clipping disabled
     assert not eui_fsi_map.plot_settings['norm'].clip
+
+
+def test_wcs(eui_fsi_map):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    eui_fsi_map.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_euvi_source.py
+++ b/sunpy/map/sources/tests/test_euvi_source.py
@@ -6,6 +6,8 @@ This particular test file pertains to EUVIMap.
 import os
 import glob
 
+import astropy.units as u
+
 import sunpy.data.test
 from sunpy.coordinates import sun
 from sunpy.map import Map
@@ -56,3 +58,8 @@ def test_rsun_missing():
 def test_norm_clip():
     # Tests that the default normalizer has clipping disabled
     assert not euvi.plot_settings['norm'].clip
+
+
+def test_wcs():
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    euvi.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_hi_source.py
+++ b/sunpy/map/sources/tests/test_hi_source.py
@@ -5,6 +5,8 @@ This particular test file pertains to HIMap.
 import os
 import glob
 
+import astropy.units as u
+
 import sunpy.data.test
 from sunpy.map import Map
 from sunpy.map.sources.stereo import HIMap
@@ -39,3 +41,8 @@ def test_observatory():
 def test_norm_clip():
     # Tests that the default normalizer has clipping disabled
     assert not hi.plot_settings['norm'].clip
+
+
+def test_wcs():
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    hi.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_hmi_source.py
+++ b/sunpy/map/sources/tests/test_hmi_source.py
@@ -6,6 +6,8 @@ This particular test file pertains to HMIMap.
 import os
 import glob
 
+import astropy.units as u
+
 import sunpy.data.test
 from sunpy.map import Map
 from sunpy.map.sources.sdo import HMIMap
@@ -38,3 +40,8 @@ def test_observatory():
 def test_measurement():
     """Tests the measurement property of the HMIMap object."""
     assert hmi.measurement == "continuum"
+
+
+def test_wcs():
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    hmi.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_hmi_synoptic_source.py
+++ b/sunpy/map/sources/tests/test_hmi_synoptic_source.py
@@ -8,6 +8,7 @@ from astropy.io import fits
 
 from sunpy.map import Map
 from sunpy.map.sources.sdo import HMISynopticMap
+from sunpy.util.exceptions import SunpyMetadataWarning
 
 
 @pytest.fixture
@@ -133,3 +134,9 @@ def test_unit(hmi_synoptic):
     assert hmi_synoptic.unit == u.G
     hmi_synoptic.meta['bunit'] = 'm'
     assert hmi_synoptic.unit == u.m
+
+
+def test_wcs(hmi_synoptic):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):
+        hmi_synoptic.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_iris_source.py
+++ b/sunpy/map/sources/tests/test_iris_source.py
@@ -8,10 +8,12 @@ import glob
 
 import pytest
 
+import astropy.units as u
+
 import sunpy.data.test
 from sunpy.map import Map
 from sunpy.map.sources.iris import SJIMap
-from sunpy.util.exceptions import SunpyUserWarning
+from sunpy.util.exceptions import SunpyMetadataWarning, SunpyUserWarning
 
 
 @pytest.fixture
@@ -39,3 +41,9 @@ def test_is_datasource_for(irismap):
 def test_observatory(irismap):
     """Tests the observatory property of SJIMap."""
     assert irismap.observatory == "IRIS"
+
+
+def test_wcs(irismap):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):
+        irismap.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_kcor_source.py
+++ b/sunpy/map/sources/tests/test_kcor_source.py
@@ -49,3 +49,8 @@ def test_observatory(kcor):
 def test_norm_clip(kcor):
     # Tests that the default normalizer has clipping disabled
     assert not kcor.plot_settings['norm'].clip
+
+
+def test_wcs(kcor):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    kcor.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_lasco_source.py
+++ b/sunpy/map/sources/tests/test_lasco_source.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
+import astropy.units as u
 from astropy.io import fits
 
 import sunpy.data.test
@@ -17,6 +18,7 @@ from sunpy.map import Map
 from sunpy.map.sources.soho import LASCOMap
 from sunpy.tests.helpers import skip_glymur
 from sunpy.time import parse_time
+from sunpy.util.exceptions import SunpyMetadataWarning
 
 path = sunpy.data.test.rootdir
 
@@ -179,3 +181,9 @@ def test_helioviewer_rotation(lasco_map, lasco_helioviewer):
                'C3': [[1, 0], [0, 1]]}[lasco_map.detector]
     np.testing.assert_allclose(lasco_map.rotation_matrix, rmatrix, rtol=1e-6)
     np.testing.assert_array_equal(lasco_helioviewer.rotation_matrix, [[1., 0.], [0., 1.]])
+
+
+def test_wcs(lasco_map):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):
+        lasco_map.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_mdi_source.py
+++ b/sunpy/map/sources/tests/test_mdi_source.py
@@ -157,3 +157,10 @@ def test_synoptic_source(mdi_synoptic):
     # Check that the WCS is valid
     with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):
         mdi_synoptic.wcs
+
+
+def test_wcs(mdi, mdi_synoptic):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    mdi.pixel_to_world(0*u.pix, 0*u.pix)
+    with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):
+        mdi_synoptic.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_suvi_source.py
+++ b/sunpy/map/sources/tests/test_suvi_source.py
@@ -7,6 +7,8 @@ import glob
 
 import pytest
 
+import astropy.units as u
+
 import sunpy.data.test
 from sunpy.map import Map
 from sunpy.map.sources.suvi import SUVIMap
@@ -47,3 +49,12 @@ def test_detector(suvi):
 def test_norm_clip(suvi):
     # Tests that the default normalizer has clipping disabled
     assert not suvi.plot_settings['norm'].clip
+
+
+# SUVI provides observer coordinate information in an OBSGEO system, so this test
+# needs remote data to access the latest IERS table to do a coordiante transformation from
+# OBSGEO to heliographic Stonyhurst coordiantes.
+@pytest.mark.remote_data
+def test_wcs(suvi):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    suvi.pixel_to_world(0*u.pix, 0*u.pix)

--- a/sunpy/map/sources/tests/test_trace_source.py
+++ b/sunpy/map/sources/tests/test_trace_source.py
@@ -2,9 +2,12 @@ import os
 
 import pytest
 
+import astropy.units as u
+
 import sunpy.data.test
 from sunpy.map import Map
 from sunpy.map.sources.trace import TRACEMap
+from sunpy.util.exceptions import SunpyMetadataWarning
 
 path = sunpy.data.test.rootdir
 fitspath = os.path.join(path, "tsi20010130_025823_a2.fits")
@@ -42,3 +45,9 @@ def test_observatory(createTRACE):
 def test_norm_clip(createTRACE):
     # Tests that the default normalizer has clipping disabled
     assert not createTRACE.plot_settings['norm'].clip
+
+
+def test_wcs(createTRACE):
+    # Smoke test that WCS is valid and can transform from pixels to world coordinates
+    with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):
+        createTRACE.pixel_to_world(0*u.pix, 0*u.pix)


### PR DESCRIPTION
Before https://github.com/sunpy/sunpy/pull/5501 goes in, we should make sure that all the `WCS`es of our map sources are valid. This just checks that they work, not that they return a correct result.

Note there are some sources missing in this PR - that's because they need fixes, which I will put in other PRs.