### PR TITLE
Fix tox conda env spec

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ commands =
     python -c "import sunpy; sunpy.self_test()"
 
 # Requires tox-conda
-[testenv:conda]
+[testenv:py{37,38,39,310}-conda]
 pypi_filter =
 extras =
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}{,-oldestdeps,-devdeps,-online,-figure,-hypothesis,-conda}
+    py{38,39,310}{,-oldestdeps,-devdeps,-online,-figure,-hypothesis,-conda}
     build_docs{,-gallery}
     codestyle
     base_deps
@@ -121,14 +121,16 @@ commands =
     python -c "import sunpy; sunpy.self_test()"
 
 # Requires tox-conda
-[testenv:py{37,38,39,310}-conda]
+[testenv:py{38,39,310}-conda]
 pypi_filter =
 extras =
 deps =
 conda_deps =
     asdf
+    asdf-astropy
     astropy
     beautifulsoup4
+    cdflib
     conda
     dask
     drms
@@ -137,19 +139,25 @@ conda_deps =
     h5netcdf
     hypothesis
     jinja2
+    jplephem
     libopenblas>=0.3.12
     lxml
     matplotlib
+    mpl_animators
     numpy
+    opencv
     openjpeg
     pandas
     parfive
     pillow
+    py-opencv
     pytest
     pytest-astropy
     pytest-cov
     pytest-mock
+    pytest-mpl
     pytest-xdist
+    reproject
     scikit-image
     scipy
     sphinx


### PR DESCRIPTION
Not sure whether this is intended or a bug in `tox`. Either way this should fix running the tox job. I've tested this locally and it works.