### PR TITLE
Allow for passing `cmap` and `norm` to `MapSequence.plot`

### DIFF
--- a/changelog/5889.bugfix.rst
+++ b/changelog/5889.bugfix.rst
@@ -1,0 +1,2 @@
+Fixes a bug where the ``cmap`` and ``norm`` keyword arguments were ignored when calling
+`~sunpy.map.MapSequence.plot`.

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -350,9 +350,9 @@ class MapSequence:
                 removes.pop(0).remove()
 
             im.set_array(ani_data[i].data)
-            im.set_cmap(ani_data[i].plot_settings['cmap'])
+            im.set_cmap(kwargs.get('cmap', ani_data[i].plot_settings['cmap']))
 
-            norm = deepcopy(ani_data[i].plot_settings['norm'])
+            norm = deepcopy(kwargs.get('norm', ani_data[i].plot_settings['norm']))
             # The following explicit call is for bugged versions of Astropy's
             # ImageNormalize
             norm.autoscale_None(ani_data[i].data)

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -8,6 +8,7 @@ import pytest
 
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.visualization import ImageNormalize
 
 import sunpy
 import sunpy.data.test
@@ -197,6 +198,12 @@ def test_norm_animator(hmi_test_map):
 def test_map_sequence_plot(aia171_test_map, hmi_test_map):
     seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
     seq.plot()
+
+
+@figure_test
+def test_map_sequence_plot_custom_cmap_norm(aia171_test_map, hmi_test_map):
+    seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
+    seq.plot(cmap='Greys', norm=ImageNormalize(vmin=0, vmax=100))
 
 
 def test_save(aia171_test_map, hmi_test_map, tmp_path):

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -203,7 +203,9 @@ def test_map_sequence_plot(aia171_test_map, hmi_test_map):
 @figure_test
 def test_map_sequence_plot_custom_cmap_norm(aia171_test_map, hmi_test_map):
     seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
-    seq.plot(cmap='Greys', norm=ImageNormalize(vmin=0, vmax=100))
+    animation = seq.plot(cmap='Greys', norm=ImageNormalize(vmin=0, vmax=100))
+    animation._step()
+    return animation
 
 
 def test_save(aia171_test_map, hmi_test_map, tmp_path):

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -205,7 +205,6 @@ def test_map_sequence_plot_custom_cmap_norm(aia171_test_map, hmi_test_map):
     seq = sunpy.map.Map([aia171_test_map, hmi_test_map], sequence=True)
     animation = seq.plot(cmap='Greys', norm=ImageNormalize(vmin=0, vmax=100))
     animation._step()
-    return animation
 
 
 def test_save(aia171_test_map, hmi_test_map, tmp_path):

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_421_animators_100.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_421_animators_100.json
@@ -9,7 +9,7 @@
   "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "3835ea8f163f8b843088524fb6f1ea7b1357ee00224bd9ea625c641d974f17b7",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "a400eef26fdd915ccf12769031bd8dadedbf8f6a93e31cd5982bffe2484702ee",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "15c8aee7d3a6ff3d39856dc37e02afa983e1ebc1582f810699defd14b3f6cec7",
-  "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "dc2e41cc8109e47445b5d24f0b2c59daaa886fead0d9076c23490708e9d7006b",
+  "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "7f115dedaf88653dff71f784b0d8173d66638e429f92239a7a6f7d6f10fd05f5",
   "sunpy.map.tests.test_plotting.test_plot_aia171": "15c8aee7d3a6ff3d39856dc37e02afa983e1ebc1582f810699defd14b3f6cec7",
   "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "dc20869be4f5d68ac01078412320b93060fcac86330126362627567e48f089ef",
   "sunpy.map.tests.test_plotting.test_plot_aia171_clip": "a99f0072685b693410bccee49f4733d312f1c397067fb85388ef5b14160b6497",

--- a/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_421_animators_100.json
+++ b/sunpy/tests/figure_hashes_mpl_332_ft_261_astropy_421_animators_100.json
@@ -9,6 +9,7 @@
   "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "3835ea8f163f8b843088524fb6f1ea7b1357ee00224bd9ea625c641d974f17b7",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "a400eef26fdd915ccf12769031bd8dadedbf8f6a93e31cd5982bffe2484702ee",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "15c8aee7d3a6ff3d39856dc37e02afa983e1ebc1582f810699defd14b3f6cec7",
+  "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "dc2e41cc8109e47445b5d24f0b2c59daaa886fead0d9076c23490708e9d7006b",
   "sunpy.map.tests.test_plotting.test_plot_aia171": "15c8aee7d3a6ff3d39856dc37e02afa983e1ebc1582f810699defd14b3f6cec7",
   "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "dc20869be4f5d68ac01078412320b93060fcac86330126362627567e48f089ef",
   "sunpy.map.tests.test_plotting.test_plot_aia171_clip": "a99f0072685b693410bccee49f4733d312f1c397067fb85388ef5b14160b6497",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
@@ -9,6 +9,7 @@
   "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "817ef0de8c17246fc4e728d55d119b08c803b6a6906d4b0923f3969eaab0177f",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "5a7217dd55ab3a593a27741fecfe0851208fd1d31baeca4cbd018d65aaf3f483",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "3cdc53f41914028a4e9f23112d7e616ce8a423ef5670c8365fdadbc0e59780ca",
+  "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "71cc49282fd5907bc93de741407b9631039df1c695b739466532a53121fa6e35",
   "sunpy.map.tests.test_plotting.test_plot_aia171": "3cdc53f41914028a4e9f23112d7e616ce8a423ef5670c8365fdadbc0e59780ca",
   "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "9df0409afa257ebe481aa5170321072ddca349fe596f3d662208e127f39a938e",
   "sunpy.map.tests.test_plotting.test_plot_aia171_clip": "920852d09b1b0af6ed406312e8e54ce2b327d38061a0652d95df03b41e1c552d",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
@@ -9,7 +9,7 @@
   "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "817ef0de8c17246fc4e728d55d119b08c803b6a6906d4b0923f3969eaab0177f",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "5a7217dd55ab3a593a27741fecfe0851208fd1d31baeca4cbd018d65aaf3f483",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "3cdc53f41914028a4e9f23112d7e616ce8a423ef5670c8365fdadbc0e59780ca",
-  "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "71cc49282fd5907bc93de741407b9631039df1c695b739466532a53121fa6e35",
+  "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "c1276702147f4debaa14c17f6b0b2ab7f9e0b1ace309c72e767b2af071c4405e",
   "sunpy.map.tests.test_plotting.test_plot_aia171": "3cdc53f41914028a4e9f23112d7e616ce8a423ef5670c8365fdadbc0e59780ca",
   "sunpy.map.tests.test_plotting.test_plot_rotated_aia171": "9df0409afa257ebe481aa5170321072ddca349fe596f3d662208e127f39a938e",
   "sunpy.map.tests.test_plotting.test_plot_aia171_clip": "920852d09b1b0af6ed406312e8e54ce2b327d38061a0652d95df03b41e1c552d",


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

Fixes #5884 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [x] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
