### PR TITLE
Stagger daily scheduled builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,11 +11,21 @@ schedules:
          #   \ \ \________ Days
          #    \ \__________Hours
          #     \__________ Minutes
-    displayName: Daily 9am UTC build
+    displayName: Daily main build
     branches:
       include:
       - main
+    always: true
+  - cron: "15 9 * * *"
+    displayName: Daily 3.0 build
+    branches:
+      include:
       - 3.0
+    always: true
+  - cron: "30 9 * * *"
+    displayName: Daily 3.1 build
+    branches:
+      include:
       - 3.1
     always: true
 
@@ -54,7 +64,7 @@ stages:
         submodules: false
         coverage: codecov
         toxdeps: tox-pypi-filter
-        posargs: -n=4
+        posargs: -n auto --dist loadgroup
         libraries:
           apt:
             - libopenjp2-7


### PR DESCRIPTION
As discussed in #5827, stagger the daily scheduled builds to reduce the chance of download errors. I set main at 09:00, 3.0 at 09:15 and 3.1 at 09:30. That should be enough to ensure the online tests are far enough apart.