### PR TITLE
Ignore ImageIO deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -181,6 +181,8 @@ filterwarnings =
     ignore:Please use `laplace` from the `scipy.ndimage` namespace:DeprecationWarning
     # This should be removed when astropy v5.0.5 is released (see astropy #13044)
     ignore:FLIP_TOP_BOTTOM is deprecated and will be removed in Pillow 10:DeprecationWarning
+    # Deprecation warning added in ImageIO 2.16.2, called by scikit-image
+    ignore:Starting with ImageIO v3 the behavior of this function will switch:DeprecationWarning
 
 [pycodestyle]
 max_line_length = 110


### PR DESCRIPTION
scikit-image is triggering a deprecation warning in ImageIO that was just added in ImageIO 2.16.2