### PR TITLE
Remove pytest-intercept-remote test dep

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,6 @@ tests =
   jplephem  # For some coordinates tests
   pytest-astropy>=0.8  # 0.8 is the first release to include filter-subpackage
   pytest-doctestplus>=0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
-  pytest-intercept-remote>=1.2
   pytest-mock
   pytest-mpl>=0.12 # First version to support our figure tests
 docs =


### PR DESCRIPTION
This originally came in via. https://github.com/sunpy/sunpy/pull/5233, but we do not use it by default when running the tests (see discussion in https://github.com/sunpy/sunpy/pull/5233). Because this plugin isn't available on conda, it's currently preventing us from running tests on conda, so I think it's best to remove this and if users want to use this pytest plugin they can just manually install it themselves.