### PR TITLE
Fixed `GenericMap.rotate()` when using a matrix that is not a pure rotation

### DIFF
--- a/changelog/5803.bugfix.1.rst
+++ b/changelog/5803.bugfix.1.rst
@@ -1,0 +1,2 @@
+Fixed a bug when rotating a map by a matrix that is not purely a rotation.
+The likely way to inadvertently encounter this bug was when de-rotating a map with rectangular pixels that were not aligned with the coordinate axes.

--- a/changelog/5803.bugfix.2.rst
+++ b/changelog/5803.bugfix.2.rst
@@ -1,0 +1,1 @@
+Fixed a bug where rotating a map while simultaneously scaling it could result in some of the map data being cropped out.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -7,6 +7,7 @@ import html
 import inspect
 import numbers
 import textwrap
+import itertools
 import webbrowser
 from io import BytesIO
 from base64 import b64encode
@@ -1615,15 +1616,23 @@ class GenericMap(NDData):
             rmatrix = np.array([[c, -s],
                                 [s, c]])
 
+        # The data will be rotated by the inverse of the rotation matrix
+        inv_rmatrix = np.linalg.inv(rmatrix)
+
         # Calculate the shape in pixels to contain all of the image data
-        extent = np.max(np.abs(np.vstack((self.data.shape @ rmatrix,
-                                          self.data.shape @ rmatrix.T))), axis=0)
+        corners = itertools.product([-0.5, self.data.shape[1]-0.5],
+                                    [-0.5, self.data.shape[0]-0.5])
+        rot_corners = np.vstack([rmatrix @ c for c in corners])
+        extent = np.max(rot_corners, axis=0) - np.min(rot_corners, axis=0)
 
         # Calculate the needed padding or unpadding
-        diff = np.asarray(np.ceil((extent - self.data.shape) / 2), dtype=int).ravel()
+        diff = np.asarray(np.ceil((extent - np.flipud(self.data.shape)) / 2), dtype=int)
+        pad_x = np.max((diff[0], 0))
+        pad_y = np.max((diff[1], 0))
+        unpad_x = -np.min((diff[0], 0))
+        unpad_y = -np.min((diff[1], 0))
+
         # Pad the image array
