### PR TITLE
Raise exception if download errors during database fetch

### DIFF
--- a/changelog/5835.bugfix.rst
+++ b/changelog/5835.bugfix.rst
@@ -1,0 +1,2 @@
+In the case where `sunpy.database.Database.fetch()` successfully downloads only some of the search results, a `~sunpy.database.PartialFetchError` is raised. This fixes a bug where the successful downloads would have been added to the database, but sometimes with incorrect metadata.
+

--- a/changelog/5835.bugfix.rst
+++ b/changelog/5835.bugfix.rst
@@ -1,2 +1,1 @@
 In the case where `sunpy.database.Database.fetch()` successfully downloads only some of the search results, a `~sunpy.database.PartialFetchError` is raised. This fixes a bug where the successful downloads would have been added to the database, but sometimes with incorrect metadata.
-

--- a/sunpy/database/__init__.py
+++ b/sunpy/database/__init__.py
@@ -11,6 +11,7 @@ from sunpy.database.database import (
     EntryNotFoundError,
     NoSuchTagError,
     TagAlreadyAssignedError,
+    PartialFetchError,
     disable_undo,
     split_database,
 )
@@ -19,4 +20,4 @@ __all__ = [
     'Database', 'EntryAlreadyAddedError', 'NoSuchEntryError', 'NoSuchTagError',
     'NonRemovableTagError', 'EntryAlreadyStarredError',
     'EntryAlreadyUnstarredError', 'EntryNotFoundError',
-    'TagAlreadyAssignedError', 'disable_undo', 'split_database']
+    'TagAlreadyAssignedError', 'PartialFetchError', 'disable_undo', 'split_database']

--- a/sunpy/database/__init__.py
+++ b/sunpy/database/__init__.py
@@ -10,8 +10,8 @@ from sunpy.database.database import (
     EntryAlreadyUnstarredError,
     EntryNotFoundError,
     NoSuchTagError,
-    TagAlreadyAssignedError,
     PartialFetchError,
+    TagAlreadyAssignedError,
     disable_undo,
     split_database,
 )

--- a/sunpy/database/database.py
+++ b/sunpy/database/database.py
@@ -122,18 +122,18 @@ class TagAlreadyAssignedError(Exception):
 
 
 class PartialFetchError(Exception):
-    """This exception is raised if the number of files returned by the
+    """
+    This exception is raised if the number of files returned by the
     downloader does not match the number expected.
-
     """
 
-    def __init__(self, paths, expected):
+    def __init__(self, paths, n_expected):
         self.paths = paths
-        self.expected = int(expected)
+        self.n_expected = int(n_expected)
 
     def __str__(self):
         return (f"The downloader returned {len(self.paths)} file(s) "
-                f"but {self.expected} file(s) were expected.\n"
+                f"but {self.n_expected} file(s) were expected.\n"
                 f"Successful downloads: {self.paths}\n"
                 f"Errors: {self.paths.errors}")
 


### PR DESCRIPTION
If there are download errors during a database fetch, metadata for expected downloads may not matched to downloaded files correctly. (Due to `zip()` with unequal lengths.) I can't see a good way to handle this, so raising an exception is probably the best approach.

Fixes #5826

A better fix would be for the `parfive.Results` object to include errors in the list rather than just the `errors` attribute, however this would probably cause problems elsewhere.

## Code to reproduce error
Notice how the first time it's run it gives (NSO, JSOC, JSOC). When it's run for a second time the NSO file, which was already downloaded via FTP, fails (possibly due to a bug in parfive). (I was planning to force it to fail by editing my `/etc/hosts` so this was handy 😆 ) However, it returns (NSO, NSO) instead of (JSOC, JSOC), as the first expected result was the NSO file but the first (and only) element of `paths` is the JSOC file. This PR will just raise a new `PartialFetchError` exception in such a case.

```python
from sunpy.database import Database
from sunpy.net import attrs

db = Database('sqlite:///', default_waveunit='Angstrom')

download_query = [
    attrs.Time('2012-08-05', '2012-08-05 00:01:05'),
    attrs.Instrument('HMI'),
    attrs.Physobs.los_magnetic_field
]

# This returns: (provider, url)
# NSO, ftp://solis.nso.edu/HMI/x73/201208/x9x73120805/x9x73120805t000000_map-err_dim-180_source-SDO-HMI_type-m-720s.fits.gz
# JSOC, http://netdrms01.nispdc.nso.edu/cgi-bin/netdrms/drms_export.cgi?series=hmi__M_45s;compress=rice;record=13739522-13739522

db.fetch(*download_query, path=".")

for entry in db:
    print(entry.provider, entry.path)

print(db)
```
