### PR TITLE
Move automodapi files into generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,6 @@ sunpy/cython_version.py
 sunpy/_version.py
 docs/_build
 docs/generated
-docs/api/
 docs/whatsnew/latest_changelog.txt
 examples/**/*.asdf
 examples/**/*.csv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,9 @@ extensions = [
     "sphinxext.opengraph",
 ]
 
+# Set automodapi to generate files inside the generated directory
+automodapi_toctreedirnm = "generated/api"
+
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
 


### PR DESCRIPTION
This is an idea I had while looking at #5668 

It moves the generated files made by automodapi into the generated directory which is also used by sphinx-gallery and sphinx itself (for the modules tree).

**The major issue with this, is that it changes the URLs. Which means that some links that use our `/latest/` path will break.**