### PR TITLE
fixing Sun orientation in example: `Plotting a Map without any Axes`

### DIFF
--- a/examples/map/plot_frameless_image.py
+++ b/examples/map/plot_frameless_image.py
@@ -32,8 +32,10 @@ norm = smap.plot_settings['norm']
 norm.vmin, norm.vmax = np.percentile(smap.data, [1, 99.9])
 ax.imshow(smap.data,
           norm=norm,
-          cmap=smap.plot_settings['cmap'], 
+          cmap=smap.plot_settings['cmap'],
           origin="lower")
+
+# sphinx_gallery_defer_figures
 
 ##############################################################################
 # At this point you could save the figure with ``plt.savefig()`` or show it:

--- a/examples/map/plot_frameless_image.py
+++ b/examples/map/plot_frameless_image.py
@@ -13,7 +13,7 @@ import sunpy.map
 from sunpy.data.sample import AIA_171_IMAGE
 
 ##############################################################################
-# Create a `sunpy.map.GenericMap`.
+# Create a sunpy map from the sample data.
 
 smap = sunpy.map.Map(AIA_171_IMAGE)
 
@@ -32,7 +32,8 @@ norm = smap.plot_settings['norm']
 norm.vmin, norm.vmax = np.percentile(smap.data, [1, 99.9])
 ax.imshow(smap.data,
           norm=norm,
-          cmap=smap.plot_settings['cmap'])
+          cmap=smap.plot_settings['cmap'], 
+          origin="lower")
 
 ##############################################################################
 # At this point you could save the figure with ``plt.savefig()`` or show it:


### PR DESCRIPTION
### Description

I was just looking through the examples are noticed that the Sun is plotted upside down  [here](https://docs.sunpy.org/en/stable/generated/gallery/map/plot_frameless_image.html#sphx-glr-generated-gallery-map-plot-frameless-image-py)  `plt.imshow` is used, without the `origin="lower"` keyword. 

This PR fixes this. 

However - is there a reason this is plotted with `plt.imshow` and not just `smap.plot`? I feel like it would be easier like?


```python
figure = plt.figure(frameon=False)
ax = figure.add_subplot(projection=smap)
# Disable the axis
ax.set_axis_off()
smap.plot(clip_interval=[1, 99.9]*u.percent, axes=ax, title='')
```
