### PR TITLE
Clean up timeseries factory tests

### DIFF
--- a/sunpy/timeseries/sources/tests/test_eve.py
+++ b/sunpy/timeseries/sources/tests/test_eve.py
@@ -1,0 +1,27 @@
+import pytest
+
+import sunpy.timeseries
+from sunpy.data.test import get_test_filepath
+from sunpy.util.exceptions import SunpyUserWarning
+
+esp_filepath = get_test_filepath('eve_l1_esp_2011046_00_truncated.fits')
+eve_filepath = get_test_filepath('EVE_L0CS_DIODES_1m_truncated.txt')
+
+
+def test_eve():
+    # Test an EVE TimeSeries
+    with pytest.warns(SunpyUserWarning, match='Unknown units for x_cool proxy'):
+        ts_eve = sunpy.timeseries.TimeSeries(eve_filepath, source='EVE')
+    assert isinstance(ts_eve, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
+
+
+def test_implicit_esp():
+    # Test an ESP TimeSeries
+    ts_esp = sunpy.timeseries.TimeSeries(esp_filepath)
+    assert isinstance(ts_esp, sunpy.timeseries.sources.eve.ESPTimeSeries)
+
+
+def test_esp():
+    # Test an ESP TimeSeries
+    ts_esp = sunpy.timeseries.TimeSeries(esp_filepath, source='ESP')
+    assert isinstance(ts_esp, sunpy.timeseries.sources.eve.ESPTimeSeries)

--- a/sunpy/timeseries/sources/tests/test_fermi_gbm.py
+++ b/sunpy/timeseries/sources/tests/test_fermi_gbm.py
@@ -1,0 +1,16 @@
+import sunpy.timeseries
+from sunpy.data.test import get_test_filepath
+
+fermi_gbm_filepath = get_test_filepath('gbm.fits')
+
+
+def test_implicit_fermi_gbm():
+    # Test a GBMSummary TimeSeries
+    ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath)
+    assert isinstance(ts_gbm, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)
+
+
+def test_fermi_gbm():
+    # Test a GBMSummary TimeSeries
+    ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, source='GBMSummary')
+    assert isinstance(ts_gbm, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)

