### PR TITLE
Fix and tidy tests

### DIFF
--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -295,7 +295,7 @@ def test_tag_undo(database):
     assert len(entry.tags) == 1
 
 
-def remove_nonexisting_tag(database):
+def test_remove_nonexisting_tag(database):
     with pytest.raises(NoSuchTagError):
         database.remove_tag('foo')
 
@@ -367,7 +367,7 @@ def test_star_undo(database):
     assert entry.starred
 
 
-def unstar_entry(database):
+def test_unstar_entry(database):
     entry = DatabaseEntry()
     assert not entry.starred
     database.star(entry)

--- a/sunpy/database/tests/test_database.py
+++ b/sunpy/database/tests/test_database.py
@@ -296,8 +296,10 @@ def test_tag_undo(database):
 
 
 def test_remove_nonexisting_tag(database):
+    entry = DatabaseEntry()
+    database.add(entry)
     with pytest.raises(NoSuchTagError):
-        database.remove_tag('foo')
+        database.remove_tag(entry, 'foo')
 
 
 def test_remove_tag(filled_database):

--- a/sunpy/io/_fits.py
+++ b/sunpy/io/_fits.py
@@ -37,6 +37,7 @@ import sys
 import math
 import traceback
 import collections
+import collections.abc
 
 from astropy.io import fits
 
@@ -76,7 +77,7 @@ def read(filepath, hdus=None, memmap=None, **kwargs):
         if hdus is not None:
             if isinstance(hdus, int):
                 hdulist = hdulist[hdus]
-            elif isinstance(hdus, collections.Iterable):
+            elif isinstance(hdus, collections.abc.Iterable):
                 hdulist = [hdulist[i] for i in hdus]
 
         hdulist = fits.hdu.HDUList(hdulist)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in heade
     [(RHESSI_IMAGE, None, 4),
      (RHESSI_IMAGE, 1, 1),
      (RHESSI_IMAGE, [1, 2], 2),
-     (RHESSI_IMAGE, range(0, 1), 2)]
+     (RHESSI_IMAGE, range(0, 2), 2)]
 )
 def test_read_hdus(fname, hdus, length):
     pairs = sunpy.io._fits.read(fname, hdus=hdus)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in heade
      (RHESSI_IMAGE, [1, 2], 2),
      (RHESSI_IMAGE, range(0, 1), 2)]
 )
-def read_hdus(fname, hdus, length):
+def test_read_hdus(fname, hdus, length):
     pairs = sunpy.io._fits.read(fname, hdus=hdus)
     assert len(pairs) == length
 

--- a/sunpy/map/sources/tests/test_mdi_source.py
+++ b/sunpy/map/sources/tests/test_mdi_source.py
@@ -170,7 +170,7 @@ def test_wcs(mdi, mdi_synoptic):
         mdi_synoptic.pixel_to_world(0*u.pix, 0*u.pix)
 
 
-def test_unit(mdi_synoptic):
+def test_unit_synoptic(mdi_synoptic):
     assert mdi_synoptic.unit == u.G
     assert mdi_synoptic.unit == u.Unit("Mx/cm^2")
     assert mdi_synoptic.unit.to_string() == 'Mx / cm2'

--- a/sunpy/map/tests/test_compositemap.py
+++ b/sunpy/map/tests/test_compositemap.py
@@ -108,10 +108,10 @@ def test_set_alpha_composite_map(composite_test_map):
     composite_test_map.plot()
 
 
-def test_set_alpha_out_of_range_composite_map(composite_test_map):
+@pytest.mark.parametrize("index,alpha", [(0, 5.0), (1, -3.0)])
+def test_set_alpha_out_of_range_composite_map(composite_test_map, index, alpha):
     with pytest.raises(Exception) as excinfo:
