### PR TITLE
Relax conditions for HMI Synoptic map source

### DIFF
--- a/changelog/6018.bugfix.rst
+++ b/changelog/6018.bugfix.rst
@@ -1,0 +1,1 @@
+Relax condition check for a HMI Synoptic map source.

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -208,5 +208,5 @@ class HMISynopticMap(HMIMap):
         Determines if header corresponds to an HMI synoptic map.
         """
         return (str(header.get('TELESCOP', '')).endswith('HMI') and
-                str(header.get('CONTENT', '')) ==
-                'Carrington Synoptic Chart Of Br Field')
+                'carrington synoptic chart' in
+                str(header.get('CONTENT', '')).lower())

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -207,6 +207,4 @@ class HMISynopticMap(HMIMap):
         """
         Determines if header corresponds to an HMI synoptic map.
         """
-        return (str(header.get('TELESCOP', '')).endswith('HMI') and
-                'carrington synoptic chart' in
-                str(header.get('CONTENT', '')).lower())
+        return str(header.get('TELESCOP', '')).endswith('HMI') and 'carrington synoptic chart' in str(header.get('CONTENT', '')).lower()


### PR DESCRIPTION
## PR Description

Fixes #5978. When reading certain HMI Synoptic Map source files, the is_datasource_for method of the HMISynopticMap class does not recognize files without the exact string 'Carrington Synoptic Chart Of Br Field' in the file header. This fix relaxes the condition to search only for 'carrington synoptic chart' in the data field header, case insensitive. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
- [x] I have followed the guidelines in the [Contributing document](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)
- [x] Changes follow the coding style of this project
- [x] Changes have been formatted and linted
- [x] Changes pass pytest style unit tests (and `pytest` passes).
- [x] Changes include any required corresponding changes to the documentation
- [x] Changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] Changes have a descriptive commit message with a short title
- [x] I have added a `Fixes #XXXX -` or `Closes #XXXX -` comment to auto-close the issue that your PR addresses
