### PR TITLE
Run 3.0 oldestdeps on py37

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,13 +23,13 @@ jobs:
       # building wheels for dependencies
       python-version: '3.9'
       tox-env: py39
-  linux-py38-oldestdeps:
+  linux-py37-oldestdeps:
     uses: ./.github/workflows/python-test-workflow.yml
     needs: linux-py39
     with:
       os: ubuntu-latest
-      python-version: '3.8'
-      tox-env: py38-oldestdeps
+      python-version: '3.7'
+      tox-env: py37-oldestdeps
   linux-remote-py39:
     uses: ./.github/workflows/python-test-workflow.yml
     needs: linux-py39


### PR DESCRIPTION
The pinned pandas version does not have wheels for py38, and sunpy 3.0.x supports py37.

Closes #5949 