### PR TITLE
Fix horizons deprecation warning

### DIFF
--- a/changelog/5707.bugfix.rst
+++ b/changelog/5707.bugfix.rst
@@ -1,0 +1,5 @@
+The default ``id_type`` in :func:`sunpy.coordinates.get_horizons_coord` is now
+`None` to match the deafult ``id_type`` in astroquery 0.4.4, which will search
+major bodies first, and if no major bodies are found, then search small bodies.
+For older versions of astroquery the default ``id_type`` used by
+:func:`~sunpy.coordinates.get_horizons_coord` is still ``'majorbody'``.


### PR DESCRIPTION
This fixes a deprecation warning with `astroquery` 0.4.4, where the default `id_type` changed in horizons queries. I've changed our default `id_type` to `None` to match. To keep back compatibility in sunpy, if `astroquery < 0.4.4` is being used `id_type= None` gets translated to `id_type='majorbody'`, the old default.

I'm unsure what to do re. backporting here.