### PR TITLE
Memmap tests for io

### DIFF
--- a/sunpy/io/tests/test_ana.py
+++ b/sunpy/io/tests/test_ana.py
@@ -79,7 +79,7 @@ def test_f32c():
 
 @skip_ana
 def test_read_memmap():
-    # Test to check memmap is passed to the reader
+    # Test to check that passing memmap=True doesn't raise an error
     afilename = tempfile.NamedTemporaryFile().name
     ana.write(afilename, img_f32, 'testcase', 0)
     img_f32c_rec = ana.read(afilename, memmap=True)

--- a/sunpy/io/tests/test_ana.py
+++ b/sunpy/io/tests/test_ana.py
@@ -3,6 +3,7 @@ import tempfile
 
 import numpy as np
 import pytest
+import mmap
 
 from sunpy.io import ana
 from sunpy.tests.helpers import skip_ana
@@ -84,3 +85,7 @@ def test_read_memmap():
     ana.write(afilename, img_f32, 'testcase', 0)
     img_f32c_rec = ana.read(afilename, memmap=True)
     assert np.sum(img_f32c_rec[0][0] - img_f32) == 0
+
+    # Test to check that passing memmap=False doesn't raise an error
+    img_f32c_rec = ana.read(afilename, memmap=False)
+    assert not isinstance(img_f32c_rec, mmap.mmap)

--- a/sunpy/io/tests/test_ana.py
+++ b/sunpy/io/tests/test_ana.py
@@ -79,6 +79,7 @@ def test_f32c():
 
 @skip_ana
 def test_read_memmap():
+    # Test to check memmap is passed to the reader
     afilename = tempfile.NamedTemporaryFile().name
     ana.write(afilename, img_f32, 'testcase', 0)
     img_f32c_rec = ana.read(afilename, memmap=True)

--- a/sunpy/io/tests/test_ana.py
+++ b/sunpy/io/tests/test_ana.py
@@ -75,3 +75,12 @@ def test_f32c():
     afilename = tempfile.NamedTemporaryFile().name
     with pytest.raises(RuntimeError):
         ana.write(afilename, img_f32, 'testcase', 1)
+
+
+@skip_ana
+def test_memmap():
+    # Test if float 32 compressed functions
+    afilename = tempfile.NamedTemporaryFile().name
+    ana.write(afilename, img_f32, 'testcase', 0)
+    img_f32c_rec = ana.read(afilename, memmap=True)
+    assert np.sum(img_f32c_rec[0][0] - img_f32) == 0

--- a/sunpy/io/tests/test_ana.py
+++ b/sunpy/io/tests/test_ana.py
@@ -79,7 +79,6 @@ def test_f32c():
 
 @skip_ana
 def test_memmap():
-    # Test if float 32 compressed functions
     afilename = tempfile.NamedTemporaryFile().name
     ana.write(afilename, img_f32, 'testcase', 0)
     img_f32c_rec = ana.read(afilename, memmap=True)

--- a/sunpy/io/tests/test_ana.py
+++ b/sunpy/io/tests/test_ana.py
@@ -78,7 +78,7 @@ def test_f32c():
 
 
 @skip_ana
-def test_memmap():
+def test_read_memmap():
     afilename = tempfile.NamedTemporaryFile().name
     ana.write(afilename, img_f32, 'testcase', 0)
     img_f32c_rec = ana.read(afilename, memmap=True)

--- a/sunpy/io/tests/test_ana.py
+++ b/sunpy/io/tests/test_ana.py
@@ -1,9 +1,9 @@
 
+import mmap
 import tempfile
 
 import numpy as np
 import pytest
-import mmap
 
 from sunpy.io import ana
 from sunpy.tests.helpers import skip_ana

--- a/sunpy/io/tests/test_filetools.py
+++ b/sunpy/io/tests/test_filetools.py
@@ -10,8 +10,8 @@ import sunpy.io
 from sunpy.data.test import get_test_filepath
 from sunpy.tests.helpers import skip_ana, skip_glymur
 
