### PR TITLE
Deprecate image.coalignment

### DIFF
--- a/changelog/5957.deprecation.rst
+++ b/changelog/5957.deprecation.rst
@@ -1,3 +1,3 @@
-Deprecate the `~sunpy.image.coalignment` as the code has now been moved to
+Deprecate `~sunpy.image.coalignment` as the code has now been moved to
 `~sunkit_image.coalignment`.
 This module will be removed in sunpy 4.1.

--- a/changelog/5957.deprecation.rst
+++ b/changelog/5957.deprecation.rst
@@ -1,0 +1,3 @@
+Deprecate the `~sunpy.image.coalignment` as the code has now been moved to
+`~sunkit_image.coalignment`.
+This module will be removed in sunpy 4.1.

--- a/changelog/5957.deprecation.rst
+++ b/changelog/5957.deprecation.rst
@@ -1,3 +1,3 @@
-Deprecate `~sunpy.image.coalignment` as the code has now been moved to
-`~sunkit_image.coalignment`.
+Deprecate `sunpy.image.coalignment` as the code has now been moved to
+`sunkit_image.coalignment` with an identical API.
 This module will be removed in sunpy 4.1.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,6 +188,7 @@ intersphinx_mapping = {
     "reproject": ("https://reproject.readthedocs.io/en/stable/", None),
     "skimage": ("https://scikit-image.org/docs/stable/", None),
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/latest/", None),
+    "sunkit_image": ("https://docs.sunpy.org/projects/sunkit-image/en/stable/", None),
     "sunkit_instruments": ("https://docs.sunpy.org/projects/sunkit-instruments/en/stable/", None),
     "zeep": ("https://docs.python-zeep.org/en/stable/", None),
 }

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -754,7 +754,7 @@ To coalign a `~sunpy.map.MapSequence`, simply import
 the function and apply it to your `~sunpy.map.MapSequence`::
 
     >>> from sunpy.image.coalignment import mapsequence_coalign_by_match_template
