### PR TITLE
Add support for skipping stage 2 tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,7 @@ resources:
     name: ConorMacBride/azure-pipelines-templates
     ref: fix-fork-skipping
 
+
 trigger:
   branches:
     include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ resources:
     type: github
     endpoint: sunpy
     name: OpenAstronomy/azure-pipelines-templates
-    ref: master
 
 trigger:
   branches:
@@ -48,6 +47,7 @@ stages:
   - stage: FirstPhaseTests
     displayName: Core Tests
     jobs:
+    - template: check-skip.yml@OpenAstronomy
     - template: run-tox-env.yml@OpenAstronomy
       parameters:
         default_python: '3.8'
@@ -66,6 +66,7 @@ stages:
   - stage: SecondPhaseTests
     displayName: Stage 2 Tests
     dependsOn: FirstPhaseTests
+    condition: and(succeeded(), ne(dependencies.FirstPhaseTests.outputs['check_skip.search.found'], 'true'))
     jobs:
     - template: run-tox-env.yml@OpenAstronomy
       parameters:
@@ -92,6 +93,7 @@ stages:
   - stage: SecondPhaseTestsAllowedFail
     displayName: Stage 2 Tests - Online
     dependsOn: FirstPhaseTests
+    condition: and(succeeded(), ne(dependencies.FirstPhaseTests.outputs['check_skip.search.found'], 'true'))
     jobs:
     - template: run-tox-env.yml@OpenAstronomy
       parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,7 @@ resources:
   - repository: OpenAstronomy
     type: github
     endpoint: sunpy
-    name: ConorMacBride/azure-pipelines-templates
-    ref: fix-fork-skipping
+    name: OpenAstronomy/azure-pipelines-templates
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,6 @@ resources:
     name: ConorMacBride/azure-pipelines-templates
     ref: fix-fork-skipping
 
-
 trigger:
   branches:
     include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,8 @@ resources:
   - repository: OpenAstronomy
     type: github
     endpoint: sunpy
-    name: OpenAstronomy/azure-pipelines-templates
+    name: ConorMacBride/azure-pipelines-templates
+    ref: fix-fork-skipping
 
 trigger:
   branches:


### PR DESCRIPTION


<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
- Implements CI skipping as documented in [OpenAstronomy/azure-pipelines-templates](https://openastronomy-azure-pipelines.readthedocs.io/en/latest/check_skip.html).
- Also deletes the `ref: master` from the `OpenAstronomy` connection. [Azure will use the default branch anyway.](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checking-out-a-specific-ref)

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #5589 
