### PR TITLE
Change workflow trigger from `schedule` to `workflow_dispatch`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         - linux: py38-online
 
   cron:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       default_python: '3.8'
@@ -92,7 +92,6 @@ jobs:
     if: |
       github.event_name != 'pull_request' && (
         github.ref_name != 'main' ||
-        github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch' )
     needs: [test]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@main
@@ -108,7 +107,7 @@ jobs:
       pypi_token: ${{ secrets.pypi_token }}
 
   notify_pass:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'workflow_dispatch'
     needs: [cron, publish, online]
     runs-on: ubuntu-latest
     steps:
@@ -119,7 +118,7 @@ jobs:
           homeserver: ${{ secrets.matrix_homeserver }}
 
   notify_fail:
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && github.event_name == 'workflow_dispatch'
     needs: [cron, publish, online]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Scheduled workflow runs are triggered through the separate `scheduled_builds.yml` workflow which uses the GitHub CLI to trigger workflow runs on specific branches (`main`, `3.1` and `3.0`). (Because schedules only work on the default branch.) Therefore, the `github.event_name` in the `ci.yml` workflow is actually `workflow_dispatch` (i.e. manually triggered) rather than `schedule`.