### PR TITLE
ASV action fully restored

### DIFF
--- a/.github/workflows/asv-regular.yml
+++ b/.github/workflows/asv-regular.yml
@@ -26,9 +26,6 @@ jobs:
           repository: sunpy/sunpy-benchmarks
           ref: main
           path: asv_results
-      - name: Symlink results
-        run: |
-          ln -s asv_results/results ./results
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -42,7 +39,7 @@ jobs:
         run: asv machine --machine GH-Actions --os ubuntu-20.04 --arch x64 --cpu "2-core unknown" --ram 7GB
       - name: Run benchmarks for commits since v1.1
         # On main the release of v1.1 is the 2.0dev tag
-        run: taskset -c 0 asv run --skip-existing-successful v3.0.dev..
+        run: taskset -c 0 asv run --skip-existing-successful v2.0.dev..
       - name: Install SSH Client 🔑
         uses: webfactory/ssh-agent@v0.5.3
         with:

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -10,6 +10,7 @@
     "environment_type": "virtualenv",
     "show_commit_url": "https://github.com/sunpy/sunpy/commit/",
     "benchmark_dir": "benchmarks",
+    "results_dir": "asv_results/results",
     "env_dir": "asv_env",
     "install_command": [
         "in-dir={env_dir} python -mpip install {wheel_file}[map]"


### PR DESCRIPTION
So https://github.com/sunpy/sunpy/pull/5567 worked.

This restores it back to 2.0 and removes the symlink from the action.