### PR TITLE
Skip dim>=3 data when reading CDF files

### DIFF
--- a/changelog/5975.bugfix.rst
+++ b/changelog/5975.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed reading CDF files when a variable has more than 2 dimensions. If this is the case the variable will be ignored, and a user warning is provided.

--- a/sunpy/io/cdf.py
+++ b/sunpy/io/cdf.py
@@ -89,7 +89,12 @@ def read_cdf(fname):
                           'Assigning dimensionless units.')
                 unit = u.dimensionless_unscaled
 
-            if data.ndim == 2:
+            if data.ndim > 2:
+                # Skip data with dimensions >= 3 and give user warning
+                warn_user(f'The variable "{var_key}" has more than 2 dimensions, '
+                          'which is not supported at the moment. '
+                          f'Skipping variable "{var_key}" for now.')
+            elif data.ndim == 2:
                 # Multiple columns, give each column a unique label
                 for i, col in enumerate(data.T):
                     df[var_key + f'_{i}'] = col

--- a/sunpy/io/cdf.py
+++ b/sunpy/io/cdf.py
@@ -91,9 +91,7 @@ def read_cdf(fname):
 
             if data.ndim > 2:
                 # Skip data with dimensions >= 3 and give user warning
-                warn_user(f'The variable "{var_key}" has more than 2 dimensions, '
-                          'which is not supported at the moment. '
-                          f'Skipping variable "{var_key}" for now.')
+                warn_user(f'The variable "{var_key}" has been skipped because it has more than 2 dimensions, which is unsupported.')
             elif data.ndim == 2:
                 # Multiple columns, give each column a unique label
                 for i, col in enumerate(data.T):


### PR DESCRIPTION
## PR Description

Fixes #5869. When reading CDF files, now variables with more than 2 dimensions (respectively dependencies) are skipped and a user warning is provided. This allows to at least read the 1- and 2-dimensional data of the corresponding CDF file (instead of just crashing). This is needed e.g. for charged particle data obtained by Parker Solar Probe's ISOIS instrument.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [x] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
