### PR TITLE
Update database __repr__ methods

### DIFF
--- a/changelog/5790.bugfix.rst
+++ b/changelog/5790.bugfix.rst
@@ -1,0 +1,3 @@
+The ``__repr__`` of several `sunpy.database` classes have been updated to remove angular
+brackets and add equals signs. As an example, ``'<DatabaseEntry(id 3)>'`` has changed to
+``'DatabaseEntry(id=3)'``

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -102,7 +102,7 @@ class JSONDump(Base):
         return self.dump
 
     def __repr__(self):
-        return f'<{self.__class__.__name__}(dump {self.dump!r})>'
+        return f'{self.__class__.__name__}(dump={self.dump!r})'
 
 
 class FitsHeaderEntry(Base):
@@ -130,7 +130,7 @@ class FitsHeaderEntry(Base):
         return not (self == other)
 
     def __repr__(self):
-        return '<{}(id {}, key {!r}, value {!r})>'.format(
+        return '{}(id={}, key={!r}, value={!r})'.format(
             self.__class__.__name__, self.id, self.key, self.value)
 
 
@@ -163,7 +163,7 @@ class FitsKeyComment(Base):
         return not (self == other)
 
     def __repr__(self):
-        return '<{}(id {}, key {!r}, value {!r})>'.format(
+        return '{}(id={}, key={!r}, value={!r})>'.format(
             self.__class__.__name__, self.id, self.key, self.value)
 
 
@@ -188,7 +188,7 @@ class Tag(Base):
         return self.name
 
     def __repr__(self):
-        return f'<{self.__class__.__name__}(name {self.name!r})>'
+        return f'{self.__class__.__name__}(name={self.name!r})'
 
 
 class DatabaseEntry(DatabaseEntryType, Base):
@@ -474,13 +474,13 @@ class DatabaseEntry(DatabaseEntryType, Base):
             'observation_time_start', 'observation_time_end', 'instrument',
             'size', 'wavemin', 'wavemax', 'path', 'download_time', 'starred',
             'fits_header_entries', 'tags']
-        ret = f'<{self.__class__.__name__}('
+        ret = f'{self.__class__.__name__}('
         for attr in attrs:
             value = getattr(self, attr, None)
             if value:
-                ret += f'{attr} {value!r}, '
+                ret += f'{attr}={value!r}, '
         ret = ret.rstrip(', ')
-        ret += ')>'
+        ret += ')'
         return ret
 
 

--- a/sunpy/database/tests/test_commands.py
+++ b/sunpy/database/tests/test_commands.py
@@ -129,7 +129,7 @@ def test_remove_entry_repr(session):
     expected_repr_result = (
         '<RemoveEntry('
         'session <sqlalchemy.orm.session.Session object at *>, '
-        'entry <DatabaseEntry(id 3)>)>'.format(id(session)))
+        'entry DatabaseEntry(id=3))>'.format(id(session)))
     assert fnmatch.fnmatch(repr(RemoveEntry(session, entry)), expected_repr_result)
 
 


### PR DESCRIPTION
A couple of updates to `__repr__` methods, to make them into a string that can be evaluated with `eval()` to create a new object. This makes updating some of the tests significantly easier as the remote data changes.

- Remove leading and trailing <>
- Add missing = sign