### PR TITLE
Move some cibuildwheel configuration to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,6 @@ jobs:
     needs: [test]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@main
     with:
-      test_extras: 'dev'
-      test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
       targets: |
         - cp3{8,9,10}-manylinux*_x86_64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,11 @@ requires = [
          ]
 build-backend = 'setuptools.build_meta'
 
+[tool.cibuildwheel]
+test-extras = "dev"
+test-command = 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
+
+
 [ tool.gilesbot ]
   [ tool.gilesbot.circleci_artifacts ]
     enabled = true


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5924. I don't think there's an easy way to move the platform/python configuration because of the way we're using the OpenAstronomy actions/the way those actions are set up, but happy to  be corrected on that @ConorMacBride ?