### PR TITLE
Add an environment variable which can skip compiling the ANA extension

### DIFF
--- a/changelog/6166.trivial.rst
+++ b/changelog/6166.trivial.rst
@@ -1,0 +1,2 @@
+Add an environment variable ``SUNPY_NO_BUILD_ANA_EXTENSION`` which when present
+will cause sunpy to not compile the ANA C extension when building from source.

--- a/sunpy/io/setup_package.py
+++ b/sunpy/io/setup_package.py
@@ -9,7 +9,7 @@ from setuptools import Extension
 
 def get_extensions():
 
-    if get_compiler() == 'msvc':
+    if get_compiler() == 'msvc' or os.environ.get("SUNPY_NO_BUILD_ANA_EXTENSION", None):
         return list()
     else:
         cfg = defaultdict(list)

--- a/sunpy/io/special/asdf/tests/test_genericmap.py
+++ b/sunpy/io/special/asdf/tests/test_genericmap.py
@@ -13,12 +13,15 @@ from .helpers import roundtrip_object
 def assert_roundtrip_map(old):
     new = roundtrip_object(old)
     np.testing.assert_allclose(old.data, new.data)
+
     # Test the meta by force!
     for ok, ov in old.meta.items():
         assert ok in new.meta
         assert new.meta[ok] == ov
+
     if old.mask is not None and new.mask is not None:
         np.testing.assert_allclose(old.mask, new.mask)
+
     assert old.unit == new.unit
 
 


### PR DESCRIPTION
This is to help out in https://github.com/holzschu/Carnets/issues/226