### PR TITLE
Add a policy on supported test dependencies

### DIFF
--- a/docs/dev_guide/contents/dependencies.rst
+++ b/docs/dev_guide/contents/dependencies.rst
@@ -17,4 +17,5 @@ The minimum version of these packages that we enforce follows this policy.
 
 Sponsored affiliated packages will support *at least* the sunpy LTS version at the time of their release.
 
+For dependencies only needed to run our tests we will support versions released in the prior 12 months to the current date.
 .. _NEP-0029: https://numpy.org/neps/nep-0029-deprecation_policy.html


### PR DESCRIPTION
It's probably useful to have this whilst fighting the 🗑️ 🔥 that is our CI at the moment. I think 12 months strikes a good balance between us not having to support too many versions and others (especially packagers) having to have the latest version available.