### PR TITLE
Don't auto download IERS during testing

### DIFF
--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -9,6 +9,7 @@ import pytest
 import astropy
 import astropy.config.paths
 import astropy.io.fits
+from astropy.utils import iers
 
 from sunpy.data.test import get_test_filepath, test_data_filenames, write_image_file_from_header_file
 from sunpy.map import Map
@@ -41,6 +42,17 @@ console_logger.setLevel('INFO')
 @pytest.fixture
 def jsoc_test_email():
     return "nabil.freij@gmail.com"
+
+
+@pytest.fixture(scope='session', autouse=True)
+def no_download_iers(request):
+    # Don't try and download IERS during tests
+    # See https://github.com/astropy/astropy/issues/12998 for issue that this
+    # sidesteps
+    old_value = iers.conf.auto_download
+    iers.conf.auto_download = False
+    yield
+    iers.conf.auto_download = old_value
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
Our wheel building is currently failing due to https://github.com/astropy/astropy/issues/12998. I think this should fix the wheel building. Disabling this completely might be a blunt approach that we should update, but as long as it doesn't break other tests I'd advocate merging this to get releases of 3.0, 3.1, and 4.0 out.