### PR TITLE
Updated comment on a test to state when a warning filter can be removed

### DIFF
--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -264,8 +264,8 @@ def test_heliographic_quadrangle_top_right(heliographic_test_map):
     heliographic_test_map.draw_quadrangle(bottom_left, top_right=top_right, edgecolor='cyan')
 
 
-# See https://github.com/sunpy/sunpy/issues/4294 to track this warning. Ideally
-# it should not be filtered, and the cause of it fixed.
+# This warning filter can be removed once we depend on Astropy 5.0+.
+# See https://github.com/sunpy/sunpy/issues/4294
 @pytest.mark.filterwarnings(r'ignore:Numpy has detected that you \(may be\) writing to an array with\noverlapping memory')
 @figure_test
 def test_heliographic_grid_annotations(heliographic_test_map):


### PR DESCRIPTION
We currently filter a warning for a particular test, but the underlying bug has been fixed in Astropy 5.0, so we'll eventually be able to remove that warning filter.

Closes #4294