### PR TITLE
Use Python Limited API

### DIFF
--- a/changelog/6171.trivial.rst
+++ b/changelog/6171.trivial.rst
@@ -1,0 +1,2 @@
+``sunpy`` now uses the `Limited Python API <https://docs.python.org/3/c-api/stable.html>`__.
+Therefore, one binary distribution (wheel) per platform is now published and it is compatible with all Python versions ``sunpy`` supports.

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,6 +110,10 @@ asdf.resource_mappings =
 asdf.extensions =
   sunpy = sunpy.io.special.asdf.entry_points:get_extensions
 
+[bdist_wheel]
+# the Py_LIMITED_API version hex in _pyana.c should match the version specified here
+py_limited_api = cp38
+
 [tool:pytest]
 testpaths = "sunpy" "docs"
 norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "examples" "sunpy[/\]_dev" ".jupyter" ".history" "tools" "sunpy[\/]extern"

--- a/sunpy/io/setup_package.py
+++ b/sunpy/io/setup_package.py
@@ -23,5 +23,5 @@ def get_extensions():
                                           '-Wno-unused-result',
                                           '-Wno-sign-compare'])
 
-        e = Extension('sunpy.io._pyana', **cfg)
+        e = Extension('sunpy.io._pyana', py_limited_api=True, **cfg)
         return [e]

--- a/sunpy/io/src/ana/_pyana.c
+++ b/sunpy/io/src/ana/_pyana.c
@@ -6,6 +6,13 @@ Based on Michiel van Noort's IDL DLM library 'f0' which contains
 a cleaned up version of the original anarw routines.
 */
 
+#define Py_LIMITED_API 0x030800f0
+
+// Needed due to https://github.com/numpy/numpy/issues/16970
+struct _typeobject {
+  int foo;
+};
+
 #include <Python.h>				// For python extension
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h> 	// For numpy


### PR DESCRIPTION
Not sure if we want to do this. Basically, it compiles the extensions in such a way that they are compatible with all the Python versions, so we only need one wheel per OS. It will still test the wheel across all supported Python version so there won't be much of a speed up when publishing.

The ANA tests passed for me locally on macOS. Will see if all the tests pass in the CI. This is assuming the tests have good coverage of the C extension.

This is based on https://github.com/astrofrog/fast-histogram/pull/56. See also [PEP 384 – Defining a Stable ABI](https://peps.python.org/pep-0384/).