### PR TITLE
Refactor TimeSeries to use astropy TimeSeries underneath

### DIFF
--- a/changelog/5834.deprecation.1.rst
+++ b/changelog/5834.deprecation.1.rst
@@ -1,0 +1,3 @@
+Using `sunpy.timeseries.GenericTimeSeries.data` is deprecated.
+Use :meth:`sunpy.timeseries.GenericTimeSeries.to_dataframe` to get a pandas DataFrame or
+:meth:`sunpy.timeseries.GenericTimeSeries.to_table` to get an astropy Table instead."

--- a/changelog/5834.deprecation.3.rst
+++ b/changelog/5834.deprecation.3.rst
@@ -1,0 +1,6 @@
+Using :meth:`sunpy.timeseries.GenericTimeSeries.concatenate` without the new
+``method`` argument will raise a warning that ``method='pandas'`` is no longer
+supported, and will be removed in sunpy 4.1. To remove this warning pass
+``method=astropy`` to concatenate the series using astropy. This will be the
+only way of concatenating in sunpy 4.1, and takes advantage of support for
+leapseconds when concatenating two timeseries.

--- a/changelog/5834.deprecation.rst
+++ b/changelog/5834.deprecation.rst
@@ -1,0 +1,3 @@
+Passing a `~pandas.DataFrame` to `~sunpy.timeseries.GenericTimeSeries` is
+deprecated. Convert it to a `astropy.timeseries.TimeSeries` first,
+or pass the DataFrame to `sunpy.timeseries.TimeSeries` instead.

--- a/changelog/5834.feature.rst
+++ b/changelog/5834.feature.rst
@@ -1,0 +1,1 @@
+`~sunpy.timeseries` now has support for times that fall within a leapsecond.

--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -93,7 +93,15 @@ As part of this the following API has been deprecated:
   :meth:`sunpy.timeseries.GenericTimeSeries.to_table` or
   :meth:`sunpy.timeseries.GenericTimeSeries.to_dataframe` instead.
 
-Improvements to map and image rotation
+Calling :meth:`sunpy.timeseries.GenericTimeSeries.concatenate` without
+specifying the new method argument as ``method='astropy'`` is also deprecated.
+The default value is ``method='pandas'``, which reproduces previous default
+behaviour, but will be removed in sunpy 4.1. The only difference between the
+two methods is that ``method='astropy'`` will not remove duplicate rows.
+
+This change allows sunpy 4.0 to be backward compatible with sunpy 3.1,
+whilst raising a warning that allows us to break this compatability in sunp
+4.1.
 
 Improved return types of HEK queries
 ====================================

--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -78,6 +78,22 @@ Also, there is now the option to rotate using `OpenCV <https://opencv.org>`__.
 The rotation function to use can be selected via the ``method`` keyword argument.
 New rotation functions beyond these three can be added using the new decorator :func:`~sunpy.image.transform.add_rotation_function`.
 
+Reworked internals of TimeSeries
+================================
+`~sunpy.timeseries.GenericTimeseries` has been re-worked to use astropy time
+handling underneath. This allows users to take full advantage of astropy time
+handling (e.g. different time systems, support for leapseconds) when using
+`~sunpy.timeseries.GenericTimeseries`.
+
+As part of this the following API has been deprecated:
+- `sunpy.timeseries.GenericTimeseries.index`. Use
+  `sunpy.timeseries.GenericTimeseries.times` instead.
+- `sunpy.timeseries.GenericTimeseries.data`. Use
+  :meth:`sunpy.timeseries.GenericTimeseries.to_table` or
+  :meth:`sunpy.timeseries.GenericTimeseries.to_dataframe` instead.
+
+Improvements to map and image rotation
+
 Improved return types of HEK queries
 ====================================
 The 'event_endtime', 'event_starttime' and 'event_peaktime' columns in a HEK