-    >>> coaligned = mapsequence_coalign_by_match_template(mc)  # doctest: +REMOTE_DATA
+    >>> coaligned = mapsequence_coalign_by_match_template(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
 
 This will return a new `~sunpy.map.MapSequence`, coaligned to a template extracted from the
 center of the first map in the `~sunpy.map.MapSequence`, with the map dimensions clipped as
@@ -769,7 +769,7 @@ If you just want to calculate the shifts required to compensate for solar
 rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use::
 
     >>> from sunpy.image.coalignment import calculate_match_template_shift
-    >>> shifts = calculate_match_template_shift(mc)  # doctest: +REMOTE_DATA
+    >>> shifts = calculate_match_template_shift(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
 
 This is the function used to calculate the shifts in `~sunpy.map.MapSequence` coalignment
 function above.  Please see `~sunpy.image.coalignment.calculate_match_template_shift` to learn more about its features.

--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -43,6 +43,18 @@ Printing a `.MetaDict` now prints each entry on a new line, making it much easie
   naxis2: 1024
   ...
 
+Deprecation of `sunpy.image.coalignment`
+========================================
+The `sunpy.image.coalignment` module has been deprecated and will be removed in version 4.1.
+Users should instead use `sunkit_image.coalignment` which includes identical functionality and
+an identical API.
+The reason for deprecating and moving `sunpy.image.coalignment` is twofold.
+First, the scope of the core `sunpy` package has increasingly narrowed, with more analysis-specific
+functionality moved out to affiliated packages.
+Second, the module has seen little development in several years and by moving
+it to `sunkit_image.coalignment`, we hope to increase its visibility and attract a larger number
+of contributors.
+
 Contributors to this Release
 ============================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -177,6 +177,8 @@ filterwarnings =
     # These should be removed when our scikit-image pinning is removed
     ignore:Please use `gaussian_filter` from the `scipy.ndimage` namespace:DeprecationWarning
     ignore:Please use `laplace` from the `scipy.ndimage` namespace:DeprecationWarning
+    # Remove this once we remove sunpy.image.coalignment in v4.1
+    ignore:sunpy.image.coalignment is deprecated and will be removed in sunpy 4.1.
 
 [pycodestyle]
 max_line_length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -177,6 +177,8 @@ filterwarnings =
     # These should be removed when our scikit-image pinning is removed
     ignore:Please use `gaussian_filter` from the `scipy.ndimage` namespace:DeprecationWarning
     ignore:Please use `laplace` from the `scipy.ndimage` namespace:DeprecationWarning
+    # Remove this in 4.1 when we remove the image.coalignment module.
+    ignore:The .* function is deprecated and may be removed in version 4.1.\s+Use sunkit_image.coalignment .* instead.:sunpy.util.exceptions.SunpyDeprecationWarning
 
 [pycodestyle]
 max_line_length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -178,7 +178,7 @@ filterwarnings =
     ignore:Please use `gaussian_filter` from the `scipy.ndimage` namespace:DeprecationWarning
     ignore:Please use `laplace` from the `scipy.ndimage` namespace:DeprecationWarning
     # Remove this in 4.1 when we remove the image.coalignment module.
-    ignore:The .* function is deprecated and may be removed in version 4.1.\s+Use sunkit_image.coalignment .* instead.:sunpy.util.exceptions.SunpyDeprecationWarning
+    ignore:The .* function is deprecated and may be removed in version 4.1.\s+Use `~sunkit_image.coalignment.* instead.:sunpy.util.exceptions.SunpyDeprecationWarning
 
 [pycodestyle]
 max_line_length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -177,8 +177,6 @@ filterwarnings =
     # These should be removed when our scikit-image pinning is removed
     ignore:Please use `gaussian_filter` from the `scipy.ndimage` namespace:DeprecationWarning
     ignore:Please use `laplace` from the `scipy.ndimage` namespace:DeprecationWarning
-    # Remove this in 4.1 when we remove the image.coalignment module.
-    ignore:The .* function is deprecated and may be removed in version 4.1.\s+Use `~sunkit_image.coalignment.* instead.:sunpy.util.exceptions.SunpyDeprecationWarning
 
 [pycodestyle]
 max_line_length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -177,8 +177,6 @@ filterwarnings =
     # These should be removed when our scikit-image pinning is removed
     ignore:Please use `gaussian_filter` from the `scipy.ndimage` namespace:DeprecationWarning
     ignore:Please use `laplace` from the `scipy.ndimage` namespace:DeprecationWarning
-    # Remove this once we remove sunpy.image.coalignment in v4.1
-    ignore:sunpy.image.coalignment is deprecated and will be removed in sunpy 4.1.
 
 [pycodestyle]
 max_line_length = 110

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -40,6 +40,9 @@ __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'apply_shifts', 'mapsequence_coalign_by_match_template',
            'calculate_match_template_shift']
 
+DEPRECATED_SINCE = '4.0'
+ALT_MESSAGE = 'sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)'
+
 
 def _default_fmap_function(data):
     """
@@ -51,8 +54,7 @@ def _default_fmap_function(data):
     return np.float64(data)
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 def calculate_shift(this_layer, template):
     """
     Calculates the pixel shift required to put the template in the "best"
@@ -80,8 +82,7 @@ def calculate_shift(this_layer, template):
     return find_best_match_location(corr)
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 @u.quantity_input
 def clip_edges(data, yclips: u.pix, xclips: u.pix):
     """
@@ -115,8 +116,7 @@ def clip_edges(data, yclips: u.pix, xclips: u.pix):
                 int(xclips[0].value): nx - int(xclips[1].value)]
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 @u.quantity_input
 def calculate_clipping(y: u.pix, x: u.pix):
     """
@@ -174,8 +174,7 @@ def _lower_clip(z):
     return zlower
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 def match_template_to_layer(layer, template):
     """
     Calculate the correlation array that describes how well the template
@@ -197,8 +196,7 @@ def match_template_to_layer(layer, template):
     return match_template(layer, template)
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 def find_best_match_location(corr):
     """
     Calculate an estimate of the location of the peak of the correlation result
@@ -231,8 +229,7 @@ def find_best_match_location(corr):
     return y_shift_correlation_array, x_shift_correlation_array
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 def get_correlation_shifts(array):
     """
     Estimate the location of the maximum of a fit to the input array. The
@@ -278,8 +275,7 @@ def get_correlation_shifts(array):
     return y_location * u.pix, x_location * u.pix
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 def parabolic_turning_point(y):
     """
     Find the location of the turning point for a parabola
@@ -304,8 +300,7 @@ def parabolic_turning_point(y):
     return numerator / denominator
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 def check_for_nonfinite_entries(layer_image, template_image):
     """
     Issue a warning if there is any nonfinite entry in the layer or template images.
@@ -332,8 +327,7 @@ def check_for_nonfinite_entries(layer_image, template_image):
                   'local mean.')
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 @u.quantity_input
 def apply_shifts(mc, yshift: u.pix, xshift: u.pix, clip=True, **kwargs):
     """
@@ -393,8 +387,7 @@ def apply_shifts(mc, yshift: u.pix, xshift: u.pix, clip=True, **kwargs):
     return sunpy.map.Map(new_mc, sequence=True)
 
 
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 def calculate_match_template_shift(mc, template=None, layer_index=0,
                                    func=_default_fmap_function):
     """
@@ -486,8 +479,7 @@ def calculate_match_template_shift(mc, template=None, layer_index=0,
 
 
 # Coalignment by matching a template
-@deprecated(since='4.0',
-            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
+@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
 def mapsequence_coalign_by_match_template(mc, template=None, layer_index=0,
                                           func=_default_fmap_function, clip=True,
                                           shift=None, **kwargs):

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -1,4 +1,8 @@
 """
+.. warning::
+    This module will be removed in sunpy 4.1.
+    This code has been moved to `~sunkit_image.coalignment`.
+
 This module provides routines for the co-alignment of images and
 `~sunpy.map.mapsequence.MapSequence`.
 
@@ -26,7 +30,7 @@ import astropy.units as u
 
 import sunpy.map
 from sunpy.map.mapbase import GenericMap
-from sunpy.util.exceptions import warn_user
+from sunpy.util.exceptions import warn_deprecated, warn_user
 
 __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'match_template_to_layer', 'find_best_match_location',
@@ -34,6 +38,9 @@ __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'check_for_nonfinite_entries',
            'apply_shifts', 'mapsequence_coalign_by_match_template',
            'calculate_match_template_shift']
