### PR TITLE
Prevent JSOC tests from being run in parallel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ stages:
         submodules: false
         coverage: codecov
         toxdeps: tox-pypi-filter
-        posargs: -n=4
+        posargs: -n auto --dist loadgroup
         libraries:
           apt:
             - libopenjp2-7
@@ -97,7 +97,7 @@ stages:
         submodules: false
         coverage: codecov
         toxdeps: tox-pypi-filter
-        posargs: -n=4
+        posargs: -n auto --dist loadgroup
         libraries:
           apt:
             - libopenjp2-7
@@ -122,7 +122,7 @@ stages:
           submodules: false
           coverage: codecov
           toxdeps: tox-pypi-filter
-          posargs: -n=4
+          posargs: -n auto --dist loadgroup
           libraries:
             apt:
               - libopenjp2-7

--- a/changelog/5827.trivial.rst
+++ b/changelog/5827.trivial.rst
@@ -1,0 +1,3 @@
+Running the tests now requires the ``pytest-xdist`` package. By
+default tests are *not* run in parallel, but can be configured to do so
+using ``pytest-xdist`` command line options.

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ tests =
   pytest-doctestplus>=0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
   pytest-mock
   pytest-mpl>=0.12 # First version to support our figure tests
+  pytest-xdist
 docs =
   astroquery
   jplephem
@@ -109,7 +110,7 @@ testpaths = "sunpy" "docs"
 norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "examples" "sunpy[/\]_dev" ".jupyter" ".history" "tools" "sunpy[\/]extern" ".pyinstaller"
 doctest_plus = enabled
 doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
-addopts = --doctest-rst --doctest-ignore-import-errors -p no:unraisableexception -p no:threadexception
+addopts = --dist no --doctest-rst --doctest-ignore-import-errors -p no:unraisableexception -p no:threadexception
 asdf_schema_tests_enabled = true
 asdf_schema_root = sunpy/io/special/asdf/schemas/
 mpl-results-path = figure_test_images

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -15,6 +15,9 @@ import sunpy.net.attrs as a
 from sunpy.net.jsoc import JSOCClient, JSOCResponse
 from sunpy.util.exceptions import SunpyUserWarning
 
+# Ensure all JSOC tests are run on the same parallel worker
+pytestmark = pytest.mark.xdist_group(name="jsoc")
+
 
 @pytest.fixture
 def client():

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -479,6 +479,7 @@ def test_fido_repr():
     assert output[:50] == '<sunpy.net.fido_factory.UnifiedDownloaderFactory o'
 
 
+@pytest.mark.xdist_group(name="jsoc")
 @pytest.mark.remote_data
 def test_fido_metadata_queries():
     results = Fido.search(a.Time('2010/8/1 03:40', '2010/8/1 3:40:10'),

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,6 @@ setenv =
     HIDE_PARFIVE_PROGESS = True
     NO_VERIFY_HELIO_SSL = 1
 deps =
-    # We run the tests in parallel
-    pytest-xdist
     # devdeps is intended to be used to install the latest developer version of key dependencies.
     devdeps: git+https://github.com/astropy/astropy
     devdeps: git+https://github.com/matplotlib/matplotlib


### PR DESCRIPTION
Today's CI failure was
```python
E       drms.exceptions.DrmsExportError: User jsoc@cadair.com has 1 pending export requests (JSOC_20220121_387); please wait until at least one request has completed before submitting a new one. [status=7]

../../.tox/py38-online/lib/python3.8/site-packages/drms/client.py:185: DrmsExportError
```

This PR:
- Uses `pytest-xdist` by default, with the auto option (this was already being used on CI)
- Marks tests that download JSOC data as being in the same group. This ensures they are allocated the same worker and are run in serial, hopefully avoiding pending export errors.

I don't think we should backport a new test dependency, but am open to other opinions on that.