### PR TITLE
Bump minimum astropy version

### DIFF
--- a/docs/whatsnew/3.1.rst
+++ b/docs/whatsnew/3.1.rst
@@ -33,6 +33,7 @@ Increase in required package versions
 We have bumped the minimum version of several packages we depend on; these are the new minimum versions for sunpy 3.1:
 
 - astropy >= 4.2
+- numpy >= 1.17.0
 
 .. _whatsnew-3.1-contributors:
 

--- a/docs/whatsnew/3.1.rst
+++ b/docs/whatsnew/3.1.rst
@@ -32,6 +32,8 @@ Increase in required package versions
 =====================================
 We have bumped the minimum version of several packages we depend on; these are the new minimum versions for sunpy 3.1:
 
+- astropy >= 4.2
+
 .. _whatsnew-3.1-contributors:
 
 Changes to map date/time handling

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ setup_requires =
   setuptools_scm
 install_requires =
   astropy>=4.2.0
-  numpy>=1.16.0
+  numpy>=1.17.0
   parfive[ftp]>=1.2.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ include_package_data = True
 setup_requires =
   setuptools_scm
 install_requires =
-  astropy>=4.1.0
+  astropy>=4.2.0
   numpy>=1.16.0
   parfive[ftp]>=1.2.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ deps =
     devdeps: git+https://github.com/asdf-format/asdf
 
     # Oldest deps we pin against.
-    oldestdeps: astropy<4.2
+    oldestdeps: astropy<4.3
     oldestdeps: numpy<1.17.0
     oldestdeps: parfive<1.3.0
     oldestdeps: asdf<2.7.0
@@ -135,7 +135,7 @@ commands =
 description = Check the test suite does not fail if all optional dependencies are missing
 extras =
 deps =
-  astropy>=4.0.3
+  astropy>=4.2
   numpy>=1.16.0
   parfive[ftp]>=1.1.0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -62,8 +62,8 @@ deps =
     devdeps: git+https://github.com/asdf-format/asdf
 
     # Oldest deps we pin against.
-    oldestdeps: astropy<4.3
-    oldestdeps: numpy<1.17.0
+    oldestdeps: astropy<4.3.0
+    oldestdeps: numpy<1.18.0  # Astropy 4.2 requires 1.17
     oldestdeps: parfive<1.3.0
     oldestdeps: asdf<2.7.0
     oldestdeps: dask[array]<2.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ deps =
 
     # Oldest deps we pin against.
     oldestdeps: astropy<4.3.0
-    oldestdeps: numpy<1.18.0  # Astropy 4.2 requires 1.17
+    oldestdeps: numpy<1.18.0
     oldestdeps: parfive<1.3.0
     oldestdeps: asdf<2.7.0
     oldestdeps: dask[array]<2.1.0
@@ -135,9 +135,9 @@ commands =
 description = Check the test suite does not fail if all optional dependencies are missing
 extras =
 deps =
-  astropy>=4.2
-  numpy>=1.16.0
-  parfive[ftp]>=1.1.0
+  astropy
+  numpy
+  parfive[ftp]
 commands =
     python -c "import sunpy; sunpy.self_test()"
 


### PR DESCRIPTION
As per our new depedency policy we can bumpy to astropy 4.2 (released 24/11/2020) for sunpy 3.1. This will allow us to address https://github.com/sunpy/sunpy/issues/5291.