### PR TITLE
Fix norh plotting with pandas 1.4.0

### DIFF
--- a/changelog/5830.bugfix.rst
+++ b/changelog/5830.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed plotting and peeking NORH timeseries data with ``pandas`` 1.4.0.

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -77,7 +77,7 @@ class NoRHTimeSeries(GenericTimeSeries):
         plt.xticks(rotation=30)
         data_lab = str(self.meta.get('OBS-FREQ').values()).replace('[', '').replace(
             ']', '').replace('\'', '')
-        axes.plot(self.to_dataframe().index, self.to_dataframe(), label=data_lab, **kwargs)
+        axes.plot(self.to_dataframe(), label=data_lab, **kwargs)
         axes.set_yscale("log")
         axes.set_ylim(1e-4, 1)
         axes.set_xlabel('Start time: ' + self.to_dataframe().index[0].strftime(TIME_FORMAT))


### PR DESCRIPTION
This was broken with pandas 1.4.0 for some reason. Hopefully this fixes it.