### PR TITLE
Checkout local repository for Matrix Notify Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
     needs: [cron, publish, online]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/matrix
         with:
           status: 'Succeeded'
@@ -122,6 +123,7 @@ jobs:
     needs: [cron, publish, online]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/matrix
         with:
           status: 'Failed'


### PR DESCRIPTION
As shown in the [GitHub Actions logs](https://github.com/sunpy/sunpy/runs/5679802720?check_suite_focus=true), we need to checkout the repository in order to access the local Matrix Notify Action.