### PR TITLE
Set `GITHUB_TOKEN` to be `WORKFLOW_TOKEN` secret

### DIFF
--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -17,4 +17,4 @@ jobs:
       - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 3.1
       - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 3.0
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -1,6 +1,8 @@
 name: Scheduled builds
 
 on:
+  # Allow manual runs through the web UI
+  workflow_dispatch:
   schedule:
     #        ┌───────── minute (0 - 59)
     #        │ ┌───────── hour (0 - 23)


### PR DESCRIPTION
#### To do
- [ ] Add a `repo` scoped PAT as a `sunpy/sunpy` (or `sunpy` org) secret named `WORKFLOW_TOKEN`

Fixes #6044 