-RHESSI_IMAGE = get_test_filepath('hsi_image_20101016_191218.fits')
-AIA_171_IMAGE = get_test_filepath('aia_171_level1.fits')
+TEST_RHESSI_IMAGE = get_test_filepath('hsi_image_20101016_191218.fits')
+TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
 
 # Some of the tests images contain an invalid BLANK keyword;
 pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in header")
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in heade
 
 def test_read_file_network_fits():
     url = "https://hesperia.gsfc.nasa.gov/rhessi_extras/imagecube_fits/2015/12/20/20151220_2228_2248/hsi_imagecube_clean_20151220_2228_13tx3e.fits"
-    with patch("astropy.io.fits.file.download_file", return_value=AIA_171_IMAGE) as mock:
+    with patch("astropy.io.fits.file.download_file", return_value=TEST_AIA_IMAGE) as mock:
         data = sunpy.io.read_file(url)
         assert mock.call_args[0] == (url,)
     assert isinstance(data, list)
@@ -30,7 +30,7 @@ def test_read_file_network_fits():
 
 
 def test_read_file_fits():
-    aiapair = sunpy.io.read_file(AIA_171_IMAGE)
+    aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)
     assert isinstance(aiapair, list)
     assert len(aiapair) == 1
     assert len(aiapair[0]) == 2
@@ -39,7 +39,7 @@ def test_read_file_fits():
 
 
 def test_read_file_fits_multple_hdu():
-    pairs = sunpy.io.read_file(RHESSI_IMAGE)
+    pairs = sunpy.io.read_file(TEST_RHESSI_IMAGE)
     assert isinstance(pairs, list)
     assert len(pairs) == 4
     assert all([len(p) == 2 for p in pairs])
@@ -81,7 +81,7 @@ def test_read_file_header_jp2():
 
 
 def test_read_file_header_fits():
-    hlist = sunpy.io.read_file_header(AIA_171_IMAGE)
+    hlist = sunpy.io.read_file_header(TEST_AIA_IMAGE)
     assert isinstance(hlist, list)
     assert len(hlist) == 1
     assert isinstance(hlist[0], sunpy.io.header.FileHeader)
@@ -128,22 +128,22 @@ def test_read_file_header_jp2():
 @pytest.mark.parametrize('fname', ['aia_171_image.fits',
                                    pathlib.Path('aia_171_image.fits')])
 def test_write_file_fits(fname):
-    aiapair = sunpy.io.read_file(AIA_171_IMAGE)[0]
+    aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
     sunpy.io.write_file(fname, aiapair[0], aiapair[1],
                         overwrite=True)
     assert os.path.exists("aia_171_image.fits")
-    outpair = sunpy.io.read_file(AIA_171_IMAGE)[0]
+    outpair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
     assert np.all(np.equal(outpair[0], aiapair[0]))
     assert outpair[1] == aiapair[1]
     os.remove("aia_171_image.fits")
 
 
 def test_write_file_fits_bytes():
-    aiapair = sunpy.io.read_file(AIA_171_IMAGE)[0]
+    aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
     with open("aia_171_image_bytes.fits", 'wb') as fileo:
         sunpy.io.write_file(fileo, aiapair[0], aiapair[1], filetype='fits')
     assert os.path.exists("aia_171_image_bytes.fits")
-    outpair = sunpy.io.read_file(AIA_171_IMAGE)[0]
+    outpair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
     assert np.all(np.equal(outpair[0], aiapair[0]))
     assert outpair[1] == aiapair[1]
     os.remove("aia_171_image_bytes.fits")

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -184,6 +184,3 @@ def test_read_memmap():
     # Create memmap array with data and header
     mm = np.memmap(AIA_171_IMAGE, dtype=data.dtype, mode='r', shape=data.shape)
     assert isinstance(mm, np.memmap)
-
-
-test_read_memmap()

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -1,3 +1,4 @@
+import mmap
 from pathlib import Path
 from collections import OrderedDict
 
@@ -178,10 +179,13 @@ def test_warn_longkey():
     assert 'BADLONGKEY' not in fits.keys()
 
 
