### PR TITLE
Pin pytest in oldestdeps tests

### DIFF
--- a/.github/workflows/python-test-workflow.yml
+++ b/.github/workflows/python-test-workflow.yml
@@ -37,6 +37,6 @@ jobs:
     - name: Run tests
       if: startsWith(inputs.tox-env, 'py')
       run: |
-        tox -e ${{ inputs.tox-env }} -- -n auto --dist loadgroup
+        tox -e ${{ inputs.tox-env }} -- -n auto --dist loadfile
     - name: Upload test coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ net =
   tqdm>=4.32.1
   zeep>=3.4.0
 timeseries =
-  cdflib>=0.3.19
+  cdflib>=0.3.19,!=0.4.0
   h5netcdf>=0.8.1
   # While a not direct dependency
   # We need to raise this to ensure the goes netcdf files open.

--- a/setup.cfg
+++ b/setup.cfg
@@ -135,6 +135,8 @@ filterwarnings =
     # is being ignored
     #
     #
+    # Ignore this on our oldestdeps run that doesn't support the xdist_group marker
+    ignore:Unknown pytest.mark.xdist_group
     # Fixed in https://github.com/h5netcdf/h5netcdf/pull/121
     ignore:distutils Version classes are deprecated
     # This is due to dependencies building with a numpy version different from

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,11 +79,12 @@ visualization =
 tests =
   hypothesis>=6.0.0  # Included in pytest-astropy. 6.0 is the first version to support disabling function-scoped fixture warning
   jplephem  # For some coordinates tests
+  pytest>=5.4
   pytest-astropy>=0.8  # 0.8 is the first release to include filter-subpackage
   pytest-doctestplus>=0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
   pytest-mock
   pytest-mpl>=0.12 # First version to support our figure tests
-  pytest-xdist
+  pytest-xdist>=1.27
 docs =
   astroquery
   jplephem

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -101,7 +101,7 @@ def test_check_for_nonfinite_entries():
 
             assert len(warning_list) == 1
 
-            with pytest.warns() as warning_list:
+            with pytest.warns(Warning) as warning_list:
                 check_for_nonfinite_entries(b, b)
 
             assert len(warning_list) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,7 @@ extras =
     tests
 commands =
     pip freeze --all --no-input
+    oldestdeps: python -c "import astropy.time; astropy.time.update_leap_seconds()"
     !online-!hypothesis-!figure: {env:PYTEST_COMMAND} {posargs}
     online: {env:PYTEST_COMMAND} --hypothesis-show-statistics --reruns 2 --reruns-delay 15 --timeout=180 --remote-data=any {posargs}
     hypothesis: {env:PYTEST_COMMAND} --hypothesis-show-statistics --remote-data=any -m "hypothesis" {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,8 @@ deps =
     oldestdeps: zeep<3.5.0
     oldestdeps: h5netcdf<0.9
     oldestdeps: cdflib<0.3.20
+    oldestdeps: pytest<5.5
+    oldestdeps: pytest-xdist<1.28
     # These are specific extras we use to run in specific factors
     online: pytest-rerunfailures
     online: pytest-timeout


### PR DESCRIPTION
To help external packagers (e.g. Debian) we should also make sure we support older versions of pytest. I've pinned following our dependency support policy (24 months prior).

xref https://github.com/sunpy/sunpy/issues/5904