### PR TITLE
Report total filesize in Fido queries

### DIFF
--- a/changelog/5659.feature.rst
+++ b/changelog/5659.feature.rst
@@ -1,0 +1,7 @@
+Added the :meth:`~sunpy.net.base_client.QueryResponseTable.total_size`, which
+estimates the total size of the results from a Fido query. If this is supported
+by a client, the total size is printed alongside the results.
+
+To add support for this in external clients, make sure one column contains
+the individual filesizes as `~astropy.units.Quantity`, and set the
+``size_column`` class attribute to the name of this column.

--- a/docs/dev_guide/contents/extending_fido.rst
+++ b/docs/dev_guide/contents/extending_fido.rst
@@ -319,6 +319,12 @@ We also pretend that the response is a json object in the form of a Python dicti
 In reality, you probably want to post-process the results from your API before you put them in the table, they should be human readable first, with spaces and capitalisation as appropriate.
 
 
+Supporting filesize estimates
+#############################
+The base client has a method for automatically estimating the total size of files in a given query: :meth:`~sunpy.net.base_client.QueryResponseTable.total_size`.
+To enable to support for this, make sure the table returned by ``search`` has a column that contains filesizes as astropy quantities convertible to ``u.byte``, and set the ``size_column`` class attribute to the name of this column.
+
+
 The ``_can_handle_query`` method
 ---------------------------------
 
@@ -431,7 +437,6 @@ If your filepath is a callback function, pass this to the ``filename=`` argument
 
 Your fetch method does not need to return anything, as long as ``enqueue_file`` is called for every file you want ``Fido`` to download.
 
-
 Putting it all Together
 -----------------------
 
@@ -475,6 +480,8 @@ An example client class may look something like::
 
 
   class ExampleClient(BaseClient):
+      size_column = 'Filesize'
+
       def search(self, query):
           queries = walker.create(query)
 

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -143,6 +143,7 @@ To search for data at a given cadence use the `a.Sample <sunpy.net.attrs.Sample>
     <BLANKLINE>
     289 Results from the VSOClient:
     Source: http://vso.stanford.edu/cgi-bin/search
+    Total estimated size: 19.591 Gbyte
     <BLANKLINE>
            Start Time       ...
                             ...
@@ -290,6 +291,7 @@ For example if we did a query for some AIA and HMI data::
     <BLANKLINE>
     201 Results from the VSOClient:
     Source: http://vso.stanford.edu/cgi-bin/search
+    Total estimated size: 13.626 Gbyte
     <BLANKLINE>
            Start Time       ...
                             ...

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from textwrap import dedent
 from collections.abc import Sequence
 
+import numpy as np
 import parfive
 
 from astropy.table import Table
@@ -183,7 +184,11 @@ class UnifiedResponse(Sequence):
         for block in self:
             ret += f"{len(block)} Results from the {block.client.__class__.__name__}:\n"
             if block.client.info_url is not None:
-                ret += f'Source: {block.client.info_url}\n\n'
+                ret += f'Source: {block.client.info_url}\n'
+            size = block.total_size()
+            if np.isfinite(size):
+                ret += f'Total estimated size: {size}\n'
+            ret += '\n'
             lines = repr(block).split('\n')
             ret += '\n'.join(lines[1:])
             ret += '\n\n'

--- a/sunpy/net/vso/table_response.py
+++ b/sunpy/net/vso/table_response.py
@@ -4,7 +4,6 @@ Classes and helper functions for VSO responses.
 from collections import defaultdict
 from collections.abc import Mapping
 
-import numpy as np
 from zeep.helpers import serialize_object
 
 import astropy.units as u
@@ -51,6 +50,7 @@ def iter_sort_response(response):
 class VSOQueryResponseTable(QueryResponseTable):
     hide_keys = ['fileid', 'fileurl']
     errors = TableAttribute(default=[])
+    size_column = 'Size'
 
     @classmethod
     def from_zeep_response(cls, response, *, client, _sort=True):
@@ -105,11 +105,6 @@ class VSOQueryResponseTable(QueryResponseTable):
         return data._reorder_columns(['Start Time', 'End Time', 'Source',
                                       'Instrument', 'Type', 'Wavelength'],
                                      remove_empty=True)
-
-    def total_size(self):
-        if 'size' not in self.colnames:
-            return np.nan
-        return np.nansum(self['size'])
 
     def add_error(self, exception):
         self.errors.append(exception)


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5282. A short example:
```python
from sunpy.net import Fido, attrs as a

result = Fido.search(a.Instrument('AIA'), a.Time('2020-01-01', '2020-01-02'))
print(result)
```

```
Results from 1 Provider:

1328 Results from the VSOClient:
Source: http://vso.stanford.edu/cgi-bin/search
Total size: 3.905 Tbyte
```