### PR TITLE
Update JSOC email fixture and cancel workflow

### DIFF
--- a/.github/workflows/cancel_ci.yml
+++ b/.github/workflows/cancel_ci.yml
@@ -2,7 +2,7 @@ name: 'Cancel Previous Runs'
 
 on:
   workflow_run:
-    workflows: ["CI", "Automated tests", "Scheduled builds", "asv-benchmarks-daily"]
+    workflows: ["CI"]
     types:
       - requested
 
@@ -13,5 +13,4 @@ jobs:
     steps:
     - uses: styfle/cancel-workflow-action@0.9.1
       with:
-        all_but_latest: true
         workflow_id: ${{ github.event.workflow.id }}

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -34,10 +34,9 @@ console_logger = logging.getLogger()
 console_logger.setLevel('INFO')
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture
 def jsoc_test_email():
-    # JSOC Test email
-    pytest.jsoc_test_email = "nabil.freij@gmail.com"
+    return "nabil.freij@gmail.com"
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -29,7 +29,7 @@ def jsoc_response_double(jsoc_test_email):
                          {'T_REC': '2011/01/02T00:00', 'INSTRUME': 'AIA'}])
     resp.query_args = [{'start_time': astropy.time.Time("2020-01-01T01:00:36.000"),
                         'end_time': astropy.time.Time("2020-01-01T01:00:38.000"),
-                        'series': 'hmi.M_45s', 'notify': pytest.jsoc_test_email}]
+                        'series': 'hmi.M_45s', 'notify': jsoc_test_email}]
     return resp
 
 
@@ -96,7 +96,7 @@ def test_post_wave_series(client):
 def test_wait_get(client, jsoc_test_email):
     responses = client.search(
         a.Time('2020/1/1T1:00:36', '2020/1/1T01:00:38'),
-        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(pytest.jsoc_test_email))
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(jsoc_test_email))
     path = tempfile.mkdtemp()
     res = client.fetch(responses, path=path)
     assert isinstance(res, Results)
@@ -107,7 +107,7 @@ def test_wait_get(client, jsoc_test_email):
 def test_get_request_tar(client, jsoc_test_email):
     responses = client.search(
         a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(pytest.jsoc_test_email))
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(jsoc_test_email))
     bb = client.request_data(responses, method='url-tar')
     bb.wait()
     path = tempfile.mkdtemp()
@@ -116,7 +116,7 @@ def test_get_request_tar(client, jsoc_test_email):
 
     responses = client.search(
         a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(pytest.jsoc_test_email),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(jsoc_test_email),
         a.jsoc.Protocol('as-is'))
     bb = client.request_data(responses, method='url-tar')
     bb.wait()
@@ -249,7 +249,7 @@ def test_make_recordset(client):
 def test_request_data_error(client, jsoc_test_email):
     responses = client.search(
         a.Time('2020/1/1T1:00:36', '2020/1/1T01:00:38'),
-        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(pytest.jsoc_test_email),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(jsoc_test_email),
         a.jsoc.Protocol('foo'))
     with pytest.raises(TypeError):
         client.request_data(responses)
@@ -259,7 +259,7 @@ def test_request_data_error(client, jsoc_test_email):
 def test_request_data_method(client, jsoc_test_email):
     responses = client.search(
         a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(pytest.jsoc_test_email))
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(jsoc_test_email))
     req = client.request_data(responses, method='url-tar')
     req.wait()
     assert req.status == 0
@@ -268,7 +268,7 @@ def test_request_data_method(client, jsoc_test_email):
 
     responses = client.search(
         a.Time('2012/1/1T1:00:36', '2012/1/1T01:00:38'),
-        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(pytest.jsoc_test_email),
+        a.jsoc.Series('hmi.M_45s'), a.jsoc.Notify(jsoc_test_email),
         a.jsoc.Protocol('as-is'))
     req = client.request_data(responses, method='url-tar')
     req.wait()
@@ -304,7 +304,7 @@ def test_jsoc_cutout_attrs(client, jsoc_test_email):
         a.Time(m_ref.date, m_ref.date + 1 * u.min),
         a.Wavelength(171*u.angstrom),
         a.jsoc.Series.aia_lev1_euv_12s,
-        a.jsoc.Notify(pytest.jsoc_test_email),
+        a.jsoc.Notify(jsoc_test_email),
         a.jsoc.Segment.image,
         cutout,
     )

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -462,7 +462,7 @@ def test_slice_jsoc(jsoc_test_email):
     tstart = '2011/06/07 06:32:45'
     tend = '2011/06/07 06:33:15'
     res = Fido.search(a.Time(tstart, tend), a.jsoc.Series('hmi.M_45s'),
-                      a.jsoc.Notify(pytest.jsoc_test_email))
+                      a.jsoc.Notify(jsoc_test_email))
     with pytest.warns(SunpyUserWarning, match="Downloading of sliced JSOC results is not supported."):
         Fido.fetch(res[0, 0])
 
@@ -477,7 +477,7 @@ def test_fido_repr():
 def test_fido_metadata_queries(jsoc_test_email):
     results = Fido.search(a.Time('2010/8/1 03:40', '2010/8/1 3:40:10'),
                           a.hek.FI | a.hek.FL & (a.hek.FL.PeakFlux > 1000) |
-                          a.jsoc.Series('hmi.m_45s') & a.jsoc.Notify(pytest.jsoc_test_email))
+                          a.jsoc.Series('hmi.m_45s') & a.jsoc.Notify(jsoc_test_email))
     assert len(results['hek']) == 2
     assert isinstance(results['hek'], UnifiedResponse)
     assert isinstance(results['hek'][0], QueryResponseTable)


### PR DESCRIPTION
- [Update jsoc_test_email fixture](https://github.com/sunpy/sunpy/commit/3c2d16735a0638cbc230cb965bcef63f8eb50cde)
  Don't add to pytest namespace

- [Simplify cancel workflow](https://github.com/sunpy/sunpy/commit/6a68a41a0d4aa6439c28e0a493c5059ec3af78d4)
  We only need to cancel the "CI" workflow as the others are scheduled, and "Automated tests" no longer exists. Also removing "all_but_latest" as it should not be necessary.

#### Why the cancel workflow is not working:
GitHub are having issues searching workflows, [as you can see in the error message here](https://github.com/sunpy/sunpy/actions/workflows/ci.yml?query=branch%3Amain+), so the cancel action is filtering an incomplete list of workflows. I have checked and if you remove [this line](https://github.com/styfle/cancel-workflow-action/blob/6944bfe92a80484201dab549e0c7b5c769b010df/src/index.ts#L70) from the action upstream it causes the expected workflow runs to be returned by the API. I guess we'll just have to wait for GitHub to fix this issue. I'll open a PR to revert the changes to the cancel workflow.