-def test_read_memmap():
-    # Test that memmap=False gives the same data as memmap=True
-    data, header = sunpy.io.read_file(AIA_171_IMAGE, memmap=False)[0]
-    data_memmap, header_memmap = sunpy.io.read_file(AIA_171_IMAGE, memmap=True)[0]
+def is_memmap(data):
+    if data.base is None:
+        return False
+    return isinstance(data.base, mmap.mmap) or is_memmap(data.base)
 
-    assert np.all(data == data_memmap)
-    assert np.all(header == header_memmap)
+
+def test_read_memmap():
+    # Check that memmap is passed as an argument to read function doesnot raise an error.
+    data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)[0]
+    assert is_memmap(data)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -180,7 +180,7 @@ def test_warn_longkey():
 
 def test_read_memmap():
     # Test that memmap is passed correctly to the FITS reader
-    # Expecting ValueError: not enough values to unpack (expected 2, got 1)
-    with pytest.raises(ValueError):
-        data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)
-        assert isinstance(data, np.memmap)
+    data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)[0]
+    # Create memmap array
+    mm = np.memmap(AIA_171_IMAGE, dtype='float32', mode='r', shape=data.shape)
+    assert isinstance(mm, np.memmap)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -182,14 +182,10 @@ def test_warn_longkey():
 def test_read_memmap():
     # Check that the FITS reader can read a memmap without memmap argument by default
     data, header = sunpy.io._fits.read(TEST_AIA_IMAGE)[0]
-    if data.base is None:
-        assert False
     assert isinstance(data.base, mmap.mmap)
 
     # Check that memmap=True does the same thing
     data, header = sunpy.io._fits.read(TEST_AIA_IMAGE, memmap=True)[0]
-    if data.base is None:
-        assert False
     assert isinstance(data.base, mmap.mmap)
 
     # Check that memmap=False doesn't do memory mapping

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -180,8 +180,12 @@ def test_warn_longkey():
 
 
 def test_read_memmap():
-    # Check that memmap is read correctly from a file
+    # Check that memmap=True does memory map to the file
     data, header = sunpy.io._fits.read(TEST_AIA_IMAGE, memmap=True)[0]
     if data.base is None:
         assert False
-    assert isinstance(data.base, mmap.mmap) or isinstance(data.base, np.memmap)
+    assert isinstance(data.base, mmap.mmap)
+
+    # Check that memmap=False doesn't do memory mapping
+    data, header = sunpy.io._fits.read(TEST_AIA_IMAGE, memmap=False)[0]
+    assert data.base is None

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -179,7 +179,9 @@ def test_warn_longkey():
 
 
 def test_read_memmap():
-    # Test that memmap is passed correctly to the FITS reader
-    data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)[0]
-    assert isinstance(data, np.ndarray)
-    assert isinstance(header, sunpy.io.header.FileHeader)
+    # Test that memmap=False gives the same data as memmap=True
+    data, header = sunpy.io.read_file(AIA_171_IMAGE, memmap=False)[0]
+    data_memmap, header_memmap = sunpy.io.read_file(AIA_171_IMAGE, memmap=True)[0]
+
+    assert np.all(data == data_memmap)
+    assert np.all(header == header_memmap)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -1,4 +1,3 @@
-from cgi import print_directory
 from pathlib import Path
 from collections import OrderedDict
 

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -19,7 +19,7 @@ EIT_195_IMAGE = get_test_filepath('EIT_header/efz20040301.000010_s.header')
 AIA_171_IMAGE = get_test_filepath('aia_171_level1.fits')
 SWAP_LEVEL1_IMAGE = get_test_filepath('SWAP/resampled1_swap.header')
 
-# Some of the tests iamges contain an invalid BLANK keyword; ignore the warning
+# Some of the tests images contain an invalid BLANK keyword; ignore the warning
 # raised by this
 pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in header")
 
@@ -178,7 +178,14 @@ def test_warn_longkey():
     assert 'BADLONGKEY' not in fits.keys()
 
 
