### PR TITLE
Set a default rotation of 0deg in the header helper

### DIFF
--- a/changelog/5763.bugfix.rst
+++ b/changelog/5763.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`sunpy.map.make_fitswcs_header` now includes a PC_ij matrix in the returned
+header if no rotation is specified.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -92,7 +92,9 @@ Here's an example of creating a header from some generic data and an `astropy.co
     ctype2: HPLT-TAN
     crval1: 0.0
     crval2: 0.0
-    ...
+    lonpole: 180.0
+    latpole: 0.0
+    mjdref: 0.0
     date-obs: 2013-10-28T00:00:00.000
     rsun_ref: 695700000.0
     dsun_obs: 148644585949.49
@@ -101,6 +103,10 @@ Here's an example of creating a header from some generic data and an `astropy.co
     naxis: 2
     naxis1: 10
     naxis2: 10
+    pc1_1: 1.0
+    pc1_2: -0.0
+    pc2_1: 0.0
+    pc2_2: 1.0
     rsun_obs: 965.3829548285768
 
 
@@ -128,7 +134,9 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
     ctype2: HPLT-TAN
     crval1: 0.0
     crval2: 0.0
-    ...
+    lonpole: 180.0
+    latpole: 0.0
+    mjdref: 0.0
     date-obs: 2013-10-28T00:00:00.000
     rsun_ref: 695700000.0
     dsun_obs: 148644585949.49
@@ -137,6 +145,10 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
     naxis: 2
     naxis1: 10
     naxis2: 10
+    pc1_1: 1.0
+    pc1_2: -0.0
+    pc2_1: 0.0
+    pc2_2: 1.0
     rsun_obs: 965.3829548285768
 
 As we can see, a list of WCS and observer meta information is contained within the generated headers,

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -64,7 +64,7 @@ def make_fitswcs_header(data, coordinate,
     rotation_angle : `~astropy.units.Quantity`, optional
         Coordinate system rotation angle, will be converted to a rotation
         matrix and stored in the ``PCi_j`` matrix. Can not be specified with
-        ``rotation_matrix``.
+        ``rotation_matrix``. Defaults to no rotation.
     rotation_matrix : `~numpy.ndarray` of dimensions 2x2, optional
         Matrix describing the rotation required to align solar North with
         the top of the image in FITS ``PCi_j`` convention. Can not be specified
@@ -150,6 +150,8 @@ def _validate_coordinate(coordinate):
 def _set_rotation_params(meta_wcs, rotation_angle, rotation_matrix):
     if rotation_angle is not None and rotation_matrix is not None:
         raise ValueError("Can not specify both rotation angle and rotation matrix.")
+    if rotation_angle is None and rotation_matrix is None:
+        rotation_angle = 0 * u.deg
 
     if rotation_angle is not None:
         lam = meta_wcs['cdelt1'] / meta_wcs['cdelt2']

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -65,6 +65,12 @@ def test_metakeywords():
     assert isinstance(meta, dict)
 
 
+def test_deafult_rotation(map_data, hpc_coord):
+    header = make_fitswcs_header(map_data, hpc_coord)
+    wcs = WCS(header)
+    np.testing.assert_allclose(wcs.wcs.pc, [[1, 0], [0, 1]], atol=1e-5)
+
+
 def test_rotation_angle(map_data, hpc_coord):
     header = make_fitswcs_header(map_data, hpc_coord,
                                  rotation_angle=90*u.deg)


### PR DESCRIPTION
If the user did not supply any rotation information to the header helper, we were returning a header that did not contain PC_ij, CROTA2, or CD_ij values. One of these is required for a valid WCS. We weren't noticing this, as we silently assume CROTA2 = 0 in `GenericMap`.

This PR makes sure we always include an identify PC matrix if no rotation is specified.