### PR TITLE
Fix references for build_docs_ci

### DIFF
--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -10,6 +10,7 @@ In between versions x.1 are non-LTS releases, and supported for 6 months until t
    :maxdepth: 1
 
    changelog
+   4.0
    3.1
    3.0
    2.1

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -279,7 +279,7 @@ class MapSequence:
 
         See Also
         --------
-        MapSequenceAnimator
+        `sunpy.visualization.animator.MapSequenceAnimator`
 
         Examples
         --------

--- a/sunpy/sun/constants.py
+++ b/sunpy/sun/constants.py
@@ -34,7 +34,7 @@ def get(key):
 
     See Also
     --------
-    constants :
+    `~sunpy.sun.constants` :
         Contains the description of ``constants``, which, as a dictionary literal object, does not
         itself possess a docstring.
 
@@ -65,7 +65,7 @@ def find(sub=None):
 
     See Also
     --------
-    constants :
+    `~sunpy.sun.constants` :
         Contains the description of ``constants``, which, as a dictionary literal object, does not itself possess a docstring.
     """
     if sub is None:


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
Fixes references not found during docs builds. This only needs backported to 3.1 as the bug was introduced in https://github.com/sunpy/sunpy/pull/5769. Although I'll need to edit the backport PR to not add 4.0 to the docs.

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->


