### PR TITLE
Adds extra group to optional dependencies in system_info

### DIFF
--- a/changelog/6011.bugfix.rst
+++ b/changelog/6011.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `system_info` so it returns the extra group when an optional dependency is missing.

--- a/changelog/6011.bugfix.rst
+++ b/changelog/6011.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed `system_info` so it returns the extra group when an optional dependency is missing.
+Fixed `.system_info` so it returns the extra group when an optional dependency is missing.

--- a/sunpy/util/sysinfo.py
+++ b/sunpy/util/sysinfo.py
@@ -60,11 +60,17 @@ def resolve_requirement_versions(package_versions):
         resolved.extras = resolved.extras.union(package_version.extras)
         resolved.url = resolved.url or package_version.url
         if resolved.marker and package_version.marker:
-            resolved.marker = Marker(f"{resolved.marker} and {package_version.marker}")
+            resolved.marker = Marker(f"{resolved.marker} or {package_version.marker}")
         elif package_version.marker:
             resolved.marker = package_version.marker
 
     return resolved
+
+
+def format_requirement_string(requirement):
+    formatted_string = f"Missing {requirement}"
+    formatted_string = formatted_string.replace("or extra ==", "or").strip()
+    return formatted_string
 
 
 def find_dependencies(package="sunpy", extras=None):
@@ -89,7 +95,8 @@ def find_dependencies(package="sunpy", extras=None):
             except PackageNotFoundError:
                 missing_requirements[package].append(package_details)
     for package, package_versions in missing_requirements.items():
-        missing_requirements[package] = resolve_requirement_versions(package_versions)
+        missing_requirements[package] = format_requirement_string(
+            resolve_requirement_versions(package_versions))
     return missing_requirements, installed_requirements
 
 

--- a/sunpy/util/tests/test_sysinfo.py
+++ b/sunpy/util/tests/test_sysinfo.py
@@ -1,4 +1,11 @@
-from sunpy.util.sysinfo import find_dependencies, missing_dependencies_by_extra, system_info
+from packaging.requirements import Requirement
+
+from sunpy.util.sysinfo import (
+    find_dependencies,
+    missing_dependencies_by_extra,
+    resolve_requirement_versions,
+    system_info,
+)
 
 
 def test_find_dependencies():
@@ -17,13 +24,41 @@ def test_find_dependencies():
 
 def test_missing_dependencies_by_extra():
     missing = missing_dependencies_by_extra()
-    assert sorted(list(missing.keys())) == sorted(['all', 'asdf', 'required', 'dask', 'database', 'dev', 'docs',
-                                                   'image', 'jpeg2000', 'map', 'net', 'tests', 'timeseries',
+    assert sorted(list(missing.keys())) == sorted(['all',
+                                                   'asdf',
+                                                   'required',
+                                                   'dask',
+                                                   'database',
+                                                   'dev',
+                                                   'docs',
+                                                   'image',
+                                                   'jpeg2000',
+                                                   'map',
+                                                   'net',
+                                                   'tests',
+                                                   'timeseries',
                                                    'visualization'])
     missing = missing_dependencies_by_extra(exclude_extras=["all"])
     assert sorted(list(missing.keys())) == sorted(['asdf', 'required', 'dask', 'database', 'dev', 'docs',
                                                    'image', 'jpeg2000', 'map', 'net', 'tests', 'timeseries',
                                                    'visualization'])
+
+
+def test_resolve_requirement_versions():
+    package1 = Requirement('test-package[ext1]>=1.1.1; extra == "group1"')
+    package2 = Requirement('test-package[ext2]<=2.0.0; extra == "group2"')
+    assert str(resolve_requirement_versions([package1, package2])) == str(Requirement(
+        'test-package[ext1,ext2]<=2.0.0,>=1.1.1; extra == "group1" and extra == "group2"'))
+
+    package3 = Requirement('test-package==1.1.0; extra == "group3"')
+    package4 = Requirement('test-package==1.1.0; extra == "group4"')
+    assert str(resolve_requirement_versions([package3, package4])) == str(
+        Requirement('test-package==1.1.0; extra == "group3" and extra == "group4"'))
+
+    package5 = Requirement('test-package; extra == "group5"')
+    package6 = Requirement('test-package[ext3]@https://foo.com')
+    assert str(resolve_requirement_versions([package5, package6])) == str(
+        Requirement('test-package[ext3]@ https://foo.com ; extra == "group5"'))
 
 
 def test_system_info(capsys):

--- a/sunpy/util/tests/test_sysinfo.py
+++ b/sunpy/util/tests/test_sysinfo.py
@@ -4,6 +4,7 @@ from sunpy.util.sysinfo import (
     find_dependencies,
     missing_dependencies_by_extra,
     resolve_requirement_versions,
+    format_requirement_string,
     system_info,
 )
 
@@ -48,17 +49,29 @@ def test_resolve_requirement_versions():
     package1 = Requirement('test-package[ext1]>=1.1.1; extra == "group1"')
     package2 = Requirement('test-package[ext2]<=2.0.0; extra == "group2"')
     assert str(resolve_requirement_versions([package1, package2])) == str(Requirement(
-        'test-package[ext1,ext2]<=2.0.0,>=1.1.1; extra == "group1" and extra == "group2"'))
+        'test-package[ext1,ext2]<=2.0.0,>=1.1.1; extra == "group1" or extra == "group2"'))
 
     package3 = Requirement('test-package==1.1.0; extra == "group3"')
     package4 = Requirement('test-package==1.1.0; extra == "group4"')
     assert str(resolve_requirement_versions([package3, package4])) == str(
-        Requirement('test-package==1.1.0; extra == "group3" and extra == "group4"'))
+        Requirement('test-package==1.1.0; extra == "group3" or extra == "group4"'))
 
     package5 = Requirement('test-package; extra == "group5"')
     package6 = Requirement('test-package[ext3]@https://foo.com')
     assert str(resolve_requirement_versions([package5, package6])) == str(
         Requirement('test-package[ext3]@ https://foo.com ; extra == "group5"'))
+
+
+def test_format_requirement_string():
+    package1 = Requirement('test-package[ext1]>=1.1.1; extra == "group1"')
+    assert format_requirement_string(package1) == 'Missing test-package[ext1]>=1.1.1; extra == "group1"'
+
+    package2 = Requirement('test-package>=1.1.1; extra == "group1" or extra == "group2" or extra == "group3"')
+    assert format_requirement_string(
+        package2) == 'Missing test-package>=1.1.1; extra == "group1" or "group2" or "group3"'
+
+    package3 = Requirement('test-package>=1.1.1')
+    assert format_requirement_string(package3) == 'Missing test-package>=1.1.1'
 
 
 def test_system_info(capsys):

--- a/sunpy/util/tests/test_sysinfo.py
+++ b/sunpy/util/tests/test_sysinfo.py
@@ -2,9 +2,9 @@ from packaging.requirements import Requirement
 
 from sunpy.util.sysinfo import (
     find_dependencies,
+    format_requirement_string,
     missing_dependencies_by_extra,
     resolve_requirement_versions,
-    format_requirement_string,
     system_info,
 )
 


### PR DESCRIPTION
## PR Description

Fixes #5976, by adding back the `extra` info to missing optional dependencies, as well as making the `extra` group more specific rather than returning `all`. To implement this change, more details are returned by `get_requirements` (including the extra group name and version required), and in `system_info`, the list of extra groups (aside from `all` and `dev`) is supplied to `find_dependencies` in order to retrieve the right extra group details.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [x] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
