### PR TITLE
Get scikit-image 0.19.0 working

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,9 +48,7 @@ dask =
 database =
   sqlalchemy>=1.3.4
 image =
-  # TODO: remove the <0.19 pin when discrepenies in
-  # sunpy/image/tests/test_transform.py::test_scale have been resolved
-  scikit-image>=0.16.0,<0.19
+  scikit-image>=0.16.0
   scipy>=1.3.0
 jpeg2000 =
   glymur>=0.8.18,!=0.9.0,!=0.9.5

--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -127,7 +127,7 @@ def test_scale(original, scale_factor):
 
     # Check a scaled image against the expected outcome
     newim = tf.rescale(original / original.max(), scale_factor, order=4,
-                       mode='constant', multichannel=False, anti_aliasing=False) * original.max()
+                       mode='constant', anti_aliasing=False) * original.max()
     # Old width and new center of image
     w = original.shape[0] / 2.0 - 0.5
     new_c = (newim.shape[0] / 2.0) - 0.5
@@ -160,7 +160,7 @@ def test_all(original, angle, dx, dy, scale_factor):
     s = np.round(np.sin(angle))
     rmatrix = np.array([[c, -s], [s, c]])
     scale = tf.rescale(original / original.max(), scale_factor, order=4,
-                       mode='constant', multichannel=False, anti_aliasing=False) * original.max()
+                       mode='constant', anti_aliasing=False) * original.max()
     new = np.zeros(original.shape)
 
     disp = np.array([dx, dy])

--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -41,10 +41,12 @@ def compare_results(expect, result, allclose=True):
 
         # Print out every mismatch
         if not t2:
-            mismatches = np.stack([*notclose.nonzero(), exp[notclose], res[notclose]]).T
-            for row in mismatches:
-                print(f"i={int(row[0]+1)}, j={int(row[1]+1)}: expected={row[2]}, result={row[3]}, "
-                      f"adiff={row[2]-row[3]}, rdiff={(row[2]-row[3])/row[2]}")
+            with np.errstate(divide='ignore'):
+                mismatches = np.stack([*notclose.nonzero(), exp[notclose], res[notclose]]).T
+                for row in mismatches:
+                    print(f"i={int(row[0]+1)}, j={int(row[1]+1)}: ",
+                          f"expected={row[2]}, result={row[3]}, "
+                          f"adiff={row[2]-row[3]}, rdiff={(row[2]-row[3])/row[2]}")
 
     return t1 and t2
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ description =
 setenv =
     MPLBACKEND = agg
     SUNPY_SAMPLEDIR = {env:SUNPY_SAMPLEDIR:{toxinidir}/.tox/{envname}/sample_data/}
-    PYTEST_COMMAND = pytest -vvv -s -raR --pyargs sunpy --cov-report=xml --cov=sunpy --cov-config={toxinidir}/setup.cfg {toxinidir}/docs
+    PYTEST_COMMAND = pytest -vvv -raR --pyargs sunpy --cov-report=xml --cov=sunpy --cov-config={toxinidir}/setup.cfg {toxinidir}/docs
     devdeps,build_docs,online: HOME = {envtmpdir}
     build_docs: HIDE_PARFIVE_PROGESS = True
     NO_VERIFY_HELIO_SSL = 1


### PR DESCRIPTION
The just-released `scikit-image` 0.19 has deprecated the `multichannel` keyword argument for `rescale()`, which breaks our CI build.  We were specifying the default value of `multichannel` anyway, so we can simply remove it where used.

`scikit-image` 0.19 also has different behavior when filling in constant values beyond the image when shrinking.  This PR is currently testing possible solutions.