--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -80,17 +80,18 @@ New rotation functions beyond these three can be added using the new decorator :
 
 Reworked internals of TimeSeries
 ================================
-`~sunpy.timeseries.GenericTimeseries` has been re-worked to use astropy time
+`sunpy.timeseries.GenericTimeSeries` has been re-worked to use astropy time
 handling underneath. This allows users to take full advantage of astropy time
 handling (e.g. different time systems, support for leapseconds) when using
-`~sunpy.timeseries.GenericTimeseries`.
+`sunpy.timeseries.GenericTimeSeries`.
 
 As part of this the following API has been deprecated:
-- `sunpy.timeseries.GenericTimeseries.index`. Use
-  `sunpy.timeseries.GenericTimeseries.times` instead.
-- `sunpy.timeseries.GenericTimeseries.data`. Use
-  :meth:`sunpy.timeseries.GenericTimeseries.to_table` or
-  :meth:`sunpy.timeseries.GenericTimeseries.to_dataframe` instead.
+
+- `sunpy.timeseries.GenericTimeSeries.index`. Use
+  `sunpy.timeseries.GenericTimeSeries.times` instead.
+- `sunpy.timeseries.GenericTimeSeries.data`. Use
+  :meth:`sunpy.timeseries.GenericTimeSeries.to_table` or
+  :meth:`sunpy.timeseries.GenericTimeSeries.to_dataframe` instead.
 
 Improvements to map and image rotation
 

--- a/sunpy/timeseries/conftest.py
+++ b/sunpy/timeseries/conftest.py
@@ -135,12 +135,25 @@ def table_ts():
     return sunpy.timeseries.TimeSeries(table, meta, units)
 
 
-# =============================================================================
-# Test Resulting TimeSeries Parameters
-# =============================================================================
 @pytest.fixture(params=['eve_test_ts', 'esp_test_ts', 'fermi_gbm_test_ts', 'norh_test_ts', 'goes_test_ts',
                         'lyra_test_ts', 'rhessi_test_ts', 'noaa_ind_json_test_ts',
                         'noaa_pre_json_test_ts', 'generic_ts', 'table_ts'])
 def many_ts(request):
     # Fixture to return lots of different timeseries
     return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def data_meta_units():
+    base = parse_time("2016/10/01T05:00:00")
+    dates = base - TimeDelta(np.arange(24 * 60)*u.minute)
+    intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24 * 60))))
+    intensity2 = np.cos(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24 * 60))))
+
+    data = DataFrame(np.column_stack([intensity, intensity2]),
+                     index=dates.isot.astype('datetime64'),
+                     columns=['intensity', 'intensity2'])
+    units = {'intensity': u.W / u.m**2,
+             'intensity2': u.W / u.m**2}
+    meta = MetaDict({'key': 'value'})
+    return data, meta, units

--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -5,10 +5,10 @@ from collections import OrderedDict
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 
 import astropy.units as u
 from astropy.time import TimeDelta
+from astropy.timeseries import TimeSeries
 
 import sunpy.io
 from sunpy.time import parse_time