--- a/sunpy/timeseries/sources/tests/test_goes.py
+++ b/sunpy/timeseries/sources/tests/test_goes.py
@@ -1,0 +1,94 @@
+import pytest
+
+import sunpy.timeseries
+from sunpy.data.test import get_test_filepath
+
+goes_filepath = get_test_filepath('go1520110607.fits')
+goes_filepath_com = get_test_filepath('go1520120601.fits.gz')
+new_goes15_filepath = get_test_filepath('goes_truncated_test_goes15.nc')
+new_goes17_filepath = get_test_filepath('goes_truncated_test_goes17.nc')
+
+
+def test_implicit_goes():
+    # Test a GOES TimeSeries
+    ts_goes = sunpy.timeseries.TimeSeries(goes_filepath)
+    assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+
+
+def test_implicit_goes_com():
+    # Test a GOES TimeSeries
+    ts_goes = sunpy.timeseries.TimeSeries(goes_filepath_com)
+    assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+
+
+def test_implicit_new_goes15():
+    # Test a GOES TimeSeries
+    ts_goes = sunpy.timeseries.TimeSeries(new_goes15_filepath)
+    assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+
+
+def test_implicit_new_goes17():
+    # Test a GOES TimeSeries
+    ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath)
+    assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+
+
+def test_implicit_goes_satno():
+    # Test a GOES TimeSeries for satellite number
+    ts_goes = sunpy.timeseries.TimeSeries(goes_filepath)
+    assert ts_goes.observatory == 'GOES-15'
+
+
+def test_implicit_new_goes15_satno():
+    # Test a GOES TimeSeries for satellite number
+    ts_goes = sunpy.timeseries.TimeSeries(new_goes15_filepath)
+    assert ts_goes.observatory == 'GOES-15'
+
+
+def test_implicit_new_goes17_satno():
+    # Test a GOES TimeSeries for satellite number
+    ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath)
+    assert ts_goes.observatory == 'GOES-17'
+
+
+def test_implicit_goes_satno_missing():
+    # Test a GOES TimeSeries for a missing satellite number
+    ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath)
+    del ts_goes.meta.metas[0]['id']
+    assert ts_goes.observatory is None
+
+
+def test_goes():
+    # Test a GOES TimeSeries
+    ts_goes = sunpy.timeseries.TimeSeries(goes_filepath, source='XRS')
+    assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+
+
+def test_goes_com():
+    # Test a GOES TimeSeries
+    ts_goes = sunpy.timeseries.TimeSeries(goes_filepath_com, source='XRS')
+    assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+
+
+def test_new_goes15():
+    # Test a GOES TimeSeries
+    ts_goes = sunpy.timeseries.TimeSeries(new_goes15_filepath, source='XRS')
+    assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+
+
+def test_new_goes16():
+    # Test a GOES TimeSeries
+    ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath, source='XRS')
+    assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+
+
+@pytest.mark.remote_data
+def test_goes_remote():
+    # Older format file
+    goes = sunpy.timeseries.TimeSeries(
+        'https://umbra.nascom.nasa.gov/goes/fits/1986/go06860129.fits')
+    assert isinstance(goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
+    # Newer format
+    goes = sunpy.timeseries.TimeSeries(
+        'https://umbra.nascom.nasa.gov/goes/fits/2018/go1520180626.fits')
+    assert isinstance(goes, sunpy.timeseries.sources.goes.XRSTimeSeries)

--- a/sunpy/timeseries/sources/tests/test_lyra.py
+++ b/sunpy/timeseries/sources/tests/test_lyra.py
@@ -1,0 +1,16 @@
+import sunpy.timeseries
+from sunpy.data.test import get_test_filepath
+
+lyra_filepath = get_test_filepath('lyra_20150101-000000_lev3_std_truncated.fits.gz')
+
+
+def test_implicit_lyra():
+    # Test a LYRA TimeSeries
+    ts_lyra = sunpy.timeseries.TimeSeries(lyra_filepath)
+    assert isinstance(ts_lyra, sunpy.timeseries.sources.lyra.LYRATimeSeries)
+
+
+def test_lyra():
+    # Test a LYRA TimeSeries
+    ts_lyra = sunpy.timeseries.TimeSeries(lyra_filepath, source='LYRA')
+    assert isinstance(ts_lyra, sunpy.timeseries.sources.lyra.LYRATimeSeries)

--- a/sunpy/timeseries/sources/tests/test_noaa.py
+++ b/sunpy/timeseries/sources/tests/test_noaa.py
@@ -1,0 +1,23 @@
+import pytest
+
+import sunpy.timeseries
+from sunpy.data.test import get_test_filepath
+
+noaa_ind_json_filepath = get_test_filepath('observed-solar-cycle-indices-truncated.json')
+noaa_pre_json_filepath = get_test_filepath('predicted-solar-cycle-truncated.json')
+
+
+def test_noaa_ind_json():
+    # Test a NOAAPredictIndices TimeSeries json
+    ts_noaa_ind = sunpy.timeseries.TimeSeries(noaa_ind_json_filepath, source='NOAAIndices')
+    assert isinstance(ts_noaa_ind, sunpy.timeseries.sources.noaa.NOAAIndicesTimeSeries)
+
+
+# The pre- data involves dates long in the future, so ignore an ERFA warning
+# when parsing these dates.
+@pytest.mark.filterwarnings('ignore:ERFA function.*dubious year')
+def test_noaa_pre_json():
+    # Test a NOAAIndices TimeSeries json
+    ts_noaa_pre = sunpy.timeseries.TimeSeries(
+        noaa_pre_json_filepath, source='NOAAPredictIndices')
+    assert isinstance(ts_noaa_pre, sunpy.timeseries.sources.noaa.NOAAPredictIndicesTimeSeries)

--- a/sunpy/timeseries/sources/tests/test_norh.py
+++ b/sunpy/timeseries/sources/tests/test_norh.py
@@ -1,0 +1,16 @@
+import sunpy.timeseries
+from sunpy.data.test import get_test_filepath
+
+norh_filepath = get_test_filepath('tca110810_truncated')
+
+
+def test_implicit_norh():
+    # Test a NoRH TimeSeries
+    ts_norh = sunpy.timeseries.TimeSeries(norh_filepath)
+    assert isinstance(ts_norh, sunpy.timeseries.sources.norh.NoRHTimeSeries)
+
+
+def test_norh():
+    # Test a NoRH TimeSeries
+    ts_norh = sunpy.timeseries.TimeSeries(norh_filepath, source='NoRH')
+    assert isinstance(ts_norh, sunpy.timeseries.sources.norh.NoRHTimeSeries)

--- a/sunpy/timeseries/sources/tests/test_rhessi.py
+++ b/sunpy/timeseries/sources/tests/test_rhessi.py
@@ -1,0 +1,16 @@
+import sunpy.timeseries
+from sunpy.data.test import get_test_filepath
+
+rhessi_filepath = get_test_filepath('hsi_obssumm_20120601_018_truncated.fits.gz')
+
+
+def test_implicit_rhessi():
+    # Test a RHESSI TimeSeries
+    ts_rhessi = sunpy.timeseries.TimeSeries(rhessi_filepath)
+    assert isinstance(ts_rhessi, sunpy.timeseries.sources.rhessi.RHESSISummaryTimeSeries)
+
+
+def test_rhessi():
+    # Test a RHESSI TimeSeries
+    ts_rhessi = sunpy.timeseries.TimeSeries(rhessi_filepath, source='RHESSI')
+    assert isinstance(ts_rhessi, sunpy.timeseries.sources.rhessi.RHESSISummaryTimeSeries)

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -17,557 +17,389 @@ import sunpy.data.test
 import sunpy.io
 import sunpy.net.attrs as a
 import sunpy.timeseries
+from sunpy.data.test import get_test_filepath
 from sunpy.net import Fido
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.datatype_factory_base import NoMatchError
 from sunpy.util.metadata import MetaDict
 
-# =============================================================================
-# TimeSeries Factory Tests
-# =============================================================================
-
-filepath = sunpy.data.test.rootdir
-esp_filepath = os.path.join(filepath, 'eve_l1_esp_2011046_00_truncated.fits')
-eve_filepath = os.path.join(filepath, 'EVE_L0CS_DIODES_1m_truncated.txt')
-eve_many_filepath = glob.glob(os.path.join(filepath, "eve", "*"))
-fermi_gbm_filepath = os.path.join(filepath, 'gbm.fits')
-goes_filepath = os.path.join(filepath, 'go1520110607.fits')
-goes_filepath_com = os.path.join(filepath, 'go1520120601.fits.gz')
-lyra_filepath = os.path.join(filepath, 'lyra_20150101-000000_lev3_std_truncated.fits.gz')
-new_goes15_filepath = os.path.join(filepath, 'goes_truncated_test_goes15.nc')
-new_goes17_filepath = os.path.join(filepath, 'goes_truncated_test_goes17.nc')
-noaa_ind_json_filepath = os.path.join(filepath, 'observed-solar-cycle-indices-truncated.json')
-noaa_ind_txt_filepath = os.path.join(filepath, 'RecentIndices_truncated.txt')
-noaa_pre_json_filepath = os.path.join(filepath, 'predicted-solar-cycle-truncated.json')
-noaa_pre_txt_filepath = os.path.join(filepath, 'predicted-sunspot-radio-flux_truncated.txt')
-norh_filepath = os.path.join(filepath, 'tca110810_truncated')
-rhessi_filepath = os.path.join(filepath, 'hsi_obssumm_20120601_018_truncated.fits.gz')
-psp_filepath = os.path.join(filepath, 'psp_fld_l2_mag_rtn_1min_20200104_v02.cdf')
-
-# =============================================================================
-# Multi file Tests
-# =============================================================================
+eve_filepath = get_test_filepath('EVE_L0CS_DIODES_1m_truncated.txt')
+eve_many_filepath = glob.glob(os.path.join(sunpy.data.test.rootdir, "eve", "*"))
+goes_filepath = get_test_filepath('go1520110607.fits')
+psp_filepath = get_test_filepath('psp_fld_l2_mag_rtn_1min_20200104_v02.cdf')
 
 
-class TestTimeSeries:
-    @pytest.mark.filterwarnings('ignore:Unknown units')
-    def test_factory_concatenate_same_source(self):
-        # Test making a TimeSeries that is the concatenation of multiple files
-        ts_from_list = sunpy.timeseries.TimeSeries(eve_many_filepath, source='EVE', concatenate=True)
-        assert isinstance(ts_from_list, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
+@pytest.mark.filterwarnings('ignore:Unknown units')
+def test_factory_concatenate_same_source():
+    # Test making a TimeSeries that is the concatenation of multiple files
+    ts_from_list = sunpy.timeseries.TimeSeries(eve_many_filepath, source='EVE', concatenate=True)
+    assert isinstance(ts_from_list, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
 
-        ts_from_folder = sunpy.timeseries.TimeSeries(
-            os.path.join(filepath, "eve"), source='EVE', concatenate=True)
-        assert isinstance(ts_from_folder, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
-        # text the two methods get identical dataframes
-        assert ts_from_list == ts_from_folder
-        # test the frames have correct headings/keys (correct concatenation axis)
-        ts_from_list.columns == sunpy.timeseries.TimeSeries(
-            eve_many_filepath[0], source='EVE', concatenate=True).columns
+    ts_from_folder = sunpy.timeseries.TimeSeries(
+        os.path.join(sunpy.data.test.rootdir, "eve"), source='EVE', concatenate=True)
+    assert isinstance(ts_from_folder, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
+    # text the two methods get identical dataframes
+    assert ts_from_list == ts_from_folder
+    # test the frames have correct headings/keys (correct concatenation axis)
+    ts_from_list.columns == sunpy.timeseries.TimeSeries(
+        eve_many_filepath[0], source='EVE', concatenate=True).columns
 
-    @pytest.mark.filterwarnings('ignore:Unknown units')
-    def test_factory_concatenate_different_source(self):
-        # Test making a TimeSeries that is the concatenation of multiple files
-        ts_from_list = sunpy.timeseries.TimeSeries(eve_many_filepath, source='EVE', concatenate=True)
-        assert isinstance(ts_from_list, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
-        ts_from_folder = sunpy.timeseries.TimeSeries(
-            os.path.join(filepath, "eve"), source='EVE', concatenate=True)
-        assert isinstance(ts_from_folder, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
-        # text the two methods get identical dataframes
-        assert ts_from_list == ts_from_folder
-        # test the frames have correct headings/keys (correct concatenation axis)
-        ts_from_list.columns == sunpy.timeseries.TimeSeries(
-            eve_many_filepath[0], source='EVE', concatenate=True).columns
 
-    @pytest.mark.filterwarnings('ignore:Unknown units')
-    def test_factory_generate_list_of_ts(self):
-        # Test making a list TimeSeries from multiple files
-        ts_list = sunpy.timeseries.TimeSeries(eve_many_filepath, source='EVE')
-        assert isinstance(ts_list, list)
-        for ts in ts_list:
-            assert isinstance(ts, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
+@pytest.mark.filterwarnings('ignore:Unknown units')
+def test_factory_concatenate_different_source():
+    # Test making a TimeSeries that is the concatenation of multiple files
+    ts_from_list = sunpy.timeseries.TimeSeries(eve_many_filepath, source='EVE', concatenate=True)
+    assert isinstance(ts_from_list, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
+    ts_from_folder = sunpy.timeseries.TimeSeries(
+        os.path.join(sunpy.data.test.rootdir, "eve"), source='EVE', concatenate=True)
+    assert isinstance(ts_from_folder, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
+    # text the two methods get identical dataframes
+    assert ts_from_list == ts_from_folder
+    # test the frames have correct headings/keys (correct concatenation axis)
+    ts_from_list.columns == sunpy.timeseries.TimeSeries(
+        eve_many_filepath[0], source='EVE', concatenate=True).columns
 
-    @pytest.mark.filterwarnings('ignore:Unknown units')
-    def test_factory_generate_from_glob(self):
-        # Test making a TimeSeries from a glob
-        ts_from_glob = sunpy.timeseries.TimeSeries(os.path.join(
-            filepath, "eve", "*"), source='EVE', concatenate=True)
-        assert isinstance(ts_from_glob, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
 
-    @pytest.mark.filterwarnings('ignore:Unknown units')
-    def test_factory_generate_from_pathlib(self):
-        # Test making a TimeSeries from a : pathlib.PosixPath
-        ts_from_pathlib = sunpy.timeseries.TimeSeries(Path(filepath).joinpath("gbm.fits"),
-                                                      source="GBMSummary")
-        assert isinstance(ts_from_pathlib, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)
+@pytest.mark.filterwarnings('ignore:Unknown units')
+def test_factory_generate_list_of_ts():
+    # Test making a list TimeSeries from multiple files
+    ts_list = sunpy.timeseries.TimeSeries(eve_many_filepath, source='EVE')
+    assert isinstance(ts_list, list)
+    for ts in ts_list:
+        assert isinstance(ts, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
 
-    def test_read_cdf(self):
-        ts_psp = sunpy.timeseries.TimeSeries(psp_filepath)
-        assert len(ts_psp) == 2
 
-        ts = ts_psp[0]
-        assert ts.columns == ['psp_fld_l2_mag_RTN_1min_0',
-                              'psp_fld_l2_mag_RTN_1min_1',
-                              'psp_fld_l2_mag_RTN_1min_2']
-        assert ts.quantity('psp_fld_l2_mag_RTN_1min_0').unit == u.nT
-        assert len(ts.quantity('psp_fld_l2_mag_RTN_1min_0')) == 118
+@pytest.mark.filterwarnings('ignore:Unknown units')
+def test_factory_generate_from_glob():
+    # Test making a TimeSeries from a glob
+    ts_from_glob = sunpy.timeseries.TimeSeries(os.path.join(
+        sunpy.data.test.rootdir, "eve", "*"), source='EVE', concatenate=True)
+    assert isinstance(ts_from_glob, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
 
-        ts = ts_psp[1]
-        assert ts.columns == ['psp_fld_l2_quality_flags']
-        assert ts.quantity('psp_fld_l2_quality_flags').unit == u.dimensionless_unscaled
-        assert len(ts.quantity('psp_fld_l2_quality_flags')) == 1440
 
-    @pytest.mark.remote_data
-    def test_read_cdf_empty_variable(self):
-        # This tests that:
-        # - A CDF file with an empty column can be read
-        # - Unknown unit handling works as expected
-        result = sunpy.net.Fido.search(a.Time('2020-01-01', '2020-01-02'),
-                                       a.cdaweb.Dataset('AC_H6_SWI'))
-        filename = Fido.fetch(result[0, 0])
+@pytest.mark.filterwarnings('ignore:Unknown units')
+def test_factory_generate_from_pathlib():
+    # Test making a TimeSeries from a : pathlib.PosixPath
+    ts_from_pathlib = sunpy.timeseries.TimeSeries(Path(sunpy.data.test.rootdir).joinpath("gbm.fits"),
+                                                  source="GBMSummary")
+    assert isinstance(ts_from_pathlib, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)
 
-        # Temporarily reset sunpy.io.cdf registry of known unit conversions
-        import sunpy.io.cdf as sunpy_cdf
-        known_units = sunpy_cdf._known_units
-        sunpy_cdf._known_units = {}
 
-        with pytest.warns(SunpyUserWarning, match='Assigning dimensionless units'):
-            ts = sunpy.timeseries.TimeSeries(filename)
+def test_read_cdf():
+    ts_psp = sunpy.timeseries.TimeSeries(psp_filepath)
+    assert len(ts_psp) == 2
 
-        assert ts.quantity('nH').unit == u.dimensionless_unscaled
+    ts = ts_psp[0]
+    assert ts.columns == ['psp_fld_l2_mag_RTN_1min_0',
+                          'psp_fld_l2_mag_RTN_1min_1',
+                          'psp_fld_l2_mag_RTN_1min_2']
+    assert ts.quantity('psp_fld_l2_mag_RTN_1min_0').unit == u.nT
+    assert len(ts.quantity('psp_fld_l2_mag_RTN_1min_0')) == 118
 
-        # Put back known unit registry, and check that units are recognised
-        sunpy_cdf._known_units = known_units
+    ts = ts_psp[1]
+    assert ts.columns == ['psp_fld_l2_quality_flags']
+    assert ts.quantity('psp_fld_l2_quality_flags').unit == u.dimensionless_unscaled
+    assert len(ts.quantity('psp_fld_l2_quality_flags')) == 1440
+
+
+@pytest.mark.remote_data
+def test_read_cdf_empty_variable():
+    # This tests that:
+    # - A CDF file with an empty column can be read
+    # - Unknown unit handling works as expected
+    result = sunpy.net.Fido.search(a.Time('2020-01-01', '2020-01-02'),
+                                   a.cdaweb.Dataset('AC_H6_SWI'))
+    filename = Fido.fetch(result[0, 0])
+
+    # Temporarily reset sunpy.io.cdf registry of known unit conversions
+    import sunpy.io.cdf as sunpy_cdf
+    known_units = sunpy_cdf._known_units
+    sunpy_cdf._known_units = {}
+
+    with pytest.warns(SunpyUserWarning, match='Assigning dimensionless units'):
         ts = sunpy.timeseries.TimeSeries(filename)
-        assert ts.quantity('nH').unit == u.cm**-3
-
-        # Reset again to check that registring units via. astropy works too
-        sunpy_cdf._known_units = {}
-        u.add_enabled_units([u.def_unit('#/cm^3', represents=u.cm**-3)])
-        ts = sunpy.timeseries.TimeSeries(filename)
-        assert ts.quantity('nH').unit == u.cm**-3
-
-        sunpy_cdf._known_units = known_units
-
-# =============================================================================
-# Individual Implicit Source Tests
-# =============================================================================
-
-    def test_implicit_fermi_gbm(self):
-        # Test a GBMSummary TimeSeries
-        ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath)
-        assert isinstance(ts_gbm, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)
-
-    def test_implicit_norh(self):
-        # Test a NoRH TimeSeries
-        ts_norh = sunpy.timeseries.TimeSeries(norh_filepath)
-        assert isinstance(ts_norh, sunpy.timeseries.sources.norh.NoRHTimeSeries)
-
-    def test_implicit_goes(self):
-        # Test a GOES TimeSeries
-        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath)
-        assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-    def test_implicit_goes_com(self):
-        # Test a GOES TimeSeries
-        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath_com)
-        assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-    def test_implicit_new_goes15(self):
-        # Test a GOES TimeSeries
-        ts_goes = sunpy.timeseries.TimeSeries(new_goes15_filepath)
-        assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-    def test_implicit_new_goes17(self):
-        # Test a GOES TimeSeries
-        ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath)
-        assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-    def test_implicit_goes_satno(self):
-        # Test a GOES TimeSeries for satellite number
-        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath)
-        assert ts_goes.observatory == 'GOES-15'
-
-    def test_implicit_new_goes15_satno(self):
-        # Test a GOES TimeSeries for satellite number
-        ts_goes = sunpy.timeseries.TimeSeries(new_goes15_filepath)
-        assert ts_goes.observatory == 'GOES-15'
-
-    def test_implicit_new_goes17_satno(self):
-        # Test a GOES TimeSeries for satellite number
-        ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath)
-        assert ts_goes.observatory == 'GOES-17'
-
-    def test_implicit_goes_satno_missing(self):
-        # Test a GOES TimeSeries for a missing satellite number
-        ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath)
-        del ts_goes.meta.metas[0]['id']
-        assert ts_goes.observatory is None
-
-    def test_implicit_lyra(self):
-        # Test a LYRA TimeSeries
-        ts_lyra = sunpy.timeseries.TimeSeries(lyra_filepath)
-        assert isinstance(ts_lyra, sunpy.timeseries.sources.lyra.LYRATimeSeries)
-
-    def test_implicit_rhessi(self):
-        # Test a RHESSI TimeSeries
-        ts_rhessi = sunpy.timeseries.TimeSeries(rhessi_filepath)
-        assert isinstance(ts_rhessi, sunpy.timeseries.sources.rhessi.RHESSISummaryTimeSeries)
-
-    def test_implicit_esp(self):
-        # Test an ESP TimeSeries
-        ts_esp = sunpy.timeseries.TimeSeries(esp_filepath)
-        assert isinstance(ts_esp, sunpy.timeseries.sources.eve.ESPTimeSeries)
-
-# =============================================================================
-# Individual Explicit Sources Tests
-# =============================================================================
-
-    def test_eve(self):
-        # Test an EVE TimeSeries
-        with pytest.warns(SunpyUserWarning, match='Unknown units for x_cool proxy'):
-            ts_eve = sunpy.timeseries.TimeSeries(eve_filepath, source='EVE')
-        assert isinstance(ts_eve, sunpy.timeseries.sources.eve.EVESpWxTimeSeries)
-
-    def test_esp(self):
-        # Test an ESP TimeSeries
-        ts_esp = sunpy.timeseries.TimeSeries(esp_filepath, source='ESP')
-        assert isinstance(ts_esp, sunpy.timeseries.sources.eve.ESPTimeSeries)
-
-    def test_fermi_gbm(self):
-        # Test a GBMSummary TimeSeries
-        ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, source='GBMSummary')
-        assert isinstance(ts_gbm, sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries)
-
-    def test_norh(self):
-        # Test a NoRH TimeSeries
-        ts_norh = sunpy.timeseries.TimeSeries(norh_filepath, source='NoRH')
-        assert isinstance(ts_norh, sunpy.timeseries.sources.norh.NoRHTimeSeries)
-
-    def test_goes(self):
-        # Test a GOES TimeSeries
-        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath, source='XRS')
-        assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-    def test_goes_com(self):
-        # Test a GOES TimeSeries
-        ts_goes = sunpy.timeseries.TimeSeries(goes_filepath_com, source='XRS')
-        assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-    def test_new_goes15(self):
-        # Test a GOES TimeSeries
-        ts_goes = sunpy.timeseries.TimeSeries(new_goes15_filepath, source='XRS')
-        assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-    def test_new_goes16(self):
-        # Test a GOES TimeSeries
-        ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath, source='XRS')
-        assert isinstance(ts_goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-    def test_lyra(self):
-        # Test a LYRA TimeSeries
-        ts_lyra = sunpy.timeseries.TimeSeries(lyra_filepath, source='LYRA')
-        assert isinstance(ts_lyra, sunpy.timeseries.sources.lyra.LYRATimeSeries)
-
-    def test_rhessi(self):
-        # Test a RHESSI TimeSeries
-        ts_rhessi = sunpy.timeseries.TimeSeries(rhessi_filepath, source='RHESSI')
-        assert isinstance(ts_rhessi, sunpy.timeseries.sources.rhessi.RHESSISummaryTimeSeries)
-
-    def test_noaa_ind_json(self):
-        # Test a NOAAPredictIndices TimeSeries json
-        ts_noaa_ind = sunpy.timeseries.TimeSeries(noaa_ind_json_filepath, source='NOAAIndices')
-        assert isinstance(ts_noaa_ind, sunpy.timeseries.sources.noaa.NOAAIndicesTimeSeries)
-
-    # The pre- data involves dates long in the future, so ignore an ERFA warning
-    # when parsing these dates.
-
-    @pytest.mark.filterwarnings('ignore:ERFA function.*dubious year')
-    def test_noaa_pre_json(self):
-        # Test a NOAAIndices TimeSeries json
-        ts_noaa_pre = sunpy.timeseries.TimeSeries(
-            noaa_pre_json_filepath, source='NOAAPredictIndices')
-        assert isinstance(ts_noaa_pre, sunpy.timeseries.sources.noaa.NOAAPredictIndicesTimeSeries)
-
-# ==============================================================================
-# Remote Sources Tests
-# ==============================================================================
-
-    @pytest.mark.remote_data
-    def test_goes_remote(self):
-        # Older format file
-        goes = sunpy.timeseries.TimeSeries(
-            'https://umbra.nascom.nasa.gov/goes/fits/1986/go06860129.fits')
-        assert isinstance(goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-        # Newer format
-        goes = sunpy.timeseries.TimeSeries(
-            'https://umbra.nascom.nasa.gov/goes/fits/2018/go1520180626.fits')
-        assert isinstance(goes, sunpy.timeseries.sources.goes.XRSTimeSeries)
-
-# =============================================================================
-# Manual TimeSeries Tests
-# =============================================================================
-
-    def test_meta_from_fits_header(self):
-        # Generate the data and the corrisponding dates
-        base = parse_time(datetime.datetime.today())
-        times = base - TimeDelta(np.arange(24*60)*u.minute)
-        intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-        units = {'intensity': u.W/u.m**2}
-        data = DataFrame(intensity, index=times, columns=['intensity'])
-
-        # Use a FITS file HDU using sunpy.io
-        hdulist = sunpy.io.read_file(goes_filepath)
-        meta = hdulist[0].header
-        meta_md = MetaDict(OrderedDict(meta))
-        ts_hdu_meta = sunpy.timeseries.TimeSeries(data, meta, units)
-        ts_md_meta = sunpy.timeseries.TimeSeries(data, meta_md, units)
-        assert ts_hdu_meta == ts_md_meta
-
-        # Use a FITS file HDU using astropy.io
-        hdulist = fits.open(goes_filepath)
-        meta = hdulist[0].header
-        hdulist.close()
-        meta_md = MetaDict(sunpy.io.header.FileHeader(meta))
-        ts_hdu_meta = sunpy.timeseries.TimeSeries(data, meta, units)
-        ts_md_meta = sunpy.timeseries.TimeSeries(data, meta_md, units)
-        assert ts_hdu_meta == ts_md_meta
-
-    def test_generic_construction_basic(self):
-        # Generate the data and the corrisponding dates
-        base = parse_time(datetime.datetime.today())
-        times = base - TimeDelta(np.arange(24 * 60)*u.minute)
-        intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-
-        # Create the data DataFrame, header MetaDict and units OrderedDict
-        data = DataFrame(intensity, index=times, columns=['intensity'])
-        units = OrderedDict([('intensity', u.W/u.m**2)])
-        meta = MetaDict({'key': 'value'})
-
-        # Create normal TS from dataframe and check
-        ts_generic = sunpy.timeseries.TimeSeries(data, meta, units)
-        assert isinstance(ts_generic, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
-        assert ts_generic.columns == ['intensity']
-        assert ts_generic.units == units
-        assert ts_generic.meta.metadata[0][2] == meta
-
-        # Create TS using a tuple of values
-        ts_tuple = sunpy.timeseries.TimeSeries(((data, meta, units),))
-        assert isinstance(ts_tuple, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
-        assert ts_generic == ts_tuple
-
-    def test_generic_construction_basic_omitted_details(self):
-        # Generate the data and the corrisponding dates
-        base = parse_time(datetime.datetime.today())
-        times = base - TimeDelta(np.arange(24 * 60)*u.minute)
-        intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-
-        # Create the data DataFrame, header MetaDict and units OrderedDict
-        data = DataFrame(intensity, index=times, columns=['intensity'])
-        units = OrderedDict([('intensity', u.W/u.m**2)])
-        meta = MetaDict({'key': 'value'})
-
-        # Create TS omitting units input arguments
-        with pytest.warns(SunpyUserWarning, match='Unknown units for intensity'):
-            ts_1 = sunpy.timeseries.TimeSeries(data, meta)
-        assert isinstance(ts_1, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
-        assert ts_1.columns == ['intensity']
-        assert ts_1.units == OrderedDict([('intensity', u.dimensionless_unscaled)])
-        assert ts_1.meta.metadata[0][2] == meta
-
-        ts_2 = sunpy.timeseries.TimeSeries(data, units)
-        assert isinstance(ts_2, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
-        assert ts_2.columns == ['intensity']
-        assert ts_2.units == units
-        assert ts_2.meta.metadata[0][2] == MetaDict()
-
-    def test_generic_construction_basic_different_meta_types(self):
-        # Generate the data and the corrisponding dates
-        base = parse_time(datetime.datetime.today())
-        times = base - TimeDelta(np.arange(24 * 60)*u.minute)
-        intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-        tr = sunpy.time.TimeRange(times[0], times[-1])
-
-        # Create the data DataFrame, header MetaDict and units OrderedDict
-        data = DataFrame(intensity, index=times, columns=['intensity'])
-        units = OrderedDict([('intensity', u.W/u.m**2)])
-        meta_md = MetaDict({'key': 'value'})
-        meta_di = {'key': 'value'}
-        meta_od = OrderedDict({'key': 'value'})
-        meta_obj = sunpy.timeseries.TimeSeriesMetaData(timerange=tr, colnames=['GOES'],
-                                                       meta=MetaDict({'key': 'value'}))
-
-        # Create TS using different dictionary meta types
-        ts_md = sunpy.timeseries.TimeSeries(data, meta_md, units)
-        ts_di = sunpy.timeseries.TimeSeries(data, meta_di, units)
-        ts_od = sunpy.timeseries.TimeSeries(data, meta_od, units)
-        ts_obj = sunpy.timeseries.TimeSeries(data, meta_obj, units)
-        assert ts_md == ts_di == ts_od == ts_obj
-        assert ts_md.meta.metadata[0][2] == ts_di.meta.metadata[0][2] == ts_od.meta.metadata[0][2] == ts_obj.meta.metadata[0][2]
-
-    def test_generic_construction_ts_list(self):
-        # Generate the data and the corrisponding dates
-        base = parse_time(datetime.datetime.today())
-        times = base - TimeDelta(np.arange(24 * 60)*u.minute)
-        intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-        intensity2 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-
-        # Create the data DataFrame, header MetaDict and units OrderedDict
-        data = DataFrame(intensity1, index=times, columns=['intensity'])
-        data2 = DataFrame(intensity2, index=times, columns=['intensity2'])
-        units = OrderedDict([('intensity', u.W/u.m**2)])
-        units2 = OrderedDict([('intensity2', u.W/u.m**2)])
-        meta = MetaDict({'key': 'value'})
-        meta2 = MetaDict({'key2': 'value2'})
-
-        # Create TS individually
-        ts_1 = sunpy.timeseries.TimeSeries(data, meta, units)
-        ts_2 = sunpy.timeseries.TimeSeries(data2, meta2, units2)
-
-        # Create TS list using
-        ts_list = sunpy.timeseries.TimeSeries(data, meta, units, data2, meta2, units2)
-        assert isinstance(ts_list, list)
-        assert len(ts_list) == 2
-        assert ts_list[0] == ts_1
-        assert ts_list[1] == ts_2
-
-        # Create TS using a tuple
-        ts_list2 = sunpy.timeseries.TimeSeries(((data, meta, units), (data2, meta2, units2)))
-        assert ts_list == ts_list2
-
-    def test_generic_construction_concatenation(self):
-        # Generate the data and the corrisponding dates
-        base = parse_time(datetime.datetime.today())
-        times = base - TimeDelta(np.arange(24 * 60)*u.minute)
-        intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-        intensity2 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-
-        # Create the data DataFrame, header MetaDict and units OrderedDict
-        data = DataFrame(intensity1, index=times, columns=['intensity'])
-        data2 = DataFrame(intensity2, index=times, columns=['intensity2'])
-        units = OrderedDict([('intensity', u.W/u.m**2)])
-        units2 = OrderedDict([('intensity2', u.W/u.m**2)])
-        meta = MetaDict({'key': 'value'})
-        meta2 = MetaDict({'key2': 'value2'})
-
-        # Create TS individually
-        ts_1 = sunpy.timeseries.TimeSeries(data, meta, units)
-        ts_2 = sunpy.timeseries.TimeSeries(data2, meta2, units2)
-        ts_concat_1 = ts_1.concatenate(ts_2)
-
-        # Concatinate during construction
-        ts_concat_2 = sunpy.timeseries.TimeSeries(
-            data, meta, units, data2, meta2, units2, concatenate=True)
-        assert isinstance(ts_concat_2, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
-
-        # Create TS using a tuple
-        ts_concat_3 = sunpy.timeseries.TimeSeries(
-            ((data, meta, units), (data2, meta2, units2)), concatenate=True)
-        assert isinstance(ts_concat_3, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
-        assert ts_concat_1 == ts_concat_2 == ts_concat_3
-
-    def test_table_to_ts(self):
-        # Generate the data and the corresponding dates
-        base = parse_time(datetime.datetime.today())
-        times = base - TimeDelta(np.arange(24 * 60)*u.minute)
-        intensity = u.Quantity(
-            np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60)))), u.W/u.m**2)
-
-        # Create the units and meta objects
-        units = OrderedDict([('intensity', u.W/u.m**2)])
-        meta = MetaDict({'key': 'value'})
-        tbl_meta = MetaDict({'t_key': 't_value'})
-
-        # Create a suitable mixin qtable
-        table = Table([times, intensity], names=['time', 'intensity'], meta=tbl_meta)
-        table.add_index('time')
-
-        # Create TS from table and check
-        ts_table = sunpy.timeseries.TimeSeries(table, meta, units)
-        assert isinstance(ts_table, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
-        ts_table2 = sunpy.timeseries.TimeSeries(table, units, meta)
-        assert (ts_table2 == ts_table)
-
-        # Create TS using a tuple of values
-        ts_table3 = sunpy.timeseries.TimeSeries((table, meta, units))
-        assert isinstance(ts_table3, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
-
-        # ToDo: Try an incompatible table
-        dual_index_table = Table([times, intensity], names=['time', 'intensity'], meta=tbl_meta)
-        dual_index_table.add_index(('time', 'intensity'))
-        with pytest.raises(ValueError):
-            sunpy.timeseries.TimeSeries((dual_index_table, meta, units))
-
-# =============================================================================
-# Test some other options
-# =============================================================================
-
-    def test_passed_ts(self):
-        # Test an EVE TimeSeries
-        with pytest.warns(SunpyUserWarning, match='Unknown units'):
-            ts_eve = sunpy.timeseries.TimeSeries(eve_filepath, source='EVE')
-        ts_from_ts_1 = sunpy.timeseries.TimeSeries(ts_eve, source='EVE')
-        ts_from_ts_2 = sunpy.timeseries.TimeSeries(ts_eve)
-        assert ts_eve == ts_from_ts_1 == ts_from_ts_2
-
-# =============================================================================
-# Test some Errors
-# =============================================================================
-
-    def test_invalid_manual_data(self):
-        meta = MetaDict({'key': 'value'})
-        data = []
-        with pytest.raises(NoMatchError):
-            sunpy.timeseries.TimeSeries(data, meta)
-
-    def test_invalid_filepath(self):
-        invalid_filepath = os.path.join(filepath, 'invalid_filepath_here')
-        with pytest.raises(ValueError, match='Did not find any files'):
-            sunpy.timeseries.TimeSeries(invalid_filepath)
-        # Now with silence_errors kwarg set
-        with pytest.raises(ValueError, match='Did not find any files'):
-            sunpy.timeseries.TimeSeries(invalid_filepath, silence_errors=True)
-
-    def test_invalid_file(self):
-        invalid_filepath = os.path.join(filepath, 'annotation_ppt.db')
-        with pytest.raises(NoMatchError):
-            sunpy.timeseries.TimeSeries(invalid_filepath)
-        # Now with silence_errors kwarg set
-        ts = sunpy.timeseries.TimeSeries(invalid_filepath, silence_errors=True)
-        assert ts == []
-
-    def test_validate_units(self):
-        valid_units = OrderedDict(
-            [('Watt Per Meter Squared', u.Unit("W / m2")), ('Meter Cubed', u.Unit("m3"))])
-        assert sunpy.timeseries.TimeSeries._is_units(valid_units)
-        # Test for not having only units for values
-        invalid_units_1 = OrderedDict(
-            [('Watt Per Meter Squared', 'string'), ('Meter Cubed', u.Unit("m3"))])
-        assert not sunpy.timeseries.TimeSeries._is_units(invalid_units_1)
-        # Test for being a MetaDict object
-        invalid_units_2 = MetaDict(OrderedDict(
-            [('Watt Per Meter Squared', u.Unit("W / m2")), ('Meter Cubed', u.Unit("m3"))]))
-        assert not sunpy.timeseries.TimeSeries._is_units(invalid_units_2)
-
-    def test_validate_meta_basic(self):
-        valid_meta_1 = MetaDict({'key': 'value'})
-        assert sunpy.timeseries.TimeSeries._is_metadata(valid_meta_1)
-        valid_meta_2 = OrderedDict({'key': 'value'})
-        assert sunpy.timeseries.TimeSeries._is_metadata(valid_meta_2)
-        time_range = sunpy.time.TimeRange('2020-01-01 12:00', '2020-01-02 12:00')
-        valid_meta_3 = sunpy.timeseries.TimeSeriesMetaData(time_range)
-        assert sunpy.timeseries.TimeSeries._is_metadata(valid_meta_3)
-        invalid_meta = []
-        assert not sunpy.timeseries.TimeSeries._is_metadata(invalid_meta)
-
-    def test_validate_meta_astropy_header(self):
-        # Manually open a goes file for the sunpy.io.header.FileHeader test
-        hdus = sunpy.io.read_file(goes_filepath)
-        header = hdus[0].header
-        assert sunpy.timeseries.TimeSeries._is_metadata(header)
-        # Manually open a goes file for the astropy.io.fits.header.Header test
-        hdulist = fits.open(goes_filepath)
-        header = hdulist[0].header
-        hdulist.close()
-        assert sunpy.timeseries.TimeSeries._is_metadata(header)
+
+    assert ts.quantity('nH').unit == u.dimensionless_unscaled
+
+    # Put back known unit registry, and check that units are recognised
+    sunpy_cdf._known_units = known_units
+    ts = sunpy.timeseries.TimeSeries(filename)
+    assert ts.quantity('nH').unit == u.cm**-3
+
+    # Reset again to check that registring units via. astropy works too
+    sunpy_cdf._known_units = {}
+    u.add_enabled_units([u.def_unit('#/cm^3', represents=u.cm**-3)])
+    ts = sunpy.timeseries.TimeSeries(filename)
+    assert ts.quantity('nH').unit == u.cm**-3
+
+    sunpy_cdf._known_units = known_units
+
+
+def test_meta_from_fits_header():
+    # Generate the data and the corrisponding dates
+    base = parse_time(datetime.datetime.today())
+    times = base - TimeDelta(np.arange(24*60)*u.minute)
+    intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+    units = {'intensity': u.W/u.m**2}
+    data = DataFrame(intensity, index=times, columns=['intensity'])
+
+    # Use a FITS file HDU using sunpy.io
+    hdulist = sunpy.io.read_file(goes_filepath)
+    meta = hdulist[0].header
+    meta_md = MetaDict(OrderedDict(meta))
+    ts_hdu_meta = sunpy.timeseries.TimeSeries(data, meta, units)
+    ts_md_meta = sunpy.timeseries.TimeSeries(data, meta_md, units)
+    assert ts_hdu_meta == ts_md_meta
+
+    # Use a FITS file HDU using astropy.io
+    hdulist = fits.open(goes_filepath)
+    meta = hdulist[0].header
+    hdulist.close()
+    meta_md = MetaDict(sunpy.io.header.FileHeader(meta))
+    ts_hdu_meta = sunpy.timeseries.TimeSeries(data, meta, units)
+    ts_md_meta = sunpy.timeseries.TimeSeries(data, meta_md, units)
+    assert ts_hdu_meta == ts_md_meta
+
+
+def test_generic_construction_basic():
+    # Generate the data and the corrisponding dates
+    base = parse_time(datetime.datetime.today())
+    times = base - TimeDelta(np.arange(24 * 60)*u.minute)
+    intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+
+    # Create the data DataFrame, header MetaDict and units OrderedDict
+    data = DataFrame(intensity, index=times, columns=['intensity'])
+    units = OrderedDict([('intensity', u.W/u.m**2)])
+    meta = MetaDict({'key': 'value'})
+
+    # Create normal TS from dataframe and check
+    ts_generic = sunpy.timeseries.TimeSeries(data, meta, units)
+    assert isinstance(ts_generic, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
+    assert ts_generic.columns == ['intensity']
+    assert ts_generic.units == units
+    assert ts_generic.meta.metadata[0][2] == meta
+
+    # Create TS using a tuple of values
+    ts_tuple = sunpy.timeseries.TimeSeries(((data, meta, units),))
+    assert isinstance(ts_tuple, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
+    assert ts_generic == ts_tuple
+
+
+def test_generic_construction_basic_omitted_details():
+    # Generate the data and the corrisponding dates
+    base = parse_time(datetime.datetime.today())
+    times = base - TimeDelta(np.arange(24 * 60)*u.minute)
+    intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+
+    # Create the data DataFrame, header MetaDict and units OrderedDict
+    data = DataFrame(intensity, index=times, columns=['intensity'])
+    units = OrderedDict([('intensity', u.W/u.m**2)])
+    meta = MetaDict({'key': 'value'})
+
+    # Create TS omitting units input arguments
+    with pytest.warns(SunpyUserWarning, match='Unknown units for intensity'):
+        ts_1 = sunpy.timeseries.TimeSeries(data, meta)
+    assert isinstance(ts_1, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
+    assert ts_1.columns == ['intensity']
+    assert ts_1.units == OrderedDict([('intensity', u.dimensionless_unscaled)])
+    assert ts_1.meta.metadata[0][2] == meta
+
+    ts_2 = sunpy.timeseries.TimeSeries(data, units)
+    assert isinstance(ts_2, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
+    assert ts_2.columns == ['intensity']
+    assert ts_2.units == units
+    assert ts_2.meta.metadata[0][2] == MetaDict()
+
+
+def test_generic_construction_basic_different_meta_types():
+    # Generate the data and the corrisponding dates
+    base = parse_time(datetime.datetime.today())
+    times = base - TimeDelta(np.arange(24 * 60)*u.minute)
+    intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+    tr = sunpy.time.TimeRange(times[0], times[-1])
+
+    # Create the data DataFrame, header MetaDict and units OrderedDict
+    data = DataFrame(intensity, index=times, columns=['intensity'])
+    units = OrderedDict([('intensity', u.W/u.m**2)])
+    meta_md = MetaDict({'key': 'value'})
+    meta_di = {'key': 'value'}
+    meta_od = OrderedDict({'key': 'value'})
+    meta_obj = sunpy.timeseries.TimeSeriesMetaData(timerange=tr, colnames=['GOES'],
+                                                   meta=MetaDict({'key': 'value'}))
+
+    # Create TS using different dictionary meta types
+    ts_md = sunpy.timeseries.TimeSeries(data, meta_md, units)
+    ts_di = sunpy.timeseries.TimeSeries(data, meta_di, units)
+    ts_od = sunpy.timeseries.TimeSeries(data, meta_od, units)
+    ts_obj = sunpy.timeseries.TimeSeries(data, meta_obj, units)
+    assert ts_md == ts_di == ts_od == ts_obj
+    assert ts_md.meta.metadata[0][2] == ts_di.meta.metadata[0][2] == ts_od.meta.metadata[0][2] == ts_obj.meta.metadata[0][2]
+
+
+def test_generic_construction_ts_list():
+    # Generate the data and the corrisponding dates
+    base = parse_time(datetime.datetime.today())
+    times = base - TimeDelta(np.arange(24 * 60)*u.minute)
+    intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+    intensity2 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+
+    # Create the data DataFrame, header MetaDict and units OrderedDict
+    data = DataFrame(intensity1, index=times, columns=['intensity'])
+    data2 = DataFrame(intensity2, index=times, columns=['intensity2'])
+    units = OrderedDict([('intensity', u.W/u.m**2)])
+    units2 = OrderedDict([('intensity2', u.W/u.m**2)])
+    meta = MetaDict({'key': 'value'})
+    meta2 = MetaDict({'key2': 'value2'})
+
+    # Create TS individually
+    ts_1 = sunpy.timeseries.TimeSeries(data, meta, units)
+    ts_2 = sunpy.timeseries.TimeSeries(data2, meta2, units2)
+
+    # Create TS list using
+    ts_list = sunpy.timeseries.TimeSeries(data, meta, units, data2, meta2, units2)
+    assert isinstance(ts_list, list)
+    assert len(ts_list) == 2
+    assert ts_list[0] == ts_1
+    assert ts_list[1] == ts_2
+
+    # Create TS using a tuple
+    ts_list2 = sunpy.timeseries.TimeSeries(((data, meta, units), (data2, meta2, units2)))
+    assert ts_list == ts_list2
+
+
+def test_generic_construction_concatenation():
+    # Generate the data and the corrisponding dates
+    base = parse_time(datetime.datetime.today())
+    times = base - TimeDelta(np.arange(24 * 60)*u.minute)
+    intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+    intensity2 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+
+    # Create the data DataFrame, header MetaDict and units OrderedDict
+    data = DataFrame(intensity1, index=times, columns=['intensity'])
+    data2 = DataFrame(intensity2, index=times, columns=['intensity2'])
+    units = OrderedDict([('intensity', u.W/u.m**2)])
+    units2 = OrderedDict([('intensity2', u.W/u.m**2)])
+    meta = MetaDict({'key': 'value'})
+    meta2 = MetaDict({'key2': 'value2'})
+
+    # Create TS individually
+    ts_1 = sunpy.timeseries.TimeSeries(data, meta, units)
+    ts_2 = sunpy.timeseries.TimeSeries(data2, meta2, units2)
+    ts_concat_1 = ts_1.concatenate(ts_2)
+
+    # Concatinate during construction
+    ts_concat_2 = sunpy.timeseries.TimeSeries(
+        data, meta, units, data2, meta2, units2, concatenate=True)
+    assert isinstance(ts_concat_2, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
+
+    # Create TS using a tuple
+    ts_concat_3 = sunpy.timeseries.TimeSeries(
+        ((data, meta, units), (data2, meta2, units2)), concatenate=True)
+    assert isinstance(ts_concat_3, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
+    assert ts_concat_1 == ts_concat_2 == ts_concat_3
+
+
+def test_table_to_ts():
+    # Generate the data and the corresponding dates
+    base = parse_time(datetime.datetime.today())
+    times = base - TimeDelta(np.arange(24 * 60)*u.minute)
+    intensity = u.Quantity(
+        np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60)))), u.W/u.m**2)
+
+    # Create the units and meta objects
+    units = OrderedDict([('intensity', u.W/u.m**2)])
+    meta = MetaDict({'key': 'value'})
+    tbl_meta = MetaDict({'t_key': 't_value'})
+
+    # Create a suitable mixin qtable
+    table = Table([times, intensity], names=['time', 'intensity'], meta=tbl_meta)
+    table.add_index('time')
+
+    # Create TS from table and check
+    ts_table = sunpy.timeseries.TimeSeries(table, meta, units)
+    assert isinstance(ts_table, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
+    ts_table2 = sunpy.timeseries.TimeSeries(table, units, meta)
+    assert (ts_table2 == ts_table)
+
+    # Create TS using a tuple of values
+    ts_table3 = sunpy.timeseries.TimeSeries((table, meta, units))
+    assert isinstance(ts_table3, sunpy.timeseries.timeseriesbase.GenericTimeSeries)
+
+    # ToDo: Try an incompatible table
+    dual_index_table = Table([times, intensity], names=['time', 'intensity'], meta=tbl_meta)
+    dual_index_table.add_index(('time', 'intensity'))
+    with pytest.raises(ValueError):
+        sunpy.timeseries.TimeSeries((dual_index_table, meta, units))
+
+
+def test_passed_ts():
+    # Test an EVE TimeSeries
+    with pytest.warns(SunpyUserWarning, match='Unknown units'):
+        ts_eve = sunpy.timeseries.TimeSeries(eve_filepath, source='EVE')
+    ts_from_ts_1 = sunpy.timeseries.TimeSeries(ts_eve, source='EVE')
+    ts_from_ts_2 = sunpy.timeseries.TimeSeries(ts_eve)
+    assert ts_eve == ts_from_ts_1 == ts_from_ts_2
+
+
+def test_invalid_manual_data():
+    meta = MetaDict({'key': 'value'})
+    data = []
+    with pytest.raises(NoMatchError):
+        sunpy.timeseries.TimeSeries(data, meta)
+
+
+def test_invalid_filepath():
+    invalid_filepath = os.path.join(sunpy.data.test.rootdir, 'invalid_filepath_here')
+    with pytest.raises(ValueError, match='Did not find any files'):
+        sunpy.timeseries.TimeSeries(invalid_filepath)
+    # Now with silence_errors kwarg set
+    with pytest.raises(ValueError, match='Did not find any files'):
+        sunpy.timeseries.TimeSeries(invalid_filepath, silence_errors=True)
+
+
+def test_invalid_file():
+    invalid_filepath = os.path.join(sunpy.data.test.rootdir, 'annotation_ppt.db')
+    with pytest.raises(NoMatchError):
+        sunpy.timeseries.TimeSeries(invalid_filepath)
+    # Now with silence_errors kwarg set
+    ts = sunpy.timeseries.TimeSeries(invalid_filepath, silence_errors=True)
+    assert ts == []
+
+
+def test_validate_units():
+    valid_units = OrderedDict(
+        [('Watt Per Meter Squared', u.Unit("W / m2")), ('Meter Cubed', u.Unit("m3"))])
+    assert sunpy.timeseries.TimeSeries._is_units(valid_units)
+    # Test for not having only units for values
+    invalid_units_1 = OrderedDict(
+        [('Watt Per Meter Squared', 'string'), ('Meter Cubed', u.Unit("m3"))])
+    assert not sunpy.timeseries.TimeSeries._is_units(invalid_units_1)
+    # Test for being a MetaDict object
+    invalid_units_2 = MetaDict(OrderedDict(
+        [('Watt Per Meter Squared', u.Unit("W / m2")), ('Meter Cubed', u.Unit("m3"))]))
+    assert not sunpy.timeseries.TimeSeries._is_units(invalid_units_2)
+
+
+def test_validate_meta_basic():
+    valid_meta_1 = MetaDict({'key': 'value'})
+    assert sunpy.timeseries.TimeSeries._is_metadata(valid_meta_1)
+    valid_meta_2 = OrderedDict({'key': 'value'})
+    assert sunpy.timeseries.TimeSeries._is_metadata(valid_meta_2)
+    time_range = sunpy.time.TimeRange('2020-01-01 12:00', '2020-01-02 12:00')
+    valid_meta_3 = sunpy.timeseries.TimeSeriesMetaData(time_range)
+    assert sunpy.timeseries.TimeSeries._is_metadata(valid_meta_3)
+    invalid_meta = []
+    assert not sunpy.timeseries.TimeSeries._is_metadata(invalid_meta)
+
+
+def test_validate_meta_astropy_header():
+    # Manually open a goes file for the sunpy.io.header.FileHeader test
+    hdus = sunpy.io.read_file(goes_filepath)
+    header = hdus[0].header
+    assert sunpy.timeseries.TimeSeries._is_metadata(header)
+    # Manually open a goes file for the astropy.io.fits.header.Header test
+    hdulist = fits.open(goes_filepath)
+    header = hdulist[0].header
+    hdulist.close()
+    assert sunpy.timeseries.TimeSeries._is_metadata(header)


### PR DESCRIPTION
This is a small cleanup to make the timeseries tests a bit better:

- Use `get_test_filepath`
- Move source tests to individual files (akin to how the map source tests work)
- Remove the useless test class