### PR TITLE
Catches missing 'UNITS' attribute while loading CDF files (and adds some _known_units)

### DIFF
--- a/sunpy/io/cdf.py
+++ b/sunpy/io/cdf.py
@@ -71,7 +71,7 @@ def read_cdf(fname):
 
             data = cdf.varget(var_key)
             # Get units
-            try:
+            if 'UNITS' in attrs:
                 unit_str = attrs['UNITS']
                 try:
                     unit = u.Unit(unit_str)
@@ -84,15 +84,10 @@ def read_cdf(fname):
                                   'If you think this unit should not be dimensionless, '
                                   'please raise an issue at https://github.com/sunpy/sunpy/issues')
                         unit = u.dimensionless_unscaled
-            except KeyError as keyerr:
-                if keyerr.args[0] == 'UNITS':
-                    warn_user(f'No units provided for variable "{var_key}". '
-                              'Assigning dimensionless units. '
-                              'If you think this variable should not be without units, '
-                              'please raise an issue at https://github.com/sunpy/sunpy/issues')
-                    unit = u.dimensionless_unscaled
-                else:
-                    raise
+            else:
+                warn_user(f'No units provided for variable "{var_key}". '
+                          'Assigning dimensionless units.')
+                unit = u.dimensionless_unscaled
 
             if data.ndim == 2:
                 # Multiple columns, give each column a unique label
