### PR TITLE
Make horizons test more reliable

### DIFF
--- a/sunpy/coordinates/tests/strategies.py
+++ b/sunpy/coordinates/tests/strategies.py
@@ -2,6 +2,7 @@
 Provide a set of hypothesis strategies for various coordinates-related tests.
 """
 import hypothesis.strategies as st
+from hypothesis.extra.numpy import arrays
 
 import astropy.units as u
 from astropy.coordinates import Latitude, Longitude
@@ -29,8 +30,10 @@ def longitudes(draw, min_lon: u.deg = -180*u.deg, max_lon: u.deg = 180*u.deg,
 
 
 @st.composite
-def times(draw, min_time='1960-01-01', max_time='2024-01-01'):
+def times(draw, min_time='1960-01-01', max_time='2024-01-01', n=1):
     days = st.floats(min_value=0,
                      max_value=(parse_time(max_time) - parse_time(min_time)).to(u.day).value,
                      allow_nan=False, allow_infinity=False)
+    if n > 1:
+        days = arrays(float, shape=n, elements=days, unique=True)
     return parse_time(min_time) + draw(days) * u.day

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -148,12 +148,14 @@ def use_DE440s():
 
 
 @pytest.mark.remote_data
-@given(obstime=times())
-@settings(deadline=5000, max_examples=5, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(obstime=times(n=50))
+@settings(deadline=5000, max_examples=1,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_consistency_with_horizons(use_DE440s, obstime):
     # Check that the high-accuracy Astropy ephemeris has been set
     assert solar_system_ephemeris.get() == 'de440s'
 
+    obstime = sorted(obstime)
     # Check whether the location of Earth is the same between Astropy and JPL HORIZONS
     e1 = get_earth(obstime)
     e2 = get_horizons_coord('Geocenter', obstime)


### PR DESCRIPTION
This test has been flaky for a while on our remote-data CI run. This PR changes it to generate N times and make a single remote query to horizons, instead of generating lots of single times and making N queries to horizons.