### PR TITLE
Fix misspelling in fprintf call

### DIFF
--- a/changelog/5610.bugfix.rst
+++ b/changelog/5610.bugfix.rst
@@ -1,3 +1,0 @@
-Fix a misspelling (`cannot`) in the fprintf call in `sunpy/io/src/ana/anarw.c#76`. The misspelling is here:
-
-> 76: k_synch_hd: error: annot handle header more than 16 blocks!\n"


### PR DESCRIPTION
`sunpy/io/src/ana/anarw.c` contains a misspelling in a `fprintf` call:

> k_synch_hd: error: annot handle header more than 16 blocks!\n"

This patch updates `annot` to `cannot`.