+
+warn_deprecated('sunpy.image.coalignment is deprecated and will be removed in sunpy 4.1.'
+                'This module has been moved to sunkit-image.coalignment.')
 
 
 def _default_fmap_function(data):

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -1,6 +1,6 @@
 """
 .. deprecated:: 4.0
-    Use `~sunkit_image.coalignment` instead.
+    Use `sunkit_image.coalignment` instead.
     This module will be removed in sunpy 4.1.
 
 This module provides routines for the co-alignment of images and
@@ -42,7 +42,7 @@ __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
 
 DEPRECATED_SINCE = '4.0'
 MESSAGE = 'The {func} {obj_type} is deprecated and may be removed in {future_version}.'
-ALT_MESSAGE = '\n        Use `~sunkit_image.coalignment.{func}` instead.'
+ALT_MESSAGE = '\n        Use `sunkit_image.coalignment.{func}` instead.'
 # Use message rather than alternative so we can directly link to functions in sunkit_image
 MESSAGE += ALT_MESSAGE
 

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -30,7 +30,8 @@ import astropy.units as u
 
 import sunpy.map
 from sunpy.map.mapbase import GenericMap
-from sunpy.util.exceptions import warn_deprecated, warn_user
+from sunpy.util.decorators import deprecated
+from sunpy.util.exceptions import warn_user
 
 __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'match_template_to_layer', 'find_best_match_location',
@@ -38,9 +39,6 @@ __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'check_for_nonfinite_entries',
            'apply_shifts', 'mapsequence_coalign_by_match_template',
            'calculate_match_template_shift']
-
-warn_deprecated('sunpy.image.coalignment is deprecated and will be removed in sunpy 4.1. '
-                'This module has been moved to sunkit-image.coalignment.')
 
 
 def _default_fmap_function(data):
@@ -53,6 +51,8 @@ def _default_fmap_function(data):
     return np.float64(data)
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 def calculate_shift(this_layer, template):
     """
     Calculates the pixel shift required to put the template in the "best"
