### PR TITLE
Tell GitHub Actions to use the sunpy repo

### DIFF
--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -13,8 +13,8 @@ jobs:
   dispatch_workflows:
     runs-on: ubuntu-latest
     steps:
-      - run: gh workflow run ci.yml --ref main
-      - run: gh workflow run ci.yml --ref 3.1
-      - run: gh workflow run ci.yml --ref 3.0
+      - run: gh workflow run ci.yml --repo sunpy/sunpy --ref main
+      - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 3.1
+      - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 3.0
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since we didn't checkout the sunpy repo in the `scheduled_builds.yml`, GitHub CLI doesn't know which repository it should run workflows on 🤦 