### PR TITLE
Publish pure Python wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
     needs: [test]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@main
     with:
+      sdist: false
       test_extras: 'dev'
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
@@ -153,9 +154,21 @@ jobs:
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
 
+  publish_pure:
+    needs: [publish]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@main
+    with:
+      test_extras: 'dev'
+      test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
+      submodules: false
+      env: |
+        SUNPY_NO_BUILD_ANA_EXTENSION: 1
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}
+
   notify:
     if: always() && github.event_name == 'workflow_dispatch'
-    needs: [publish, online, cron]
+    needs: [publish_pure, online, cron]
     runs-on: ubuntu-latest
     steps:
       - uses: Cadair/matrix-notify-action@main

--- a/changelog/6175.feature.rst
+++ b/changelog/6175.feature.rst
@@ -1,0 +1,6 @@
+A pure Python ``sunpy`` wheel is now published on PyPI with each release.
+``pip`` will now default to installing the pure Python wheel instead of the source distribution on platforms other than Linux (x86-64) and macOS (x86-64 and ARM64).
+This should mean simpler and faster installs on such platforms, which includes the Raspberry Pi as well as some cloud computing services.
+
+This wheel does not contain the ``sunpy.io.ana`` compiled extension.
+If you need this extension (not available on Windows) you can install the ``sunpy`` source distribution with ``pip install --no-binary sunpy "sunpy[all]"``.

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -60,9 +60,11 @@ Once the environment active, to acquire a full ``sunpy`` installation:
 .. note::
 
     We strive to provide binary wheels for all of our packages.
-    If you are using a Python distribution or operating system that is missing a binary wheel.
-    ``pip`` will try to compile the package from source and this is likely to fail without a C compiler (e.g., ``gcc`` or ``clang``).
-    Getting the compiler either from your system package manager or XCode should address this.
+    If you are using a Python distribution or operating system that is missing a binary wheel, ``pip`` will install a pure Python wheel.
+    This pure Python wheel does not contain the ``sunpy.io.ana`` compiled extension.
+    If you require this extension, install with ``pip install --no-binary sunpy "sunpy[all]"`` instead and ``pip`` will try to compile the package from source.
+    This is likely to fail without a C compiler (e.g., ``gcc`` or ``clang``).
+    Getting the compiler either from your system package manager or Xcode should address this.
 
 If you have a reason to want a more minimal installation, you can install sunpy with no optional dependencies, however this means a lot of submodules will not import:
 

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -59,12 +59,12 @@ Once the environment active, to acquire a full ``sunpy`` installation:
 
 .. note::
 
-    We strive to provide binary wheels for all of our packages.
-    If you are using a Python distribution or operating system that is missing a binary wheel, ``pip`` will install a pure Python wheel.
-    This pure Python wheel does not contain the ``sunpy.io.ana`` compiled extension.
-    If you require this extension, install with ``pip install --no-binary sunpy "sunpy[all]"`` instead and ``pip`` will try to compile the package from source.
-    This is likely to fail without a C compiler (e.g., ``gcc`` or ``clang``).
-    Getting the compiler either from your system package manager or Xcode should address this.
+    For fast and consistent installs, we strive to provide pure Python wheels for all of our packages.
+    The core ``sunpy`` package also provides *compiled* wheels for CPython on Linux (x86-64) and macOS (x86-64 and ARM64), containing an optional C extension (``sunpy.io.ana``).
+    On these platforms ``pip`` will install the compiled wheel by default, while on other platforms it will install the pure Python wheel without ``sunpy.io.ana``.
+    If you require this extension on other platforms, install with ``pip install --no-binary sunpy "sunpy[all]"`` and ``pip`` will try to compile the package from source.
+    Installing from source requires a C compiler (e.g., ``gcc`` or ``clang``), which can typically be installed from your system package manager, if not already installed.
+    This extension is not compatible with Windows.
 
 If you have a reason to want a more minimal installation, you can install sunpy with no optional dependencies, however this means a lot of submodules will not import:
 

--- a/sunpy/io/ana.py
+++ b/sunpy/io/ana.py
@@ -6,6 +6,9 @@ This is a modified version of `pyana <https://github.com/tvwerkhoven/pyana>`__.
 .. warning::
 
     The reading and writing of ana files is not supported under Windows.
+
+    By default, this module is not installed on platforms other than Linux (x86-64) and macOS (x86-64 and ARM64).
+    See the installation guide for more info.
 """
 import os
 
@@ -16,6 +19,11 @@ try:
     from sunpy.io import _pyana
 except ImportError:
     _pyana = None
+
+ANA_NOT_INSTALLED = (
+    "C extension for ANA is missing. For more details see: "
+    "https://docs.sunpy.org/en/stable/installation.html#installing-without-conda"
+)
 
 
 __all__ = ['read', 'get_header', 'write']
@@ -48,7 +56,7 @@ def read(filename, debug=False, **kwargs):
         raise OSError("File does not exist!")
 
     if _pyana is None:
-        raise ImportError("C extension for ANA is missing, please rebuild.")
+        raise ImportError(ANA_NOT_INSTALLED)
 
     data = _pyana.fzread(filename, debug)
     return [HDPair(data['data'], FileHeader(data['header']))]
@@ -77,7 +85,7 @@ def get_header(filename, debug=False):
     >>> header = sunpy.io.ana.get_header(filename)  # doctest: +SKIP
     """
     if _pyana is None:
-        raise ImportError("C extension for ANA is missing, please rebuild")
+        raise ImportError(ANA_NOT_INSTALLED)
 
     data = _pyana.fzread(filename, debug)
     return [FileHeader(data['header'])]
@@ -111,7 +119,7 @@ def write(filename, data, comments=False, compress=True, debug=False):
     >>> written = sunpy.io.ana.write(filename, data, comments=False, compress=True)  # doctest: +SKIP
     """
     if _pyana is None:
-        raise ImportError("C extension for ANA is missing, please rebuild")
+        raise ImportError(ANA_NOT_INSTALLED)
 
     if comments:
         return _pyana.fzwrite(filename, data, int(compress), comments, debug)


### PR DESCRIPTION
Based on discussions in #5772, this adds a pure Python wheel to the publishing workflow. (I think this PR should probably close that issue?) The pure Python wheel would be installed (by pip) when a platform specific compiled wheel is not available. 

For example, by default pip on aarch64 will install the pure Python wheel (without the `sunpy.io.ana` compiled extension) rather than compiling from the sdist. And for macOS, it would continue to use the specific compiled wheel rather than the pure Python wheel.

Due to how we detect whether to build pure python or not on GitHub Actions, this means the `ana` test no longer run when testing the sdist on GitHub Actions. I don't think this is an issue.

- [x] Update documentation
- [x] Document how to install sdist instead of pure wheel (pip `--no-binary :all:` option)
- [x] Improve `ana.py` import errors https://github.com/sunpy/sunpy/blob/5a351a8e6161cab6bc4cb7974d0d8a93ad92a3ef/sunpy/io/ana.py#L51