### PR TITLE
Fix order of astropy and hypothesis decorators

### DIFF
--- a/sunpy/coordinates/tests/strategies.py
+++ b/sunpy/coordinates/tests/strategies.py
@@ -10,8 +10,8 @@ from astropy.coordinates import Latitude, Longitude
 from sunpy.time import parse_time
 
 
-@u.quantity_input
 @st.composite
+@u.quantity_input
 def latitudes(draw, min_lat: u.deg = -90*u.deg, max_lat: u.deg = 90*u.deg):
     lat = st.floats(min_value=min_lat.to_value(u.deg),
                     max_value=max_lat.to_value(u.deg),
@@ -19,8 +19,8 @@ def latitudes(draw, min_lat: u.deg = -90*u.deg, max_lat: u.deg = 90*u.deg):
     return Latitude(draw(lat) * u.deg)
 
 
-@u.quantity_input
 @st.composite
+@u.quantity_input
 def longitudes(draw, min_lon: u.deg = -180*u.deg, max_lon: u.deg = 180*u.deg,
                wrap_angle: u.deg = 180*u.deg):
     lon = st.floats(min_value=min_lon.to_value(u.deg),


### PR DESCRIPTION
## PR Description
Fixes the order of the decorators used for astropy units and the hypothesis strategy.

Closes #5927 

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [x] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