@@ -80,6 +80,8 @@ def calculate_shift(this_layer, template):
     return find_best_match_location(corr)
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 @u.quantity_input
 def clip_edges(data, yclips: u.pix, xclips: u.pix):
     """
@@ -113,6 +115,8 @@ def clip_edges(data, yclips: u.pix, xclips: u.pix):
                 int(xclips[0].value): nx - int(xclips[1].value)]
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 @u.quantity_input
 def calculate_clipping(y: u.pix, x: u.pix):
     """
@@ -170,6 +174,8 @@ def _lower_clip(z):
     return zlower
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 def match_template_to_layer(layer, template):
     """
     Calculate the correlation array that describes how well the template
@@ -191,6 +197,8 @@ def match_template_to_layer(layer, template):
     return match_template(layer, template)
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 def find_best_match_location(corr):
     """
     Calculate an estimate of the location of the peak of the correlation result
@@ -223,6 +231,8 @@ def find_best_match_location(corr):
     return y_shift_correlation_array, x_shift_correlation_array
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 def get_correlation_shifts(array):
     """
     Estimate the location of the maximum of a fit to the input array. The
@@ -268,6 +278,8 @@ def get_correlation_shifts(array):
     return y_location * u.pix, x_location * u.pix
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 def parabolic_turning_point(y):
     """
     Find the location of the turning point for a parabola
@@ -292,6 +304,8 @@ def parabolic_turning_point(y):
     return numerator / denominator
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 def check_for_nonfinite_entries(layer_image, template_image):
     """
     Issue a warning if there is any nonfinite entry in the layer or template images.
@@ -318,6 +332,8 @@ def check_for_nonfinite_entries(layer_image, template_image):
                   'local mean.')
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 @u.quantity_input
 def apply_shifts(mc, yshift: u.pix, xshift: u.pix, clip=True, **kwargs):
     """
@@ -377,6 +393,8 @@ def apply_shifts(mc, yshift: u.pix, xshift: u.pix, clip=True, **kwargs):
     return sunpy.map.Map(new_mc, sequence=True)
 
 
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 def calculate_match_template_shift(mc, template=None, layer_index=0,
                                    func=_default_fmap_function):
     """
@@ -468,6 +486,8 @@ def calculate_match_template_shift(mc, template=None, layer_index=0,
 
 
 # Coalignment by matching a template
+@deprecated(since='4.0',
+            alternative='sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)')
 def mapsequence_coalign_by_match_template(mc, template=None, layer_index=0,
                                           func=_default_fmap_function, clip=True,
                                           shift=None, **kwargs):

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -1,10 +1,10 @@
 """
-This module provides routines for the co-alignment of images and
-`~sunpy.map.mapsequence.MapSequence`.
-
 .. deprecated:: 4.0
     Use `~sunkit_image.coalignment` instead.
     This module will be removed in sunpy 4.1.
+
+This module provides routines for the co-alignment of images and
+`~sunpy.map.mapsequence.MapSequence`.
 
 Currently this module provides image co-alignment by template matching.
 Which is partially inspired by the SSWIDL routine
@@ -39,7 +39,7 @@ __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'apply_shifts', 'mapsequence_coalign_by_match_template',
            'calculate_match_template_shift']
 
