### PR TITLE
Fix pytest capture in hpc test

### DIFF
--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -228,7 +228,7 @@ def test_hpc_low_precision_float_warning():
                           u.Quantity(0, u.arcsec, dtype=np.float16),
                           observer=HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU))
 
-    with pytest.raises(SunpyUserWarning, match="Tx is float32, and Ty is float16"):
+    with pytest.warns(SunpyUserWarning, match="Tx is float32, and Ty is float16"):
         hpc.make_3d()
 
 


### PR DESCRIPTION
This should probably have been in https://github.com/sunpy/sunpy/pull/5818, and fixes the wheel builds. I'm not sure why the normal tests pass without this, but the wheel tests fail? Testing locally also doesn't fail for me with `raises`.

If we merge this into main, I can manually add it to the backports, #5819 and #5820