### PR TITLE
Add method argument to rotate and affine_transform

### DIFF
--- a/changelog/5916.feature.rst
+++ b/changelog/5916.feature.rst
@@ -1,0 +1,5 @@
+`sunpy.image.transform.affine_transform` and :meth:`sunpy.map.GenericMap.rotate`
+have both had their ``use_scipy`` arguments deprecated. Instead use the new
+``method`` argument, which can currently be set to either ``'skimage'``
+(the default) or ``'scipy'``. In the future we hope to use this new argument
+to support generic user supplied transformation functions.


### PR DESCRIPTION
This PR replaces the `use_scipy` argument with the `method` argument, allowing us more flexibility in how `affine_transform` methods are specified/implemented in the future.

This is pulled out of https://github.com/sunpy/sunpy/pull/4502/files for easier review/discussion. 