### PR TITLE
Add simple GitHub actions script

### DIFF
--- a/.github/workflows/python-test-workflow.yml
+++ b/.github/workflows/python-test-workflow.yml
@@ -1,0 +1,30 @@
+name: Python test workflow
+
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+      tox-env:
+        required: true
+        type: string
+
+jobs:
+  linux-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Install system dependencies
+      run: |
+        sudo apt-get install -y libopenjp2-7 graphviz
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-pypi-filter
+    - name: Run tests
+      run: |
+        tox -e ${{ inputs.tox-env }} -- -n auto --dist loadgroup

--- a/.github/workflows/python-test-workflow.yml
+++ b/.github/workflows/python-test-workflow.yml
@@ -34,3 +34,5 @@ jobs:
     - name: Run tests
       run: |
         tox -e ${{ inputs.tox-env }} -- -n auto --dist loadgroup
+    - name: Upload test coverage to Codecov
+      uses: codecov/codecov-action@v2

--- a/.github/workflows/python-test-workflow.yml
+++ b/.github/workflows/python-test-workflow.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 jobs:
-  linux-tests:
+  python-tests:
     runs-on: ${{ inputs.os }}
     steps:
     - uses: actions/checkout@v2
@@ -23,9 +23,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ inputs.python-version }}
-    - name: Install system dependencies
+    - name: Install linux dependencies
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y libopenjp2-7 graphviz
+    - name: Install tox
+      run: |
         python -m pip install --upgrade pip
         python -m pip install tox tox-pypi-filter
     - name: Run tests

--- a/.github/workflows/python-test-workflow.yml
+++ b/.github/workflows/python-test-workflow.yml
@@ -4,6 +4,9 @@ name: Python test workflow
 on:
   workflow_call:
     inputs:
+      os:
+        required: true
+        type: string
       python-version:
         required: true
         type: string
@@ -13,7 +16,7 @@ on:
 
 jobs:
   linux-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ inputs.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,32 +7,32 @@ on:
     branches: [ main ]
 
 jobs:
-  linux-tests:
-    uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
+  linux-py39:
+    uses: ./.github/workflows/python-test-workflow.yml
     with:
       os: ubuntu-latest
       python-version: '3.9'
       tox-env: py39
 
-  macosx-tests:
-    uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
-    needs: linux-tests
+  macosx-py38:
+    uses: ./.github/workflows/python-test-workflow.yml
+    needs: linux-py39
     with:
       os: macos-latest
       python-version: '3.8'
       tox-env: py38
 
-  windows-tests:
-    uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
-    needs: linux-tests
+  windows-py310:
+    uses: ./.github/workflows/python-test-workflow.yml
+    needs: linux-py39
     with:
       os: windows-latest
       python-version: '3.10'
       tox-env: py310
 
-  remote-tests:
-    needs: linux-tests
-    uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
+  linux-remote-py38:
+    needs: linux-py39
+    uses: ./.github/workflows/python-test-workflow.yml
     with:
       os: ubuntu-latest
       python-version: '3.8'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
 
   macosx-tests:
     uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
+    needs: linux-tests
     with:
       os: macos-latest
       python-version: '3.8'
@@ -23,6 +24,7 @@ jobs:
 
   windows-tests:
     uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
+    needs: linux-tests
     with:
       os: windows-latest
       python-version: '3.10'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,3 +12,10 @@ jobs:
     with:
       python-version: '3.9'
       tox-env: py39
+
+  remote-tests:
+    needs: core-tests
+    uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
+    with:
+      python-version: '3.8'
+      tox-env: py38-online

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,15 +7,29 @@ on:
     branches: [ main ]
 
 jobs:
-  core-tests:
+  linux-tests:
     uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
     with:
       os: ubuntu-latest
       python-version: '3.9'
       tox-env: py39
 
+  macosx-tests:
+    uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
+    with:
+      os: macos-latest
+      python-version: '3.8'
+      tox-env: py38
+
+  windows-tests:
+    uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
+    with:
+      os: windows-latest
+      python-version: '3.10'
+      tox-env: py310
+
   remote-tests:
-    needs: core-tests
+    needs: linux-tests
     uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
     with:
       os: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,26 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - python-version: '3.9'
-            tox-env: py39
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install system dependencies
-      run: |
-        sudo apt-get install -y libopenjp2-7 graphviz
-        python -m pip install --upgrade pip
-        python -m pip install tox tox-pypi-filter
-    - name: Run tests
-      run: |
-        tox -e ${{ matrix.tox-env }} -- -n auto --dist loadgroup
+  core-tests:
+    uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
+    with:
+      python-version: '3.9'
+      tox-env: py39

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
   core-tests:
     uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
     with:
+      os: ubuntu-latest
       python-version: '3.9'
       tox-env: py39
 
@@ -17,5 +18,6 @@ jobs:
     needs: core-tests
     uses: dstansby/sunpy/.github/workflows/python-test-workflow.yml@gh-actions
     with:
+      os: ubuntu-latest
       python-version: '3.8'
       tox-env: py38-online

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Automated tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - python-version: '3.9'
+            tox-env: py39
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install system dependencies
+      run: |
+        sudo apt-get install -y libopenjp2-7 graphviz
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-pypi-filter
+    - name: Run tests
+      run: |
+        tox -e ${{ matrix.tox-env }} -- -n auto --dist loadgroup


### PR DESCRIPTION
This provides a very small bit of redundnacy against having all our tests on Azure, and a platform upon which someone can always extend if we want to port more/all of the CI to GH actions in the future.