### PR TITLE
Bugfixes for errors detected in asdf downstream testing of sunpy

### DIFF
--- a/sunpy/io/special/asdf/resources/schemas/heliographic_carrington-1.0.0.yaml
+++ b/sunpy/io/special/asdf/resources/schemas/heliographic_carrington-1.0.0.yaml
@@ -25,6 +25,6 @@ allOf:
         type: object
         properties:
           obstime:
-            $ref: "tag:stsci.edu:asdf/time/time-1.1.0"
+            tag: "tag:stsci.edu:asdf/time/time-1.1.0"
         additionalProperties: False
 ...

--- a/sunpy/io/special/asdf/resources/schemas/heliographic_carrington-1.1.0.yaml
+++ b/sunpy/io/special/asdf/resources/schemas/heliographic_carrington-1.1.0.yaml
@@ -40,7 +40,7 @@ allOf:
         properties:
           observer:
             anyOf:
-              - tag: "tag:sunpy.org:sunpy/coordinates/frames/heliographic_stonyhurst-1.1.0"
+              - tag: "tag:sunpy.org:sunpy/coordinates/frames/heliographic_stonyhurst-1.0.0"
               - type: string
           obstime:
             tag: "tag:stsci.edu:asdf/time/time-1.1.0"


### PR DESCRIPTION
## PR Description

Bugfixes for errors detected by the various automated asdf downstream testing CI suites, e.g. https://github.com/asdf-format/asdf-transform-schemas/runs/6152565340?check_suite_focus=true


<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

The error detected was an incorrect `heliographic_stonyhurst` tag (was 1.1.0 should have been 1.0.0) in the `heliographic_carrington_1.1.0` schema. While debugging this issue I also noticed an error in the `heliographic_carrington_1.0.0` schema; namely, a `$ref:` which should have been a `tag:`.