### PR TITLE
Adds support for saving maps as jp2 files

### DIFF
--- a/changelog/6153.feature.rst
+++ b/changelog/6153.feature.rst
@@ -1,0 +1,1 @@
+Add support for saving maps as jp2 files.

--- a/changelog/6153.feature.rst
+++ b/changelog/6153.feature.rst
@@ -1,1 +1,1 @@
-Add support for saving maps as jp2 files.
+Add support for saving `~sunpy.map.GenericMap` as JPEG 2000 files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ image =
   scipy>=1.3.0
 jpeg2000 =
   glymur>=0.8.18,!=0.9.0,!=0.9.5
+  lxml>=4.8.0
 map =
   matplotlib>=3.2.0
   mpl-animators>=1.0.0

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -169,7 +169,7 @@ def write(fname, data, header, **kwargs):
     jp2_data = np.uint8(data)
     jp2 = Jp2k(tmpname, jp2_data, **kwargs)
 
-    # Append the XML data to the headerp information
+    # Append the XML data to the header information
     meta_boxes = jp2.box
     target_index = len(meta_boxes) - 1
     fits_box = generate_jp2_xmlbox(header)

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -1,6 +1,7 @@
 """
 This module provides a JPEG 2000 file reader.
 """
+import os
 from xml.etree import cElementTree as ET
 
 from sunpy.io.header import FileHeader
@@ -71,6 +72,101 @@ def get_header(filepath):
 
     return [FileHeader(pydict)]
 
+def header_to_xml(header):
+    """
+    Converts image header metadata into an XML Tree that can be inserted into
+    a JP2 file header.
+
+    Parameters
+    ----------
+    header : `MetaDict`
+        A header dictionary.
+    """
+    # glymur uses lxml and will crash if trying to use
+    # python's builtin xml.etree
+    import lxml.etree as ET
+
+    fits = ET.Element("fits")
+
+    already_added = set()
+    for key in header:
+        # Some headers span multiple lines and get duplicated as keys
+        # header.get will appropriately return all data, so if we see
+        # a key again, we can assume it was already added to the xml tree.
+        if (key in already_added):
+            continue
+
+        # Add to the set so we don't duplicate entries
+        already_added.add(key)
+
+        el = ET.SubElement(fits, key)
+        data = header.get(key)
+        if type(data) == bool:
+            data = "1" if data else "0"
+        else:
+            data = str(data)
+
+        el.text = data
+
+    return fits
+
+def generate_jp2_xmlbox(header):
+    """
+    Generates the JP2 XML box to be inserted into the jp2 file.
+
+    Parameters
+    ----------
+    header : `MetaDict`
+        A header dictionary.
+    """
+    # glymur uses lxml and will crash if trying to use
+    # python's builtin xml.etree
+    import lxml.etree as ET
+    from glymur import jp2box
+
+    header_xml = header_to_xml(header)
+    meta = ET.Element("meta")
+    meta.append(header_xml)
+    tree = ET.ElementTree(meta)
+    return jp2box.XMLBox(xml=tree)
+
+def get_tmp_jp2_file_name(filename):
+    """
+    Returns a temporary file name for jp2 files since creating
+    a JP2 file with the correct header takes 2 passes.
+    """
+    return filename + ".tmp.jp2"
 
 def write(fname, data, header):
-    raise NotImplementedError("No jp2 writer is implemented.")
+    """
+    Take a data header pair and write a JP2 file.
+
+    Parameters
+    ----------
+    fname : `str`
+        File name, with extension.
+    data : `numpy.ndarray`
+        n-dimensional data array.
+    header : `dict`
+        A header dictionary.
+    """
+    import numpy as np
+    from glymur import Jp2k
+
+    # Create an initial jp2 file with the given data
+    tmpname = get_tmp_jp2_file_name(fname)
+    jp2_data = np.uint8(data)
+    jp2 = Jp2k(tmpname, jp2_data)
+
+    # Append the XML data to the headerp information
+    meta_boxes = jp2.box
+    target_index = len(meta_boxes) - 1
+    fits_box = generate_jp2_xmlbox(header)
+    meta_boxes.insert(target_index, fits_box)
+
+    # Rewrite the jp2 file with the xml data in the header
+    jp2.wrap(fname, boxes=meta_boxes)
+
+    # Remove the initial temporary file
+    os.remove(tmpname)
+

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -164,8 +164,8 @@ def write(fname, data, header, **kwargs):
 
     Notes
     -----
