### PR TITLE
Add function to extract intensity along coord

### DIFF
--- a/changelog/6189.feature.rst
+++ b/changelog/6189.feature.rst
@@ -1,3 +1,3 @@
 Add a function `sunpy.map.extract_along_coord` that, for a given set of coordinates,
-finds each array index that crosses that coordinate and returns the value of the data
+finds each array index that crosses the line traced by those coordinates and returns the value of the data
 array of a given map at those array indices.

--- a/changelog/6189.feature.rst
+++ b/changelog/6189.feature.rst
@@ -1,0 +1,3 @@
+Add a function `sunpy.map.maputils.extract_along_coord` that, for a given coordinate,
+finds each array index that crosses that coordinate and returns the value of the data
+array of a given map at those array indices.

--- a/changelog/6189.feature.rst
+++ b/changelog/6189.feature.rst
@@ -1,3 +1,3 @@
-Add a function `sunpy.map.extract_along_coord` that, for a given coordinate,
+Add a function `sunpy.map.extract_along_coord` that, for a given set of coordinates,
 finds each array index that crosses that coordinate and returns the value of the data
 array of a given map at those array indices.

--- a/changelog/6189.feature.rst
+++ b/changelog/6189.feature.rst
@@ -1,3 +1,3 @@
-Add a function `sunpy.map.maputils.extract_along_coord` that, for a given coordinate,
+Add a function `sunpy.map.extract_along_coord` that, for a given coordinate,
 finds each array index that crosses that coordinate and returns the value of the data
 array of a given map at those array indices.

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -11,7 +11,7 @@ On this page, you can read about some of the big changes in this release.
     :local:
     :depth: 1
 
-SunPy 4.1 also includes a large number of smaller improvements and bug fixes, which are described in the :ref:`changelog`.
+sunpy 4.1 also includes a large number of smaller improvements and bug fixes, which are described in the :ref:`changelog`.
 
 By the numbers:
 

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -1,0 +1,43 @@
+.. _whatsnew-4.1:
+
+************************
+What's New in SunPy 4.1?
+************************
+The SunPy project is pleased to announce the 4.1 release of the sunpy core package.
+
+On this page, you can read about some of the big changes in this release.
+
+.. contents::
+    :local:
+    :depth: 1
+
+SunPy 4.1 also includes a large number of smaller improvements and bug fixes, which are described in the :ref:`changelog`.
+
+By the numbers:
+
+This release of sunpy contains x commits in x merged pull requests closing x issues from x people, x of which are first-time contributors to sunpy.
+
+* x commits have been added since 4.0
+* x issues have been closed since 4.0
+* x pull requests have been merged since 4.0
+* x people have contributed since 4.0
+* x of which are new contributors
+
+Extracting Values from a `~sunpy.map.GenericMap` Along a Set of Coordinates
+===========================================================================
+It is now easy to extract data values from a `~sunpy.map.GenericMap` along
+a curve specified by set of coordinates using the new
+`sunpy.map.extract_along_coord` function.
+This is done by applying `Bresenham's line algorithm <http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm>`_
+between the consecutive coordinates, in pixel space, and then indexing the data
+array of the map at those points.
+See :ref:`sphx_glr_generated_gallery_units_and_coordinates_map_slit_extraction.py` for an example.
+
+Contributors to this Release
+============================
+
+The people who have contributed to the code for this release are:
+
+TODO: fill this in at release time.
+
+Where a * indicates that this release contains their first contribution to SunPy.

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -10,6 +10,7 @@ In between versions x.1 are non-LTS releases, and supported for 6 months until t
    :maxdepth: 1
 
    changelog
+   4.1
    4.0
    3.1
    3.0

