### PR TITLE
Add a no-gallery building directive to sphinx makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,6 +13,11 @@ help:
 
 .PHONY: help Makefile
 
+html-noplot:
+	@$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile


### PR DESCRIPTION
I noticed a new bit in the sphinx docs that gave this handy code snippet.