### PR TITLE
Add option to run cron and publish stages in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,6 @@ on:
       - '!*pre*'
       - '!*post*'
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
   # Allow manual runs through the web UI
   workflow_dispatch:
 
@@ -25,17 +20,6 @@ concurrency:
 
 jobs:
   core:
-    if: |
-      github.event_name != 'pull_request' || (
-        github.event_name == 'pull_request' && (
-          github.event.action != 'labeled' || (
-            github.event.action == 'labeled' && (
-              github.event.label.name == 'Run cron' ||
-              github.event.label.name == 'Run publish'
-            )
-          )
-        )
-      )
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       submodules: false
@@ -91,13 +75,9 @@ jobs:
 
   cron:
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' && (
-        (
-          github.event.action == 'labeled' &&
-          github.event.label.name == 'Run cron'
-        ) ||
-        contains(github.event.pull_request.labels.*.name, 'Run cron')
+      github.event_name == 'workflow_dispatch' || (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'Run cron CI')
       )
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
@@ -119,14 +99,13 @@ jobs:
     # Build wheels when pushing to any branch except main
     # publish.yml will only publish if tagged ^v.*
     if: |
-      github.event_name != 'pull_request' && (
-        github.ref_name != 'main' ||
-        github.event_name == 'workflow_dispatch' ) ||
-      github.event_name == 'pull_request' && (
-        (
-          github.event.action == 'labeled' &&
-          github.event.label.name == 'Run publish'
-        ) ||
+      (
+        github.event_name != 'pull_request' && (
+          github.ref_name != 'main' ||
+          github.event_name == 'workflow_dispatch'
+        )
+      ) || (
+        github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'Run publish')
       )
     needs: [test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
       - '!*pre*'
       - '!*post*'
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   # Allow manual runs through the web UI
   workflow_dispatch:
 
@@ -20,6 +25,17 @@ concurrency:
 
 jobs:
   core:
+    if: |
+      github.event_name != 'pull_request' || (
+        github.event_name == 'pull_request' && (
+          github.event.action != 'labeled' || (
+            github.event.action == 'labeled' && (
+              github.event.label.name == 'Run cron' ||
+              github.event.label.name == 'Run publish'
+            )
+          )
+        )
+      )
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       submodules: false
@@ -74,7 +90,15 @@ jobs:
         - linux: py39-online
 
   cron:
-    if: github.event_name == 'workflow_dispatch'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' && (
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'Run cron'
+        ) ||
+        contains(github.event.pull_request.labels.*.name, 'Run cron')
+      )
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       default_python: '3.8'
@@ -97,7 +121,14 @@ jobs:
     if: |
       github.event_name != 'pull_request' && (
         github.ref_name != 'main' ||
-        github.event_name == 'workflow_dispatch' )
+        github.event_name == 'workflow_dispatch' ) ||
+      github.event_name == 'pull_request' && (
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'Run publish'
+        ) ||
+        contains(github.event.pull_request.labels.*.name, 'Run publish')
+      )
     needs: [test]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@main
     with:


### PR DESCRIPTION
This updates the CI workflow to also run the `cron` stage if a `Run cron` tag is added to (or already present in) the PR. And similarly run the `publish` stage on `Run publish` tag.

As there doesn't seem to be a way to filter triggers based on specific tags, I've added a filtering conditional to the `cron` stage to skip if a different tag was added.

Can you think of better names for the tags?

Closes #6130

### Notes:
These are the defaults, so had to state them to also include `labeled`:
```
      - opened
      - synchronize
      - reopened
```