### PR TITLE
Fixed various issues with tests that were revealed by new `hypothesis` float sampling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ visualization =
   matplotlib>=3.3.0
   mpl-animators>=1.0.0
 tests =
-  hypothesis==6.46.7  # >=6.0.0  # Included in pytest-astropy. 6.0 is the first version to support disabling function-scoped fixture warning
+  hypothesis>=6.0.0  # Included in pytest-astropy. 6.0 is the first version to support disabling function-scoped fixture warning
   jplephem  # For some coordinates tests
   opencv-python
   pytest-astropy>=0.8  # 0.8 is the first release to include filter-subpackage

--- a/sunpy/coordinates/tests/test_metaframes.py
+++ b/sunpy/coordinates/tests/test_metaframes.py
@@ -214,7 +214,7 @@ def test_rotatedsun_transforms(frame, lon, lat, obstime, rotated_time1, rotated_
     desired_delta_lon1 = diff_rot((rotated_time1 - obstime).to(u.day), lat)
 
     assert_longitude_allclose(result1.lon, rsf1.lon + desired_delta_lon1, atol=1e-5*u.deg)
-    assert_quantity_allclose(base.lat, result1.lat)
+    assert_quantity_allclose(base.lat, result1.lat, atol=1e-10*u.deg)
     # Use the `spherical` property since the name of the component varies with frame
     assert_quantity_allclose(base.spherical.distance, result1.spherical.distance)
 
@@ -225,7 +225,7 @@ def test_rotatedsun_transforms(frame, lon, lat, obstime, rotated_time1, rotated_
     desired_delta_lon2 = -diff_rot((rotated_time2 - obstime).to(u.day), lat)
 
     assert_longitude_allclose(result2.lon, rsf2.lon + desired_delta_lon2, atol=1e-5*u.deg)
-    assert_quantity_allclose(base.lat, result2.lat)
+    assert_quantity_allclose(base.lat, result2.lat, atol=1e-10*u.deg)
     # Use the `spherical` property since the name of the component varies with frame
     assert_quantity_allclose(base.spherical.distance, result2.spherical.distance)
 
@@ -235,7 +235,7 @@ def test_rotatedsun_transforms(frame, lon, lat, obstime, rotated_time1, rotated_
     desired_delta_lon3 = desired_delta_lon1 + desired_delta_lon2
 
     assert_longitude_allclose(result3.lon, rsf1.lon + desired_delta_lon3, atol=1e-5*u.deg)
-    assert_quantity_allclose(result3.lat, result1.lat)
+    assert_quantity_allclose(result3.lat, result1.lat, atol=1e-10*u.deg)
     # Use the `spherical` property since the name of the component varies with frame
     assert_quantity_allclose(result3.spherical.distance, result1.spherical.distance)
 

--- a/sunpy/coordinates/tests/test_offset_frame.py
+++ b/sunpy/coordinates/tests/test_offset_frame.py
@@ -33,8 +33,7 @@ def test_transform(lon, lat):
     off = NorthOffsetFrame(north=north)
     t_north = SkyCoord(lon=0*u.deg, lat=90*u.deg, frame=off)
     t_north = t_north.transform_to('heliographic_stonyhurst')
-    assert_longitude_allclose(north.lon, t_north.lon, atol=1e-6*u.deg)
-    assert_quantity_allclose(north.lat, t_north.lat, atol=1e-6*u.deg)
+    assert_quantity_allclose(north.separation(t_north), 0*u.deg, atol=1e-6*u.deg)
 
 
 def test_south_pole():

--- a/sunpy/map/tests/strategies.py
+++ b/sunpy/map/tests/strategies.py
@@ -1,5 +1,3 @@
-import warnings
-
 import hypothesis.strategies as st
 import numpy as np
 from hypothesis import assume
@@ -19,10 +17,8 @@ def matrix_meta(draw, key):
         float, (2, 2),
         elements=st.floats(min_value=-1, max_value=1, allow_nan=False))
     )
-    # Make sure matrix isn't singular
-    with warnings.catch_warnings():
-        warnings.filterwarnings(action='ignore', category=RuntimeWarning, module='numpy.linalg')
-        assume(np.abs(np.linalg.det(arr)) > 1e-8)
+    # Make sure matrix isn't singular by manually computing the determinant
+    assume(np.abs(arr[1, 1]*arr[0, 0] - arr[0, 1]*arr[1, 0]) > 1e-8)
     return {f'{key}1_1': arr[0, 0],
             f'{key}1_2': arr[0, 1],
             f'{key}2_1': arr[1, 0],


### PR DESCRIPTION
Fixes #6180 and reverts #6178

* Now that `hypothesis` fully samples the float range, it revealed that a longitude check in a test did not account for [gimbal lock](https://en.wikipedia.org/wiki/Gimbal_lock) at the poles (latitude of +/-90 degrees), where differences in longitude are meaningless.  This PR switches to using `SkyCoord.separation()`, which is more straightforward.
* `hypothesis` also revealed that an equality check of numbers that could be zero was missing the specification of the absolute tolerance.
* It seems that `numpy.linalg.det()` is incorrectly computing the determinant of a 2x2 matrix with underflow floats (thanks to `hypothesis`) under some confluence of NumPy version, LAPACK compilation, OS, etc.  I don't want to go down that rabbit hole, and it's straightforward to manually compute the determinant of a 2x2 matrix, so I switched to doing that.