### PR TITLE
Fix distutils in pyinstaller CI

### DIFF
--- a/.pyinstaller/hooks/hook-sunpy.py
+++ b/.pyinstaller/hooks/hook-sunpy.py
@@ -3,7 +3,7 @@ from PyInstaller.utils.hooks import collect_data_files, collect_entry_point, col
 # Imports needed to run tests
 datas, hiddenimports = collect_entry_point("pytest11")
 hiddenimports += collect_submodules('numpy.distutils')
-hiddenimports += collect_submodules('distutils')
+hiddenimports += collect_submodules('setuptools')
 hiddenimports += ['sunpy.data.data_manager.tests.mocks']
 hiddenimports += collect_submodules('sunpy')
 datas += collect_data_files("sunpy")

--- a/.pyinstaller/run_tests.py
+++ b/.pyinstaller/run_tests.py
@@ -7,6 +7,7 @@ from importlib import metadata
 import pytest
 
 metadata.version('numpy')
+metadata.version('astropy')
 
 # Skipping these tests that take check the name of the current module
 # (which ends up starting with sunpy_tests rather than sunpy).


### PR DESCRIPTION


<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
This PR swaps `distutils` for `setuptools` in the hook.

We also need to add the `metadata.version('astropy')` because `astropy.wcs.wcs` is imported by pytest due to the `filterwarnings` config. (Not sure why this worked without it before but this is the only way I can get the package to build.)

Can someone with Azure access trigger a manual run to test this?

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->


