### PR TITLE
Pin skimage to <0.19

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,9 @@ dask =
 database =
   sqlalchemy>=1.3.4
 image =
-  scikit-image>=0.16.0
+  # TODO: remove the <0.19 pin when discrepenies in
+  # sunpy/image/tests/test_transform.py::test_scale have been resolved
+  scikit-image>=0.16.0,<0.19
   scipy>=1.3.0
 jpeg2000 =
   glymur>=0.8.18,!=0.9.0,!=0.9.5


### PR DESCRIPTION
This is a temporary measure to get our CI running again whilst we figure out what's going on with skimage 0.19 (see https://github.com/sunpy/sunpy/pull/5742)