### PR TITLE
Fix doctest for `get_observatory_groups`

### DIFF
--- a/sunpy/net/cdaweb/helpers.py
+++ b/sunpy/net/cdaweb/helpers.py
@@ -28,7 +28,7 @@ def get_observatory_groups():
     >>>
     >>> groups = get_observatory_groups() #doctest: +REMOTE_DATA
     >>> groups['Group'] #doctest: +REMOTE_DATA
-        <Column name='Group' dtype='str55' length=72>
+        <Column name='Group' dtype='str55' length=70>
                         ACE
                       AMPTE
         ...

--- a/sunpy/net/cdaweb/helpers.py
+++ b/sunpy/net/cdaweb/helpers.py
@@ -28,7 +28,7 @@ def get_observatory_groups():
     >>>
     >>> groups = get_observatory_groups() #doctest: +REMOTE_DATA
     >>> groups['Group'] #doctest: +REMOTE_DATA
-        <Column name='Group' dtype='str55' length=70>
+        <Column name='Group' dtype='str55' length=...>
                         ACE
                       AMPTE
         ...


### PR DESCRIPTION
## PR Description
`get_observatory_groups` now has 70 groups instead of 72. (See #5897 CI.)

This was recently changed from 75 to 72 in #5878 so maybe we should find a more permanent fix?
<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [ ] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [ ] Changes follow the coding style of this project
- [ ] Changes have been formatted and linted
- [ ] Changes pass pytest style unit tests (and `pytest` passes).
- [ ] Changes include any required corresponding changes to the documentation
- [ ] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] Changes have a descriptive commit message with a short title
- [ ] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
