### PR TITLE
Fixed our logger intercepting Astropy warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
     hooks:
       - id: prohibit-string
         args: [--prohibit-string, "from warnings import warn,warnings.warn"]
-        exclude: "sunpy/version.py|sunpy/util/decorators.py|sunpy/util/exceptions.py|sunpy/extern/"
+        exclude: "sunpy/version.py|sunpy/util/decorators.py|sunpy/util/exceptions.py|sunpy/extern/|sunpy/util/tests/test_logger.py"
 
 ci:
   autofix_prs: false

--- a/changelog/5722.bugfix.rst
+++ b/changelog/5722.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a long-standing bug where our logger could intercept Astropy warnings in addition to SunPy warnings, and thus could conflict with Astropy's logger.

--- a/changelog/5722.trivial.rst
+++ b/changelog/5722.trivial.rst
@@ -1,0 +1,1 @@
+`~sunpy.util.exceptions.SunpyWarning` is no longer a subclass of `~astropy.utils.exceptions.AstropyWarning`.

--- a/docs/guide/logger.rst
+++ b/docs/guide/logger.rst
@@ -7,7 +7,7 @@ Logging system
 Overview
 ========
 
-The sunpy logging system makes use of the `~astropy.logger.AstropyLogger`.
+The sunpy logging system is an adapted version of `~astropy.logger.AstropyLogger`.
 Its purpose is to provide users the ability to decide which log and warning messages to show,
 to capture them, and to send them to a file.
 

--- a/sunpy/util/exceptions.py
+++ b/sunpy/util/exceptions.py
@@ -6,8 +6,6 @@ but rather in the particular package.
 """
 import warnings
 
-from astropy.utils.exceptions import AstropyWarning
-
 __all__ = ["NoMapsInFileError",
            "SunpyWarning", "SunpyUserWarning", "SunpyDeprecationWarning",
            "SunpyPendingDeprecationWarning", "SunpyMetadataWarning",
@@ -20,7 +18,7 @@ class NoMapsInFileError(Exception):
     """
 
 
-class SunpyWarning(AstropyWarning):
+class SunpyWarning(Warning):
     """
     The base warning class from which all Sunpy warnings should inherit.
 

--- a/sunpy/util/exceptions.py
+++ b/sunpy/util/exceptions.py
@@ -38,7 +38,7 @@ class SunpyUserWarning(UserWarning, SunpyWarning):
     """
 
 
-class SunpyMetadataWarning(UserWarning):
+class SunpyMetadataWarning(UserWarning, SunpyWarning):
     """
     Warning class for cases metadata is missing.
 

--- a/sunpy/util/logger.py
+++ b/sunpy/util/logger.py
@@ -1,6 +1,59 @@
+import os
+import sys
 import logging
 
 from astropy.logger import AstropyLogger
+
+from sunpy.util.exceptions import SunpyWarning
+
+
+class SunpyLogger(AstropyLogger):
+    """
+    This class is used to set up logging in SunPy.
+
+    This inherits the logging enhancements of `~astropy.logger.AstropyLogger`.
+    This logger is able to capture and log warnings that are based on
+    `~sunpy.util.exceptions.SunpyWarning`.  Other warnings will be ignored and
+    passed on to other loggers (e.g., from Astropy).
+    """
+    # Override the existing _showwarning() to capture SunpyWarning instead of AstropyWarning
+    def _showwarning(self, *args, **kwargs):
+
+        # Bail out if we are not catching a warning from SunPy
+        if not isinstance(args[0], SunpyWarning):
+            return self._showwarning_orig(*args, **kwargs)
+
+        warning = args[0]
+        # Deliberately not using isinstance here: We want to display
+        # the class name only when it's not the default class,
+        # SunpyWarning.  The name of subclasses of SunpyWarning should
+        # be displayed.
+        if type(warning) not in (SunpyWarning,):
+            message = f'{warning.__class__.__name__}: {args[0]}'
+        else:
+            message = str(args[0])
+
+        mod_path = args[2]
+        # Now that we have the module's path, we look through sys.modules to
+        # find the module object and thus the fully-package-specified module
+        # name.  The module.__file__ is the original source file name.
+        mod_name = None
+        mod_path, ext = os.path.splitext(mod_path)
+        for name, mod in list(sys.modules.items()):
+            try:
+                # Believe it or not this can fail in some cases:
+                # https://github.com/astropy/astropy/issues/2671
+                path = os.path.splitext(getattr(mod, '__file__', ''))[0]
+            except Exception:
+                continue
+            if path == mod_path:
+                mod_name = mod.__name__
+                break
+
+        if mod_name is not None:
+            self.warning(message, extra={'origin': mod_name})
+        else:
+            self.warning(message)
 
 
 def _init_log(config=None):
@@ -12,7 +65,7 @@ def _init_log(config=None):
     "licenses/ASTROPY.rst".
     """
     orig_logger_cls = logging.getLoggerClass()
-    logging.setLoggerClass(AstropyLogger)
+    logging.setLoggerClass(SunpyLogger)
     try:
         log = logging.getLogger('sunpy')
         if config is not None:

--- a/sunpy/util/tests/test_logger.py
+++ b/sunpy/util/tests/test_logger.py
@@ -2,9 +2,8 @@
 import logging
 import os.path
 
-from astropy.logger import AstropyLogger
-
 from sunpy import config, log
+from sunpy.util.logger import SunpyLogger
 
 level_to_numeric = {'CRITICAL': 50, 'ERROR': 40,
                     'WARNING': 30, 'INFO': 20, 'DEBUG': 10, 'NOTSET': 0}
@@ -16,7 +15,7 @@ def test_logger_name():
 
 def test_is_the_logger_there():
     assert isinstance(log, logging.Logger)
-    assert isinstance(log, AstropyLogger)
+    assert isinstance(log, SunpyLogger)
 
 
 def test_is_level_configed():


### PR DESCRIPTION
We crib Astropy's logger (#2980), which causes some issues (see #3342).  We recently became aware that our logger captures Astropy warnings and prevents them from being handled elsewhere, which can cause test failures in other packages if SunPy gets imported (see astropy/astropy#12425).  Surprisingly, an implicit import of SunPy can occur if `asdf` is used, so a user may not even be aware that SunPy has been imported.

The long-term solution is to build our own logger.  In the meantime, this PR creates a lightweight subclass of `AstropyLogger` that overrides the warning-capturing code to capture `SunpyWarning` instead of `AstropyWarning`.  This resolves the issue with our logger capturing Astropy warnings, but does not resolve issues noted in #3342.

This PR also changes `SunpyWarning` so that it does not inherit from `AstropyWarning`, which had been the easiest way to crib Astropy's logger, but is no longer necessary given the custom warning-capturing code.  Furthermore, this prevents the issue that the Astropy logger could capture SunPy warnings.