### PR TITLE
Don't bother running online CI when publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,7 @@ jobs:
 
   online:
     # Don't run online tests for tagged releases
-    if: |
-      github.event_name == 'pull_request' &&
-          !startsWith(github.event.ref, 'refs/tags/v')
+    if: !startsWith(github.event.ref, 'refs/tags/v')
     needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,7 @@ jobs:
           libraries: ''
 
   online:
-    # Don't run online tests for tagged releases
-    if: !startsWith(github.event.ref, 'refs/tags/v')
+    if: "!startsWith(github.event.ref, 'refs/tags/v')"
     needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
           libraries: ''
 
   online:
+    # Don't run online tests for tagged releases
+    if: |
+      github.event_name == 'pull_request' &&
+          !startsWith(github.event.ref, 'refs/tags/v')
     needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:


### PR DESCRIPTION
Publishing doesn't require these builds to pass, so we might as well save ourselves ~1h of actions runtime by not running them when publishing. I think I got the if statement right, but would appreciate someone else checking...