### PR TITLE
cutdown flake8,  added autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,21 @@
 repos:
+# The warnings/errors we check for here are:
+  # E901 - SyntaxError or IndentationError
+  # E902 - IOError
+  # F822 - undefined name in __all__
+  # F823 - local variable name referenced before assignment
+  # Others are taken care of by autopep8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        args:
+          [
+            "--count",
+            "--select",
+            "E901,E902,F822,F823",
+          ]
+        exclude: ".*(.fits|.fts|.fit|.txt|tca.*|extern.*|.rst|.md|cm/__init__.py|sunpy/extern|sunpy/visualization/colormaps/color_tables.py)$"
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,75 +1,4 @@
 repos:
-  # The warnings/errors we check for here are:
-  # E101 - mix of tabs and spaces
-  # E11  - Fix indentation.
-  # E111 - 4 spaces per indentation level
-  # E112 - 4 spaces per indentation level
-  # E113 - 4 spaces per indentation level
-  # E121 - Fix indentation to be a multiple of four.
-  # E122 - Add absent indentation for hanging indentation.
-  # E123 - Align closing bracket to match opening bracket.
-  # E124 - Align closing bracket to match visual indentation.
-  # E125 - Indent to distinguish line from next logical line.
-  # E126 - Fix over-indented hanging indentation.
-  # E127 - Fix visual indentation.
-  # E128 - Fix visual indentation.
-  # E129 - Fix visual indentation.
-  # E131 - Fix hanging indent for unaligned continuation line.
-  # E133 - Fix missing indentation for closing bracket.
-  # E20  - Remove extraneous whitespace.
-  # E211 - Remove extraneous whitespace.
-  # E231 - Add missing whitespace.
-  # E241 - Fix extraneous whitespace around keywords.
-  # E242 - Remove extraneous whitespace around operator.
-  # E251 - Remove whitespace around parameter '=' sign.
-  # E252 - Missing whitespace around parameter equals.
-  # E26  - Fix spacing after comment hash for inline comments.
-  # E265 - Fix spacing after comment hash for block comments.
-  # E266 - Fix too many leading '#' for block comments.
-  # E27  - Fix extraneous whitespace around keywords.
-  # E301 - Add missing blank line.
-  # E302 - Add missing 2 blank lines.
-  # E303 - Remove extra blank lines.
-  # E304 - Remove blank line following function decorator.
-  # E305 - expected 2 blank lines after class or function definition
-  # E305 - Expected 2 blank lines after end of function or class.
-  # E306 - expected 1 blank line before a nested definition
-  # E306 - Expected 1 blank line before a nested definition.
-  # E401 - Put imports on separate lines.
-  # E402 - Fix module level import not at top of file
-  # E502 - Remove extraneous escape of newline.
-  # E701 - Put colon-separated compound statement on separate lines.
-  # E711 - Fix comparison with None.
-  # E712 - Fix comparison with boolean.
-  # E713 - Use 'not in' for test for membership.
-  # E714 - Use 'is not' test for object identity.
-  # E722 - Fix bare except.
-  # E731 - Use a def when use do not assign a lambda expression.
-  # E901 - SyntaxError or IndentationError
-  # E902 - IOError
-  # F822 - undefined name in __all__
-  # F823 - local variable name referenced before assignment
-  # W291 - Remove trailing whitespace.
-  # W292 - Add a single newline at the end of the file.
-  # W293 - Remove trailing whitespace on blank line.
-  # W391 - Remove trailing blank lines.
-  # W601 - Use "in" rather than "has_key()".
-  # W602 - Fix deprecated form of raising exception.
-  # W603 - Use "!=" instead of "<>"
-  # W604 - Use "repr()" instead of backticks.
-  # W605 - Fix invalid escape sequence 'x'.
-  # W690 - Fix various deprecated code (via lib2to3).
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        args:
-          [
-            "--count",
-            "--select",
-            "E101,E11,E111,E112,E113,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E133,E20,E211,E231,E241,E242,E251,E252,E26,E265,E266,E27,E301,E302,E303,E304,E305,E306,E401,E402,E502,E701,E711,E712,E713,E714,E722,E731,E901,E902,F822,F823,W191,W291,W292,W293,W391,W601,W602,W603,W604,W605,W690",
-          ]
-        exclude: ".*(.fits|.fts|.fit|.txt|tca.*|extern.*|.rst|.md|cm/__init__.py|sunpy/extern|sunpy/visualization/colormaps/color_tables.py)$"
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:
@@ -87,6 +16,12 @@ repos:
       - id: isort
         args: ["--sp", "setup.cfg"]
         exclude: ".*(.fits|.fts|.fit|.txt|tca.*|extern.*|.rst|.md|cm/__init__.py|sunpy/extern|docs/conf.py)$"
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.6.0
+    hooks:
+    -   id: autopep8
+        args: ["--in-place","--max-line-length", "200"]
+        exclude: ".*(.fits|.fts|.fit|.txt|tca.*|extern.*|.rst|.md|cm/__init__.py|sunpy/extern|sunpy/visualization/colormaps/color_tables.py)$"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/benchmarks/benchmarks_for_is_time.py
+++ b/benchmarks/benchmarks_for_is_time.py
@@ -7,6 +7,7 @@ class TimeSuite:
     An example benchmark that times the performance of sunpy.is_time()
     function
     """
+
     def time_is_time(self):
         t = is_time('1995-12-31 23:59:60')
 

--- a/benchmarks/benchmarks_for_map.py
+++ b/benchmarks/benchmarks_for_map.py
@@ -8,6 +8,7 @@ class TimeSuite:
     An example benchmark that times the performance of sunpy map
     creation
     """
