### PR TITLE
Adding .satellite_number as a XRSTimeSeries property.

### DIFF
--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -5,6 +5,7 @@ import datetime
 from pathlib import Path
 from collections import OrderedDict
 from distutils.version import LooseVersion
+from sunpy.net.dataretriever.attrs.goes import SatelliteNumber
 
 import h5netcdf
 import matplotlib.dates
@@ -18,6 +19,7 @@ from astropy.time import Time, TimeDelta
 
 import sunpy.io
 from sunpy import log
+from sunpy.extern import parse
 from sunpy.io.file_tools import UnrecognizedFileTypeError
 from sunpy.time import is_time_in_given_format, parse_time
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
@@ -115,6 +117,37 @@ class XRSTimeSeries(GenericTimeSeries):
         axes.fmt_xdata = matplotlib.dates.DateFormatter("%H:%M")
         return axes
 
+    @property
+    def satellite_number(self):
+        """
+        Parses the various metafields to extract GOES satellite number.
+        """
+        #various pattern matches for the meta fields.
+        pattern_old = ("{}go{SatelliteNumber:02d}{}{month:2d}{day:2d}.fits{}")
+        pattern_new = ("{}sci_gxrs-l2-irrad_g{SatelliteNumber:02d}_d{year:4d}{month:2d}{day:2d}_{}.nc{}")
+        pattern_r = ("{}sci_xrsf-l2-flx1s_g{SatelliteNumber:02d}_d{year:4d}{month:2d}{day:2d}_{}.nc{}")
+        pattern_telescop=("GOES {SatelliteNumber:02d}")
+        pattern_inst=("{}GOES 1-{SatelliteNumber:02d} {}")
+
+        try: 
+            id = self.meta.metas[0]['id']
+            parsed=parse(pattern_r,str(id))
+            if parsed==None:
+                parsed=parse(pattern_new,str(id))
+                if parsed==None:
+                    parsed=parse(pattern_old,str(id))
+                    if parsed==None:
+                        id=self.meta.metas[0]['Instrument']
+                        parsed=parse(pattern_inst,str(id))
+        except KeyError:
+            try:
+                id=self.meta.metas[0]['TELESCOP']
+                parsed=parse(pattern_telescop,str(id))
+            except KeyError:
+                print("Error: Satellite Number not found in metadata")
+                return -1                   
+        return parsed['SatelliteNumber']
+       
     @peek_show
     def peek(self, title="GOES Xray Flux", **kwargs):
         """


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
Adds  XRSTimeSeries.satellite_number, populated by scraping the GOES meta data, as a useful reference. The GOES metadata is extremely inconsistent in formatting and completeness so no guarantee the cases are exhaustive but testing it seems to cover all the data. 

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #5547