@@ -87,7 +87,7 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
         """
         axes, columns = self._setup_axes_columns(axes, columns)
         for d in columns:
-            axes.plot(self._data.index, self._data[d], label=d, **kwargs)
+            axes.plot(self.to_dataframe().index, self.to_dataframe()[d], label=d, **kwargs)
         axes.set_yscale("log")
         axes.set_ylabel('Counts/s/keV')
         axes.legend()
@@ -164,7 +164,6 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
         met_ref_time = parse_time('2001-01-01 00:00')  # Mission elapsed time
         gbm_times = met_ref_time + TimeDelta(count_data['time'], format='sec')
         gbm_times.precision = 9
-        gbm_times = gbm_times.isot.astype('datetime64')
 
         column_labels = ['4-15 keV', '15-25 keV', '25-50 keV', '50-100 keV',
                          '100-300 keV', '300-800 keV', '800-2000 keV']
@@ -174,7 +173,8 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
                              ('25-50 keV', u.ct / u.s / u.keV), ('50-100 keV', u.ct / u.s / u.keV),
                              ('100-300 keV', u.ct / u.s / u.keV), ('300-800 keV', u.ct / u.s / u.keV),
                              ('800-2000 keV', u.ct / u.s / u.keV)])
-        return pd.DataFrame(summary_counts, columns=column_labels, index=gbm_times), header, units
+        data = {name: col for name, col in zip(column_labels, np.array(summary_counts).T)}
+        return TimeSeries(data=data, time=gbm_times), header, units
 
     @classmethod
     def is_datasource_for(cls, **kwargs):

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -8,10 +8,10 @@ import h5netcdf
 import matplotlib.ticker as mticker
 import numpy as np
 import packaging.version
-from pandas import DataFrame
 
 import astropy.units as u
 from astropy.time import Time, TimeDelta
+from astropy.timeseries import TimeSeries
 
 import sunpy.io
 from sunpy import log
@@ -207,9 +207,8 @@ class XRSTimeSeries(GenericTimeSeries):
         newxrsa = xrsa.byteswap().newbyteorder()
         newxrsb = xrsb.byteswap().newbyteorder()
 
-        data = DataFrame({'xrsa': newxrsa, 'xrsb': newxrsb},
-                         index=times.isot.astype('datetime64'))
-        data.sort_index(inplace=True)
+        data = TimeSeries(data={'xrsa': newxrsa, 'xrsb': newxrsb}, time=times)
+        data.sort(['time'])
 
         # Add the units
         units = OrderedDict([('xrsa', u.W/u.m**2),
@@ -263,8 +262,14 @@ class XRSTimeSeries(GenericTimeSeries):
             )
             times[idx] = Time(times[idx].isot.tolist()[0][0][:17] + "59.999").unix
             times = times.datetime
-        data = DataFrame({"xrsa": xrsa, "xrsb": xrsb, "xrsa_quality": xrsa_quality, "xrsb_quality": xrsb_quality}, index=times)
-        data = data.replace(-9999, np.nan)
+        data = TimeSeries(data={'xrsa': xrsa,
+                                'xrsb': xrsb,
+                                "xrsa_quality": xrsa_quality,
+                                "xrsb_quality": xrsb_quality},
+                          time=times)
+        data.sort(['time'])
+        xrsa[xrsa == -9999] = np.nan
+        xrsb[xrsb == -9999] = np.nan
         units = OrderedDict(
             [
                 ("xrsa", u.W/u.m**2),

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -5,10 +5,10 @@ import sys
 from collections import OrderedDict
 
 import matplotlib.pyplot as plt
-import pandas
 
 import astropy.units as u
 from astropy.time import TimeDelta
+from astropy.timeseries import TimeSeries
 
 import sunpy.io
 from sunpy import config
@@ -183,8 +183,8 @@ class LYRATimeSeries(GenericTimeSeries):
 
         # Return the header and the data
         times.precision = 9
-        data = pandas.DataFrame(table, index=times.isot.astype('datetime64'))
-        data.sort_index(inplace=True)
+        data = TimeSeries(data=table, time=times)
+        data.sort(['time'])
 
         # Add the units data
         units = OrderedDict([('CHANNEL1', u.W/u.m**2),

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -8,10 +8,12 @@ import numpy as np
 import pandas as pd
 
 import astropy.units as u
+from astropy.timeseries import TimeSeries
 
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
+from sunpy.time import parse_time
 
 __all__ = ['NOAAIndicesTimeSeries', 'NOAAPredictIndicesTimeSeries']
 
@@ -104,6 +106,7 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         axes.set_xlim(min(to_plot.dropna(how='all').index),
                       max(to_plot.dropna(how='all').index))
         axes.set_ylim(0)
+        axes.set_xlabel('')
         axes.set_ylabel(ylabel)
         axes.yaxis.grid(True, 'major')
         axes.xaxis.grid(True, 'major')
@@ -174,7 +177,9 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         # Convoluted time index handling
         data = data.set_index('time-tag')
         data.index = pd.DatetimeIndex(data.index.values)
-
+        times = parse_time([x for x in data.index.values])
+        data = {col: data[col] for col in data.columns}
+        ts = TimeSeries(data=data, time=times)
         # Add the units data, reported in radio flux values (sfu) originally.
         units = OrderedDict([('sunspot RI', u.dimensionless_unscaled),
                              ('sunspot RI smooth', u.dimensionless_unscaled),
@@ -182,7 +187,7 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
                              ('sunspot SWO smooth', u.dimensionless_unscaled),
                              ('radio flux', 1e-22*u.W/(u.m**2*u.Hertz)),
                              ('radio flux smooth', 1e-22*u.W/(u.m**2*u.Hertz))])
-        return data, MetaDict({'comments': ""}), units
+        return ts, MetaDict({'comments': ""}), units
 
     @classmethod
     def is_datasource_for(cls, **kwargs):
@@ -260,6 +265,7 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         dataframe['sunspot high'].plot(linestyle='--', color='b', **plot_args)
         dataframe['sunspot low'].plot(linestyle='--', color='b', **plot_args)
         axes.set_ylim(0)
+        axes.set_xlabel('')
         axes.set_ylabel('Sunspot Number')
         axes.yaxis.grid(True, 'major')
         axes.xaxis.grid(True, 'major')
@@ -309,6 +315,9 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         # Convoluted time index handling
         data = data.set_index('time-tag')
         data.index = pd.DatetimeIndex(data.index.values)
+        times = parse_time([x for x in data.index.values])
+        data = {col: data[col] for col in data.columns}
+        ts = TimeSeries(data=data, time=times)
         # Add the units data, reported in radio flux values (sfu) originally.
         units = OrderedDict([('sunspot', u.dimensionless_unscaled),
                              ('sunspot high', u.dimensionless_unscaled),
@@ -316,4 +325,4 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
                              ('radio flux', 1e-22*u.W/(u.m**2*u.Hertz)),
                              ('radio flux high', 1e-22*u.W/(u.m**2*u.Hertz)),
                              ('radio flux low', 1e-22*u.W/(u.m**2*u.Hertz))])
-        return data, MetaDict({'comments': ""}), units
+        return ts, MetaDict({'comments': ""}), units

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -6,10 +6,10 @@ from collections import OrderedDict
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas
 
 import astropy.units as u
 from astropy.time import TimeDelta
+from astropy.timeseries import TimeSeries
 
 import sunpy.io
 from sunpy import config
@@ -158,8 +158,8 @@ class NoRHTimeSeries(GenericTimeSeries):
         # Add the units data
         units = OrderedDict([('Correlation Coefficient', u.dimensionless_unscaled)])
         # Todo: check units used.
-        return pandas.DataFrame(
-            data, index=norh_time, columns=('Correlation Coefficient', )), header, units
+        data = {'Correlation Coefficient': data}
+        return TimeSeries(data=data, time=norh_time), header, units
 
     @classmethod
     def is_datasource_for(cls, **kwargs):

--- a/sunpy/timeseries/sources/tests/test_goes.py
+++ b/sunpy/timeseries/sources/tests/test_goes.py
@@ -73,15 +73,15 @@ def test_new_goes16():
 
 
 def test_goes_netcdf_time_parsing15():
-    # testing to make sure the time is correctly parsed (to ignore leap seconds)
+    # testing to make sure the time is correctly parsed
     ts_goes = sunpy.timeseries.TimeSeries(new_goes15_filepath, source="XRS")
-    assert ts_goes.time[0].strftime("%Y-%m-%d %H:%M:%S.%f") == '2013-10-28 00:00:01.385'
+    assert ts_goes.time[0].isot == '2013-10-28T00:00:01.385'
 
 
 def test_goes_netcdf_time_parsing17():
-    # testing to make sure the time is correctly parsed (to ignore leap seconds)
+    # testing to make sure the time is correctly parsed
     ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath, source="XRS")
-    assert ts_goes.time[0].strftime("%Y-%m-%d %H:%M:%S.%f") == '2020-10-16 00:00:00.477'
+    assert ts_goes.time[0].isot == '2020-10-16T00:00:00.477'
 
 
 @pytest.mark.remote_data

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -288,7 +288,9 @@ def test_generic_construction_ts_list():
     assert ts_list == ts_list2
 
 
-def test_generic_construction_concatenation():
+@pytest.mark.filterwarnings('ignore:Using pandas to concatenate two TimeSeries is deprecated')
+@pytest.mark.parametrize('method', ['pandas', 'astropy'])
+def test_generic_construction_concatenation(method):
     # Generate the data and the corrisponding dates
     base = parse_time(datetime.datetime.today())
     times = base - TimeDelta(np.arange(24 * 60)*u.minute)
@@ -306,7 +308,7 @@ def test_generic_construction_concatenation():
     # Create TS individually
     ts_1 = sunpy.timeseries.TimeSeries(data, meta, units)
     ts_2 = sunpy.timeseries.TimeSeries(data2, meta2, units2)
-    ts_concat_1 = ts_1.concatenate(ts_2)
+    ts_concat_1 = ts_1.concatenate(ts_2, method=method)
 
     # Concatinate during construction
     ts_concat_2 = sunpy.timeseries.TimeSeries(

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -12,6 +12,7 @@ import astropy.units as u
 from astropy.table import Table
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time, TimeDelta
+from astropy.timeseries import TimeSeries as AstroTimeSeries
 
 import sunpy
 import sunpy.timeseries
@@ -22,6 +23,19 @@ from sunpy.util import SunpyDeprecationWarning, SunpyUserWarning
 from sunpy.util.metadata import MetaDict
 
 # Test fixtures are in ../conftest.py
+
+
+def test_from_dataframe_warns(data_meta_units):
+    data, meta, units = data_meta_units
+    msg = 'Passing a DataFrame to GenericTimeSeries is deprecated'
+    with pytest.warns(SunpyDeprecationWarning, match=msg):
+        sunpy.timeseries.GenericTimeSeries(data, meta, units)
+
+
+def test_leapsecond_times():
+    t = Time(['2015-06-30 23:59:60.891082'])
+    ts = AstroTimeSeries(data={'a': [1]*u.s}, time=t)
+    sunpy.timeseries.GenericTimeSeries(ts)
 
 
 def test_units_type(many_ts):
@@ -443,7 +457,7 @@ def test_add_column_from_array_no_units(eve_test_ts, column_quantity):
 def test_ts_to_table(generic_ts):
     tbl = generic_ts.to_table()
     assert isinstance(tbl, Table)
-    assert tbl.keys() == ['date', *generic_ts.columns]
+    assert tbl.keys() == ['time', *generic_ts.columns]
     assert len(tbl) == len(generic_ts.to_dataframe())
     assert (tbl[generic_ts.columns[0]].quantity ==
             generic_ts.quantity(generic_ts.columns[0])).all()

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -618,6 +618,20 @@ def test_timeseries_array():
         assert isinstance(ts, sunpy.timeseries.GenericTimeSeries)
 
 
+def test_timeseries_deprecations(generic_ts):
+    with pytest.warns(SunpyDeprecationWarning, match='Using .data is deprecated'):
+        assert np.all(generic_ts.to_dataframe() == generic_ts.data)
+
+
+def test_concatenate_errors(generic_ts, eve_test_ts):
+    with pytest.raises(
+            ValueError, match=r".*using method='astropy' does not support any extra keyword arguments"):
+        generic_ts.concatenate(eve_test_ts, method='astropy', kwarg='kwarg')
+
+    with pytest.raises(
+            ValueError, match="method argument must be one of"):
+        generic_ts.concatenate(eve_test_ts, method='not a method')
+
 # TODO:
 # _validate_units
 # _validate_meta

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -319,18 +319,13 @@ def test_concatenation_of_slices_list(eve_test_ts, concatenated_slices_test_list
 @pytest.fixture
 def different_data_concat(eve_test_ts, fermi_gbm_test_ts):
     # Take two different data sources and concatenate
-    return eve_test_ts.concatenate(fermi_gbm_test_ts, method='astropy')
+    with pytest.warns(SunpyDeprecationWarning, match='Using pandas to concatenate two TimeSeries is deprecated'):
+        return eve_test_ts.concatenate(fermi_gbm_test_ts, method='pandas')
 
 
 def test_concat_list(eve_test_ts, fermi_gbm_test_ts):
-    assert (eve_test_ts.concatenate(fermi_gbm_test_ts) ==
-            eve_test_ts.concatenate([fermi_gbm_test_ts]))
-
-@pytest.fixture
-def concatenation_different_data_test_list(eve_test_ts, fermi_gbm_test_ts):
-    # Take two different data sources, pass one as an iterable and concatenate
-    return eve_test_ts.concatenate([fermi_gbm_test_ts], method='astropy')
-
+    assert (eve_test_ts.concatenate(fermi_gbm_test_ts, method='astropy') ==
+            eve_test_ts.concatenate([fermi_gbm_test_ts], method='astropy'))
 
 def test_concatenation_of_different_data_ts(eve_test_ts, fermi_gbm_test_ts,
                                             different_data_concat):
@@ -357,40 +352,10 @@ def test_concatenation_of_different_data_ts(eve_test_ts, fermi_gbm_test_ts,
         comined_units)
 
     # Test data is the concatenation
-    comined_df = comined_df.sort_index()
-    assert_frame_equal(different_data_concat.to_dataframe(), comined_df)
-
-
-def test_concatenation_of_self(eve_test_ts):
-    assert_frame_equal(concatenation_different_data_test_ts.to_dataframe(), comined_df)
-
-
-def test_concatenation_of_different_data_list(eve_test_ts, fermi_gbm_test_ts,
-                                              concatenation_different_data_test_list):
-    # Same test_concatenation_of_different_data_ts except an iterable is passed to concatenate
-    value = True
-    for key in list(concatenation_different_data_test_list.meta.metadata[0][2]
-                    .keys()):
-        if concatenation_different_data_test_list.meta.metadata[0][2][
-                key] != fermi_gbm_test_ts.meta.metadata[0][2][key]:
-            value = False
-    for key in list(concatenation_different_data_test_list.meta.metadata[1][2]
-                    .keys()):
-        if concatenation_different_data_test_list.meta.metadata[1][2][
-                key] != eve_test_ts.meta.metadata[0][2][key]:
-            value = False
-    assert value
-
-    # Test units concatenation
-    comined_units = copy.deepcopy(eve_test_ts.units)
-    comined_units.update(fermi_gbm_test_ts.units)
-    assert dict(concatenation_different_data_test_list.units) == dict(
-        comined_units)
-
-    # Test data is the concatenation
     comined_df = pd.concat([eve_test_ts.to_dataframe(), fermi_gbm_test_ts.to_dataframe()],
                            sort=False)
-    assert_frame_equal(concatenation_different_data_test_list.to_dataframe(), comined_df)
+    comined_df = comined_df.sort_index()
+    assert_frame_equal(different_data_concat.to_dataframe(), comined_df)
 
 
 def test_concatenation_of_self_ts(eve_test_ts):

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -15,6 +15,7 @@ import astropy.io.fits
 import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
+from astropy.timeseries import TimeSeries as AstroTimeSeries
 
 import sunpy
 from sunpy.io.file_tools import UnrecognizedFileTypeError, detect_filetype, read_file
@@ -210,10 +211,6 @@ class TimeSeriesFactory(BasicRegistrationFactory):
 
         # Extract, convert and remove the index column from the input table
         index = table[index_name]
-        # Convert if the index is given as an astropy Time object
-        if isinstance(index, Time):
-            index = index.datetime
-        index = pd.to_datetime(index)
         table.remove_column(index_name)
 
         # Extract the column values from the table
@@ -223,9 +220,8 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             data[colname] = table[colname]
             units[colname] = table[colname].unit
 
-        # Create a dataframe with this and return
-        df = pd.DataFrame(data=data, index=index)
-        return df, MetaDict(table.meta), units
+        ts = AstroTimeSeries(data=data, time=Time(index))
+        return ts, MetaDict(table.meta), units
 
     def _parse_meta(self, meta):
         """
