### PR TITLE
Only pass line property kwargs to a contour when plotting CompositeMap

### DIFF
--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -371,8 +371,11 @@ class CompositeMap:
 
         Notes
         -----
-        If a line-width Matplotlib argument (``linewidth``, ``linewidths``, or ``lw``)
-        is provided, it will apply only to those maps that are plotted as contours.
+        Matplotlib arguments for setting the line width (``linewidths``), line style
+        (``linestyles``) or line color (``colors``) will apply only to those maps
+        that are plotted as contours. Similar arguments (i.e., ``linewidth``,
+        ``lw``, ``color``, ``c``, ``linestyle`` and ``ls``) will also be ignored
+        for maps plotted as images.
 
         If a transformation is required to overlay the maps with the correct
         alignment, the plot limits may need to be manually set because
@@ -404,8 +407,11 @@ class CompositeMap:
             # The request to show a map layer rendered as a contour is indicated by a
             # non False levels property.
             if m.levels is False:
-                # Check if any linewidth argument is provided, if so, then delete it from params.
-                for item in ['linewidth', 'linewidths', 'lw']:
+                # Check if any linewidth, color, or linestyle arguments are provided,
+                # if so, then delete them from params.
+                for item in ['linewidth', 'linewidths', 'lw',
+                             'color', 'colors', 'c',
+                             'linestyle', 'linestyles', 'ls']:
                     if item in matplot_args:
                         del params[item]
 

--- a/sunpy/map/tests/test_compositemap.py
+++ b/sunpy/map/tests/test_compositemap.py
@@ -51,6 +51,27 @@ def test_plot_composite_map_linewidths(composite_test_map):
     composite_test_map.plot(linewidths=0.5)
 
 
+@figure_test
+def test_plot_composite_map_linestyles(composite_test_map):
+    composite_test_map.set_levels(1, np.arange(-75, 76, 25) << u.percent)
+    composite_test_map.plot(linestyles='--')
+
+
+@figure_test
+def test_plot_composite_map_colors(composite_test_map):
+    composite_test_map.set_levels(1, np.arange(-75, 76, 25) << u.percent)
+    composite_test_map.plot(colors='red')
+
+
+def test_plot_composite_map_mplkwargs(composite_test_map):
+    composite_test_map.set_levels(1, np.arange(-75, 76, 25) << u.percent)
+    for k, v in [('linewidth', 0.5), ('lw', 0.5), ('color', 'red'),
+                   ('c', 'red'), ('linestyle', '--'), ('ls', '--')]:
+        with pytest.warns(UserWarning, match=f"The following kwargs were not "
+                                             f"used by contour: '{k}'"):
+            composite_test_map.plot(**{k: v})
+
+
 def test_remove_composite_map(composite_test_map):
     composite_test_map.remove_map(0)
     with pytest.raises(IndexError):

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
@@ -2,6 +2,8 @@
   "sunpy.map.tests.test_compositemap.test_plot_composite_map": "8160a5896607f62b7e7fa316236f565f54bd7a08f511808e98c9ad329678d21a",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_contours": "909ac12088dde3c15d0c7908f08b4b3c0da23e2a4966ed1ef8e705adb8727d2a",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_linewidths": "27aa1ac78d4e49f731bf1e43f4d2b398fe8a84d53ed9234794c7954fda54c45a",
+  "sunpy.map.tests.test_compositemap.test_plot_composite_map_linestyles": "aa77398390f40d90f791a3fd45ff8d92b7fe98cc8332d9828acc31e7eddc5e88",
+  "sunpy.map.tests.test_compositemap.test_plot_composite_map_colors": "ca7af0e1ee21df8b76bac76f27ac934c452f7906d4bc9000f1faa1dde742aa62",
   "sunpy.map.tests.test_compositemap.test_set_alpha_composite_map": "b9d729ff67b0307c037ac62f97c69bb80d22ad6679a0e56352075845d4ef732b",
   "sunpy.map.tests.test_compositemap.test_peek_composite_map": "bd1df27446d420f3e8cb6fa07daff88b77dd0f0441e4acf83ee48341a9e3218f",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "a400eef26fdd915ccf12769031bd8dadedbf8f6a93e31cd5982bffe2484702ee",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -3,6 +3,8 @@
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_contours": "c5d25db0fbd1fad526cab34de9ce740edea0cf63a3537748cf7523991322ec51",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_linewidths": "ce0985940b73bbe1d0142a81e2be16397df06d389bfd18ba8e977de6ab22b23e",
   "sunpy.map.tests.test_compositemap.test_set_alpha_composite_map": "f811cf6be8abfcd1b3a7f4bae7781806b37b1b2b0cb77ac34c4ed4491a1d633a",
+  "sunpy.map.tests.test_compositemap.test_plot_composite_map_linestyles": "d76aa6dfa3366be975850441779f28ae41b7358a742748f5bcd755218df736bc",
+  "sunpy.map.tests.test_compositemap.test_plot_composite_map_colors": "dff4fddd4c2ff31ae3510750009ebe48d9aa756f04162fe4325aa19154b44abf",
   "sunpy.map.tests.test_compositemap.test_peek_composite_map": "d459182443472330df9b0dde3bde647479c100f56f45b6321619fbf67810c174",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "17d50a2992e9b66ede4984376a70cd0aa67dd1434a9a3bc04e23e4e4213cf7a4",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "e4622b1aea9e0aaf076eddf93dbdc06daf5b3472d78aae31ed89a77499d58e0f",


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

This PR filters the matplotlib kwargs passed to a `CompositeMap.plot()` such that kwargs related to line style and line colour are only used when plotting contours. (Line width kwargs were already filtered.) Incorrect contour kwargs such as `linestyle`, `ls`, `color` and `c` are also filtered such that matplotlib raises a warning instead of an error.

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #5455 