@@ -180,13 +175,16 @@ _known_units = {'ratio': u.dimensionless_unscaled,
                 '#/(cm^2*s*sr*MeV/nuc)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
                 '#/(cm^2*s*sr*Mev/nuc)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
                 '#/(cm^2*s*sr*Mev/nucleon)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
+                '#/(cm2-steradian-second-MeV/nucleon) ': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
                 '1/(cm2 Sr sec MeV/nucleon)': 1 / (u.cm**2 * u.sr * u.s * u.MeV),
                 '1/(cm**2-s-sr-MeV)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
                 '1/(cm**2-s-sr-MeV/nuc.)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
                 '1/(cm^2 sec ster MeV)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
+                'cnts/sec/sr/cm^2/MeV': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
 
                 'particles / (s cm^2 sr MeV)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
                 'particles / (s cm^2 sr MeV/n)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
+                'particles/(s cm2 sr MeV/n)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
 
                 '1/(cm**2-s-sr)': 1 / (u.cm**2 * u.s * u.sr),
                 '1/(SQcm-ster-s)': 1 / (u.cm**2 * u.s * u.sr),
@@ -195,4 +193,5 @@ _known_units = {'ratio': u.dimensionless_unscaled,
                 'Counts/256sec': 1 / (256 * u.s),
                 'Counts/hour': 1 / u.hr,
                 'counts / s': 1/u.s,
+                'cnts/sec': 1/u.s,
                 }

--- a/sunpy/io/cdf.py
+++ b/sunpy/io/cdf.py
@@ -71,18 +71,29 @@ def read_cdf(fname):
 
             data = cdf.varget(var_key)
             # Get units
-            unit_str = attrs['UNITS']
             try:
-                unit = u.Unit(unit_str)
-            except ValueError:
-                if unit_str in _known_units:
-                    unit = _known_units[unit_str]
-                else:
-                    warn_user(f'astropy did not recognize units of "{unit_str}". '
+                unit_str = attrs['UNITS']
+                try:
+                    unit = u.Unit(unit_str)
+                except ValueError:
+                    if unit_str in _known_units:
+                        unit = _known_units[unit_str]
+                    else:
+                        warn_user(f'astropy did not recognize units of "{unit_str}". '
+                                  'Assigning dimensionless units. '
+                                  'If you think this unit should not be dimensionless, '
+                                  'please raise an issue at https://github.com/sunpy/sunpy/issues')
+                        unit = u.dimensionless_unscaled
+            except KeyError as keyerr:
+                if keyerr.args[0] == 'UNITS':
+                    warn_user(f'No units provided for variable "{var_key}". '
                               'Assigning dimensionless units. '
-                              'If you think this unit should not be dimensionless, '
+                              'If you think this variable should not be without units, '
                               'please raise an issue at https://github.com/sunpy/sunpy/issues')
                     unit = u.dimensionless_unscaled
+                    pass
+                else:
+                    raise
 
             if data.ndim == 2:
                 # Multiple columns, give each column a unique label
@@ -109,6 +120,8 @@ _known_units = {'ratio': u.dimensionless_unscaled,
                 'None': u.dimensionless_unscaled,
                 'none': u.dimensionless_unscaled,
                 ' none': u.dimensionless_unscaled,
+                'counts': u.dimensionless_unscaled,
+                'cnts': u.dimensionless_unscaled,
 
                 'microW m^-2': u.mW * u.m**-2,
 
@@ -165,6 +178,9 @@ _known_units = {'ratio': u.dimensionless_unscaled,
                 'milliseconds': u.ms,
 
                 '#/cm2-ster-eV-sec': 1 / (u.cm**2 * u.sr * u.eV * u.s),
+                '#/(cm^2*s*sr*MeV/nuc)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
+                '#/(cm^2*s*sr*Mev/nuc)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
+                '#/(cm^2*s*sr*Mev/nucleon)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
                 '1/(cm2 Sr sec MeV/nucleon)': 1 / (u.cm**2 * u.sr * u.s * u.MeV),
                 '1/(cm**2-s-sr-MeV)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),
                 '1/(cm**2-s-sr-MeV/nuc.)': 1 / (u.cm**2 * u.s * u.sr * u.MeV),

--- a/sunpy/io/cdf.py
+++ b/sunpy/io/cdf.py
@@ -91,7 +91,6 @@ def read_cdf(fname):
                               'If you think this variable should not be without units, '
                               'please raise an issue at https://github.com/sunpy/sunpy/issues')
                     unit = u.dimensionless_unscaled
-                    pass
                 else:
                     raise
 


### PR DESCRIPTION
## PR Description

`read_cdf()` from `sunpy.io.cdf` addresses the variable attribute `'UNITS'` without checking if it exists. But some CDF files (especially of older missions, e.g., STEREO/LET) don't follow the ISTP guide on CDF files, and don't provide `'UNITS'`. This PR fixes this problem by catching the resulting KeyError, assigning dimensionless units to the corresponding variables, and providing a SunpyUserWarning.

Fixes #5907

As a small addition, 5 variations of units for STEREO/LET CDF data files are added to the dictionary of `_known_units` used by `read_cdf()`. (Similar to #5853)

## Example

``` python
>>> import warnings
>>> from sunpy.net import Fido
>>> from sunpy.net import attrs as a
>>> from sunpy.io.cdf import read_cdf

>>> # omit Pandas' PerformanceWarning here because they originate somewhere else
>>> warnings.simplefilter(action='ignore', category=pd.errors.PerformanceWarning)

>>> trange = a.Time('2021/07/01', '2021/07/02')
>>> dataset = a.cdaweb.Dataset('STA_L1_LET')
>>> result = Fido.search(trange, dataset)
>>> downloaded_files = Fido.fetch(result)

>>> data = read_cdf(downloaded_files[0])
WARNING: SunpyUserWarning: No units provided for variable "CodeOK". Assigning dimensionless units. If you think this variable should not be without units, please raise an issue at https://github.com/sunpy/sunpy/issues [sunpy.io.cdf]
WARNING: SunpyUserWarning: No units provided for variable "DyThState". Assigning dimensionless units. If you think this variable should not be without units, please raise an issue at https://github.com/sunpy/sunpy/issues [sunpy.io.cdf]
WARNING: SunpyUserWarning: No units provided for variable "LeakConv". Assigning dimensionless units. If you think this variable should not be without units, please raise an issue at https://github.com/sunpy/sunpy/issues [sunpy.io.cdf]
WARNING: SunpyUserWarning: No units provided for variable "SWVersion". Assigning dimensionless units. If you think this variable should not be without units, please raise an issue at https://github.com/sunpy/sunpy/issues [sunpy.io.cdf]
>>> print(data)
[<sunpy.timeseries.timeseriesbase.GenericTimeSeries object at 0x7f45a75fc5b0>]
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [x] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
