### PR TITLE
Fix matplotlib links in doc build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,10 +177,7 @@ intersphinx_mapping = {
         "https://docs.scipy.org/doc/scipy/reference/",
         (None, "http://www.astropy.org/astropy-data/intersphinx/scipy.inv"),
     ),
-    "matplotlib": (
-        "https://matplotlib.org/",
-        (None, "http://www.astropy.org/astropy-data/intersphinx/matplotlib.inv"),
-    ),
+    "matplotlib": ("https://matplotlib.org/stable", None),
     "aiapy": ("https://aiapy.readthedocs.io/en/stable/", None),
     "astropy": ("https://docs.astropy.org/en/stable/", None),
     "astroquery": ("https://astroquery.readthedocs.io/en/latest/", None),


### PR DESCRIPTION
Fixes the doc build. I'm not sure why we were using astropy's copy of the inventory instead of Matplotlib's?