### PR TITLE
fixes spelling within sphinx gallery

### DIFF
--- a/examples/units_and_coordinates/README.txt
+++ b/examples/units_and_coordinates/README.txt
@@ -1,5 +1,5 @@
 Coordinates, times, and units
 =============================
 
-This section contains any examples which showcasse how sunpy handles coordinate
+This section contains any examples which showcase how sunpy handles coordinate
 information, times, and scientific units.


### PR DESCRIPTION
## PR Description

Simple spelling fix within the [Coordinates, times, and units](https://docs.sunpy.org/en/stable/generated/gallery/index.html#coordinates-times-and-units) example gallery.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [[N/A]] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [N/A] Changes pass pytest style unit tests (and `pytest` passes).
- [N/A] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [N/A] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
