### PR TITLE
Update .rotation_matrix doc

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1278,13 +1278,19 @@ class GenericMap(NDData):
     @property
     def rotation_matrix(self):
         r"""
-        Matrix describing the rotation required to align solar North with
-        the top of the image.
+        Matrix describing the transformation needed to align the reference
+        pixel with the coordinate axes.
 
         The order or precendence of FITS keywords which this is taken from is:
         - PC\*_\*
         - CD\*_\*
         - CROTA\*
+
+        Notes
+        -----
+        In many cases this is a simple rotation matrix, hence the property name.
+        It general it does not have to be a pure rotation matrix, and can encode
+        other transformations e.g., skews for non-orthgonal coordinate systems.
         """
         if 'PC1_1' in self.meta:
             return np.array([[self.meta['PC1_1'], self.meta['PC1_2']],


### PR DESCRIPTION
- `rotation_matrix` isn't actually restricted to being a rotation matrix (but we probably can't rename the property 😄 ), so add a more water-tight definition, and add in the notes that this is often a rotation matrix, but not always.
- Remove reference to "Solar north", as solar north could be along the y-axis if the CTYPEs are swapped relative to their usual lon/lat definitions.