-def test_read_memmap():
+@pytest.mark.parametrize(
+    'fname, hdus, length',
+    [(RHESSI_IMAGE, None, 4),
+     (RHESSI_IMAGE, 1, 1),
+     (RHESSI_IMAGE, [1, 2], 2),
+     (RHESSI_IMAGE, range(0, 2), 2)]
+)
+def test_read_memmap(fname, hdus, length):
     # Test that memmap is passed correctly to the FITS reader
-    data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)
+    data = sunpy.io._fits.read(fname, hdus=hdus, memmap=True)
     assert isinstance(data, np.memmap)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from collections import OrderedDict
+from re import A
 
 import numpy as np
 import pytest
@@ -178,14 +179,9 @@ def test_warn_longkey():
     assert 'BADLONGKEY' not in fits.keys()
 
 
-@pytest.mark.parametrize(
-    'fname, hdus, length',
-    [(RHESSI_IMAGE, None, 4),
-     (RHESSI_IMAGE, 1, 1),
-     (RHESSI_IMAGE, [1, 2], 2),
-     (RHESSI_IMAGE, range(0, 2), 2)]
-)
-def test_read_memmap(fname, hdus, length):
+def test_read_memmap():
     # Test that memmap is passed correctly to the FITS reader
-    data = sunpy.io._fits.read(fname, hdus=hdus, memmap=True)
-    assert isinstance(data, np.memmap)
+    # Expecting ValueError: not enough values to unpack (expected 2, got 1)
+    with pytest.raises(ValueError):
+        data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)
+        assert isinstance(data, np.memmap)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -182,4 +182,4 @@ def test_read_memmap():
     # Test that memmap is passed correctly to the FITS reader
     data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)[0]
     assert isinstance(data, np.ndarray)
-    assert isinstance(header, fits.Header)
+    assert isinstance(header, sunpy.io.header.FileHeader)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -181,6 +181,9 @@ def test_warn_longkey():
 def test_read_memmap():
     # Test that memmap is passed correctly to the FITS reader
     data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)[0]
-    # Create memmap array
-    mm = np.memmap(AIA_171_IMAGE, dtype='float32', mode='r', shape=data.shape)
+    # Create memmap array with data and header
+    mm = np.memmap(AIA_171_IMAGE, dtype=data.dtype, mode='r', shape=data.shape)
     assert isinstance(mm, np.memmap)
+
+
+test_read_memmap()

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -179,13 +179,9 @@ def test_warn_longkey():
     assert 'BADLONGKEY' not in fits.keys()
 
 
-def is_memmap(data):
-    if data.base is None:
-        return False
-    return isinstance(data.base, mmap.mmap) or is_memmap(data.base)
-
-
 def test_read_memmap():
-    # Check that memmap is passed as an argument to read function doesnot raise an error.
+    # Check that memmap is read correctly from a file
     data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)[0]
-    assert is_memmap(data)
+    if data.base is None:
+        assert False
+    assert isinstance(data.base, mmap.mmap) or isinstance(data.base, np.memmap)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -1,3 +1,4 @@
+from cgi import print_directory
 from pathlib import Path
 from collections import OrderedDict
 
@@ -176,3 +177,9 @@ def test_warn_longkey():
                                'goodkey': 'test'})
     assert 'GOODKEY' in fits.keys()
     assert 'BADLONGKEY' not in fits.keys()
+
+
+def test_read_memmap():
+    # Test that memmap is passed correctly to the FITS reader
+    data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)
+    assert isinstance(data, np.memmap)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -15,10 +15,10 @@ from sunpy.io._fits import extract_waveunit, get_header, header_to_fits
 from sunpy.io.fits import extract_waveunit, format_comments_and_history, get_header, header_to_fits
 from sunpy.util import MetaDict, SunpyMetadataWarning
 
