### PR TITLE
Remove references to DataFrame in timeseries plot methods

### DIFF
--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -61,7 +61,7 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
 
     def plot(self, axes=None, **kwargs):
         """
-        Plots the GBM timeseries with data from its pandas dataframe.
+        Plots the GBM timeseries.
 
         Parameters
         ----------

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -67,7 +67,7 @@ class XRSTimeSeries(GenericTimeSeries):
 
     def plot(self, axes=None, columns=["xrsa", "xrsb"], **kwargs):
         """
-        Plots the GOES XRS light curve from a pandas dataframe.
+        Plots the GOES XRS light curve.
 
         Parameters
         ----------

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -59,7 +59,7 @@ class LYRATimeSeries(GenericTimeSeries):
 
     def plot(self, axes=None, names=3, **kwargs):
         """
-        Plots the LYRA data from a pandas dataframe.
+        Plots the LYRA data.
 
         Parameters
         ----------

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -59,7 +59,7 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
 
     def plot(self, axes=None, plot_type='sunspot SWO', **kwargs):
         """
-        Plots NOAA Indices as a function of time from a pandas dataframe.
+        Plots NOAA Indices.
 
         Parameters
         ----------

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -56,7 +56,7 @@ class NoRHTimeSeries(GenericTimeSeries):
 
     def plot(self, axes=None, **kwargs):
         """
-        Plot the NoRH lightcurve TimeSeries from a pandas dataframe.
+        Plot the NoRH lightcurve.
 
         Parameters
         ----------

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -137,7 +137,7 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
 
     def plot(self, axes=None, **kwargs):
         """
-        Plots RHESSI Count Rate light curve from a pandas dataframe.
+        Plots RHESSI count rate light curve.
 
         Parameters
         ----------


### PR DESCRIPTION
This is an implementation detail that doesn't need to be in the docstrings.