@@ -271,7 +267,10 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                     meta.update(new_meta)
                 elif isinstance(data, np.ndarray):
                     # We have a numpy ndarray. We assume the first column is a dt index
-                    data = pd.DataFrame(data=data[:, 1:], index=Time(data[:, 0]))
+                    data = AstroTimeSeries(data=data[:, 1:], time=Time(data[:, 0]))
+                elif isinstance(data, pd.DataFrame):
+                    data = AstroTimeSeries(data={col: data[col].values for col in data.columns},
+                                           time=data.index)
 
                 # The next two could be metadata or units
                 for _ in range(2):

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -433,7 +433,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
             # Merge all these timeseries into one.
             full_timeseries = new_timeseries.pop(0)
             for timeseries in new_timeseries:
-                full_timeseries = full_timeseries.concatenate(timeseries)
+                full_timeseries = full_timeseries.concatenate(timeseries, method='astropy')
 
             new_timeseries = [full_timeseries]
 

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -136,7 +136,7 @@ class GenericTimeSeries:
         warn_deprecated("Using .data is deprecated. "
                         "Use .to_dataframe() to get a pandas DataFrame or "
                         ".to_table() to get an astropy Table instead.")
-        return self._data
+        return self.to_dataframe()
 
     @data.setter
     def data(self, d):