-        composite_test_map.set_alpha(0, 5.0)
-        composite_test_map.set_alpha(1, -3.0)
+        composite_test_map.set_alpha(index, alpha)
     assert str(excinfo.value) == 'Alpha value must be between 0 and 1.'
 
 

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -188,10 +188,13 @@ def test_invalid_inputs(map_data, hcc_coord, hpc_coord_notime, hpc_coord):
     # Check arguments not given as astropy Quantities
     with pytest.raises(TypeError):
         header = make_fitswcs_header(map_data, hpc_coord, reference_pixel=[0, 0])
+    with pytest.raises(TypeError):
         header = make_fitswcs_header(map_data, hpc_coord, scale=[0, 0])
 
     # Check arguments of reference_pixel and scale have to be given in astropy units of pix, and arcsec/pix
     with pytest.raises(u.UnitsError):
         header = make_fitswcs_header(map_data, hpc_coord, reference_pixel=u.Quantity([0, 0]))
+    with pytest.raises(u.UnitsError):
         header = make_fitswcs_header(map_data, hpc_coord, scale=u.Quantity([0, 0]))
+    with pytest.raises(u.UnitsError):
         header = make_fitswcs_header(map_data, hpc_coord, scale=u.Quantity([0, 0]*u.arcsec))

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1278,8 +1278,11 @@ def test_contour_units(simple_map):
         assert np.all(c1 == c2)
 
     # Percentage
-    contours_percent = simple_map.contour(100 * u.percent)
-    contours_ref = simple_map.contour(np.max(simple_map.data) * simple_map.unit)
+    contours_percent = simple_map.contour(50 * u.percent)
+    high = np.max(simple_map.data)
+    low = np.min(simple_map.data)
+    middle = high - (high - low) / 2
+    contours_ref = simple_map.contour(middle * simple_map.unit)
     for c1, c2 in zip(contours_percent, contours_ref):
         assert np.all(c1 == c2)
 

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -170,13 +170,6 @@ def test_quadrangle_aia17_pix_top_right_different_axes(aia171_test_map):
 
 
 @figure_test
-def test_quadrangle_aia17_pix_top_right_different_axes(aia171_test_map):
-    aia171_test_map.rotate(30*u.deg).plot()
-    aia171_test_map.draw_quadrangle(bottom_left=(50, 50)*u.pix,
-                                    top_right=(80, 90)*u.pix, edgecolor='cyan')
-
-
-@figure_test
 def test_plot_masked_aia171(aia171_test_map_with_mask):
     aia171_test_map_with_mask.plot()
 

--- a/sunpy/net/hek/tests/test_hek.py
+++ b/sunpy/net/hek/tests/test_hek.py
@@ -49,9 +49,9 @@ def test_eventtype_collide():
     with pytest.raises(TypeError):
         (attrs.hek.AR & attrs.Time((2011, 1, 1),
                                    (2011, 1, 2))) & attrs.hek.CE
-        with pytest.raises(TypeError):
-            (attrs.hek.AR | attrs.Time((2011, 1, 1),
-                                       (2011, 1, 2))) & attrs.hek.CE
+    with pytest.raises(TypeError):
+        (attrs.hek.AR | attrs.Time((2011, 1, 1),
+                                   (2011, 1, 2))) & attrs.hek.CE
 
 
 def test_eventtype_or():

--- a/sunpy/net/hek/tests/test_hek.py
+++ b/sunpy/net/hek/tests/test_hek.py
@@ -38,7 +38,6 @@ _hek_result = HEKResult()
 
 
 @pytest.fixture
-@pytest.mark.remote_data
 def hek_result():
     return _hek_result.get_result()
 

--- a/sunpy/net/hek2vso/tests/test_hek2vso.py
+++ b/sunpy/net/hek2vso/tests/test_hek2vso.py
@@ -29,19 +29,16 @@ hekEvent = a.hek.EventType(eventType)
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.remote_data
 def h2v_client():
     return hek2vso.H2VClient()
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.remote_data
 def hek_client():
     return hek.HEKClient()
 
 
 @pytest.fixture
-@pytest.mark.remote_data
 def vso_client():
     vso.VSOClient()
 

