### PR TITLE
`SJIMap` bugfix

### DIFF
--- a/changelog/5968.bugfix.rst
+++ b/changelog/5968.bugfix.rst
@@ -1,0 +1,4 @@
+Fixes a bug in `~sunpy.map.sources.IRISMap` where undefined variable was
+used when parsing the wavelength.
+Also fixes the unit parsing by removing the "corrected" string from the
+``BUNIT`` keyword as "corrected DN" cannot be parsed as a valid FITS unit.

--- a/changelog/5968.doc.rst
+++ b/changelog/5968.doc.rst
@@ -1,0 +1,3 @@
+Remove the part of the `~sunpy.map.sources.IRISMap` docstring that says
+it only works on L1 as the data work for L2 and the level checking was
+not being enforced.

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -53,14 +53,23 @@ class SJIMap(GenericMap):
         """
         Taken from WAVEUNIT, or if not present defaults to Angstrom.
         """
-        return u.Unit(header.get('waveunit', "Angstrom"))
+        return u.Unit(self.meta.get('waveunit', "Angstrom"))
 
     @property
     def wavelength(self):
         """
         Taken from WAVELNTH, or if not present TWAVE1.
         """
-        return header.get('wavelnth', header.get('twave1')) * self.waveunit
+        return self.meta.get('wavelnth', self.meta.get('twave1')) * self.waveunit
+
+    @property
+    def unit(self):
+        unit_str = self.meta.get('bunit', None)
+        if unit_str is None:
+            return
+        # Remove "corrected" so that the unit can be parsed
+        unit_str = unit_str.lower().replace('corrected', '').strip()
+        return self._parse_fits_unit(unit_str)
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
@@ -68,4 +77,4 @@ class SJIMap(GenericMap):
         tele = str(header.get('TELESCOP', '')).startswith('IRIS')
         obs = str(header.get('INSTRUME', '')).startswith('SJI')
         level = header.get('lvl_num') == 1
-        return tele and obs
+        return tele and obs and level

--- a/sunpy/map/sources/iris.py
+++ b/sunpy/map/sources/iris.py
@@ -26,10 +26,6 @@ class SJIMap(GenericMap):
 
     IRIS was launched into a Sun-synchronous orbit on 27 June 2013.
 
-    .. warning::
-
-        This object can only handle level 1 SJI files.
-
     References
     ----------
     * `IRIS Mission Page <https://iris.lmsal.com>`_
@@ -76,5 +72,4 @@ class SJIMap(GenericMap):
         """Determines if header corresponds to an IRIS SJI image"""
         tele = str(header.get('TELESCOP', '')).startswith('IRIS')
         obs = str(header.get('INSTRUME', '')).startswith('SJI')
-        level = header.get('lvl_num') == 1
-        return tele and obs and level
+        return tele and obs

--- a/sunpy/map/sources/tests/test_iris_source.py
+++ b/sunpy/map/sources/tests/test_iris_source.py
@@ -43,6 +43,21 @@ def test_observatory(irismap):
     assert irismap.observatory == "IRIS"
 
 
+def test_wavelength(irismap):
+    """Tests the wavelength and waveunit property of the SJIMap"""
+    assert irismap.wavelength == u.Quantity(1400, 'Angstrom')
+
+
+def test_level_number(irismap):
+    """Tests the processing_level property of the SJIMap"""
+    assert irismap.processing_level == 1.0
+
+
+def test_units(irismap):
+    """Tests the unit property of the SJIMap"""
+    assert irismap.unit == u.ct
+
+
 def test_wcs(irismap):
     # Smoke test that WCS is valid and can transform from pixels to world coordinates
     with pytest.warns(SunpyMetadataWarning, match='Missing metadata for observer'):

--- a/sunpy/map/sources/tests/test_iris_source.py
+++ b/sunpy/map/sources/tests/test_iris_source.py
@@ -50,7 +50,7 @@ def test_wavelength(irismap):
 
 def test_level_number(irismap):
     """Tests the processing_level property of the SJIMap"""
-    assert irismap.processing_level == 1.0
+    assert irismap.processing_level == 2.0
 
 
 def test_units(irismap):


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

Fixes #5962

I've also added better parsing for the `BUNIT` keyword in these files which, apparently, is denoted as "Corrected DN" at times.

I expect the tests to fail here because there is an inconsistency between our docs and test data. In the SJIMap docstring, we say explicitly that it only supports L1 data. However, our IRIS test data file is L2. Furthermore, it seems the check for L1 in `is_datasource_for` was unused.

We either need to a) actually use a L1 file in our test data or b) change the docs to say we actually support L2 files.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [ ] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [x] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
