### PR TITLE
Test transforming to frames with `obstime=None` errors

### DIFF
--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -873,6 +873,21 @@ def test_convert_error_with_no_obstime(frame_class):
         frame.transform_to(ICRS())
 
 
+@pytest.mark.parametrize("frame_class_1", _frames_wo_observer)
+@pytest.mark.parametrize("frame_class_2", _frames_wo_observer)
+def test_convert_error_with_no_obstime_sunpy_frames(frame_class_1, frame_class_2):
+    # Check that transforming from a frame with a time to a frame without a time
+    # errors
+    frame_1 = frame_class_1(CartesianRepresentation(0, 0, 0)*u.km, obstime=None)
+    frame_2 = frame_class_2(CartesianRepresentation(0, 0, 0)*u.km, obstime='2020-01-01')
+
+    with pytest.raises(ConvertError, match=r".*obstime.*"):
+        frame_1.transform_to(frame_2)
+
+    with pytest.raises(ConvertError, match=r".*obstime.*"):
+        frame_2.transform_to(frame_1)
+
+
 # Convenience function to check whether a transformation succeeds if the target `obstime` is `None`
 def assert_no_obstime_on_target_end(start_class, end_class):
     start_obstime = Time("2001-01-01")


### PR DESCRIPTION
I was going to make a start on https://github.com/sunpy/sunpy/issues/5454, where @ayshih said

> I think there are still some coordinate transformations that may allow a transformation from obstime=None in the source frame to obstime=<something> in the destination frame, by assuming that both frames are at the same obstime. I'd probably need to sort that out. obstime=None hasn't exactly been thoroughly tested.

This PR adds a test transforming between frames where one has `obstime is None` and one where `obstime is not None`. The list of transformations that currently don't error is:
```
[HeliographicStonyhurst-HeliographicStonyhurst]
[HeliographicStonyhurst-HeliocentricInertial]
[HeliographicStonyhurst-GeocentricSolarEcliptic]
[HeliocentricInertial-HeliographicStonyhurst]
[HeliocentricInertial-HeliocentricInertial]
[HeliocentricInertial-GeocentricSolarEcliptic]
[HeliocentricEarthEcliptic-HeliocentricInertial]
[HeliocentricEarthEcliptic-HeliocentricEarthEcliptic]
[HeliocentricEarthEcliptic-GeocentricSolarEcliptic]
[GeocentricSolarEcliptic-HeliocentricInertial]
[GeocentricSolarEcliptic-HeliocentricEarthEcliptic]
[GeocentricSolarEcliptic-GeocentricSolarEcliptic]
[GeocentricEarthEquatorial-HeliocentricInertial]
[GeocentricEarthEquatorial-GeocentricSolarEcliptic]
```
We should work out if these not erroring is fine, and exempt them from the error test, or add an appropriate error to the transformation if we shouldn't allow it.