--- a/sunpy/net/helio/tests/test_helio.py
+++ b/sunpy/net/helio/tests/test_helio.py
@@ -247,7 +247,6 @@ def test_link_test_on_urlerror(mock_link_test):
     link_test('') is None
 
 
-@pytest.mark.remote_data
 @pytest.fixture(scope="session")
 def client():
     try:

--- a/sunpy/net/tests/test_helioviewer.py
+++ b/sunpy/net/tests/test_helioviewer.py
@@ -14,7 +14,6 @@ from sunpy.tests.helpers import figure_test, skip_glymur
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.remote_data
 def client():
     """
     Fixture to create a client and skip tests if not available

--- a/sunpy/net/vso/tests/test_attrs.py
+++ b/sunpy/net/vso/tests/test_attrs.py
@@ -95,10 +95,10 @@ def test_wave_inputQuantity():
     wrong_type_mesage = "Wave inputs must be astropy Quantities"
     with pytest.raises(TypeError) as excinfo:
         core_attrs.Wavelength(10, 23)
-    assert excinfo.value.message == wrong_type_mesage
+    assert wrong_type_mesage in str(excinfo.value)
     with pytest.raises(TypeError) as excinfo:
         core_attrs.Wavelength(10 * u.AA, 23)
-    assert excinfo.value.message == wrong_type_mesage
+    assert wrong_type_mesage in str(excinfo.value)
 
 
 def test_wave_toangstrom():

--- a/sunpy/net/vso/tests/test_attrs.py
+++ b/sunpy/net/vso/tests/test_attrs.py
@@ -95,10 +95,10 @@ def test_wave_inputQuantity():
     wrong_type_mesage = "Wave inputs must be astropy Quantities"
     with pytest.raises(TypeError) as excinfo:
         core_attrs.Wavelength(10, 23)
-        assert excinfo.value.message == wrong_type_mesage
+    assert excinfo.value.message == wrong_type_mesage
     with pytest.raises(TypeError) as excinfo:
         core_attrs.Wavelength(10 * u.AA, 23)
-        assert excinfo.value.message == wrong_type_mesage
+    assert excinfo.value.message == wrong_type_mesage
 
 
 def test_wave_toangstrom():


### PR DESCRIPTION
This PR tidies up and fixes some issues with the tests:

- [Tests should start with test](https://github.com/sunpy/sunpy/commit/7d1795031a7650ad4cadd237fd75335921106a71)
These tests were not being run

- [Fix duplicate test names](https://github.com/sunpy/sunpy/commit/1d8b6d1ccc6c70a3bf4d1d3df41321755d3da3d4)
MDI test had a duplicate name (renamed) and plotting test was a duplicate test (deleted)

- [One statement per pytest context manager](https://github.com/sunpy/sunpy/commit/b85700b766d8e9447cfc8ec04cb4c88f2206632d)
In these cases, the first statement was raising the error/warning and the subsequent statements were not being run

- [Remove redundant remote_data mark from fixtures](https://github.com/sunpy/sunpy/commit/77b865d1da9edcc8a7bb41e233a1d364becc20eb)
["Marks can only be applied to tests, having no effect on fixtures."](https://docs.pytest.org/en/6.2.x/mark.html)

- [Fix contour test](https://github.com/sunpy/sunpy/commit/1733a2e3c8ec13114f0d327a12b831117c83f188)
This test wasn't returning any values so the assert statement in the for loop was not running. I have moved the percentage from 100% to 50% and there are now values to check.

Most of these issues were found by running the offline tests but generating a coverage report for all files including the test files. This shows which tests and which parts are actually being run. The rest of the issues were found with regex.

There are also quite a few fixtures and functions in the test files which are not being used, although I didn't delete any in case they are useful in the future or they are needed for online tests etc. I think it would be useful to include the test files in the coverage as we can more easily spot issues where assertions are not running. [I see that matplotlib includes test files in the coverage for example.](https://codecov.io/gh/matplotlib/matplotlib/tree/main/lib/matplotlib/tests) What do you think?