-    Saving as a jpeg 2000 will modify the provided
-    data array to support the jpeg 2000 format.
+    Saving as a JPEG2000 will cast the data array to
+    uint8 values to support the JPEG2000 format.
     """
     from glymur import Jp2k
 

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -147,7 +147,7 @@ def generate_jp2_xmlbox(header):
     return jp2box.XMLBox(xml=tree)
 
 
-def write(fname, data, header):
+def write(fname, data, header, **kwargs):
     """
     Take a data header pair and write a JP2 file.
 
@@ -159,13 +159,15 @@ def write(fname, data, header):
         n-dimensional data array.
     header : `dict`
         A header dictionary.
+    kwargs :
+        Additional keyword args are passed to the glymur.Jp2k constructor
     """
     from glymur import Jp2k
 
     # Create an initial jp2 file with the given data
     tmpname = fname + "tmp.jp2"
     jp2_data = np.uint8(data)
-    jp2 = Jp2k(tmpname, jp2_data)
+    jp2 = Jp2k(tmpname, jp2_data, **kwargs)
 
     # Append the XML data to the headerp information
     meta_boxes = jp2.box

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -72,6 +72,7 @@ def get_header(filepath):
 
     return [FileHeader(pydict)]
 
+
 def header_to_xml(header):
     """
     Converts image header metadata into an XML Tree that can be inserted into
@@ -117,6 +118,7 @@ def header_to_xml(header):
 
     return fits
 
+
 def generate_jp2_xmlbox(header):
     """
     Generates the JP2 XML box to be inserted into the jp2 file.
@@ -142,6 +144,7 @@ def generate_jp2_xmlbox(header):
     tree = ET.ElementTree(meta)
     return jp2box.XMLBox(xml=tree)
 
+
 def get_tmp_jp2_file_name(filename):
     """
     Returns
@@ -151,6 +154,7 @@ def get_tmp_jp2_file_name(filename):
         a JP2 file with the correct header takes 2 passes.
     """
     return filename + ".tmp.jp2"
+
 
 def write(fname, data, header):
     """

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -2,6 +2,7 @@
 This module provides a JPEG 2000 file reader.
 """
 import os
+import numpy as np
 from xml.etree import cElementTree as ET
 
 from sunpy.io.header import FileHeader
@@ -158,7 +159,6 @@ def write(fname, data, header):
     header : `dict`
         A header dictionary.
     """
-    import numpy as np
     from glymur import Jp2k
 
     # Create an initial jp2 file with the given data

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -161,6 +161,11 @@ def write(fname, data, header, **kwargs):
         A header dictionary.
     kwargs :
         Additional keyword args are passed to the glymur.Jp2k constructor
+
+    Notes
+    -----
+    Saving as a jpeg 2000 will modify the provided
+    data array to support the jpeg 2000 format.
     """
     from glymur import Jp2k
 

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -145,17 +145,6 @@ def generate_jp2_xmlbox(header):
     return jp2box.XMLBox(xml=tree)
 
 
-def get_tmp_jp2_file_name(filename):
-    """
-    Returns
-    ---------
-    `str`
-        a temporary file name for jp2 files since creating
-        a JP2 file with the correct header takes 2 passes.
-    """
-    return filename + ".tmp.jp2"
-
-
 def write(fname, data, header):
     """
     Take a data header pair and write a JP2 file.
@@ -173,7 +162,7 @@ def write(fname, data, header):
     from glymur import Jp2k
 
     # Create an initial jp2 file with the given data
