### PR TITLE
Fix some problems around `warn_deprecated`

### DIFF
--- a/docs/dev_guide/contents/api.rst
+++ b/docs/dev_guide/contents/api.rst
@@ -44,15 +44,15 @@ The same applies if you want to change the default value of a keyword argument f
 
 .. code-block:: python
 
+    from sunpy.util.exceptions import warn_deprecated
+
     if response_format is None:
         response_format = "legacy"
-        warnings.warn("The default response format from the VSO client will "
-                    "be changing to 'table' in version 3.1. "
-                    "To remove this warning set response_format='legacy' "
-                    "to maintain the old behaviour or response_format='table'"
-                    " to use the new behaviour.",
-                    SunpyDeprecationWarning,
-                    stacklevel=2)
+        warn_deprecated("The default response format from the VSO client will "
+                        "be changing to 'table' in version 3.1. "
+                        "To remove this warning set response_format='legacy' "
+                        "to maintain the old behaviour or response_format='table'"
+                        " to use the new behaviour.")
 
 .. note::
 

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -11,7 +11,7 @@ from functools import wraps
 
 import astropy.units as u
 
-from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyPendingDeprecationWarning
+from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyPendingDeprecationWarning, warn_deprecated
 
 __all__ = ['deprecated']
 


### PR DESCRIPTION
This PR fixes two minor issues

* There is a code path in `deprecate_positional_args_since` that calls `warn_deprecated` but the import for it was missing. I guess we've never hit this code path?
* The dev guide was using `warnings.warn` instead of `warn_deprecated` which contradicts our pre-commit config (https://github.com/sunpy/sunpy/blob/3d3cfcf2669e0435e4f6a037fb2cf5314f10d7f4/.pre-commit-config.yaml#L108). The example now uses `warn_deprecated`.