### PR TITLE
Update ASDF schemas to reference by URI not tag

### DIFF
--- a/changelog/5723.bugfix.rst
+++ b/changelog/5723.bugfix.rst
@@ -1,0 +1,2 @@
+Update asdf schemas so that references use URIs not tags as this is not
+supported by the new asdf extensions API.

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/geocentricearthequatorial-1.0.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/geocentricearthequatorial-1.0.0.yaml
@@ -27,7 +27,7 @@ examples:
             obstime: !time/time-1.1.0 '2011-01-01T01:01:01.000'
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/geocentricsolarecliptic-1.0.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/geocentricsolarecliptic-1.0.0.yaml
@@ -20,7 +20,7 @@ examples:
           frame_attributes: {obstime: !time/time-1.1.0 '2011-01-01T01:01:01.000'}
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliocentric-1.0.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliocentric-1.0.0.yaml
@@ -36,7 +36,7 @@ examples:
             obstime: !time/time-1.1.0 '2011-01-01T01:01:01.000'
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliocentricearthecliptic-1.0.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliocentricearthecliptic-1.0.0.yaml
@@ -20,7 +20,7 @@ examples:
           frame_attributes: {obstime: !time/time-1.1.0 '2011-01-01T01:01:01.000'}
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliocentricinertial-1.0.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliocentricinertial-1.0.0.yaml
@@ -20,7 +20,7 @@ examples:
           frame_attributes: {obstime: !time/time-1.1.0 '2011-01-01T01:01:01.000'}
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_carrington-1.0.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_carrington-1.0.0.yaml
@@ -20,7 +20,7 @@ examples:
           frame_attributes: {obstime: !time/time-1.1.0 '2011-01-01T01:01:01.000'}
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_carrington-1.1.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_carrington-1.1.0.yaml
@@ -34,7 +34,7 @@ examples:
             obstime: !time/time-1.1.0 2011-01-01T01:01:01.000
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_carrington-1.2.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_carrington-1.2.0.yaml
@@ -38,7 +38,7 @@ examples:
             rsun: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km, value: 695700.0}
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_stonyhurst-1.0.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_stonyhurst-1.0.0.yaml
@@ -20,7 +20,7 @@ examples:
           frame_attributes: {obstime: !time/time-1.1.0 '2011-01-01T01:01:01.000'}
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_stonyhurst-1.1.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/heliographic_stonyhurst-1.1.0.yaml
@@ -23,7 +23,7 @@ examples:
             rsun: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km, value: 695700.0}
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object

--- a/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/helioprojective-1.0.0.yaml
+++ b/sunpy/io/special/asdf/schemas/sunpy.org/sunpy/coordinates/frames/helioprojective-1.0.0.yaml
@@ -38,7 +38,7 @@ examples:
             rsun: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km, value: 695700.0}
 
 allOf:
-  - $ref: "tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0"
+  - $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
   - properties:
       frame_attributes:
         type: object


### PR DESCRIPTION
The asdf Python package has a new extension API which doesn't support references by tag, only by URI. This changes our schemas to use URIs which are also supported by the old API, so this change is backwards compatible, while making us compatible with the new API as well.