### PR TITLE
Ignore warnings when calculating determinant

### DIFF
--- a/sunpy/map/tests/strategies.py
+++ b/sunpy/map/tests/strategies.py
@@ -1,3 +1,5 @@
+import warnings
+
 import hypothesis.strategies as st
 import numpy as np
 from hypothesis import assume
@@ -18,7 +20,9 @@ def matrix_meta(draw, key):
         elements=st.floats(min_value=-1, max_value=1, allow_nan=False))
     )
     # Make sure matrix isn't singular
-    assume(np.abs(np.linalg.det(arr)) > 1e-8)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action='ignore', category=RuntimeWarning, module='numpy.linalg')
+        assume(np.abs(np.linalg.det(arr)) > 1e-8)
     return {f'{key}1_1': arr[0, 0],
             f'{key}1_2': arr[0, 1],
             f'{key}2_1': arr[1, 0],


### PR DESCRIPTION
Catch any "overflow encountered" or "invalid value encountered" warnings when checking if a PC or CD matrix is singular.

(This issue has come to light as hypothesis have recently changes how they deal with the floats strategy: https://github.com/HypothesisWorks/hypothesis/releases/tag/hypothesis-python-6.46.8 "You may notice that hypothesis is more likely to test values near boundaries, and values that are very close to zero.")

We need to solve #6180 before removing the `hypothesis` pin.