### PR TITLE
Remove GenericTimeSeries_sanitize_units()

### DIFF
--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -439,10 +439,6 @@ class TimeSeriesFactory(BasicRegistrationFactory):
 
             new_timeseries = [full_timeseries]
 
-        # Sanitize any units OrderedDict details
-        for timeseries in new_timeseries:
-            timeseries._sanitize_units()
-
         # Only return single time series, not in a list if we only have one.
         if len(new_timeseries) == 1:
             return new_timeseries[0]


### PR DESCRIPTION
This is some refactoring ahead of https://github.com/sunpy/sunpy/pull/5834.

`_sanitize_units()` is a bit of a blunt instrument to use, when it's easy enough to manually update the units when they need to be. As such, inline each time the units need to be updated as appropriate, and remove `_sanitize_units` altogether.