-RHESSI_IMAGE = get_test_filepath('hsi_image_20101016_191218.fits')
-EIT_195_IMAGE = get_test_filepath('EIT_header/efz20040301.000010_s.header')
-AIA_171_IMAGE = get_test_filepath('aia_171_level1.fits')
-SWAP_LEVEL1_IMAGE = get_test_filepath('SWAP/resampled1_swap.header')
+TEST_RHESSI_IMAGE = get_test_filepath('hsi_image_20101016_191218.fits')
+TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
+TEST_EIT_HEADER = get_test_filepath('EIT_header/efz20040301.000010_s.header')
+TEST_SWAP_HEADER = get_test_filepath('SWAP/resampled1_swap.header')
 
 # Some of the tests images contain an invalid BLANK keyword; ignore the warning
 # raised by this
@@ -27,10 +27,10 @@ pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in heade
 
 @pytest.mark.parametrize(
     'fname, hdus, length',
-    [(RHESSI_IMAGE, None, 4),
-     (RHESSI_IMAGE, 1, 1),
-     (RHESSI_IMAGE, [1, 2], 2),
-     (RHESSI_IMAGE, range(0, 2), 2)]
+    [(TEST_RHESSI_IMAGE, None, 4),
+     (TEST_RHESSI_IMAGE, 1, 1),
+     (TEST_RHESSI_IMAGE, [1, 2], 2),
+     (TEST_RHESSI_IMAGE, range(0, 2), 2)]
 )
 def test_read_hdus(fname, hdus, length):
     pairs = sunpy.io._fits.read(fname, hdus=hdus)
@@ -39,13 +39,13 @@ def test_read_hdus(fname, hdus, length):
 
 @pytest.mark.parametrize(
     'fname, waveunit',
-    [(RHESSI_IMAGE, None),
-     (EIT_195_IMAGE, None),
-     (AIA_171_IMAGE, 'angstrom'),
+    [(TEST_RHESSI_IMAGE, None),
+     (TEST_EIT_HEADER, None),
+     (TEST_AIA_IMAGE, 'angstrom'),
      (MEDN_IMAGE, 'nm'),
      (MQ_IMAGE, 'angstrom'),
      (NA_IMAGE, 'm'),
-     (SWAP_LEVEL1_IMAGE, 'angstrom'),
+     (TEST_SWAP_HEADER, 'angstrom'),
      (SVSM_IMAGE, 'nm')]
 )
 def test_extract_waveunit(fname, waveunit):
@@ -58,14 +58,14 @@ def test_extract_waveunit(fname, waveunit):
 
 
 def test_simple_write(tmpdir):
-    data, header = sunpy.io._fits.read(AIA_171_IMAGE)[0]
+    data, header = sunpy.io._fits.read(TEST_AIA_IMAGE)[0]
     outfile = tmpdir / "test.fits"
     sunpy.io._fits.write(str(outfile), data, header)
     assert outfile.exists()
 
 
 def test_extra_comment_write(tmpdir):
-    data, header = sunpy.io._fits.read(AIA_171_IMAGE)[0]
+    data, header = sunpy.io._fits.read(TEST_AIA_IMAGE)[0]
     header["KEYCOMMENTS"]["TEST"] = "Hello world"
     outfile = tmpdir / "test.fits"
     sunpy.io._fits.write(str(outfile), data, header)
@@ -73,7 +73,7 @@ def test_extra_comment_write(tmpdir):
 
 
 def test_simple_write_compressed(tmpdir):
-    data, header = sunpy.io._fits.read(AIA_171_IMAGE)[0]
+    data, header = sunpy.io._fits.read(TEST_AIA_IMAGE)[0]
     outfile = tmpdir / "test.fits"
     sunpy.io._fits.write(str(outfile), data, header, hdu_type=fits.CompImageHDU)
     assert outfile.exists()
@@ -85,7 +85,7 @@ def test_simple_write_compressed(tmpdir):
 def test_simple_write_compressed_difftypeinst(tmpdir):
     # `hdu_type=fits.CompImageHDU` and `hdu_type=fits.CompImageHDU()`
     # should produce identical FITS files
-    data, header = sunpy.io._fits.read(AIA_171_IMAGE)[0]
+    data, header = sunpy.io._fits.read(TEST_AIA_IMAGE)[0]
     outfile_type = str(tmpdir / "test_type.fits")
     outfile_inst = str(tmpdir / "test_inst.fits")
     sunpy.io._fits.write(outfile_type, data, header, hdu_type=fits.CompImageHDU)
@@ -99,7 +99,7 @@ def test_simple_write_compressed_difftypeinst(tmpdir):
      ({'quantize_level': -32}, True)]
 )
 def test_simple_write_compressed_instance(tmpdir, kwargs, should_fail):
