### PR TITLE
Updates HMIMap to check INSTRUME instead of TELESCOP

### DIFF
--- a/changelog/5886.bugfix.rst
+++ b/changelog/5886.bugfix.rst
@@ -1,0 +1,1 @@
+`HMIMap` now looks for ``'INSTRUME`` instead of ``'TELESCOP'`` in order to support Helioviewer JPEG2000 versions of HMI data which do not preserve the ``'TELESCOP'`` keyword as expected in the JSOC standard.

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -131,7 +131,7 @@ class HMIMap(GenericMap):
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an HMI image"""
-        return (str(header.get('TELESCOP', '')).endswith('HMI') and
+        return (str(header.get('INSTRUME', '')).startswith('HMI') and
                 not HMISynopticMap.is_datasource_for(data, header))
 
 


### PR DESCRIPTION
## PR Description
Updates how HMIMap is selected when using the map factory.
Fixes #5883

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [x] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