--- a/examples/units_and_coordinates/map_slit_extraction.py
+++ b/examples/units_and_coordinates/map_slit_extraction.py
@@ -1,0 +1,61 @@
+"""
+=====================================================
+Extracting intensity of a map between two coordinates
+=====================================================
+
+In this example we will define a slit in world coordinates and then extract the intensity values of all the pixels that the path intersects with.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+import sunpy.map
+from sunpy.data.sample import AIA_171_ROLL_IMAGE
+
+###############################################################################
+# First we construct a map, using some sample data.
+aia_map = sunpy.map.Map(AIA_171_ROLL_IMAGE)
+
+
+###############################################################################
+# Next we define a path in a `SkyCoord` object.
+# In this example we are just going to use a straight line, however a path with
+# any number of points can be used, and the slit will be defined as straight
+# line segments between all the points.
+line_limits = SkyCoord([-1024, -908], [20, 633], unit=(u.arcsec, u.arcsec),
+                       frame=aia_map.coordinate_frame)
+
+
+###############################################################################
+# Next we call the `sunpy.map.extract_along_coord` function with the map and
+# the coordinates we want to extract.
+# This function returns two items, the first is a numpy array of all the
+# intensities and the second is a `SkyCoord` object of the same length, which
+# describes the world coordinates of each pixel that has been extracted.
+intensity, coord = sunpy.map.extract_along_coord(aia_map, line_limits)
+
+
+###############################################################################
+# Next we will calculate the angular separation between the first point and
+# every other coordinate we extracted. We are doing this to give us a
+# meaningful scale for our line plot below.
+angular_separation = coord.separation(coord[0]).to(u.arcsec)
+
+###############################################################################
+# Finally let's plot the results.
+fig = plt.figure()
+ax1 = fig.add_subplot(121, projection=aia_map)
+aia_map.plot(axes=ax1)
+ax1.plot_coord(coord)
+ax1.plot_coord(line_limits[0], marker="o", color="blue", label="start")
+ax1.plot_coord(line_limits[1], marker="o", color="green", label="end")
+ax1.legend()
+
+ax2 = fig.add_subplot(122)
+ax2.plot(angular_separation, intensity)
+ax2.set_xlabel("Angular distance along slit [arcsec]")
+ax2.set_ylabel(f"Intensity [{aia_map.unit}]")
+
+plt.show()

--- a/examples/units_and_coordinates/map_slit_extraction.py
+++ b/examples/units_and_coordinates/map_slit_extraction.py
@@ -3,7 +3,8 @@
 Extracting intensity of a map along a line
 =====================================================
 
-In this example we will define a slit in world coordinates and then extract the intensity values of all the pixels that the path intersects with.
+In this example we will extract the intensity values of all the pixels
+that intersect with a given set of coordinates.
 """
 import matplotlib.pyplot as plt
 
@@ -20,10 +21,9 @@ aia_map = sunpy.map.Map(AIA_171_ROLL_IMAGE)
 
 ###############################################################################
 # Next we define a path in a `~astropy.coordinates.SkyCoord` object.