-    tmpname = get_tmp_jp2_file_name(fname)
+    tmpname = fname + "tmp.jp2"
     jp2_data = np.uint8(data)
     jp2 = Jp2k(tmpname, jp2_data)
 

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -2,8 +2,9 @@
 This module provides a JPEG 2000 file reader.
 """
 import os
-import numpy as np
 from xml.etree import cElementTree as ET
+
+import numpy as np
 
 from sunpy.io.header import FileHeader
 from sunpy.util.io import HDPair, string_is_float
@@ -177,4 +178,3 @@ def write(fname, data, header):
 
     # Remove the initial temporary file
     os.remove(tmpname)
-

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -80,7 +80,14 @@ def header_to_xml(header):
     Parameters
     ----------
     header : `MetaDict`
-        A header dictionary.
+        A header dictionary to convert to xml.
+
+    Returns
+    ----------
+    `lxml.etree._Element`
+        A fits element where each child is an xml element
+        in the form <key>value</key> derived from the key/value
+        pairs in the given header dictionary
     """
     # glymur uses lxml and will crash if trying to use
     # python's builtin xml.etree
@@ -118,6 +125,11 @@ def generate_jp2_xmlbox(header):
     ----------
     header : `MetaDict`
         A header dictionary.
+
+    Returns
+    ----------
+    `XMLBox`
+        XML box containing FITS metadata to be used in jp2 headers
     """
     # glymur uses lxml and will crash if trying to use
     # python's builtin xml.etree
@@ -132,8 +144,11 @@ def generate_jp2_xmlbox(header):
 
 def get_tmp_jp2_file_name(filename):
     """
-    Returns a temporary file name for jp2 files since creating
-    a JP2 file with the correct header takes 2 passes.
+    Returns
+    ---------
+    `str`
+        a temporary file name for jp2 files since creating
+        a JP2 file with the correct header takes 2 passes.
     """
     return filename + ".tmp.jp2"
 

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -164,19 +164,17 @@ def write(fname, data, header, **kwargs):
     """
     from glymur import Jp2k
 
-    # Create an initial jp2 file with the given data
     tmpname = fname + "tmp.jp2"
     jp2_data = np.uint8(data)
     jp2 = Jp2k(tmpname, jp2_data, **kwargs)
 
-    # Append the XML data to the header information
+    # Append the XML data to the header information stored in jp2.box
     meta_boxes = jp2.box
     target_index = len(meta_boxes) - 1
     fits_box = generate_jp2_xmlbox(header)
     meta_boxes.insert(target_index, fits_box)
 
-    # Rewrite the jp2 file with the xml data in the header
+    # Rewrites the jp2 file on disk with the xml data in the header
     jp2.wrap(fname, boxes=meta_boxes)
 
-    # Remove the initial temporary file
     os.remove(tmpname)

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -39,3 +39,7 @@ def test_simple_write(tmpdir):
     jp2.write(str(outfile), data, header)
     assert outfile.exists()
 
+    # Sanity check that reading back the jp2 returns coherent data
+    jp2_readback = jp2.read(outfile)
+    assert header['DATE'] == jp2_readback[0].header['DATE']
+

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -3,7 +3,6 @@ import sunpy.io.jp2 as jp2
 
 from sunpy.data.test import get_test_filepath
 from sunpy.io.header import FileHeader
-from sunpy.io.jp2 import get_header, read
 from sunpy.io import _fits
 from sunpy.tests.helpers import skip_glymur
 
@@ -12,7 +11,7 @@ TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
 
 @skip_glymur
 def test_read():
-    data, header = read(AIA_193_JP2)[0]
+    data, header = jp2.read(AIA_193_JP2)[0]
     assert isinstance(data, np.ndarray)
     assert data.shape == (4096, 4096)
     assert isinstance(header, FileHeader)
@@ -20,17 +19,17 @@ def test_read():
 
 @skip_glymur
 def test_read_header():
-    header = get_header(AIA_193_JP2)[0]
+    header = jp2.get_header(AIA_193_JP2)[0]
     assert isinstance(header, FileHeader)
 
 
 @skip_glymur
 def test_read_memmap():
-    data, _ = read(AIA_193_JP2, memmap=True)[0]
+    data, _ = jp2.read(AIA_193_JP2, memmap=True)[0]
     # The data is shared, with what, I am unclear
     assert data.base is not None
     # Keyword is not passed in the function call
-    data, _ = read(AIA_193_JP2, memmap=False)[0]
+    data, _ = jp2.read(AIA_193_JP2, memmap=False)[0]
     assert data.base is not None
 
 

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -33,6 +33,7 @@ def test_read_memmap():
     data, _ = read(AIA_193_JP2, memmap=False)[0]
     assert data.base is not None
 
