### PR TITLE
Add derotate() method

### DIFF
--- a/examples/acquiring_data/downloading_hmi.py
+++ b/examples/acquiring_data/downloading_hmi.py
@@ -49,7 +49,7 @@ hmi_map.plot()
 plt.show()
 
 ###############################################################################
-# Now rotate the image such that solar North is pointed up.
+# Now derotate the image such that solar North is pointed up.
 # We have to do this because the HMI instrument is mounted upside-down
 # relative to the AIA instrument on the SDO satellite, which means most
 # of the images are taken with solar North pointed up.
@@ -61,7 +61,7 @@ plt.show()
 # The order keyword, below, specifies the type of interpolation;
 # in this case, 3 refers to bi-cubic.
 
-hmi_rotated = hmi_map.rotate(order=3)
+hmi_rotated = hmi_map.derotate(order=3)
 plt.figure()
 hmi_rotated.plot()
 plt.show()

--- a/examples/plotting/hmi_cutout.py
+++ b/examples/plotting/hmi_cutout.py
@@ -24,7 +24,7 @@ from sunpy.data.sample import HMI_LOS_IMAGE
 # First, we use the sample HMI LOS image and focus the cutout over an active
 # region near the solar center.
 
-magnetogram = sunpy.map.Map(HMI_LOS_IMAGE).rotate()
+magnetogram = sunpy.map.Map(HMI_LOS_IMAGE).derotate()
 left_corner = SkyCoord(Tx=-142*u.arcsec, Ty=50*u.arcsec, frame=magnetogram.coordinate_frame)
 right_corner = SkyCoord(Tx=158*u.arcsec, Ty=350*u.arcsec, frame=magnetogram.coordinate_frame)
 

--- a/examples/units_and_coordinates/radec_to_hpc_map.py
+++ b/examples/units_and_coordinates/radec_to_hpc_map.py
@@ -147,10 +147,10 @@ lofar_map.draw_limb(axes=ax)
 plt.show()
 
 ##########################################################################
-# We can now rotate the image so that solar north is pointing up and create
+# We can now derotate the image so that solar north is pointing up and create
 # a submap in the field of view of interest.
 
-lofar_map_rotate = lofar_map.rotate()
+lofar_map_rotate = lofar_map.derotate()
 bl = SkyCoord(-1500*u.arcsec, -1500*u.arcsec, frame=lofar_map_rotate.coordinate_frame)
 tr = SkyCoord(1500*u.arcsec, 1500*u.arcsec, frame=lofar_map_rotate.coordinate_frame)
 lofar_submap = lofar_map_rotate.submap(bl, top_right=tr)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -949,13 +949,13 @@ def test_rotate_recenter(generic_map):
 
 
 def test_rotate_crota_remove(aia171_test_map):
-    rot_map = aia171_test_map.rotate()
+    rot_map = aia171_test_map.derotate()
     assert rot_map.meta.get('CROTA1', None) is None
     assert rot_map.meta.get('CROTA2', None) is None
 
 
 def test_rotate_scale_cdelt(generic_map):
-    rot_map = generic_map.rotate(scale=10.)
+    rot_map = generic_map.rotate(angle=0*u.deg, scale=10.)
     assert rot_map.meta['CDELT1'] == generic_map.meta['CDELT1'] / 10.
     assert rot_map.meta['CDELT2'] == generic_map.meta['CDELT2'] / 10.
 
@@ -973,9 +973,9 @@ def test_rotate_rmatrix_angle(generic_map):
 
 def test_rotate_invalid_order(generic_map):
     with pytest.raises(ValueError):
-        generic_map.rotate(order=6)
+        generic_map.derotate(order=6)
     with pytest.raises(ValueError):
-        generic_map.rotate(order=-1)
+        generic_map.derotate(order=-1)
 
 
 def test_rotate_assumed_obstime():
@@ -1430,7 +1430,7 @@ def test_derotating_nonpurerotation_pcij(aia171_test_map):
     weird_map = aia171_test_map.rotate(30*u.deg).superpixel([2, 1]*u.pix)
 
     # De-rotating the map by its PCij matrix should result in a normal-looking map
-    derotated_map = weird_map.rotate()
+    derotated_map = weird_map.derotate()
 
     fig = Figure(figsize=(8, 4))
 
@@ -1441,6 +1441,18 @@ def test_derotating_nonpurerotation_pcij(aia171_test_map):
     derotated_map.plot(axes=ax2, title='De-rotated map')
 
     return fig
+
+
+def test_rotate_warning(aia171_test_map):
+    # The following map has a a PCij matrix that is not a pure rotation
+    weird_map = aia171_test_map.rotate(30*u.deg).superpixel([2, 1]*u.pix)
+
+    with pytest.warns(SunpyDeprecationWarning, match='Calling rotate without an angle or rotation matrix is deprecated'):
+        rotate = weird_map.rotate()
+
+    derotate = weird_map.derotate()
+
+    assert np.all(rotate.data == derotate.data)
 
 
 # This function is used in the arithmetic tests below

--- a/sunpy/visualization/colormaps/color_tables.py
+++ b/sunpy/visualization/colormaps/color_tables.py
@@ -321,7 +321,7 @@ def hmi_mag_color_table():
     >>> import numpy as np
     >>> import sunpy.map
     >>> hmi = sunpy.map.Map('hmi.m_45s.2014.05.11_12_00_45_TAI.magnetogram.fits')  # doctest: +SKIP
-    >>> hmir = hmi.rotate()  # doctest: +SKIP
+    >>> hmir = hmi.derotate()  # doctest: +SKIP
     >>> hmir.plot_settings['cmap'] = plt.get_cmap('hmimag')  # doctest: +SKIP
     >>> hmir.peek(vmin=-1500.0, vmax=1500.0)  # doctest: +SKIP
 


### PR DESCRIPTION
In https://github.com/sunpy/sunpy/issues/5982, adding a `derotate()` method seemed (relatively) uncontroversial, and I think calling `map.derotate()` vs. `map.rotate()` is a clearer API. As such, I've:

- Added `derotate()`
- Deprecated calling `rotate()` without providing either `rotation` or `rmatrix`

I haven't added a changelong or what's new yet; I'll wait for at least one positive comment on this PR before doing that 😄 