### PR TITLE
[Backport 3.0] Fixed scikit-image rotation of big-endian images

### DIFF
--- a/changelog/6064.bugfix.rst
+++ b/changelog/6064.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the inability to rotate images and maps with byte ordering that is different from the native byte order of the system (e.g., big-endian values on a little-endian system) for certain interpolation orders when internally using ``scikit-image``.

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -1,6 +1,7 @@
 """
 Functions for geometrical image transformation and warping.
 """
+import sys
 import numbers
 import warnings
 
@@ -141,6 +142,10 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
             else:
                 # The input array is all one value (aside from NaNs), so no scaling is needed
                 adjusted_missing = missing - im_min
+
+        # Swap the byte order if it is non-native (e.g., big-endian on a little-endian system)
+        if adjusted_image.dtype.byteorder == ('>' if sys.byteorder == 'little' else '<'):
+            adjusted_image = adjusted_image.byteswap().newbyteorder()
 
         rotated_image = skimage.transform.warp(adjusted_image, tform, order=order,
                                                mode='constant', cval=adjusted_missing)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -800,10 +800,6 @@ def calc_new_matrix(angle):
 
 
 def test_rotate(aia171_test_map):
-    # The test map has big-endian floats, so we switch it to floats with native byte ordering
-    # Otherwise, errors can be raised by code that has been compiled
-    aia171_test_map._data = aia171_test_map.data.astype('float')
-
     rotated_map_1 = aia171_test_map.rotate(20 * u.deg)
     rotated_map_2 = rotated_map_1.rotate(20 * u.deg)
     np.testing.assert_allclose(rotated_map_1.rotation_matrix,


### PR DESCRIPTION
Backport #6064.