### PR TITLE
Capture warnings in new test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,6 @@ asdf_schema_tests_enabled = true
 asdf_schema_root = sunpy/io/special/asdf/schemas/
 mpl-results-path = figure_test_images
 mpl-use-full-test-name = True
-asyncio_mode = auto
 markers =
     remote_data: marks this test function as needing remote data.
     online: marks this test function as needing online connectivity.

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -176,13 +176,13 @@ def test_hpc_distance_off_limb():
     assert hpc1.Tx == 1500 * u.arcsec
     assert hpc1.Ty == 0 * u.arcsec
 
-    with pytest.raises(SunpyUserWarning, match="is all NaNs"):
+    with pytest.warns(SunpyUserWarning, match="is all NaNs"):
         hpc2 = hpc1.make_3d()
-        assert isinstance(hpc2._data, SphericalRepresentation)
-        # Check the attrs are correct
-        assert hpc2.Tx == 1500 * u.arcsec
-        assert hpc2.Ty == 0 * u.arcsec
-        assert_quantity_allclose(hpc2.distance, u.Quantity(np.nan, u.km))
+    assert isinstance(hpc2._data, SphericalRepresentation)
+    # Check the attrs are correct
+    assert hpc2.Tx == 1500 * u.arcsec
+    assert hpc2.Ty == 0 * u.arcsec
+    assert_quantity_allclose(hpc2.distance, u.Quantity(np.nan, u.km))
 
 
 def test_hpc_distance_3D():


### PR DESCRIPTION
This fixes the warning capture in wheel tests (i.e. pytest with `-p no:warnings`) for a new test that was added. 

Also removes [a configuration option for `pytest-asyncio`](https://github.com/pytest-dev/pytest-asyncio#modes) which was causing a `PytestConfigWarning: Unknown config option: asyncio_mode` warning. I suspect it was added originally because someone also had `pytest-asyncio` installed in their SunPy environment, although we don't depend on it.