### PR TITLE
Describe release schedule on Release History page

### DIFF
--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -2,6 +2,10 @@
 Release History
 ***************
 
+A new version of sunpy core is released twice a year, with target release months of May and November.
+Versions x.0 are long term support (LTS) releases, and are supported for 12 months.
+In between versions x.1 are non-LTS releases, and supported for 6 months until the next LTS release.
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
I periodically wonder what the sunpy release cycle is, and this page seems like a good place to put it in the docs.