### PR TITLE
Force `_new instance` to preserve plot settings 

### DIFF
--- a/changelog/5687.bugfix.rst
+++ b/changelog/5687.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where custom values in the ``plot_settings`` dictionary were not being propagated
+to new map instances created when calling map methods (e.g. ``.submap``).

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -494,7 +494,14 @@ class GenericMap(NDData):
         Instantiate a new instance of this class using given data.
         This is a shortcut for ``type(self)(data, meta, plot_settings)``.
         """
-        return cls(data, meta, plot_settings=plot_settings, **kwargs)
+        new_map = cls(data, meta, **kwargs)
+        # plot_settings are set explicitly here as some map sources
+        # explicitly set some of the plot_settings in the constructor
+        # and we want to preserve the plot_settings of the previous
+        # instance.
+        if plot_settings is not None:
+            new_map.plot_settings.update(plot_settings)
+        return new_map
 
     def _get_lon_lat(self, frame):
         """
@@ -516,10 +523,10 @@ class GenericMap(NDData):
         """
         new_meta = copy.deepcopy(self.meta)
         new_meta['bunit'] = new_data.unit.to_string('fits')
-        return self._new_instance(new_data.value, new_meta)
+        return self._new_instance(new_data.value, new_meta, plot_settings=self.plot_settings)
 
     def __neg__(self):
-        return self._new_instance(-self.data, self.meta)
+        return self._new_instance(-self.data, self.meta, plot_settings=self.plot_settings)
 
     @check_arithmetic_compatibility
     def __pow__(self, value):

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -627,7 +627,7 @@ def differential_rotate(smap, observer=None, time=None, **diff_rot_kwargs):
         padded_meta['crpix2'] += deltay
 
         # Create the padded map that will be used to create the rotated map.
-        smap = smap._new_instance(padded_data, padded_meta)
+        smap = smap._new_instance(padded_data, padded_meta, smap.plot_settings)
 
     # Check for masked maps
     if smap.mask is not None:
@@ -670,6 +670,6 @@ def differential_rotate(smap, observer=None, time=None, **diff_rot_kwargs):
             ((center_rotated.Tx - smap.center.Tx)/smap.scale.axis1).value
         out_meta['crpix2'] = 1 + smap.data.shape[0]/2.0 + \
             ((center_rotated.Ty - smap.center.Ty)/smap.scale.axis2).value
-        return smap._new_instance(out_data, out_meta).submap(rotated_bl, top_right=rotated_tr)
+        return smap._new_instance(out_data, out_meta, smap.plot_settings).submap(rotated_bl, top_right=rotated_tr)
     else:
-        return smap._new_instance(out_data, out_meta)
+        return smap._new_instance(out_data, out_meta, smap.plot_settings)


### PR DESCRIPTION
Fixes #5667 

This PR explicitly updates the plot settings when creating a new map instance through `_new_instance`. This is needed because we explicitly set the plot settings in the constructors of some map sources and those constructors ignore the presence of the `plot_settings` kwarg.

I've only backported this to 3.1 because I've also included fixes on the arithmetic operations. If we really want to backport this to 3.0, I can separate these out into a separate PR and backport this one to 3.0 as well.