### PR TITLE
Fix for `py38-oldestdeps` Quantity equality

### DIFF
--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -771,8 +771,8 @@ def test_superpixel_dims_values(aia171_test_map, f):
     # Check dimensions of new map
     old_dims = u.Quantity(aia171_test_map.dimensions)
     expected_new_dims = old_dims * (1 * u.pix / dimensions)
-    new_dims = superpix_map.dimensions
-    assert np.all(new_dims == expected_new_dims)
+    assert superpix_map.dimensions[0] == expected_new_dims[0]
+    assert superpix_map.dimensions[1] == expected_new_dims[1]
 
     # Check value of lower left pixel is calculated correctly
     expected = f(aia171_test_map.data[0:2, 0:2])
@@ -791,12 +791,14 @@ def test_superpixel_masked(aia171_test_map_with_mask):
 
     # Test that the offset is respected
     superpix_map = aia171_test_map_with_mask.superpixel(dimensions, offset=(1, 1) * u.pix)
-    assert np.all(superpix_map.dimensions == expected_shape - 1*u.pix)
+    assert superpix_map.dimensions[0] == expected_shape[0] - 1 * u.pix
+    assert superpix_map.dimensions[1] == expected_shape[1] - 1 * u.pix
 
     dimensions = (7, 9) * u.pix
     superpix_map = aia171_test_map_with_mask.superpixel(dimensions, offset=(4, 4) * u.pix)
     expected_shape = np.round(input_dims * (1 * u.pix / dimensions))
-    assert np.all(superpix_map.dimensions == expected_shape - 1*u.pix)
+    assert superpix_map.dimensions[0] == expected_shape[0] - 1 * u.pix
+    assert superpix_map.dimensions[1] == expected_shape[1] - 1 * u.pix
 
 
 def test_superpixel_units(generic_map):


### PR DESCRIPTION


<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
This PR fixes the `py38-oldestdeps` CI. Prior to astropy 5.0, comparisons such as `(1*u.pix, 1*u.pix) == [1, 1]*u.pix` would be `False`. The comparison was added in #5787.

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->


