### PR TITLE
Use map arithmetic in difference image example

### DIFF
--- a/examples/acquiring_data/downloading_cutouts.py
+++ b/examples/acquiring_data/downloading_cutouts.py
@@ -107,5 +107,5 @@ m_seq = sunpy.map.Map(files, sequence=True)
 for m in m_seq:
     m.plot_settings['norm'] = ImageNormalize(vmin=0, vmax=5e3, stretch=SqrtStretch())
 plt.figure()
-m_seq.plot()
+ani = m_seq.plot()
 plt.show()

--- a/examples/map/difference_images.py
+++ b/examples/map/difference_images.py
@@ -3,10 +3,7 @@
 Plotting a difference image
 ===========================
 
-How to compute and plot a difference image.
-The example uses `sunpy.map.MapSequence` to compute a difference image and then plot it.
-This basic method works for base difference or running difference. Just change whether
-you're subtracting the previous image or the first image in a sequence.
+This example shows how to compute and plot a difference image.
 """
 # sphinx_gallery_thumbnail_number = 2
 import matplotlib.colors as colors
@@ -18,41 +15,69 @@ import sunpy.data.sample
 import sunpy.map
 
 ###########################################################################
-# First load a couple of images taken from the sample dataset. These are
-# two cutouts taken during a flare.
-maps = sunpy.map.Map([sunpy.data.sample.AIA_193_CUTOUT03_IMAGE,
-                      sunpy.data.sample.AIA_193_CUTOUT04_IMAGE],
-                     sequence=True)
+# When analyzing solar imaging data, particularly for flares, it is often
+# useful to look at the difference from one time step to the next (running
+# difference) or the difference from the start of the sequence (base
+# difference). In this example, we'll use a sequence of AIA 193 cutout
+# images taken during a flare.
+#
+# First, load a series of images into a `~sunpy.map.MapSequence`.
+
+m_seq = sunpy.map.Map([
+    sunpy.data.sample.AIA_193_CUTOUT01_IMAGE,
+    sunpy.data.sample.AIA_193_CUTOUT02_IMAGE,
+    sunpy.data.sample.AIA_193_CUTOUT03_IMAGE,
+    sunpy.data.sample.AIA_193_CUTOUT04_IMAGE,
+    sunpy.data.sample.AIA_193_CUTOUT05_IMAGE,
+], sequence=True)
 
 ###########################################################################
-# Now we'll do a standard plot of the second image just to see it.
+# Let's take a look at each image in the sequence. Note that these images
+# are sampled at a 6.4 minute cadence, much lower than the actual 12 s
+# AIA cadence.
 
-plt.figure()
-ax = plt.subplot(projection=maps[1])
-maps[1].plot(clip_interval=(0.5, 99.9)*u.percent)
+fig = plt.figure(figsize=(12, 3))
+for i, m in enumerate(m_seq):
+    ax = fig.add_subplot(1, 5, i+1, projection=m)
+    delta_t = (m.date - m_seq[0].date).to('minute')
+    m.plot(axes=ax, clip_interval=(0.5, 99.9)*u.percent,
+           title=f'{delta_t:.2f}')
+    ax.coords[0].set_axislabel('Solar-X' if i == 0 else ' ')
+    ax.coords[0].set_ticklabel_visible(i == 0)
+    ax.coords[1].set_axislabel('Solar-Y' if i == 0 else ' ')
+    ax.coords[1].set_ticklabel_visible(i == 0)
+plt.show()
 
 ###########################################################################
-# And now we can do take the actual difference.
-
-diff = maps[1].data - maps[0].data
-
-###########################################################################
+# And now we can take the actual difference. We will compute the running
+# difference and the base difference for the last image in the sequence.
+#
 # But we have to decide what to do with the metadata. For example, what
 # time does this difference image correspond to? The time of the first or
 # second image? The mean time? You'll have to decide what makes most sense
-# for your application. Here we'll just use the metadata from the second
-# image. Then we can store the difference and header back in a Map.
+# for your application. Here, by subtracting the data of the first (and
+# second to last) data array from the last map in the sequence, the resulting
+# difference map has the same metadata as the last map in the sequence.
 
-meta = maps[1].meta
-diff_map = sunpy.map.Map(diff, meta)
+m_diff_base = m_seq[-1] - m_seq[0].quantity
+m_diff_running = m_seq[-1] - m_seq[-2].quantity
 
 ###########################################################################
-# Finally, we'll plot it. We'll apply a colormap and re-normalize the
-# intensity so that it shows up well.
+# Finally, let's plot the difference maps.
+# We'll apply a colormap and re-normalize the intensity so that it shows
+# up well.
+# First, we show the base difference map.
+
+norm = colors.Normalize(vmin=-200, vmax=200)
+plt.figure()
+m_diff_base.plot(cmap='Greys_r', norm=norm, title='Base Difference')
+plt.colorbar(extend='both', label=m_diff_base.unit.to_string())
+plt.show()
+
+###########################################################################
+# Then, we show the running difference map.
 
 plt.figure()
-plt.subplot(projection=diff_map)
-diff_map.plot(cmap='Greys_r',
-              norm=colors.Normalize(vmin=-200, vmax=200))
-plt.colorbar(extend='both', label=maps[1].unit.to_string())
+m_diff_running.plot(cmap='Greys_r', norm=norm, title='Running Difference')
+plt.colorbar(extend='both', label=m_diff_running.unit.to_string())
 plt.show()

--- a/examples/map/difference_images.py
+++ b/examples/map/difference_images.py
@@ -60,6 +60,8 @@ plt.show()
 # Note that, because arithmetic operations between `~sunpy.map.GenericMap`
 # objects are not supported, we subtract just the array data (with units
 # attached) of the second map from the first map. The ``quantity`` attribute
+# returns the image data as an `~astropy.units.Quantity`, where the resulting
+# units are those returned by the ``unit`` attribute of the map.
 
 m_seq_base = sunpy.map.Map([m - m_seq[0].quantity for m in m_seq], sequence=True)
 m_seq_running = sunpy.map.Map(

--- a/examples/map/difference_images.py
+++ b/examples/map/difference_images.py
@@ -64,10 +64,7 @@ plt.show()
 # units are those returned by the ``unit`` attribute of the map.
 
 m_seq_base = sunpy.map.Map([m - m_seq[0].quantity for m in m_seq], sequence=True)
-m_seq_running = sunpy.map.Map(
-    [m_seq[i] - m_seq[i-1 if i > 0 else 0].quantity for i in range(len(m_seq))],
-    sequence=True
-)
+m_seq_running = sunpy.map.Map([map - prev_map.quantity for map, prev_map in zip(m_seq[:-1], m_seq[1:])], sequence=True)
 
 ###########################################################################
 # Finally, let's plot the difference maps.

--- a/examples/map/difference_images.py
+++ b/examples/map/difference_images.py
@@ -63,8 +63,11 @@ plt.show()
 # returns the image data as an `~astropy.units.Quantity`, where the resulting
 # units are those returned by the ``unit`` attribute of the map.
 
-m_seq_base = sunpy.map.Map([m - m_seq[0].quantity for m in m_seq], sequence=True)
-m_seq_running = sunpy.map.Map([map - prev_map.quantity for map, prev_map in zip(m_seq[:-1], m_seq[1:])], sequence=True)
+m_seq_base = sunpy.map.Map([m - m_seq[0].quantity for m in m_seq[1:]], sequence=True)
+m_seq_running = sunpy.map.Map(
+    [m - prev_m.quantity for m, prev_m in zip(m_seq[1:], m_seq[:-1])],
+    sequence=True
+)
 
 ###########################################################################
 # Finally, let's plot the difference maps.


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

This PR updates the difference map example to use the recent arithmetic capabilities of map and also adds an example of the running and base difference.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [ ] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [ ] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [ ] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
