### PR TITLE
Stop silently assuming stuff in GenericMap

### DIFF
--- a/changelog/5763.bugfix.rst
+++ b/changelog/5763.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`sunpy.map.make_fitswcs_header` now includes a PC_ij matrix in the returned
+header if no rotation is specified.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -64,7 +64,7 @@ def make_fitswcs_header(data, coordinate,
     rotation_angle : `~astropy.units.Quantity`, optional
         Coordinate system rotation angle, will be converted to a rotation
         matrix and stored in the ``PCi_j`` matrix. Can not be specified with
-        ``rotation_matrix``.
+        ``rotation_matrix``. Defaults to no rotation.
     rotation_matrix : `~numpy.ndarray` of dimensions 2x2, optional
         Matrix describing the rotation required to align solar North with
         the top of the image in FITS ``PCi_j`` convention. Can not be specified
@@ -150,6 +150,8 @@ def _validate_coordinate(coordinate):
 def _set_rotation_params(meta_wcs, rotation_angle, rotation_matrix):
     if rotation_angle is not None and rotation_matrix is not None:
         raise ValueError("Can not specify both rotation angle and rotation matrix.")
+    if rotation_angle is None and rotation_matrix is None:
+        rotation_angle = 0 * u.deg
 
     if rotation_angle is not None:
         lam = meta_wcs['cdelt1'] / meta_wcs['cdelt2']

--- a/sunpy/map/tests/conftest.py
+++ b/sunpy/map/tests/conftest.py
@@ -54,6 +54,8 @@ def heliographic_test_map():
     header['CUNIT2'] = 'deg'
     # Set observer location to avoid warnings later
     header['HGLN_OBS'] = 0.0
+    # Set rotation information
+    header['crota2'] = 0
     return sunpy.map.Map((data, header))
 
 

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -65,6 +65,12 @@ def test_metakeywords():
     assert isinstance(meta, dict)
 
 
+def test_deafult_rotation(map_data, hpc_coord):
+    header = make_fitswcs_header(map_data, hpc_coord)
+    wcs = WCS(header)
+    np.testing.assert_allclose(wcs.wcs.pc, [[1, 0], [0, 1]], atol=1e-5)
+
+
 def test_rotation_angle(map_data, hpc_coord):
     header = make_fitswcs_header(map_data, hpc_coord,
                                  rotation_angle=90*u.deg)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -926,6 +926,7 @@ def test_rotate_assumed_obstime():
         'crval2': 0,
         'cdelt1': 1,
         'cdelt2': 1,
+        'crota2': 0,
         'ctype1': 'HPLN-TAN',
         'ctype2': 'HPLT-TAN',
         'naxis': 2,


### PR DESCRIPTION
This PR removes what I think are the remaining 'silent' assumptions we make about missing metadata. I am very pro the deprecation warnings I've put in saying that we will raise errors or return `None` in the future. I feel like I must have tried to do this before, so perhaps there are arguments not to do this that I am forgetting?

Note that for at least `.scale` it is desirable for us to return `None` when only a CD_ij matrix is provided (when we support this), as we can't know what `.scale` is in that instance.

Depends on https://github.com/sunpy/sunpy/pull/5763