### PR TITLE
Add GH actions oldestdeps workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,12 @@ jobs:
       os: ubuntu-latest
       python-version: '3.10'
       tox-env: py310
+  linux-py38-oldestdeps:
+    uses: ./.github/workflows/python-test-workflow.yml
+    with:
+      os: ubuntu-latest
+      python-version: '3.8'
+      tox-env: py38-oldestdeps
   linux-remote-py39:
     uses: ./.github/workflows/python-test-workflow.yml
     needs: linux-py310

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       tox-env: py310
   linux-py38-oldestdeps:
     uses: ./.github/workflows/python-test-workflow.yml
+    needs: linux-py310
     with:
       os: ubuntu-latest
       python-version: '3.8'


### PR DESCRIPTION
Putting this in a separate PR to #5906 so we can get it working before trying to pin pytest and pytest-xdist. Before merging we should make the new job run after the linux-py310 build.