### PR TITLE
Make codecov report on failing CI

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -4,3 +4,8 @@ coverage:
     project:
       default:
         threshold: 0.2%
+
+codecov:
+  require_ci_to_pass: false
+  notify:
+    wait_for_ci: true


### PR DESCRIPTION
This will let codecov report if a CI run fails, which can be helpful for checking coverage even if an unreleated remote data test fails.