### PR TITLE
Error gracefully if a map doesn't have spatial axes

### DIFF
--- a/changelog/5602.trivial.rst
+++ b/changelog/5602.trivial.rst
@@ -1,0 +1,2 @@
+`sunpy.map.Map` now raises a clear error when the map is constructed if units
+of either two axes are not angular units.

--- a/sunpy/map/__init__.py
+++ b/sunpy/map/__init__.py
@@ -3,7 +3,7 @@ SunPy Map
 
 isort:skip_file
 """
-from sunpy.map.mapbase import GenericMap
+from sunpy.map.mapbase import *
 
 from sunpy.map import sources
 from sunpy.map.header_helper import *

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -110,7 +110,7 @@ Within this scope it also makes some other assumptions.
     rest will be discarded.
 """
 
-__all__ = ['GenericMap']
+__all__ = ['GenericMap', 'MapMetaValidationError']
 
 
 class MapMetaValidationError(AttributeError):
@@ -1321,8 +1321,13 @@ class GenericMap(NDData):
             warn_user("sunpy Map does not support three dimensional data "
                       "and therefore cannot represent heliocentric coordinates. Proceed at your own risk.")
 
-# #### Data conversion routines #### #
+        if not all(su.is_equivalent(u.arcsec) for su in self.spatial_units):
+            units = [su.to_string() for su in self.spatial_units]
+            raise MapMetaValidationError(
+                'Map only supports spherical coordinate systems with angular units '
+                f'(ie. equivalent to arcsec), but this map has units {units}')
 
+# #### Data conversion routines #### #
     def world_to_pixel(self, coordinate):
         """
         Convert a world (data) coordinate to a pixel coordinate.

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -994,6 +994,14 @@ def test_validate_meta(generic_map):
     assert 'waveunit'.upper() in str(w[0].message)
 
 
+def test_validate_non_spatial(generic_map):
+    generic_map.meta['cunit2'] = 'Angstrom'
+    err_msg = ("Map only supports spherical coordinate systems with angular units "
+               "(ie. equivalent to arcsec), but this map has units ['arcsec', 'Angstrom']")
+    with pytest.raises(sunpy.map.MapMetaValidationError, match=re.escape(err_msg)):
+        sunpy.map.Map(generic_map.data, generic_map.meta)
+
+
 # Heliographic Map Tests
 
 
@@ -1018,38 +1026,6 @@ def test_hg_data_to_pix(heliographic_test_map):
             0 * u.deg, 0 * u.deg, frame=heliographic_test_map.coordinate_frame))
     assert_quantity_allclose(out[0], 180 * u.pix)
     assert_quantity_allclose(out[1], 90 * u.pix)
-
-# Heliocentric Map Tests
-
-
-def test_hc_warn():
-    data = np.ones([6, 6], dtype=np.float64)
-    header = {
-        'CRVAL1': 0,
-        'CRVAL2': 0,
-        'CRPIX1': 5,
-        'CRPIX2': 5,
-        'CDELT1': 10,
-        'CDELT2': 10,
-        'CUNIT1': 'km',
-        'CUNIT2': 'km',
-        'CTYPE1': 'SOLX    ',
-        'CTYPE2': 'SOLY    ',
-        'PC1_1': 0,
-        'PC1_2': -1,
-        'PC2_1': 1,
-        'PC2_2': 0,
-        'NAXIS1': 6,
-        'NAXIS2': 6,
-        'date-obs': '1970/01/01T00:00:00',
-        'obsrvtry': 'Foo',
-        'detector': 'bar',
-        'wavelnth': 10,
-        'waveunit': 'm'
-    }
-
-    with pytest.warns(UserWarning):
-        sunpy.map.Map((data, header))
 
 # Dimension testing
 


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5507. As far as I can tell `Map` only supports two spatial axes, so this PR adds a graceful error message if that is not the case.

This is dependent on https://github.com/sunpy/sunpy/pull/5501 and #5618 going in first.