### PR TITLE
Fix superpixel() metadata computations

### DIFF
--- a/changelog/5786.bugfix.rst
+++ b/changelog/5786.bugfix.rst
@@ -1,5 +1,5 @@
 Maps created from :meth:`~sunpy.map.GenericMap.resample` and
-:meth:`~sunpy.map.GenericMap.superpixel` have bene fixed in the case where
+:meth:`~sunpy.map.GenericMap.superpixel` have been fixed in the case where
 the resampling was not square, and the PCi_j matrix (often a rotation matrix)
 was not a multiple of the identity matrix. When the PCi_j or CDi_j formalisms
 are used in the metadata these are now correctly modified, and the CDELT values

--- a/changelog/5786.bugfix.rst
+++ b/changelog/5786.bugfix.rst
@@ -1,0 +1,6 @@
+Maps created from :meth:`~sunpy.map.GenericMap.resample` and
+:meth:`~sunpy.map.GenericMap.superpixel` have bene fixed in the case where
+the resampling was not square, and the PCi_j matrix (often a rotation matrix)
+was not a multiple of the identity matrix. When the PCi_j or CDi_j formalisms
+are used in the metadata these are now correctly modified, and the CDELT values
+are left unchanged.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1501,13 +1501,20 @@ class GenericMap(NDData):
         new_meta = self.meta.copy()
 
         # Update metadata
-        new_meta['cdelt1'] *= scale_factor_x
-        new_meta['cdelt2'] *= scale_factor_y
-        if 'CD1_1' in new_meta:
-            new_meta['CD1_1'] *= scale_factor_x
-            new_meta['CD2_1'] *= scale_factor_x
-            new_meta['CD1_2'] *= scale_factor_y
-            new_meta['CD2_2'] *= scale_factor_y
+        if 'pc1_1' in self.meta:
+            new_meta['pc1_1'] *= scale_factor_x
+            new_meta['pc2_1'] *= scale_factor_x
+            new_meta['pc1_2'] *= scale_factor_y
+            new_meta['pc2_2'] *= scale_factor_y
+        if 'cd1_1' in self.meta:
+            new_meta['cd1_1'] *= scale_factor_x
+            new_meta['cd2_1'] *= scale_factor_x
+            new_meta['cd1_2'] *= scale_factor_y
+            new_meta['cd2_2'] *= scale_factor_y
+        if 'cd1_1' not in self.meta and 'pc1_1' not in self.meta:
+            # Using the CROTA2 and CDELT formalism
+            new_meta['cdelt1'] *= scale_factor_x
+            new_meta['cdelt2'] *= scale_factor_y
         new_meta['crpix1'] = (self.reference_pixel.x.to_value(u.pix) + 0.5) / scale_factor_x + 0.5
         new_meta['crpix2'] = (self.reference_pixel.y.to_value(u.pix) + 0.5) / scale_factor_y + 0.5
         new_meta['naxis1'] = new_data.shape[1]
@@ -1992,16 +1999,22 @@ class GenericMap(NDData):
         # create copy of new meta data
         new_meta = self.meta.copy()
 
-        scale = [self.scale[i].to_value(self.spatial_units[i] / u.pix) for i in range(2)]
-
         # Update metadata
-        new_meta['cdelt1'] = dimensions[0] * scale[0]
-        new_meta['cdelt2'] = dimensions[1] * scale[1]
-        if 'CD1_1' in new_meta:
-            new_meta['CD1_1'] *= dimensions[0]
-            new_meta['CD2_1'] *= dimensions[0]
-            new_meta['CD1_2'] *= dimensions[1]
-            new_meta['CD2_2'] *= dimensions[1]
+        if 'pc1_1' in self.meta:
+            new_meta['pc1_1'] *= dimensions[0]
+            new_meta['pc2_1'] *= dimensions[0]
+            new_meta['pc1_2'] *= dimensions[1]
+            new_meta['pc2_2'] *= dimensions[1]
+        if 'cd1_1' in self.meta:
+            new_meta['cd1_1'] *= dimensions[0]
+            new_meta['cd2_1'] *= dimensions[0]
+            new_meta['cd1_2'] *= dimensions[1]
+            new_meta['cd2_2'] *= dimensions[1]
+        if 'cd1_1' not in self.meta and 'pc1_1' not in self.meta:
+            # Using the CROTA2 and CDELT formalism
+            new_meta['cdelt1'] *= dimensions[0]
+            new_meta['cdelt2'] *= dimensions[1]
+
         new_meta['crpix1'] = ((self.reference_pixel.x.to_value(u.pix) +
                                0.5 - offset[0]) / dimensions[0]) + 0.5
         new_meta['crpix2'] = ((self.reference_pixel.y.to_value(u.pix) +

--- a/sunpy/map/tests/conftest.py
+++ b/sunpy/map/tests/conftest.py
@@ -103,8 +103,7 @@ def generic_map():
     return sunpy.map.Map((data, header))
 
 
-@pytest.fixture
-def simple_map():
+def make_simple_map():
     # A 3x3 map, with it's center at (0, 0), and scaled differently in
     # each direction
     data = np.arange(9).reshape((3, 3))
@@ -115,6 +114,9 @@ def simple_map():
     scale = [2, 1] * u.arcsec / u.pix
     header = sunpy.map.make_fitswcs_header(data, ref_coord, reference_pixel=ref_pix, scale=scale)
     return sunpy.map.Map(data, header)
+
+
+simple_map = pytest.fixture(make_simple_map)
 
 
 @pytest.fixture

--- a/sunpy/map/tests/strategies.py
+++ b/sunpy/map/tests/strategies.py
@@ -1,0 +1,25 @@
+import hypothesis.strategies as st
+import numpy as np
+from hypothesis import assume
+from hypothesis.extra.numpy import arrays
+
+
+@st.composite
+def matrix_meta(draw, key):
+    """
+    Create an arbitrary but valid (ie non-singular) PCi_j or CDi_j matrix.
+
+    Parameters
+    ----------
+    key : {'pc', 'cd'}
+    """
+    arr = draw(arrays(
+        float, (2, 2),
+        elements=st.floats(min_value=-1, max_value=1, allow_nan=False))
+    )
+    # Make sure matrix isn't singular
+    assume(np.abs(np.linalg.det(arr)) > 1e-8)
+    return {f'{key}1_1': arr[0, 0],
+            f'{key}1_2': arr[0, 1],
+            f'{key}2_1': arr[1, 0],
+            f'{key}2_2': arr[1, 1]}


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5783.

If using the `PC_ij` or `CD_ij` formalisms to describe the transformation, the scaling must be applied to the PC/CD matrices, *not* the CDELT values. This is because the PC/CD matrices multiply pixel coordinates before the CDELT scaling is applied. If the new `superpixel()` dimensions are square (e.g. `[2, 2]`), the scalar factor can be taken through to the other side of the PC/CD matrix multiplication which is why we didn't notice this, but for non-square matrices this is not the case.