### PR TITLE
Update cron schedule and add GitHub CLI token

### DIFF
--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -7,7 +7,7 @@ on:
     #        │ │ ┌───────── day of the month (1 - 31)
     #        │ │ │ ┌───────── month (1 - 12 or JAN-DEC)
     #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
-    - cron: '0 3 * * 1'  # Every Monday at 03:00 UTC
+    - cron: '0 7 * * *'  # Every day at 07:00 UTC
 
 jobs:
   dispatch_workflows:
@@ -16,3 +16,5 @@ jobs:
       - run: gh workflow run ci.yml --ref main
       - run: gh workflow run ci.yml --ref 3.1
       - run: gh workflow run ci.yml --ref 3.0
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the schedule of the cron to daily at 07:00 UTC, which is what I think we agreed on Matrix. There was also an 
issue with authentication on the scheduled workflow run yesterday. The GitHub CLI needs a `GITHUB_TOKEN` to be present as an 
env variable. Do we need to create a new GitHub account for this purpose? Ideally it should only have permission to dispatch 
workflows. (This PR was opened from the GitHub CLI!)

- ~[ ] Add `GITHUB_TOKEN` secret to the `main` branch environment~
