### PR TITLE
Drop python 3.7 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,10 +80,10 @@ stages:
           brew:
             - openjpeg
         envs:
-          - macos: py37
+          - macos: py38
           - windows: py310
-          - linux: py37-oldestdeps
-          - linux: py38-conda
+          - linux: py38-oldestdeps
+          - linux: py39-conda
             libraries: {}
 
   - stage: SecondPhaseTestsAllowedFail
@@ -151,8 +151,8 @@ stages:
           test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
           submodules: false
           targets:
-            - wheels_cp3[789]-manylinux*x86_64
-            - wheels_cp3[789]-macosx*
+            - wheels_cp3[89]-manylinux*x86_64
+            - wheels_cp3[89]-macosx*
             - wheels_cp310-manylinux*x86_64
             - wheels_cp310-macosx*
             - sdist

--- a/changelog/5773.feature.rst
+++ b/changelog/5773.feature.rst
@@ -1,0 +1,1 @@
+Removed support for Python 3.7.

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -7,7 +7,7 @@ Installation
 Requirements
 ============
 
-sunpy requires Python 3.7 or higher.
+sunpy requires Python 3.8 or higher.
 
 Installing Scientific Python and sunpy
 ======================================

--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -1,0 +1,35 @@
+.. doctest-skip-all
+
+.. _whatsnew-4.0:
+
+************************
+What's New in SunPy 4.0?
+************************
+The SunPy project is pleased to announce the 4.0 release of the sunpy core package.
+
+On this page, you can read about some of the big changes in this release.
+
+.. contents::
+    :local:
+    :depth: 1
+
+SunPy 4.0 also includes a large number of smaller improvements and bug fixes, which are described in the :ref:`changelog`.
+
+By the numbers:
+
+TODO: fill this in at release time.
+
+Increase in required package versions
+=====================================
+We have bumped the minimum version of several packages we depend on; these are the new minimum versions:
+
+- python >= 3.8
+
+Contributors to this Release
+============================
+
+The people who have contributed to the code for this release are:
+
+TODO: fill this in at release time.
+
+Where a * indicates that this release contains their first contribution to SunPy.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,14 +21,14 @@ classifiers =
   Operating System :: OS Independent
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Topic :: Scientific/Engineering :: Physics
 
 [options]
 zip_safe = False
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find:
 include_package_data = True
 setup_requires =

--- a/sunpy/data/data_manager/cache.py
+++ b/sunpy/data/data_manager/cache.py
@@ -6,7 +6,6 @@ from urllib.request import urlopen
 import astropy.units as u
 from astropy.time import TimeDelta
 
-from sunpy.time import parse_time
 from sunpy.util.exceptions import warn_user
 from sunpy.util.net import get_filename
 from sunpy.util.util import hash_file
@@ -107,12 +106,7 @@ class Cache:
             Whether the url has expired or not.
         """
         time = details.get("time", datetime.now().isoformat())
-
-        # TODO: Remove this once we depend on Python >=3.7
-        if hasattr(datetime, "fromisoformat"):
-            time = datetime.fromisoformat(time)
-        else:
-            time = parse_time(time).datetime
+        time = datetime.fromisoformat(time)
         return self._expiry and datetime.now() - time > self._expiry
 
     def get_by_hash(self, sha_hash):


### PR DESCRIPTION
[Python 3.7 was released on 2018-06-27](https://www.python.org/downloads/). By my maths, 42 months (3.5 years) from then is 2022-01-27, which means we can safely drop Python 3.7 support for sunpy 4.0.