-# In this example we are just going to use a straight line, however a path with
-# any number of points can be used, and the slit will be defined as straight
-# line segments between all the points.
-line_limits = SkyCoord([-1024, -908], [20, 633], unit=(u.arcsec, u.arcsec),
+# In this example we are just going to use a straight line defined by two points.
+# However a path with any number of points and any shape can be used.
+line_coords = SkyCoord([-1024, -908], [20, 633], unit=(u.arcsec, u.arcsec),
                        frame=aia_map.coordinate_frame)
 
 
@@ -34,23 +34,23 @@ line_limits = SkyCoord([-1024, -908], [20, 633], unit=(u.arcsec, u.arcsec),
 # intensities and the second is a `~astropy.coordinates.SkyCoord` object of the
 # same length, which describes the world coordinates of each pixel that has
 # been extracted.
-intensity, coord = sunpy.map.extract_along_coord(aia_map, line_limits)
+intensity, intensity_coords = sunpy.map.extract_along_coord(aia_map, line_coords)
 
 
 ###############################################################################
 # Next we will calculate the angular separation between the first point and
 # every other coordinate we extracted. We are doing this to give us a
 # meaningful scale for our line plot below.
-angular_separation = coord.separation(coord[0]).to(u.arcsec)
+angular_separation = intensity_coords.separation(intensity_coords[0]).to(u.arcsec)
 
 ###############################################################################
 # Finally let's plot the results.
 fig = plt.figure()
 ax1 = fig.add_subplot(121, projection=aia_map)
 aia_map.plot(axes=ax1)
-ax1.plot_coord(coord)
-ax1.plot_coord(line_limits[0], marker="o", color="blue", label="start")
-ax1.plot_coord(line_limits[1], marker="o", color="green", label="end")
+ax1.plot_coord(intensity_coords)
+ax1.plot_coord(line_coords[0], marker="o", color="blue", label="start")
+ax1.plot_coord(line_coords[1], marker="o", color="green", label="end")
 ax1.legend()
 
 ax2 = fig.add_subplot(122)

--- a/examples/units_and_coordinates/map_slit_extraction.py
+++ b/examples/units_and_coordinates/map_slit_extraction.py
@@ -1,7 +1,7 @@
 """
-=====================================================
+==========================================
 Extracting intensity of a map along a line
-=====================================================
+==========================================
 
 In this example we will extract the intensity values of all the pixels
 that intersect with a given set of coordinates.

--- a/examples/units_and_coordinates/map_slit_extraction.py
+++ b/examples/units_and_coordinates/map_slit_extraction.py
@@ -1,6 +1,6 @@
 """
 =====================================================
-Extracting intensity of a map between two coordinates
+Extracting intensity of a map along a line
 =====================================================
 
 In this example we will define a slit in world coordinates and then extract the intensity values of all the pixels that the path intersects with.

--- a/examples/units_and_coordinates/map_slit_extraction.py
+++ b/examples/units_and_coordinates/map_slit_extraction.py
@@ -5,7 +5,6 @@ Extracting intensity of a map between two coordinates
 
 In this example we will define a slit in world coordinates and then extract the intensity values of all the pixels that the path intersects with.
 """
-import numpy as np
 import matplotlib.pyplot as plt
 
 import astropy.units as u
@@ -20,7 +19,7 @@ aia_map = sunpy.map.Map(AIA_171_ROLL_IMAGE)
 
 
 ###############################################################################
-# Next we define a path in a `SkyCoord` object.
+# Next we define a path in a `~astropy.coordinates.SkyCoord` object.
 # In this example we are just going to use a straight line, however a path with
 # any number of points can be used, and the slit will be defined as straight
 # line segments between all the points.
@@ -32,8 +31,9 @@ line_limits = SkyCoord([-1024, -908], [20, 633], unit=(u.arcsec, u.arcsec),
 # Next we call the `sunpy.map.extract_along_coord` function with the map and
 # the coordinates we want to extract.
 # This function returns two items, the first is a numpy array of all the
-# intensities and the second is a `SkyCoord` object of the same length, which
-# describes the world coordinates of each pixel that has been extracted.
+# intensities and the second is a `~astropy.coordinates.SkyCoord` object of the
+# same length, which describes the world coordinates of each pixel that has
+# been extracted.
 intensity, coord = sunpy.map.extract_along_coord(aia_map, line_limits)
 
 

--- a/examples/units_and_coordinates/map_slit_extraction.py
+++ b/examples/units_and_coordinates/map_slit_extraction.py
@@ -40,7 +40,7 @@ intensity, intensity_coords = sunpy.map.extract_along_coord(aia_map, line_coords
 ###############################################################################
 # Next we will calculate the angular separation between the first point and
 # every other coordinate we extracted. We are doing this to give us a
-# meaningful scale for our line plot below.
+# meaningful x-axis for our line plot below.
 angular_separation = intensity_coords.separation(intensity_coords[0]).to(u.arcsec)
 
 ###############################################################################

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -489,7 +489,7 @@ def extract_along_coord(smap, coord):
         pix.append(b)
     pix = np.vstack(pix)
 
-    intensity = u.Quantity(smap.data[pix[:, 1], pix[:, 0]], smap.unit)
-    loop_coord = smap.pixel_to_world(pix[:, 0]*u.pix, pix[:, 1]*u.pix)
+    intensity = u.Quantity(smap.data[pix[:, 0], pix[:, 1]], smap.unit)
+    coord_new = smap.pixel_to_world(pix[:, 1]*u.pix, pix[:, 0]*u.pix)
 
-    return intensity, loop_coord
+    return intensity, coord_new

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -459,7 +459,7 @@ def extract_along_coord(smap, coord):
     For a given coordinate ``coord``, find all the pixels that cross the coordinate
     and extract the values of the image array in ``smap`` at these points. This is done by applying
     `Bresenham's line algorithm <http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm>`_
-    between the consecutive pairs of points in the coordinate and then indexing the data
+    between the consecutive coordinates, in pixel space, and then indexing the data
     array of ``smap`` at those points.
 
     Parameters
@@ -471,7 +471,7 @@ def extract_along_coord(smap, coord):
     Returns
     -------
     values : `~astropy.units.Quantity`
-   value_coords : `~astropy.coordinates.SkyCoord`
+    value_coords : `~astropy.coordinates.SkyCoord`
     """
     if not len(coord.shape) or coord.shape[0] < 2:
         raise ValueError('At least two points are required for extracting intensity along a '
@@ -485,7 +485,7 @@ def extract_along_coord(smap, coord):
     px, py = smap.wcs.world_to_array_index(coord)
     pix = []
     for i in range(len(px)-1):
-        b = _bresenham(px[i], py[i], px[i+1], py[i+1])
+        b = _bresenham(x1=px[i], y1=py[i], x2=px[i+1], y2=py[i+1])
         # Pop the last one, unless this is the final entry because the first point
         # of the next section will be the same
         if i < (len(px) - 2):

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -1,6 +1,7 @@
 """
 This submodule provides utility functions to act on `sunpy.map.GenericMap` instances.
 """
+import numbers
 from itertools import product
 
 import numpy as np

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -477,6 +477,10 @@ def extract_along_coord(smap, coord):
         raise ValueError('At least two points are required for extracting intensity along a '
                          'line. To extract points at single coordinates, use '
                          'sunpy.map.maputils.sample_at_coords.')
+    if not all(contains_coordinate(smap, coord)):
+        raise ValueError('At least one coordinate is not within the bounds of the map.'
+                         'To extract the intensity along a coordinate, all points must fall within '
+                         'the bounds of the map.')
     # Find pixels between each loop segment
     px, py = smap.wcs.world_to_array_index(coord)
     pix = []

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -413,7 +413,7 @@ def contains_coordinate(smap, coordinates):
             (yc <= ys - point5pix))
 
 
-def _bresenham(x1, y1, x2, y2):
+def _bresenham(*, x1, y1, x2, y2):
     """
     Returns an array of all pixel coordinates which the line defined by `x1, y1` and
     `x2, y2` crosses. Uses Bresenham's line algorithm to enumerate the pixels along
@@ -429,7 +429,7 @@ def _bresenham(x1, y1, x2, y2):
     * http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
     """
     for x in [x1, y1, x2, y2]:
-        if type(x) not in (int, np.int64):
+        if not isinstance(x, (int, np.int_)):
             raise TypeError('All pixel coordinates must be of type int')
     dx = abs(x2 - x1)
     dy = abs(y2 - y1)
@@ -454,7 +454,7 @@ def _bresenham(x1, y1, x2, y2):
 
 def extract_along_coord(smap, coord):
     """
-    Return the value of the image array at every point along the coordinate.
+    Return the value of the image array at every pixel the coordinate path intersects.
 
     For a given coordinate ``coord``, find all the pixels that cross the coordinate
     and extract the values of the image array in ``smap`` at these points. This is done by applying
@@ -470,8 +470,8 @@ def extract_along_coord(smap, coord):
 
     Returns
     -------
-    intensity : `~astropy.units.Quantity`
-    loop_coord : `~astropy.coordinates.SkyCoord`
+    values : `~astropy.units.Quantity`
+   value_coords : `~astropy.coordinates.SkyCoord`
     """
     if not len(coord.shape) or coord.shape[0] < 2:
         raise ValueError('At least two points are required for extracting intensity along a '

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -466,8 +466,9 @@ def extract_along_coord(smap, coord):
     Parameters
     ----------
     smap : `~sunpy.map.GenericMap`
+        The sunpy map.
     coord : `~astropy.coordinates.SkyCoord`
-        Coordinate along which to extract intensity
+        Coordinate along which to extract intensity.
 
     Returns
     -------

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -494,6 +494,6 @@ def extract_along_coord(smap, coord):
     pix = np.vstack(pix)
 
     intensity = u.Quantity(smap.data[pix[:, 0], pix[:, 1]], smap.unit)
-    coord_new = smap.pixel_to_world(pix[:, 1]*u.pix, pix[:, 0]*u.pix)
+    coord_new = smap.wcs.pixel_to_world(pix[:, 1], pix[:, 0])
 
     return intensity, coord_new

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -454,13 +454,13 @@ def _bresenham(x1, y1, x2, y2):
 
 def extract_along_coord(smap, coord):
     """
-    Return the value of the image array in `smap` at every point along `coord`.
+    Return the value of the image array at every point along the coordinate.
 
-    For a given coordinate `coord`, find all the pixels that cross the coordinate
-    and extract the values of the image array at this points. This is done by applying
+    For a given coordinate ``coord``, find all the pixels that cross the coordinate
+    and extract the values of the image array in ``smap`` at these points. This is done by applying
     `Bresenham's line algorithm <http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm>`_
     between the consecutive pairs of points in the coordinate and then indexing the data
-    array of `smap` at those points.
+    array of ``smap`` at those points.
 
     Parameters
     ----------

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -16,7 +16,8 @@ __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'contains_full_disk', 'is_all_off_disk', 'is_all_on_disk',
            'contains_limb', 'coordinate_is_on_solar_disk',
            'on_disk_bounding_coordinates',
-           'contains_coordinate', 'contains_solar_center']
+           'contains_coordinate', 'contains_solar_center',
+           'extract_along_coord']
 
 
 def all_pixel_indices_from_map(smap):
@@ -410,3 +411,85 @@ def contains_coordinate(smap, coordinates):
             (xc <= xs - point5pix) &
             (yc >= -point5pix) &
             (yc <= ys - point5pix))
+
+
+def _bresenham(x1, y1, x2, y2):
+    """
+    Returns an array of all pixel coordinates which the line defined by `x1, y1` and
+    `x2, y2` crosses. Uses Bresenham's line algorithm to enumerate the pixels along
+    a line. This was adapted from ginga.
+
+    Parameters
+    ----------
+    x1, y1, x2, y2 :`int`
+
+    References
+    ----------
+    * https://github.com/ejeschke/ginga/blob/c8ceaf8e559acc547bf25661842a53ed44a7b36f/ginga/BaseImage.py#L503
+    * http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
+    """
+    for x in [x1, y1, x2, y2]:
+        if type(x) not in (int, np.int64):
+            raise TypeError('All pixel coordinates must be of type int')
+    dx = abs(x2 - x1)
+    dy = abs(y2 - y1)
+    sx = 1 if x1 < x2 else -1
+    sy = 1 if y1 < y2 else -1
+    err = dx - dy
+    res = []
+    x, y = x1, y1
+    while True:
+        res.append((x, y))
+        if (x == x2) and (y == y2):
+            break
+        e2 = 2 * err
+        if e2 > -dy:
+            err = err - dy
+            x += sx
+        if e2 < dx:
+            err = err + dx
+            y += sy
+    return np.array(res)
+
+
+def extract_along_coord(smap, coord):
+    """
+    Return the value of the image array in `smap` at every point along `coord`.
+
+    For a given coordinate `coord`, find all the pixels that cross the coordinate
+    and extract the values of the image array at this points. This is done by applying
+    `Bresenham's line algorithm <http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm>`_
+    between the consecutive pairs of points in the coordinate and then indexing the data
+    array of `smap` at those points.
+
+    Parameters
+    ----------
+    smap : `~sunpy.map.GenericMap`
+    coord : `~astropy.coordinates.SkyCoord`
+        Coordinate along which to extract intensity
+
+    Returns
+    -------
+    intensity : `~astropy.units.Quantity`
+    loop_coord : `~astropy.coordinates.SkyCoord`
+    """
+    if not len(coord.shape) or coord.shape[0] < 2:
+        raise ValueError('At least two points are required for extracting intensity along a '
+                         'line. To extract points at single coordinates, use '
+                         'sunpy.map.maputils.sample_at_coords.')
+    # Find pixels between each loop segment
+    px, py = smap.wcs.world_to_array_index(coord)
+    pix = []
+    for i in range(len(px)-1):
+        b = _bresenham(px[i], py[i], px[i+1], py[i+1])
+        # Pop the last one, unless this is the final entry because the first point
+        # of the next section will be the same
+        if i < (len(px) - 2):
+            b = b[:-1]
+        pix.append(b)
+    pix = np.vstack(pix)
+
+    intensity = u.Quantity(smap.data[pix[:, 1], pix[:, 0]], smap.unit)
+    loop_coord = smap.pixel_to_world(pix[:, 0]*u.pix, pix[:, 1]*u.pix)
+
+    return intensity, loop_coord

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -429,7 +429,7 @@ def _bresenham(*, x1, y1, x2, y2):
     * http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
     """
     for x in [x1, y1, x2, y2]:
-        if not isinstance(x, (int, np.int_)):
+        if not isinstance(x, numbers.Integral):
             raise TypeError('All pixel coordinates must be of type int')
     dx = abs(x2 - x1)
     dy = abs(y2 - y1)

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -19,6 +19,7 @@ from sunpy.map.maputils import (
     contains_limb,
     contains_solar_center,
     coordinate_is_on_solar_disk,
+    extract_along_coord,
     is_all_off_disk,
     is_all_on_disk,
     map_edges,
@@ -272,3 +273,19 @@ def test_contains_coord(aia171_test_map):
     multi_coord = SkyCoord([0, 2000]*u.arcsec, [0, 2000]*u.arcsec,
                            frame=smap.coordinate_frame)
     assert (contains_coordinate(smap, multi_coord) == [True, False]).all()
+
+
+def test_extract_along_coord(aia171_test_map):
+    nmax = max(*aia171_test_map.data.shape)
+    top_right = aia171_test_map.pixel_to_world((nmax-1)*u.pix, (nmax-1)*u.pix)
+    line = SkyCoord([aia171_test_map.bottom_left_coord, top_right])
+    intensity, line_discrete = extract_along_coord(aia171_test_map, line)
+    pix_diag = np.array([(i, i) for i in range(nmax)])
+    intensity_diag = u.Quantity(
+        [aia171_test_map.data[i[0], i[1]] for i in pix_diag],
+        aia171_test_map.unit
+    )
+    line_discrete_pix = aia171_test_map.world_to_pixel(line_discrete)
+    assert np.allclose(pix_diag[:, 0], line_discrete_pix.x.value)
+    assert np.allclose(pix_diag[:, 1], line_discrete_pix.y.value)
+    assert u.quantity.allclose(intensity_diag, intensity)

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -289,3 +289,16 @@ def test_extract_along_coord(aia171_test_map):
     assert np.allclose(pix_diag[:, 0], line_discrete_pix.x.value)
     assert np.allclose(pix_diag[:, 1], line_discrete_pix.y.value)
     assert u.quantity.allclose(intensity_diag, intensity)
+
+
+def test_extract_along_coord_one_point_exception(aia171_test_map):
+    with pytest.raises(ValueError, match='At least two points are required*'):
+        _ = extract_along_coord(aia171_test_map, aia171_test_map.bottom_left_coord)
+    with pytest.raises(ValueError, match='At least two points are required*'):
+        _ = extract_along_coord(aia171_test_map, SkyCoord([aia171_test_map.bottom_left_coord]))
+
+
+def test_extract_along_coord_out_of_bounds_exception(aia171_test_map):
+    point = aia171_test_map.pixel_to_world([-1, 1]*u.pix, [-1, 1]*u.pix)
+    with pytest.raises(ValueError, match='At least one coordinate is not within the bounds of the map.*'):
+        _ = extract_along_coord(aia171_test_map, point)


### PR DESCRIPTION
Fixes #6187 

This PR adds a function in `sunpy/map/maputils.py` to extract the intensity from a map along a given coordinate by applying Bresenham's line algorithm between consecutive pairs of integer pixel coordinates along the coordinate and then indexing the array at those points.

## TODO

- [x] Test
- [x] Docstring?
- [x] Changelog