### PR TITLE
Test speedups

### DIFF
--- a/sunpy/image/tests/test_resample.py
+++ b/sunpy/image/tests/test_resample.py
@@ -28,15 +28,10 @@ def resample_meta(aia171_test_map, dimensions, method, center, minusone):
 
 
 def resample_method(aia171_test_map, method):
-    assert resample_meta(aia171_test_map, (512, 512) * u.pix, method, False, False) == (512, 512)
-    assert resample_meta(aia171_test_map, (2056, 2056) * u.pix,
-                         method, False, False) == (2056, 2056)
-    assert resample_meta(aia171_test_map, (512, 512) * u.pix, method, False, True) == (512, 512)
-    assert resample_meta(aia171_test_map, (2056, 2056) * u.pix, method, False, True) == (2056, 2056)
-    assert resample_meta(aia171_test_map, (512, 512) * u.pix, method, True, False) == (512, 512)
-    assert resample_meta(aia171_test_map, (2056, 2056) * u.pix, method, True, False) == (2056, 2056)
-    assert resample_meta(aia171_test_map, (512, 512) * u.pix, method, True, True) == (512, 512)
-    assert resample_meta(aia171_test_map, (2056, 2056) * u.pix, method, True, True) == (2056, 2056)
+    for shape in [(64, 64), (256, 256)]:
+        for center in [False, True]:
+            for minusone in [False, True]:
+                assert resample_meta(aia171_test_map, shape * u.pix, method, center, minusone) == shape
 
 
 def test_resample_neighbor(aia171_test_map):

--- a/sunpy/map/tests/conftest.py
+++ b/sunpy/map/tests/conftest.py
@@ -67,7 +67,7 @@ def aia171_test_map_with_mask(aia171_test_map):
 
 @pytest.fixture
 def generic_map():
-    data = np.ones([6, 6], dtype=np.float64)
+    data = np.arange(36, dtype=np.float64).reshape((6, 6))
     dobs = Time('1970-01-01T00:00:00')
     l0 = sun.L0(dobs).to_value(u.deg)
     b0 = sun.B0(dobs).to_value(u.deg)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -117,19 +117,19 @@ def test_dtype(generic_map):
 
 
 def test_min(generic_map):
-    assert generic_map.min() == 1
+    assert generic_map.min() == 0
 
 
 def test_max(generic_map):
-    assert generic_map.max() == 1
+    assert generic_map.max() == 35
 
 
 def test_mean(generic_map):
-    assert generic_map.mean() == 1
+    assert generic_map.mean() == 17.5
 
 
 def test_std(generic_map):
-    assert generic_map.std() == 0
+    np.testing.assert_allclose(generic_map.std(), 10.388294694831615)
 
 
 def test_unit(generic_map):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1205,10 +1205,10 @@ def test_quicklook(aia171_test_map):
         assert aia171_test_map._repr_html_() in html_string
 
 
-def test_dask_array(aia171_test_map):
+def test_dask_array(generic_map):
     dask_array = pytest.importorskip('dask.array')
-    da = dask_array.from_array(aia171_test_map.data, chunks=(1, 1))
-    pair_map = sunpy.map.Map(da, aia171_test_map.meta)
+    da = dask_array.from_array(generic_map.data, chunks=(1, 1))
+    pair_map = sunpy.map.Map(da, generic_map.meta)
 
     # Check that _repr_html_ functions for a dask array
     html_dask_repr = pair_map._repr_html_(compute_dask=False)


### PR DESCRIPTION
This speeds up a couple of the slowest tests for me when running the tests locally by:

- Using `generic_map` for the dask test, which is only 6x6 pixels
- Reudcing the dimensions used for resampling, which reduces the number of arithmetic operations and therefore running time.
- Give `generic_map` a range of values, which makes for more meaningful min/max/mean/std tests where the results aren't all the same.