### PR TITLE
Dynamic Matplotlib argument lists for filtering plotting setting in `CompositeMap.plot`

### DIFF
--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -3,17 +3,34 @@
 Author: `Keith Hughitt <keith.hughitt@nasa.gov>`
 """
 import matplotlib.pyplot as plt
+from matplotlib.image import AxesImage, _ImageBase
+from matplotlib.contour import ContourSet, QuadContourSet
+from matplotlib.collections import QuadMesh, Collection
 
 import astropy.units as u
 
 from sunpy.map import GenericMap
-from sunpy.util import expand_list
+from sunpy.util import expand_list, get_keywords, get_set_methods
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
 
 __all__ = ['CompositeMap']
 
 __author__ = "Keith Hughitt"
 __email__ = "keith.hughitt@nasa.gov"
+
+# Valid keyword arguments for each plotting method
+VALID_IMSHOW_KWARGS = ACCEPTED_IMSHOW_KWARGS = get_keywords(
+    [GenericMap.plot, plt.Axes.imshow, AxesImage.__init__, _ImageBase.__init__]
+) | get_set_methods(AxesImage)
+
+VALID_PCOLORMESH_KWARGS = get_keywords(
+    [GenericMap.plot, plt.Axes.pcolormesh, QuadMesh.__init__, Collection.__init__]
+) | get_set_methods(QuadMesh)
+ACCEPTED_PCOLORMESH_KWARGS = VALID_PCOLORMESH_KWARGS - {'linewidths', 'linestyles'}
+
+VALID_CONTOUR_KWARGS = ACCEPTED_CONTOUR_KWARGS = get_keywords(
+    [GenericMap.draw_contours, ContourSet.__init__, QuadContourSet._process_args]
+)
 
 
 class CompositeMap:

--- a/sunpy/map/tests/test_compositemap.py
+++ b/sunpy/map/tests/test_compositemap.py
@@ -65,11 +65,12 @@ def test_plot_composite_map_colors(composite_test_map):
 
 def test_plot_composite_map_mplkwargs(composite_test_map):
     composite_test_map.set_levels(1, np.arange(-75, 76, 25) << u.percent)
-    for k, v in [('linewidth', 0.5), ('lw', 0.5), ('color', 'red'),
-                 ('c', 'red'), ('linestyle', '--'), ('ls', '--')]:
-        with pytest.warns(UserWarning, match=f"The following kwargs were not "
-                                             f"used by contour: '{k}'"):
-            composite_test_map.plot(**{k: v})
+    with pytest.raises(TypeError) as e:
+        composite_test_map.plot(linestyles='--', unused_a=1, unused_b=2)
+    assert 'plot() got unexpected keyword arguments' in str(e.value)
+    assert 'unused_a' in str(e.value)
+    assert 'unused_b' in str(e.value)
+    assert 'linestyles' not in str(e.value)
 
 
 def test_remove_composite_map(composite_test_map):

--- a/sunpy/util/tests/test_util.py
+++ b/sunpy/util/tests/test_util.py
@@ -63,3 +63,43 @@ def test_partial_key_match():
 def test_dict_keys_same():
     dicts = [{'x': 42}, {'x': 23, 'y': 5}]
     assert util.dict_keys_same(dicts) == [{'y': None, 'x': 42}, {'y': 5, 'x': 23}]
+
+
+def test_get_keywords():
+
+    def f(a, b, c=1, d=2, **e):
+        pass
+
+    def g(a, b, *, c=1, h=2, **e):
+        pass
+
+    assert util.get_keywords(f) == {'c', 'd'}  # POSITIONAL_OR_KEYWORD
+    assert util.get_keywords(g) == {'c', 'h'}  # KEYWORD_ONLY
+    assert util.get_keywords([f, g]) == {'c', 'd', 'h'}
+
+
+def test_get_set_methods():
+
+    class A:
+
+        def _set_test1(self, *args, **kwargs):
+            pass
+
+        def set_test2(self, *args, **kwargs):
+            pass
+
+        @property
+        def set_test3(self):
+            pass
+
+        def test4(self, *args, **kwargs):
+            pass
+
+        @property
+        def test5(self, *args, **kwargs):
+            pass
+
+        def set_test6_n(self, *args, **kwargs):
+            pass
+
+    assert util.get_set_methods(A()) == {'test2', 'test6_n'}

--- a/sunpy/util/util.py
+++ b/sunpy/util/util.py
@@ -3,12 +3,14 @@ This module provides general utility functions.
 """
 import os
 import hashlib
+import inspect
 from shutil import get_terminal_size
 from itertools import chain, count
 from collections import UserList
 
 __all__ = ['unique', 'replacement_filename', 'expand_list',
-           'expand_list_generator', 'dict_keys_same', 'hash_file', "get_width"]
+           'expand_list_generator', 'dict_keys_same', 'hash_file', 'get_width',
+           'get_keywords', 'get_set_methods']
 
 
 def unique(itr, key=None):
@@ -215,3 +217,57 @@ def get_width():
     else:
         width, _ = get_terminal_size()
     return width
+
+
+def get_keywords(func):
+    """
+    Returns a set of keyword names from `func`'s signature.
+    Recursive if `func` is a list of functions and methods.
+
+    Parameters
+    ----------
+    func : `function` or `method` or `list`
+        Function or method (or list of those) to extract a
+        set of accepted keyword arguments for.
+
+    Returns
+    -------
+    keywords : `set`
+        A set of accepted keyword arguments.
+    """
+    if isinstance(func, list):
+        keywords = set()
+        for f in func:
+            keywords.update(get_keywords(f))
+        return keywords
+    sig = inspect.signature(func)
+    keywords = {param.name for param in sig.parameters.values()
+                if param.default is not inspect.Parameter.empty}
+    return keywords
+
+
+def get_set_methods(obj):
+    """
+    Returns a set of keyword names that can be handled by
+    an object's `set_...` methods.
+
+    Parameters
+    ----------
+    obj : `object`
+        Matplotlib object such as `~matplotlib.image.AxesImage`
+        to extract handled keyword arguments for.
+
+    Returns
+    -------
+    keywords : `set`
+        A set of accepted keyword arguments.
+
+    Notes
+    -----
+    See :meth:`matplotlib.artist.Artist.update` for an example
+    of Matplotlib relying on this capability.
+    """
+    return {
+        m[4:] for m in dir(obj)
+        if m.startswith('set_') and callable(getattr(obj, m, None))
+    }


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
This PR builds upon the fix implemented in #5521 by dynamically generating a list of accepted kwargs for each possible Matplotlib plotting method and then filtering the kwargs passed by `CompositeMap.plot` to each plotting method, instead of implementing exceptions for specific arguments.
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->