+
     def setup(self):
         self._map = sunpy.data.sample.AIA_171_IMAGE
 

--- a/benchmarks/benchmarks_for_parse_time.py
+++ b/benchmarks/benchmarks_for_parse_time.py
@@ -7,6 +7,7 @@ class TimeSuite:
     An example benchmark that times the performance of sunpy.parse_time()
     function
     """
+
     def time_parse_time(self):
         t = parse_time('1995-12-31 23:59:60')
 

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -152,6 +152,7 @@ class HMISynopticMap(HMIMap):
     * `SDO Mission Page <https://sdo.gsfc.nasa.gov/>`__
     * `JSOC's HMI Synoptic Charts <http://jsoc.stanford.edu/HMI/LOS_Synoptic_charts.html>`__
     """
+
     def __init__(self, data, header, **kwargs):
         super().__init__(data, header, **kwargs)
         self.plot_settings['cmap'] = 'hmimag'

--- a/sunpy/net/hek/tests/test_hek.py
+++ b/sunpy/net/hek/tests/test_hek.py
@@ -16,6 +16,7 @@ class HEKResult:
     """
     Basic caching class to run the remote query once and return the result many times.
     """
+
     def __init__(self):
         self._result = None
 

--- a/sunpy/util/logger.py
+++ b/sunpy/util/logger.py
@@ -17,6 +17,7 @@ class SunpyLogger(AstropyLogger):
     passed on to other loggers (e.g., from Astropy).
     """
     # Override the existing _showwarning() to capture SunpyWarning instead of AstropyWarning
+
     def _showwarning(self, *args, **kwargs):
 
         # Bail out if we are not catching a warning from SunPy


### PR DESCRIPTION
Removes flake8 which just tells you your code is bad with a program that fixes it for you.

autopep8 fixes:

```
E101 - Reindent all lines.
E11  - Fix indentation.
E121 - Fix indentation to be a multiple of four.
E122 - Add absent indentation for hanging indentation.
E123 - Align closing bracket to match opening bracket.
E124 - Align closing bracket to match visual indentation.
E125 - Indent to distinguish line from next logical line.
E126 - Fix over-indented hanging indentation.
E127 - Fix visual indentation.
E128 - Fix visual indentation.
E129 - Fix visual indentation.
E131 - Fix hanging indent for unaligned continuation line.
E133 - Fix missing indentation for closing bracket.
E20  - Remove extraneous whitespace.
E211 - Remove extraneous whitespace.
E22  - Fix extraneous whitespace around keywords.
E224 - Remove extraneous whitespace around operator.
E225 - Fix missing whitespace around operator.
E226 - Fix missing whitespace around arithmetic operator.
E227 - Fix missing whitespace around bitwise/shift operator.
E228 - Fix missing whitespace around modulo operator.
E231 - Add missing whitespace.
E241 - Fix extraneous whitespace around keywords.
E242 - Remove extraneous whitespace around operator.
E251 - Remove whitespace around parameter '=' sign.
E252 - Missing whitespace around parameter equals.
E26  - Fix spacing after comment hash for inline comments.
E265 - Fix spacing after comment hash for block comments.
E266 - Fix too many leading '#' for block comments.
E27  - Fix extraneous whitespace around keywords.
E301 - Add missing blank line.
E302 - Add missing 2 blank lines.
E303 - Remove extra blank lines.
E304 - Remove blank line following function decorator.
E305 - Expected 2 blank lines after end of function or class.
E306 - Expected 1 blank line before a nested definition.
E401 - Put imports on separate lines.
E402 - Fix module level import not at top of file
E501 - Try to make lines fit within --max-line-length characters.
E502 - Remove extraneous escape of newline.
E701 - Put colon-separated compound statement on separate lines.
E70  - Put semicolon-separated compound statement on separate lines.
E711 - Fix comparison with None.
E712 - Fix comparison with boolean.
E713 - Use 'not in' for test for membership.
E714 - Use 'is not' test for object identity.
E721 - Use "isinstance()" instead of comparing types directly.
E722 - Fix bare except.
E731 - Use a def when use do not assign a lambda expression.
W291 - Remove trailing whitespace.
W292 - Add a single newline at the end of the file.
W293 - Remove trailing whitespace on blank line.
W391 - Remove trailing blank lines.
W503 - Fix line break before binary operator.
W504 - Fix line break after binary operator.
W601 - Use "in" rather than "has_key()".
W602 - Fix deprecated form of raising exception.
W603 - Use "!=" instead of "<>"
W604 - Use "repr()" instead of backticks.
W605 - Fix invalid escape sequence 'x'.
W690 - Fix various deprecated code (via lib2to3).
```