### PR TITLE
Use astropy and matplotlib nightly feeds for devdeps CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
           - openjpeg
       envs: |
         - macos: py38
-        - windows: py310
+        - windows: py39
+        - linux: base_deps
+        - linux: py39-devdeps
         - linux: py38-oldestdeps
         - linux: py39-conda
           libraries: ''
@@ -83,8 +85,7 @@ jobs:
         apt:
           - libopenjp2-7
       envs: |
-        - linux: base_deps
-        - linux: py39-devdeps
+        - windows: py310
 
   publish:
     # Build wheels when pushing to any branch except main

--- a/tox.ini
+++ b/tox.ini
@@ -31,10 +31,14 @@ setenv =
     devdeps,build_docs,online: HOME = {envtmpdir}
     HIDE_PARFIVE_PROGESS = True
     NO_VERIFY_HELIO_SSL = 1
+    devdeps: PIP_EXTRA_INDEX_URL = https://pkgs.dev.azure.com/astropy-project/astropy/_packaging/nightly/pypi/simple/ https://pypi.anaconda.org/scipy-wheels-nightly/simple
+pip_pre =
+    devdeps: true
+    !devdeps: false
 deps =
     # devdeps is intended to be used to install the latest developer version of key dependencies.
-    devdeps: git+https://github.com/astropy/astropy
-    devdeps: git+https://github.com/matplotlib/matplotlib
+    devdeps: astropy
+    devdeps: matplotlib
     devdeps: git+https://github.com/asdf-format/asdf
     devdeps: git+https://github.com/sunpy/mpl-animators
     # Oldest deps we pin against

--- a/tox.ini
+++ b/tox.ini
@@ -32,13 +32,10 @@ setenv =
     HIDE_PARFIVE_PROGESS = True
     NO_VERIFY_HELIO_SSL = 1
     devdeps: PIP_EXTRA_INDEX_URL = https://pkgs.dev.azure.com/astropy-project/astropy/_packaging/nightly/pypi/simple/ https://pypi.anaconda.org/scipy-wheels-nightly/simple
-pip_pre =
-    devdeps: true
-    !devdeps: false
 deps =
     # devdeps is intended to be used to install the latest developer version of key dependencies.
-    devdeps: astropy
-    devdeps: matplotlib
+    devdeps: astropy>=0.0.dev0
+    devdeps: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/asdf-format/asdf
     devdeps: git+https://github.com/sunpy/mpl-animators
     # Oldest deps we pin against


### PR DESCRIPTION
This PR updates the tox configuration to search for the latest pre-release from the Astropy and Matplotlib nightly PyPI repositories when installing `astropy` and `matplotlib` in any of the `-devdeps` environments. This should significantly speed up the devdeps cron test on GitHub Actions and the devdeps figure tests on CircleCI. The remaining dev packages (`asdf` and `mpl-animators`) seem to be pure python so should't be a significant bottleneck.

The Astropy feed is at: https://dev.azure.com/astropy-project/astropy/_artifacts/feed/nightly/PyPI/astropy/5.1.dev781/overview

The Matplotlib feed is at: https://anaconda.org/scipy-wheels-nightly/matplotlib

Closes #6019 