### PR TITLE
Use `--mpl-results-always`

### DIFF
--- a/docs/code_ref/known_issues.rst
+++ b/docs/code_ref/known_issues.rst
@@ -22,3 +22,15 @@ There is not anything we can do to fix this on our side.
 `The specific section of the SDO users guide explaining this <https://www.lmsal.com/sdodocs/doc/dcur/SDOD0060.zip/zip/entry/sdoguidese4.html#x9-240004.2.4>`__.
 
 `Reference issue <https://github.com/sunpy/sunpy/issues/5447>`__.
+
+``scikit-image`` versions used to rotate/transform maps
+=======================================================
+sunpy requires a version of ``scikit-image < 0.19`` to be installed for
+rotating or transforming maps using ``scikit-image``. This is due to
+`changes in version 0.19 <https://github.com/scikit-image/scikit-image/issues/6093>`__.
+that are backwards incompatible with earlier ``scikit-image`` versions.
+
+It is anticipated that the default package used to transform or rotate maps will
+be changed from ``scikit-image`` to ``scipy`` in sunpy 4.0.
+
+`Reference issue <https://github.com/sunpy/sunpy/issues/5750>`__.

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ tests =
   pytest-astropy>=0.8  # 0.8 is the first release to include filter-subpackage
   pytest-doctestplus>=0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
   pytest-mock
-  pytest-mpl>=0.12 # First version to support our figure tests
+  pytest-mpl>=0.14rc1  # First version to support our figure tests
   pytest-xdist
 docs =
   astroquery

--- a/setup.cfg
+++ b/setup.cfg
@@ -169,6 +169,11 @@ filterwarnings =
     # Ignore numpy warning in py37-oldestdeps figure tests
     ignore:invalid value encountered in greater:RuntimeWarning
     ignore:invalid value encountered in less:RuntimeWarning
+    # Emitted by scipy>1.8 and scikit-image<0.19 , which is pinned due to
+    # rotation issues (https://github.com/sunpy/sunpy/issues/5750).
+    # These should be removed when our scikit-image pinning is removed
+    ignore:Please use `gaussian_filter` from the `scipy.ndimage` namespace:DeprecationWarning
+    ignore:Please use `laplace` from the `scipy.ndimage` namespace:DeprecationWarning
 
 [pycodestyle]
 max_line_length = 110

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -19,7 +19,7 @@ References
 from copy import deepcopy
 
 import numpy as np
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import shift
 from skimage.feature import match_template
 
 import astropy.units as u

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_almost_equal
-from scipy.ndimage.interpolation import shift as sp_shift
+from scipy.ndimage import shift as sp_shift
 
 import astropy.units as u
 

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -4,7 +4,7 @@ Functions for geometrical image transformation and warping.
 import numbers
 
 import numpy as np
-import scipy.ndimage.interpolation
+import scipy.ndimage
 
 from sunpy.util.exceptions import warn_user
 
@@ -103,7 +103,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         if np.any(np.isnan(image)):
             warn_user("Setting NaNs to 0 for SciPy rotation.")
         # Transform the image using the scipy affine transform
-        rotated_image = scipy.ndimage.interpolation.affine_transform(
+        rotated_image = scipy.ndimage.affine_transform(
             np.nan_to_num(image).T, rmatrix, offset=shift, order=order,
             mode='constant', cval=missing).T
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,6 @@ deps =
     figure-!devdeps: astropy==4.2.1
     figure-!devdeps: matplotlib==3.3.2
     figure-!devdeps: mpl-animators==1.0.0
-    figure: git+https://github.com/matplotlib/pytest-mpl
 extras =
     all
     tests
@@ -79,7 +78,7 @@ commands =
     figure: /bin/bash -c "pip freeze >> ./figure_test_images/figure_version_info.txt"
     figure: /bin/bash -c "cat ./figure_test_images/figure_version_info.txt"
     figure: python -c "import sunpy.tests.helpers as h; print(h.get_hash_library_name())"
-    figure: {env:PYTEST_COMMAND} -m "mpl_image_compare" --mpl --remote-data=any --mpl-results-always --mpl-generate-summary=html --mpl-baseline-path=https://raw.githubusercontent.com/sunpy/sunpy-figure-tests/sunpy-master/figures/{envname}/ {posargs}
+    figure: {env:PYTEST_COMMAND} -m "mpl_image_compare" --mpl --remote-data=any --mpl-generate-summary=html --mpl-baseline-path=https://raw.githubusercontent.com/sunpy/sunpy-figure-tests/sunpy-master/figures/{envname}/ {posargs}
 
 [testenv:build_docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ deps =
     figure-!devdeps: astropy==4.2.1
     figure-!devdeps: matplotlib==3.3.2
     figure-!devdeps: mpl-animators==1.0.0
+    figure: git+https://github.com/matplotlib/pytest-mpl
 extras =
     all
     tests
@@ -78,7 +79,7 @@ commands =
     figure: /bin/bash -c "pip freeze >> ./figure_test_images/figure_version_info.txt"
     figure: /bin/bash -c "cat ./figure_test_images/figure_version_info.txt"
     figure: python -c "import sunpy.tests.helpers as h; print(h.get_hash_library_name())"
-    figure: {env:PYTEST_COMMAND} -m "mpl_image_compare" --mpl --remote-data=any --mpl-generate-summary=html --mpl-baseline-path=https://raw.githubusercontent.com/sunpy/sunpy-figure-tests/sunpy-master/figures/{envname}/ {posargs}
+    figure: {env:PYTEST_COMMAND} -m "mpl_image_compare" --mpl --remote-data=any --mpl-results-always --mpl-generate-summary=html --mpl-baseline-path=https://raw.githubusercontent.com/sunpy/sunpy-figure-tests/sunpy-master/figures/{envname}/ {posargs}
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION


<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
Uses the new `--mpl-results-always` option of pytest-mpl so all tests (including passing tests) are shown in the HTML output during figure tests.

The pytest-mpl git repository is installed as the new option is not in a release yet.
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->


