### PR TITLE
Added a test for rotation on data that is a rectangle. The best shape

### DIFF
--- a/docs/dev_guide/contents/tests.rst
+++ b/docs/dev_guide/contents/tests.rst
@@ -235,6 +235,10 @@ Generally we do not run the tests on our sample data, so only do this if you hav
 Figure unit tests
 -----------------
 
+.. note::
+    The figure tests and the hashes they use are only checked on Linux and might be different on other platforms.
+    We should suggest if you do not use a Linux, to add a fake hash to the json files and then CircleCi (ran on a PR) will tell you the real hash to use.
+
 You can write sunpy unit tests that test the generation of matplotlib figures by adding the decorator ``sunpy.tests.helpers.figure_test``.
 Here is a simple example::
 
@@ -277,8 +281,7 @@ If you want to check what the images look like, you can do::
 
     $ tox -e py38-figure -- --mpl-generate-path=baseline
 
-The images output from the tests will be stored in a folder called baseline so you can double check the test works as you expected.
-
+The images output from the tests will be stored in a folder called ``.tmp/py38-figure/baseline`` or ``baseline`` in the sunpy folder, so you can double check the test works as you expected.
 
 .. _doctests:
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -21,7 +21,6 @@ from astropy.visualization import wcsaxes
 
 import sunpy
 import sunpy.coordinates
-import sunpy.data.sample
 import sunpy.data.test
 import sunpy.map
 import sunpy.sun

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -21,11 +21,13 @@ from astropy.visualization import wcsaxes
 
 import sunpy
 import sunpy.coordinates
+import sunpy.data.sample
 import sunpy.data.test
 import sunpy.map
 import sunpy.sun
 from sunpy.coordinates import HeliographicCarrington, HeliographicStonyhurst, sun
 from sunpy.map.sources import AIAMap
+from sunpy.tests.helpers import figure_test
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyMetadataWarning
@@ -1335,3 +1337,11 @@ def test_rsun_meters_no_warning_for_hgs(heliographic_test_map):
 
     assert_quantity_allclose(heliographic_test_map.rsun_meters,
                              heliographic_test_map.meta['rsun_ref'] << u.m)
+
+
+@figure_test
+def test_rotation_rect_pixelated_data(aia171_test_map):
+    aia_map = sunpy.map.Map(aia171_test_map)
+    rect_map = aia_map.superpixel([2, 1] * u.pix, func=np.mean)
+    rect_rot_map = rect_map.rotate(30 * u.deg)
+    rect_rot_map.peek()

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
@@ -6,7 +6,7 @@
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_colors": "ca7af0e1ee21df8b76bac76f27ac934c452f7906d4bc9000f1faa1dde742aa62",
   "sunpy.map.tests.test_compositemap.test_set_alpha_composite_map": "b9d729ff67b0307c037ac62f97c69bb80d22ad6679a0e56352075845d4ef732b",
   "sunpy.map.tests.test_compositemap.test_peek_composite_map": "bd1df27446d420f3e8cb6fa07daff88b77dd0f0441e4acf83ee48341a9e3218f",
-  "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "0eb48e01800dbd54d031e362008f19a55ad78a865706c3331ce64b96483feb7d",
+  "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "4592fe2709c1ff7c43d82f46239dba0abdbdd011f0b52d81202433f33f7fd7f1",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "a400eef26fdd915ccf12769031bd8dadedbf8f6a93e31cd5982bffe2484702ee",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "1e5435af7bb854d47ebeabf354350f27bf989325aa5d77b930bdcdb043ce25df",
   "sunpy.map.tests.test_plotting.test_plot_aia171": "1e5435af7bb854d47ebeabf354350f27bf989325aa5d77b930bdcdb043ce25df",

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_42.json
@@ -6,6 +6,7 @@
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_colors": "ca7af0e1ee21df8b76bac76f27ac934c452f7906d4bc9000f1faa1dde742aa62",
   "sunpy.map.tests.test_compositemap.test_set_alpha_composite_map": "b9d729ff67b0307c037ac62f97c69bb80d22ad6679a0e56352075845d4ef732b",
   "sunpy.map.tests.test_compositemap.test_peek_composite_map": "bd1df27446d420f3e8cb6fa07daff88b77dd0f0441e4acf83ee48341a9e3218f",
+  "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "0eb48e01800dbd54d031e362008f19a55ad78a865706c3331ce64b96483feb7d",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "a400eef26fdd915ccf12769031bd8dadedbf8f6a93e31cd5982bffe2484702ee",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "1e5435af7bb854d47ebeabf354350f27bf989325aa5d77b930bdcdb043ce25df",
   "sunpy.map.tests.test_plotting.test_plot_aia171": "1e5435af7bb854d47ebeabf354350f27bf989325aa5d77b930bdcdb043ce25df",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -4,7 +4,7 @@
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_linewidths": "ce0985940b73bbe1d0142a81e2be16397df06d389bfd18ba8e977de6ab22b23e",
   "sunpy.map.tests.test_compositemap.test_set_alpha_composite_map": "f811cf6be8abfcd1b3a7f4bae7781806b37b1b2b0cb77ac34c4ed4491a1d633a",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_linestyles": "9cef7e320ddb45e6fc8022acfe2d9c304e07e094474b0bd9e486de1ad2d77f4a",
-  "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "0eb48e01800dbd54d031e362008f19a55ad78a865706c3331ce64b96483feb7d",
+  "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "3a6f4f7c0740a52de1b4e298abf01313e63112371517d3063a5ec4b394ac5c8a",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_colors": "2e40f5b5db4ac54c5128511b4cf9afe69df5e4f566a7e65c3832644c4ca88136",
   "sunpy.map.tests.test_compositemap.test_peek_composite_map": "d459182443472330df9b0dde3bde647479c100f56f45b6321619fbf67810c174",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "17d50a2992e9b66ede4984376a70cd0aa67dd1434a9a3bc04e23e4e4213cf7a4",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev.json
@@ -4,6 +4,7 @@
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_linewidths": "ce0985940b73bbe1d0142a81e2be16397df06d389bfd18ba8e977de6ab22b23e",
   "sunpy.map.tests.test_compositemap.test_set_alpha_composite_map": "f811cf6be8abfcd1b3a7f4bae7781806b37b1b2b0cb77ac34c4ed4491a1d633a",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_linestyles": "9cef7e320ddb45e6fc8022acfe2d9c304e07e094474b0bd9e486de1ad2d77f4a",
+  "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "0eb48e01800dbd54d031e362008f19a55ad78a865706c3331ce64b96483feb7d",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_colors": "2e40f5b5db4ac54c5128511b4cf9afe69df5e4f566a7e65c3832644c4ca88136",
   "sunpy.map.tests.test_compositemap.test_peek_composite_map": "d459182443472330df9b0dde3bde647479c100f56f45b6321619fbf67810c174",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "17d50a2992e9b66ede4984376a70cd0aa67dd1434a9a3bc04e23e4e4213cf7a4",


### PR DESCRIPTION
Rebased and updated version of https://github.com/sunpy/sunpy/pull/5321.
I was unable to push to the remote fork's branch so this was born.

I was unable to run the figure dev build locally and my figure test hashes changed. 
I suspect something different with macos and freetype.

Fixes #2721