### PR TITLE
Skip CDF variables with zero elements

### DIFF
--- a/changelog/5664.bugfix.rst
+++ b/changelog/5664.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed reading CDF files when a column has no entries. If this is the case the
+column will be ignored, and a message logged at DEBUG level.

--- a/sunpy/io/cdf.py
+++ b/sunpy/io/cdf.py
@@ -4,6 +4,7 @@ from cdflib.epochs import CDFepoch
 
 import astropy.units as u
 
+from sunpy import log
 from sunpy.timeseries import GenericTimeSeries
 
 __all__ = ['read_cdf']
@@ -56,6 +57,10 @@ def read_cdf(fname):
                 continue
 
             # Get data
+            if cdf.varinq(var_key)['Last_Rec'] == -1:
+                log.debug(f'Skipping {var_key} in {fname} as it has zero elements')
+                continue
+
             data = cdf.varget(var_key)
             # Get units
             unit = attrs['UNITS']

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -15,7 +15,9 @@ from astropy.time import TimeDelta
 
 import sunpy.data.test
 import sunpy.io
+import sunpy.net.attrs as a
 import sunpy.timeseries
+from sunpy.net import Fido
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.datatype_factory_base import NoMatchError
@@ -115,6 +117,17 @@ class TestTimeSeries:
         assert ts.columns == ['psp_fld_l2_quality_flags']
         assert ts.quantity('psp_fld_l2_quality_flags').unit == u.dimensionless_unscaled
         assert len(ts.quantity('psp_fld_l2_quality_flags')) == 1440
+
+    @pytest.mark.remote_data
+    def test_read_cdf_empty_variable(self):
+        # Check that a CDF with an empty column can be correctly read
+        result = sunpy.net.Fido.search(a.Time('2020-01-01', '2020-01-02'),
+                                       a.cdaweb.Dataset('AC_H6_SWI'))
+        filename = Fido.fetch(result[0, 0])
+
+        density = u.def_unit('#/cm^3', represents=1 / u.cm**3)
+        u.add_enabled_units(density)
+        sunpy.timeseries.TimeSeries(filename)
 
 # =============================================================================
 # Individual Implicit Source Tests


### PR DESCRIPTION
I was trying to read the ACE swi_h6 data, and it wasn't working because we're trying to read in all the variables, even ones with zero elements. This PR fixes that by only loading variables with elements > 0.

Still needs a test, probably easiest to do a remote data test with the ACE swi_h6 dataset (the files are small).