### PR TITLE
Upgrade circleci codecov uploader

### DIFF
--- a/.circleci/codecov_upload.sh
+++ b/.circleci/codecov_upload.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+shasum -a 256 -c codecov.SHA256SUM
+chmod +x codecov
+./codecov "$@"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,13 +45,7 @@ jobs:
       - run: tox -v
       - run:
           name: Running codecov
-          command: |
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM && chmod +x codecov && ./codecov -f ".tmp/<< parameters.jobname >>/coverage.xml"
+          command: bash -e .circleci/codecov_upload.sh -f ".tmp/${TOXENV}/coverage.xml"
       - store_artifacts:
           path: .tmp/<< parameters.jobname >>/figure_test_images
       - run:


### PR DESCRIPTION


<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
Upgrade the codecov upload method for the circleci figure tests. (Bash uploader is being deprecated.) Discussed in #5597 also.

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->


