### PR TITLE
Switch helioviewer URL order

### DIFF
--- a/sunpy/net/helioviewer.py
+++ b/sunpy/net/helioviewer.py
@@ -21,8 +21,8 @@ from sunpy.util.xml import xml_to_dict
 __all__ = ['HelioviewerClient']
 
 HELIOVIEWER_API_URLS = [
-    "https://helioviewer-api.ias.u-psud.fr/",
     "https://api.helioviewer.org/",
+    "https://helioviewer-api.ias.u-psud.fr/",
 ]
 
 


### PR DESCRIPTION
api.helioviewer.org is the one in the official docs (e.g. https://api.helioviewer.org/docs/v2/api/api_groups/jpeg2000.html#example-binary-jpeg2000-image-data), so use that first. This should prevent some test warnings/errors because https://helioviewer-api.ias.u-psud.fr/ is currently down.