-    data, header = sunpy.io._fits.read(AIA_171_IMAGE)[0]
+    data, header = sunpy.io._fits.read(TEST_AIA_IMAGE)[0]
     outfile = tmpdir / "test.fits"
 
     # Ensure HDU instance is used correctly
@@ -125,7 +125,7 @@ def test_simple_write_compressed_instance(tmpdir, kwargs, should_fail):
 
 
 def test_write_with_metadict_header_astropy(tmpdir):
-    with fits.open(AIA_171_IMAGE) as fits_file:
+    with fits.open(TEST_AIA_IMAGE) as fits_file:
         data, header = fits_file[0].data, fits_file[0].header
     meta_header = MetaDict(OrderedDict(header))
     temp_file = tmpdir / "temp.fits"
@@ -181,7 +181,7 @@ def test_warn_longkey():
 
 def test_read_memmap():
     # Check that memmap is read correctly from a file
-    data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)[0]
+    data, header = sunpy.io._fits.read(TEST_AIA_IMAGE, memmap=True)[0]
     if data.base is None:
         assert False
     assert isinstance(data.base, mmap.mmap) or isinstance(data.base, np.memmap)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from collections import OrderedDict
-from re import A
 
 import numpy as np
 import pytest

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -180,7 +180,13 @@ def test_warn_longkey():
 
 
 def test_read_memmap():
-    # Check that memmap=True does memory map to the file
+    # Check that the FITS reader can read a memmap without memmap argument by default
+    data, header = sunpy.io._fits.read(TEST_AIA_IMAGE)[0]
+    if data.base is None:
+        assert False
+    assert isinstance(data.base, mmap.mmap)
+
+    # Check that memmap=True does the same thing
     data, header = sunpy.io._fits.read(TEST_AIA_IMAGE, memmap=True)[0]
     if data.base is None:
         assert False

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -181,6 +181,5 @@ def test_warn_longkey():
 def test_read_memmap():
     # Test that memmap is passed correctly to the FITS reader
     data, header = sunpy.io._fits.read(AIA_171_IMAGE, memmap=True)[0]
-    # Create memmap array with data and header
-    mm = np.memmap(AIA_171_IMAGE, dtype=data.dtype, mode='r', shape=data.shape)
-    assert isinstance(mm, np.memmap)
+    assert isinstance(data, np.ndarray)
+    assert isinstance(header, fits.Header)

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -36,3 +36,12 @@ def test_read_file():
     """
     map_ = Map(AIA_193_JP2)
     assert isinstance(map_, GenericMap)
+
+
+@skip_glymur
+def test_read_memmap():
+    """
+    Tests the reading of the JP2 file with a memmap argument.
+    """
+    map_ = Map(AIA_193_JP2, memmap=True)
+    assert isinstance(map_, GenericMap)

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -41,7 +41,7 @@ def test_read_file():
 @skip_glymur
 def test_read_memmap():
     """
-    Tests the reading of the JP2 file with a memmap argument.
+    Passing memmap as keyword argument should not raise an error.
     """
     map_ = Map(AIA_193_JP2, memmap=True)
     assert isinstance(map_, GenericMap)


### PR DESCRIPTION
## PR Description
In the PR [#1750](https://github.com/sunpy/sunpy/pull/1750), to make SunPy use memory mapping for access to files, changes in the read functions of the `sunpy.io` were made. This PR adds test for those read functions, which are:
- ana.py
- file_tools.py
- fits.py
- jp2.py

Merging this PR:
* closes #1774 
<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->
