### PR TITLE
Parse HEK time columns

### DIFF
--- a/changelog/5806.feature.rst
+++ b/changelog/5806.feature.rst
@@ -1,0 +1,3 @@
+The 'event_endtime', 'event_starttime' and 'event_peaktime' columns in a HEK
+query are now returned as `~astropy.time.Time` objects. Previously they were
+timestamp strings.

--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -23,6 +23,11 @@ We have bumped the minimum version of several packages we depend on; these are t
 
 - python >= 3.8
 
+Improved return types of HEK queries
+====================================
+The 'event_endtime', 'event_starttime' and 'event_peaktime' columns in a HEK
+query are now returned as `~astropy.time.Time` objects.
+
 Better printing of metadata
 ===========================
 Printing a `.MetaDict` now prints each entry on a new line, making it much easier to read::

--- a/sunpy/net/hek/tests/test_hek.py
+++ b/sunpy/net/hek/tests/test_hek.py
@@ -2,6 +2,8 @@ import copy
 
 import pytest
 
+from astropy.time import Time
+
 from sunpy.net import attr, attrs, hek
 
 
@@ -142,6 +144,12 @@ def test_getitem(hek_result):
 def test_get_voevent(hek_result):
     ve = hek_result[0].get_voevent()
     assert len(ve['voe:VOEvent']) == 7
+
+
+@pytest.mark.remote_data
+def test_hek_time_col(hek_result):
+    assert isinstance(hek_result[0]['event_starttime'], Time)
+    assert isinstance(hek_result[0]['event_endtime'], Time)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
From https://www.lmsal.com/hek/VOEvent_Spec.html there are only three columns that are time-like. This PR parses each of those columns into `astropy.time.Time` if it is present in the result.

Also added a very basic caching mechanism to avoid running the same HEK query multiple times. 

Fixes partially https://github.com/sunpy/sunpy/issues/5006.