-warn_deprecated('sunpy.image.coalignment is deprecated and will be removed in sunpy 4.1.'
+warn_deprecated('sunpy.image.coalignment is deprecated and will be removed in sunpy 4.1. '
                 'This module has been moved to sunkit-image.coalignment.')
 
 

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -41,7 +41,10 @@ __all__ = ['calculate_shift', 'clip_edges', 'calculate_clipping',
            'calculate_match_template_shift']
 
 DEPRECATED_SINCE = '4.0'
-ALT_MESSAGE = 'sunkit_image.coalignment (https://github.com/sunpy/sunkit-image)'
+MESSAGE = 'The {func} {obj_type} is deprecated and may be removed in {future_version}.'
+ALT_MESSAGE = '\n        Use `~sunkit_image.coalignment.{func}` instead.'
+# Use message rather than alternative so we can directly link to functions in sunkit_image
+MESSAGE += ALT_MESSAGE
 
 
 def _default_fmap_function(data):
@@ -54,7 +57,7 @@ def _default_fmap_function(data):
     return np.float64(data)
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 def calculate_shift(this_layer, template):
     """
     Calculates the pixel shift required to put the template in the "best"
@@ -82,7 +85,7 @@ def calculate_shift(this_layer, template):
     return find_best_match_location(corr)
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 @u.quantity_input
 def clip_edges(data, yclips: u.pix, xclips: u.pix):
     """
@@ -116,7 +119,7 @@ def clip_edges(data, yclips: u.pix, xclips: u.pix):
                 int(xclips[0].value): nx - int(xclips[1].value)]
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 @u.quantity_input
 def calculate_clipping(y: u.pix, x: u.pix):
     """
@@ -174,7 +177,7 @@ def _lower_clip(z):
     return zlower
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 def match_template_to_layer(layer, template):
     """
     Calculate the correlation array that describes how well the template
@@ -196,7 +199,7 @@ def match_template_to_layer(layer, template):
     return match_template(layer, template)
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 def find_best_match_location(corr):
     """
     Calculate an estimate of the location of the peak of the correlation result
@@ -229,7 +232,7 @@ def find_best_match_location(corr):
     return y_shift_correlation_array, x_shift_correlation_array
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 def get_correlation_shifts(array):
     """
     Estimate the location of the maximum of a fit to the input array. The
@@ -275,7 +278,7 @@ def get_correlation_shifts(array):
     return y_location * u.pix, x_location * u.pix
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 def parabolic_turning_point(y):
     """
     Find the location of the turning point for a parabola
@@ -300,7 +303,7 @@ def parabolic_turning_point(y):
     return numerator / denominator
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 def check_for_nonfinite_entries(layer_image, template_image):
     """
     Issue a warning if there is any nonfinite entry in the layer or template images.
@@ -327,7 +330,7 @@ def check_for_nonfinite_entries(layer_image, template_image):
                   'local mean.')
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 @u.quantity_input
 def apply_shifts(mc, yshift: u.pix, xshift: u.pix, clip=True, **kwargs):
     """
@@ -387,7 +390,7 @@ def apply_shifts(mc, yshift: u.pix, xshift: u.pix, clip=True, **kwargs):
     return sunpy.map.Map(new_mc, sequence=True)
 
 
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 def calculate_match_template_shift(mc, template=None, layer_index=0,
                                    func=_default_fmap_function):
     """
