### PR TITLE
Use python 3.9 for core tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,29 +22,31 @@ on:
     - cron: "37 3 * * *" # Every day at 3:37am UTC
 
 jobs:
-  linux-py310:
+  linux-py39:
     uses: ./.github/workflows/python-test-workflow.yml
     with:
       os: ubuntu-latest
-      python-version: '3.10'
-      tox-env: py310
+      # Advisable to use current python version - 1 here to minimise time spent
+      # building wheels for dependencies
+      python-version: '3.9'
+      tox-env: py39
   linux-py38-oldestdeps:
     uses: ./.github/workflows/python-test-workflow.yml
-    needs: linux-py310
+    needs: linux-py39
     with:
       os: ubuntu-latest
       python-version: '3.8'
       tox-env: py38-oldestdeps
   linux-remote-py39:
     uses: ./.github/workflows/python-test-workflow.yml
-    needs: linux-py310
+    needs: linux-py39
     with:
       os: ubuntu-latest
       python-version: '3.9'
       tox-env: py39-online
   linux-docs-py39:
     uses: ./.github/workflows/python-test-workflow.yml
-    needs: linux-py310
+    needs: linux-py39
     with:
       os: ubuntu-latest
       python-version: '3.9'

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ net =
   tqdm>=4.32.1
   zeep>=3.4.0
 timeseries =
-  cdflib>=0.3.19
+  cdflib>=0.3.19,!=0.4.0
   h5netcdf>=0.8.1
   # While a not direct dependency
   # We need to raise this to ensure the goes netcdf files open.


### PR DESCRIPTION
This is much faster (5mins vs. 15mins for py310), I presume due to some dependencies that don't yet have binaries for python 3.10.