### PR TITLE
Fixed scikit-image rotation of big-endian images

### DIFF
--- a/changelog/6064.bugfix.rst
+++ b/changelog/6064.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the inability to rotate images and maps with byte ordering that is different from the native byte order of the system (e.g., big-endian values on a little-endian system) for certain interpolation orders when internally using ``scikit-image``.

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -1,6 +1,7 @@
 """
 Functions for geometrical image transformation and warping.
 """
+import sys
 import numbers
 from functools import wraps
 
@@ -270,6 +271,9 @@ def _rotation_skimage(image, matrix, shift, order, missing, clip):
     * The implementation for higher orders of interpolation means that the pixels
       in the output image that are beyond the extent of the input image may not have
       exactly the value of the ``missing`` parameter.
+    * An input image with byte ordering that does not match the native byte order of
+      the system (e.g., big-endian values on a little-endian system) will be
+      copied and byte-swapped prior to rotation.
     * An input image with integer data is cast to floats prior to passing to
       :func:`~skimage.transform.warp`.  The output image can be re-cast using
       :meth:`numpy.ndarray.astype` if desired.
@@ -303,6 +307,10 @@ def _rotation_skimage(image, matrix, shift, order, missing, clip):
     if im_max > 0:
         adjusted_image /= im_max
         adjusted_missing /= im_max
+
+    # Swap the byte order if it is non-native (e.g., big-endian on a little-endian system)
+    if adjusted_image.dtype.byteorder == ('>' if sys.byteorder == 'little' else '<'):
+        adjusted_image = adjusted_image.byteswap().newbyteorder()
 
     # Be aware that even though mode is set to 'constant', when skimage 0.19 calls scipy,
     # it specifies the scipy mode to be 'grid-constant' rather than 'constant'

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -865,10 +865,6 @@ def calc_new_matrix(angle):
 
 
 def test_rotate(aia171_test_map):
-    # The test map has big-endian floats, so we switch it to floats with native byte ordering
-    # Otherwise, errors can be raised by code that has been compiled
-    aia171_test_map._data = aia171_test_map.data.astype('float')
-
     # We use order=0 for many of these tests to minimize losing edge pixels due to interpolation
     # with NaNs that are used as the default `missing` value
 


### PR DESCRIPTION
For a long time, our rotation code has crashed on images stored in big-endian byte order when using `scikit-image` for certain interpolation orders (1 and 3).  With @nabobalis pointing out that our HMI sample data is stored in big-endian byte order, I have finally fixed this bug.

This can be backported, but will have to be done manually.