### PR TITLE
Use second figure in segment example

### DIFF
--- a/examples/map/map_segment.py
+++ b/examples/map/map_segment.py
@@ -6,6 +6,7 @@ Segmenting a Map based on transformation of coordinates
 This example demonstrates extracting a region of a particular map based on
 world coordinates in different systems.
 """
+# sphinx_gallery_thumbnail_number = 2
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
Change the thumbnail that we use for the north offset example to the more interesting figure.