### PR TITLE
Fix #5633

### DIFF
--- a/sunpy/net/helio/hec.py
+++ b/sunpy/net/helio/hec.py
@@ -42,6 +42,9 @@ def votable_handler(xml_table):
         A properly formatted VOtable object
 
     """
+    if xml_table.endswith(b"</helio:queryResponse></S:Body></S:Envelope>\n"):
+        # remove dangling tags
+        xml_table = xml_table.replace(b"</helio:queryResponse></S:Body></S:Envelope>\n", b"")
     fake_file = io.BytesIO()
     fake_file.write(xml_table)
     votable = parse_single_table(fake_file)


### PR DESCRIPTION
### Description

Part of the XML response contains dangling tags at the end of text. Once these are removed, the helio response can then be correctly parsed.

I've added a simple check to remove the dangling xml tags if they exist before parsing the VOTable for HEC responses.

Fixes #5633
