### PR TITLE
Fix Pillow 10 deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -179,6 +179,8 @@ filterwarnings =
     # These should be removed when our scikit-image pinning is removed
     ignore:Please use `gaussian_filter` from the `scipy.ndimage` namespace:DeprecationWarning
     ignore:Please use `laplace` from the `scipy.ndimage` namespace:DeprecationWarning
+    # This should be removed when astropy v5.0.5 is released (see astropy #13044)
+    ignore:FLIP_TOP_BOTTOM is deprecated and will be removed in Pillow 10:DeprecationWarning
 
 [pycodestyle]
 max_line_length = 110


### PR DESCRIPTION
This ignores the warning in pytest. Or maybe wait if there'll be a new astropy release in a few days anyway?