### PR TITLE
Add dictionary of CDF unit conversions

### DIFF
--- a/changelog/5692.bugfix.rst
+++ b/changelog/5692.bugfix.rst
@@ -1,0 +1,8 @@
+Added automatic conversion of some common but non-standard unit strings in CDF
+files to astropy unit objects. If sunpy does not recognise the unit string for
+a particular column, units of ``u.dimensionless_unscaled`` are applied to that
+column and a warning raised.
+
+If you think a given unit should not be dimensionless and support should be
+added for it in sunpy, please raise an issue at
+https://github.com/sunpy/sunpy/issues.

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -124,9 +124,6 @@ class TestTimeSeries:
         result = sunpy.net.Fido.search(a.Time('2020-01-01', '2020-01-02'),
                                        a.cdaweb.Dataset('AC_H6_SWI'))
         filename = Fido.fetch(result[0, 0])
-
-        density = u.def_unit('#/cm^3', represents=1 / u.cm**3)
-        u.add_enabled_units(density)
         sunpy.timeseries.TimeSeries(filename)
 
 # =============================================================================


### PR DESCRIPTION
Because CDF files do not have a standard for unit strings (😭😭😭😭😭), there are many CDF files available that do not have unit strings that astropy understands. I *think* this is the best solution - we just keep a mapping of obvious unit strings to their units. The list here is ported over from heliopy where I took the same approach.

Comments and disagreement welcome - but I can't think of a better way to do this from a reducing user friction point of view.

Fixes https://github.com/sunpy/sunpy/issues/5670