### PR TITLE
Print MetaData entries on new lines

### DIFF
--- a/changelog/5765.feature.rst
+++ b/changelog/5765.feature.rst
@@ -1,0 +1,1 @@
+Printing a `.MetaDict`  will now show each entry on a new line.

--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -1,5 +1,3 @@
-.. doctest-skip-all
-
 .. _whatsnew-4.0:
 
 ************************
@@ -24,6 +22,21 @@ Increase in required package versions
 We have bumped the minimum version of several packages we depend on; these are the new minimum versions:
 
 - python >= 3.8
+
+Better printing of metadata
+===========================
+Printing a `.MetaDict` now prints each entry on a new line, making it much easier to read::
+
+  >>> from sunpy.data.sample import AIA_171_IMAGE
+  >>> from sunpy.map import Map
+  >>> m = Map(AIA_171_IMAGE)
+  >>> print(m.meta)
+  simple: True
+  bitpix: -32
+  naxis: 2
+  naxis1: 1024
+  naxis2: 1024
+  ...
 
 Contributors to this Release
 ============================

--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -27,10 +27,10 @@ Better printing of metadata
 ===========================
 Printing a `.MetaDict` now prints each entry on a new line, making it much easier to read::
 
-  >>> from sunpy.data.sample import AIA_171_IMAGE
+  >>> from sunpy.data.sample import AIA_171_IMAGE  # doctest: +REMOTE_DATA
   >>> from sunpy.map import Map
-  >>> m = Map(AIA_171_IMAGE)
-  >>> print(m.meta)
+  >>> m = Map(AIA_171_IMAGE)  # doctest: +REMOTE_DATA
+  >>> print(m.meta)  # doctest: +REMOTE_DATA
   simple: True
   bitpix: -32
   naxis: 2

--- a/sunpy/util/metadata.py
+++ b/sunpy/util/metadata.py
@@ -67,6 +67,9 @@ class MetaDict(OrderedDict):
         if save_original and not hasattr(self, '_original_meta'):
             self._original_meta = MetaDict(*args, save_original=False)
 
+    def __str__(self):
+        return '\n'.join([f'{key}: {item}' for key, item in self.items()])
+
     # Deliberately a property to prevent external modification
     @property
     def original_meta(self):


### PR DESCRIPTION
The big block of text you get when printing `my_map.meta` has bugged me for ages. This adds a `__str__` that prints each metadata item on a new line, making it much more readable.