@@ -694,7 +694,7 @@ class GenericTimeSeries:
             data = TimeSeries.from_pandas(data)
         elif method == 'astropy':
             if len(kwargs):
-                raise ValueError("Concatenating using method='astropy' does not support"
+                raise ValueError("Concatenating using method='astropy' does not support "
                                  "any extra keyword arguments.")
             data = vstack([self._data, *list(ts._data for ts in others)])
             if sort:

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -131,10 +131,11 @@ class GenericTimeSeries:
     @property
     def data(self):
         """
-        A `pandas.DataFrame` representing one or more fields as a function of time.
+        Deprecated.
         """
-        warn_user("Using .data to access the dataframe is discouraged; "
-                  "use .to_dataframe() instead.")
+        warn_deprecated("Using .data is deprecated. "
+                        "Use .to_dataframe() to get a pandas DataFrame or "
+                        ".to_table() to get an astropy Table instead.")
         return self._data
 
     @data.setter


### PR DESCRIPTION
This PR is the minimal set of changes to use astropy TimeSeries instead of pandas DataFRame under the hood of our `GenericTimeSeries`. For ease of review there are a few PRs I plan to build on top of this, but I will open them later. This PR should not change any user-facing functionality.

See https://github.com/sunpy/sunpy/issues/3954 for the discussion/decision to do this.

These changes are tested by all the existing `TimeSeries` tests, and I have added a couple of extra ones for a new deprecation warning and leapseconds.

Fixes https://github.com/sunpy/sunpy/issues/5422
Fixes https://github.com/sunpy/sunpy/issues/4622
Fixes https://github.com/sunpy/sunpy/issues/3954

TODO:
- [ ] Fix `to_array()` to not go via. pandas