### PR TITLE
Speed up VSO time parsing in some cases

### DIFF
--- a/changelog/5681.trivial.rst
+++ b/changelog/5681.trivial.rst
@@ -1,0 +1,2 @@
+Sped up the parsing of results from the VSO. For large queries this significantly
+reduces the time needed to perform a query to the VSO.


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5107. This PR updates the time parsing so that an attempt is made at making a vectorised call to `parse_time`. If this isn't possible, it falls back to individual `parse_time` calls as before.

I've tested this locally with a search that does benefit from this, and one that doesn't (to check it's not a regression in that case):
```python
from sunpy.net import Fido
from sunpy.net import attrs as a

# Doesn't benefit from improvements
# 16 seconds before
# 16 seconds after
Fido.search(a.Time('2012/1/1', '2013/1/1'), a.Instrument('EIT'))

# Benefits from improvements
# 30 seconds before
# 21 seconds after
Fido.search(a.Time('2020/01/28', '2020/01/29'), a.Instrument('WISPR'))
```