-        pad_x = int(np.max((diff[1], 0)))
-        pad_y = int(np.max((diff[0], 0)))
 
         if issubclass(self.data.dtype.type, numbers.Integral) and (missing % 1 != 0):
             warn_user("The specified `missing` value is not an integer, but the data "
@@ -1646,12 +1655,12 @@ class GenericMap(NDData):
             pixel_center = pixel_array_center
 
         # Apply the rotation to the image data
-        new_data = affine_transform(new_data.T,
-                                    np.asarray(rmatrix),
+        new_data = affine_transform(new_data,
+                                    np.asarray(inv_rmatrix),
                                     order=order, scale=scale,
-                                    image_center=np.flipud(pixel_center),
+                                    image_center=pixel_center,
                                     recenter=recenter, missing=missing,
-                                    method=method).T
+                                    method=method)
 
         if recenter:
             new_reference_pixel = pixel_array_center
@@ -1668,11 +1677,9 @@ class GenericMap(NDData):
         new_meta['crpix2'] = new_reference_pixel[1] + 1  # FITS pixel origin is 1
 
         # Unpad the array if necessary
-        unpad_x = -np.min((diff[1], 0))
         if unpad_x > 0:
             new_data = new_data[:, unpad_x:-unpad_x]
             new_meta['crpix1'] -= unpad_x
-        unpad_y = -np.min((diff[0], 0))
         if unpad_y > 0:
             new_data = new_data[unpad_y:-unpad_y, :]
             new_meta['crpix2'] -= unpad_y
@@ -1681,7 +1688,7 @@ class GenericMap(NDData):
         # "subtracting" the rotation matrix used in the rotate from the old one
         # That being calculate the dot product of the old header data with the
         # inverse of the rotation matrix.
-        pc_C = np.dot(self.rotation_matrix, np.linalg.inv(rmatrix))
+        pc_C = np.dot(self.rotation_matrix, inv_rmatrix)
         new_meta['PC1_1'] = pc_C[0, 0]
         new_meta['PC1_2'] = pc_C[0, 1]
         new_meta['PC2_1'] = pc_C[1, 0]

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1622,7 +1622,7 @@ class GenericMap(NDData):
         # Calculate the shape in pixels to contain all of the image data
         corners = itertools.product([-0.5, self.data.shape[1]-0.5],
                                     [-0.5, self.data.shape[0]-0.5])
-        rot_corners = np.vstack([rmatrix @ c for c in corners])
+        rot_corners = np.vstack([rmatrix @ c for c in corners]) * scale
         extent = np.max(rot_corners, axis=0) - np.min(rot_corners, axis=0)
 
         # Calculate the needed padding or unpadding
@@ -1666,7 +1666,7 @@ class GenericMap(NDData):
             new_reference_pixel = pixel_array_center
         else:
             # Calculate new pixel coordinates for the rotation center
-            new_reference_pixel = pixel_center + np.dot(rmatrix,
+            new_reference_pixel = pixel_center + np.dot(rmatrix * scale,
                                                         pixel_rotation_center - pixel_center)
             new_reference_pixel = np.array(new_reference_pixel).ravel()
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1595,6 +1595,7 @@ class GenericMap(NDData):
         if angle is not None and rmatrix is not None:
             raise ValueError("You cannot specify both an angle and a rotation matrix.")
         elif angle is None and rmatrix is None:
+            # Be aware that self.rotation_matrix may not actually be a pure rotation matrix
             rmatrix = self.rotation_matrix
 
         if order not in range(6):
@@ -1616,7 +1617,8 @@ class GenericMap(NDData):
             rmatrix = np.array([[c, -s],
                                 [s, c]])
 
-        # The data will be rotated by the inverse of the rotation matrix
+        # The data will be rotated by the inverse of the rotation matrix. Because rmatrix may not
+        # actually be a pure rotation matrix, we calculate the inverse in a general manner.
         inv_rmatrix = np.linalg.inv(rmatrix)
 
         # Calculate the shape in pixels to contain all of the image data

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -865,7 +865,8 @@ def calc_new_matrix(angle):
 
 
 def test_rotate(aia171_test_map):
-    # Make sure the test map uses little-endian floats
+    # The test map has big-endian floats, so we switch it to floats with native byte ordering
+    # Otherwise, errors can be raised by code that has been compiled
     aia171_test_map._data = aia171_test_map.data.astype('float')
 
     rotated_map_1 = aia171_test_map.rotate(20 * u.deg)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from hypothesis import given, settings
+from matplotlib.figure import Figure
 from packaging import version
 
 import astropy.units as u
@@ -1420,6 +1421,25 @@ def test_rotation_rect_pixelated_data(aia171_test_map):
     rect_map = aia_map.superpixel([2, 1] * u.pix, func=np.mean)
     rect_rot_map = rect_map.rotate(30 * u.deg)
     rect_rot_map.peek()
+
+
+@figure_test
+def test_derotating_nonpurerotation_pcij(aia171_test_map):
+    # The following map has a a PCij matrix that is not a pure rotation
+    weird_map = aia171_test_map.rotate(30*u.deg).superpixel([2, 1]*u.pix)
+
+    # De-rotating the map by its PCij matrix should result in a normal-looking map
+    derotated_map = weird_map.rotate()
+
+    fig = Figure(figsize=(8, 4))
+
+    ax1 = fig.add_subplot(121, projection=weird_map)
+    weird_map.plot(axes=ax1, title='Map with a non-pure-rotation PCij matrix')
+
+    ax2 = fig.add_subplot(122, projection=derotated_map)
+    derotated_map.plot(axes=ax2, title='De-rotated map')
+
+    return fig
 
 
 # This function is used in the arithmetic tests below

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -865,6 +865,9 @@ def calc_new_matrix(angle):
 
 
 def test_rotate(aia171_test_map):
+    # Make sure the test map uses little-endian floats
+    aia171_test_map._data = aia171_test_map.data.astype('float')
+
     rotated_map_1 = aia171_test_map.rotate(20 * u.deg)
     rotated_map_2 = rotated_map_1.rotate(20 * u.deg)
     np.testing.assert_allclose(rotated_map_1.rotation_matrix,
@@ -880,17 +883,14 @@ def test_rotate(aia171_test_map):
     np.testing.assert_allclose(rotated_map_2.data[0, 0], 0., atol=1e-7)
     assert rotated_map_2.mean() < rotated_map_1.mean() < aia171_test_map.mean()
 
-    rotated_map_3 = aia171_test_map.rotate(0 * u.deg, scale=1.5)
-    assert rotated_map_3.mean() > aia171_test_map.mean()
+    # A scaled-up map should have the same mean because the output map should be expanded
+    rotated_map_3 = aia171_test_map.rotate(0 * u.deg, order=3, scale=2)
+    np.testing.assert_allclose(aia171_test_map.mean(), rotated_map_3.mean(), rtol=1e-4)
 
-    # Mean and std should be equal when angle of rotation is integral multiple
-    # of 90 degrees for a square map
-    rotated_map_4 = aia171_test_map.rotate(90 * u.deg, scale=1.5)
-    np.testing.assert_allclose(rotated_map_3.mean(), rotated_map_4.mean(), rtol=1e-3)
-    np.testing.assert_allclose(rotated_map_3.std(), rotated_map_4.std(), rtol=1e-3)
-    rotated_map_5 = aia171_test_map.rotate(180 * u.deg, scale=1.5)
-    np.testing.assert_allclose(rotated_map_3.mean(), rotated_map_5.mean(), rtol=1e-3)
-    np.testing.assert_allclose(rotated_map_3.std(), rotated_map_5.std(), rtol=2e-3)
+    # Mean and std should be equal for a 90 degree rotation
+    rotated_map_4 = aia171_test_map.rotate(90 * u.deg, order=3, scale=2)
+    np.testing.assert_allclose(rotated_map_3.mean(), rotated_map_4.mean(), rtol=1e-10)
+    np.testing.assert_allclose(rotated_map_3.std(), rotated_map_4.std(), rtol=1e-10)
 
     # Rotation of a rectangular map by a large enough angle will change which dimension is larger
     aia171_test_map_crop = aia171_test_map.submap(

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_421_animators_100.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_421_animators_100.json
@@ -7,6 +7,7 @@
   "sunpy.map.tests.test_compositemap.test_set_alpha_composite_map": "b9d729ff67b0307c037ac62f97c69bb80d22ad6679a0e56352075845d4ef732b",
   "sunpy.map.tests.test_compositemap.test_peek_composite_map": "bd1df27446d420f3e8cb6fa07daff88b77dd0f0441e4acf83ee48341a9e3218f",
   "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "3835ea8f163f8b843088524fb6f1ea7b1357ee00224bd9ea625c641d974f17b7",
+  "sunpy.map.tests.test_mapbase.test_derotating_nonpurerotation_pcij": "ea58afbd8814f450c2f22ac942400b19e67256a6342082570147e5155530b74e",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "a400eef26fdd915ccf12769031bd8dadedbf8f6a93e31cd5982bffe2484702ee",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "15c8aee7d3a6ff3d39856dc37e02afa983e1ebc1582f810699defd14b3f6cec7",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "7f115dedaf88653dff71f784b0d8173d66638e429f92239a7a6f7d6f10fd05f5",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
@@ -7,6 +7,7 @@
   "sunpy.map.tests.test_compositemap.test_set_alpha_composite_map": "f811cf6be8abfcd1b3a7f4bae7781806b37b1b2b0cb77ac34c4ed4491a1d633a",
   "sunpy.map.tests.test_compositemap.test_peek_composite_map": "d459182443472330df9b0dde3bde647479c100f56f45b6321619fbf67810c174",
   "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "817ef0de8c17246fc4e728d55d119b08c803b6a6906d4b0923f3969eaab0177f",
+  "sunpy.map.tests.test_mapbase.test_derotating_nonpurerotation_pcij": "3405502781af50c4f4d9610d6c36f5aa8915159cd9c734505a34d4eeba7a6d2c",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "5a7217dd55ab3a593a27741fecfe0851208fd1d31baeca4cbd018d65aaf3f483",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "3cdc53f41914028a4e9f23112d7e616ce8a423ef5670c8365fdadbc0e59780ca",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "c1276702147f4debaa14c17f6b0b2ab7f9e0b1ace309c72e767b2af071c4405e",


### PR DESCRIPTION
Before this PR:
![sunpy map tests test_mapbase test_derotating_nonpurerotation_pcij before](https://user-images.githubusercontent.com/991759/158305426-ba33d35e-12db-409e-ae92-e26e9e818715.png)

After this PR:
![sunpy map tests test_mapbase test_derotating_nonpurerotation_pcij after](https://user-images.githubusercontent.com/991759/158305447-b497a30f-1ae6-4a56-9194-e7d73c0d0ce2.png)

---

Fixes #5784, so see that issue for more information.  Instead of the incorrect output shown in that issue, this PR produces:
![fixed_rot](https://user-images.githubusercontent.com/991759/148322465-5ba6a28a-a8fd-42ed-a6d8-6b36522d0b85.png)

In a nutshell, parts of the code implicitly assumed that the transpose of the matrix was the same as its inverse, which is only true for a pure rotation.

This PR also fixes #3285.