### PR TITLE
Fix `HMIMap` reference for `build_docs` CI

### DIFF
--- a/changelog/5886.bugfix.rst
+++ b/changelog/5886.bugfix.rst
@@ -1,1 +1,1 @@
-`HMIMap` now looks for ``'INSTRUME`` instead of ``'TELESCOP'`` in order to support Helioviewer JPEG2000 versions of HMI data which do not preserve the ``'TELESCOP'`` keyword as expected in the JSOC standard.
+`~sunpy.map.sources.HMIMap` now looks for ``'INSTRUME'`` instead of ``'TELESCOP'`` in order to support Helioviewer JPEG2000 versions of HMI data which do not preserve the ``'TELESCOP'`` keyword as expected in the JSOC standard.


### PR DESCRIPTION
## PR Description
Fixes the `build_docs` CI issue found at #5897 (https://github.com/sunpy/sunpy/runs/5279055197?check_suite_focus=true)

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [N/A] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
