### PR TITLE
Fix bugs in changelog workflow

### DIFF
--- a/.github/workflows/changelog_bot.yml
+++ b/.github/workflows/changelog_bot.yml
@@ -7,7 +7,8 @@ on:
       - main
 
 env:
-  BOT_AUTHOR: 'SunPyBot <bot@sunpy.org>'
+  BOT_USER_NAME: 'SunPyBot'
+  BOT_USER_EMAIL: 'bot@sunpy.org'
 
 jobs:
   update-changelog:
@@ -28,10 +29,14 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.number }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          BOT_AUTHOR: ${{ env.BOT_USER_NAME }} <${{ env.BOT_USER_EMAIL }}>
       - name: Commit changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Add changelog
+          commit_message: '[skip ci] Add changelog'
           add_options: '-A'
+          disable_globbing: true
           file_pattern: 'changelog/*.rst'
-          commit_author: ${{ env.BOT_AUTHOR }}
+          commit_user_name: ${{ env.BOT_USER_NAME }}
+          commit_user_email: ${{ env.BOT_USER_EMAIL }}
+          commit_author: ${{ env.BOT_USER_NAME }} <${{ env.BOT_USER_EMAIL }}>

--- a/tools/write_changelog_entry.py
+++ b/tools/write_changelog_entry.py
@@ -46,7 +46,7 @@ for entry in existing:
 #     markdown heading of "Changelog [category]"
 #     followed by a message in the next ``` code block.
 body = re.sub("(<!--.*?-->)", "", body, flags=re.DOTALL)
-regex = r"[#]+[ ]*Changelog[ ]*\[([a-zA-Z]+)\]*[^`]*```([^`]*)```"
+regex = r"[#]+[ ]*Changelog[ ]*\[([a-zA-Z]+)\][^`]*```((?s:.)*?)```"
 results = re.findall(regex, body)
 
 # Count entries per category
@@ -66,7 +66,7 @@ for category, text in results:
         counter = ''
 
     filename = f"{pr}.{category}{counter}.rst"
-    text = text.strip()
+    text = text.strip().replace('\r', '')
     if len(text) > 0:  # ignore empty messages
         entries += [(filename, text)]
 


### PR DESCRIPTION
Fixes various bugs in the changelog workflow:
- Allow `` ` `` in changelog entry
- Ensure no `\r` characters are in the changelog entry (**I wasn't able to recreate this bug locally so this fix may not work. For some reason it was doing `\r\n` in GitHub Actions `ubuntu-latest` and not on macOS.**)
- Make the bot appear as SunPyBot instead of GitHub Actions
- Add the `[skip ci]` command to the commit messages so it CircleCI skips when updating the changelog
- Disable globbing in the commit action so it removes changelogs that are deleted (`git add -A changelog/*.rst`)

We can't test this without merging as the only version of the workflow that runs is the version in `main`.