@@ -479,7 +482,7 @@ def calculate_match_template_shift(mc, template=None, layer_index=0,
 
 
 # Coalignment by matching a template
-@deprecated(since=DEPRECATED_SINCE, alternative=ALT_MESSAGE)
+@deprecated(since=DEPRECATED_SINCE, message=MESSAGE)
 def mapsequence_coalign_by_match_template(mc, template=None, layer_index=0,
                                           func=_default_fmap_function, clip=True,
                                           shift=None, **kwargs):

--- a/sunpy/image/coalignment.py
+++ b/sunpy/image/coalignment.py
@@ -1,10 +1,10 @@
 """
-.. warning::
-    This module will be removed in sunpy 4.1.
-    This code has been moved to `~sunkit_image.coalignment`.
-
 This module provides routines for the co-alignment of images and
 `~sunpy.map.mapsequence.MapSequence`.
+
+.. deprecated:: 4.0
+    Use `~sunkit_image.coalignment` instead.
+    This module will be removed in sunpy 4.1.
 
 Currently this module provides image co-alignment by template matching.
 Which is partially inspired by the SSWIDL routine

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -27,6 +27,9 @@ from sunpy.image.coalignment import (
 from sunpy.map import Map, MapSequence
 from sunpy.util import SunpyUserWarning
 
+DEP_WARNING = r'''ignore:The .* function is deprecated and may be removed in version 4.1.
+\s+Use `sunkit_image.coalignment.* instead.:sunpy.util.exceptions.SunpyDeprecationWarning'''
+
 
 @pytest.fixture
 def aia171_test_clipping():
@@ -71,10 +74,12 @@ def aia171_test_template_shape(aia171_test_template):
     return aia171_test_template.shape
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_parabolic_turning_point():
     assert(parabolic_turning_point(np.asarray([6.0, 2.0, 0.0])) == 1.5)
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_check_for_nonfinite_entries():
     with warnings.catch_warnings(record=True) as warning_list:
         a = np.zeros((3, 3))
@@ -108,6 +113,7 @@ def test_check_for_nonfinite_entries():
             assert len(warning_list)-1 == 2
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_match_template_to_layer(aia171_test_map_layer,
                                  aia171_test_template,
                                  aia171_test_map_layer_shape,
@@ -121,6 +127,7 @@ def test_match_template_to_layer(aia171_test_map_layer,
     assert_allclose(np.max(result), 1.00, rtol=1e-2, atol=0)
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_get_correlation_shifts():
     # Input array is 3 by 3, the most common case
     test_array = np.zeros((3, 3))
@@ -151,6 +158,7 @@ def test_get_correlation_shifts():
         get_correlation_shifts(test_array)
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_find_best_match_location(aia171_test_map_layer, aia171_test_template,
                                   aia171_test_shift):
 
@@ -174,11 +182,13 @@ def test_upper_clip(aia171_test_clipping):
     assert(_upper_clip(test_array) == 0)
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_calculate_clipping(aia171_test_clipping):
     answer = calculate_clipping(aia171_test_clipping * u.pix, aia171_test_clipping * u.pix)
     assert_array_almost_equal(answer, ([2.0, 1.0]*u.pix, [2.0, 1.0]*u.pix))
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_clip_edges():
     a = np.zeros(shape=(341, 156))
     yclip = [4, 0] * u.pix
@@ -219,6 +229,7 @@ def aia171_test_mc(aia171_test_map, aia171_test_map_layer,
     return Map([aia171_test_map, m1], sequence=True)
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_calculate_match_template_shift(aia171_test_mc,
                                         aia171_mc_arcsec_displacements,
                                         aia171_test_map,
@@ -253,6 +264,7 @@ def test_calculate_match_template_shift(aia171_test_mc,
         calculate_match_template_shift(aia171_test_mc, template='broken')
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_mapsequence_coalign_by_match_template(aia171_test_mc,
                                                aia171_test_map_layer_shape):
     # Define these local variables to make the code more readable
@@ -313,6 +325,7 @@ def test_mapsequence_coalign_by_match_template(aia171_test_mc,
                             rtol=5e-2, atol=0)
 
 
+@pytest.mark.filterwarnings(DEP_WARNING)
 def test_apply_shifts(aia171_test_map):
     # take two copies of the AIA image and create a test mapsequence.
     mc = Map([aia171_test_map, aia171_test_map], sequence=True)

--- a/sunpy/image/tests/test_coalignment.py
+++ b/sunpy/image/tests/test_coalignment.py
@@ -93,18 +93,19 @@ def test_check_for_nonfinite_entries():
                               match='The layer image has nonfinite entries.') as warning_list:
                 check_for_nonfinite_entries(b, np.ones((3, 3)))
 
-            assert len(warning_list) == 1
+            # Added a -1 because pytest.warns also catches the deprecation warning
+            assert len(warning_list)-1 == 1
 
             with pytest.warns(SunpyUserWarning,
                               match='The template image has nonfinite entries.') as warning_list:
                 check_for_nonfinite_entries(np.ones((3, 3)), b)
 
-            assert len(warning_list) == 1
+            assert len(warning_list)-1 == 1
 
             with pytest.warns(Warning) as warning_list:
                 check_for_nonfinite_entries(b, b)
 
-            assert len(warning_list) == 2
+            assert len(warning_list)-1 == 2
 
 
 def test_match_template_to_layer(aia171_test_map_layer,


### PR DESCRIPTION
`image.coalignment` has been moved to `sunkit-image` (See sunpy/sunkit-image#78).
This PR deprecates the `coalignment` module.
This deprecation will be included in 4.0 and thus we can remove the module in 4.1

Addresses #5425.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [ ] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [ ] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