+
 def test_simple_write(tmpdir):
     data, header = _fits.read(TEST_AIA_IMAGE)[0]
     outfile = tmpdir / "test.jp2"

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -1,12 +1,14 @@
 import numpy as np
+import sunpy.io.jp2 as jp2
 
 from sunpy.data.test import get_test_filepath
 from sunpy.io.header import FileHeader
 from sunpy.io.jp2 import get_header, read
+from sunpy.io import _fits
 from sunpy.tests.helpers import skip_glymur
 
 AIA_193_JP2 = get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")
-
+TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
 
 @skip_glymur
 def test_read():
@@ -30,3 +32,10 @@ def test_read_memmap():
     # Keyword is not passed in the function call
     data, _ = read(AIA_193_JP2, memmap=False)[0]
     assert data.base is not None
+
+def test_simple_write(tmpdir):
+    data, header = _fits.read(TEST_AIA_IMAGE)[0]
+    outfile = tmpdir / "test.jp2"
+    jp2.write(str(outfile), data, header)
+    assert outfile.exists()
+

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -1,13 +1,14 @@
 import numpy as np
-import sunpy.io.jp2 as jp2
 
+import sunpy.io.jp2 as jp2
 from sunpy.data.test import get_test_filepath
-from sunpy.io.header import FileHeader
 from sunpy.io import _fits
+from sunpy.io.header import FileHeader
 from sunpy.tests.helpers import skip_glymur
 
 AIA_193_JP2 = get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")
 TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
+
 
 @skip_glymur
 def test_read():
@@ -42,4 +43,3 @@ def test_simple_write(tmpdir):
     # Sanity check that reading back the jp2 returns coherent data
     jp2_readback = jp2.read(outfile)
     assert header['DATE'] == jp2_readback[0].header['DATE']
-

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -1,8 +1,7 @@
 import numpy as np
 
-import sunpy.io.jp2 as jp2
 from sunpy.data.test import get_test_filepath
-from sunpy.io import _fits
+from sunpy.io import _fits, jp2
 from sunpy.io.header import FileHeader
 from sunpy.tests.helpers import skip_glymur
 

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -3,7 +3,7 @@ import numpy as np
 from sunpy.data.test import get_test_filepath
 from sunpy.io import _fits, jp2
 from sunpy.io.header import FileHeader
-from sunpy.tests.helpers import skip_glymur
+from sunpy.tests.helpers import skip_glymur, skip_windows
 
 AIA_193_JP2 = get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")
 TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
@@ -33,6 +33,7 @@ def test_read_memmap():
     assert data.base is not None
 
 
+@skip_windows
 def test_simple_write(tmpdir):
     data, header = _fits.read(TEST_AIA_IMAGE)[0]
     outfile = tmpdir / "test.jp2"

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1494,6 +1494,11 @@ class GenericMap(NDData):
         kwargs :
             Any additional keyword arguments are passed to
             `~sunpy.io.write_file`.
+
+        Notes
+        -----
+        Saving with the jp2 extension will write a modified version
+        of the given data in order to support the jpeg 2000 format.
         """
         io.write_file(filepath, self.data, self.meta, filetype=filetype,
                       **kwargs)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1498,7 +1498,8 @@ class GenericMap(NDData):
         Notes
         -----
         Saving with the jp2 extension will write a modified version
-        of the given data in order to support the jpeg 2000 format.
+        of the given data casted to uint8 values in order to support
+        the JPEG2000 format.
         """
         io.write_file(filepath, self.data, self.meta, filetype=filetype,
                       **kwargs)

--- a/sunpy/util/tests/test_sysinfo.py
+++ b/sunpy/util/tests/test_sysinfo.py
@@ -27,6 +27,7 @@ def test_find_dependencies():
                                                      'scikit-image',
                                                      'scipy',
                                                      'glymur',
+                                                     'lxml',
                                                      'matplotlib',
                                                      'mpl-animators',
                                                      'reproject',


### PR DESCRIPTION
## PR Description

Uses glymur and numpy to save images as jp2 files when executing `mapfile.save("outfile.jp2")`

For some time this has simply raised a "Not implemented" exception.