### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/changelog_bot.yml
+++ b/.github/workflows/changelog_bot.yml
@@ -10,8 +10,13 @@ env:
   BOT_USER_NAME: 'SunPyBot'
   BOT_USER_EMAIL: 'bot@sunpy.org'
 
+permissions:
+  contents: read
+
 jobs:
   update-changelog:
+    permissions:
+      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
     if: "!contains(github.event.pull_request.labels.*.name, 'No Changelog Entry Needed')"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ concurrency:
 
 jobs:
   core:
+    permissions:
+      contents: none
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       submodules: false
@@ -33,6 +35,8 @@ jobs:
         - linux: py310
 
   test:
+    permissions:
+      contents: none
     needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
@@ -51,6 +55,8 @@ jobs:
         - linux: py38-oldestdeps
 
   docs:
+    permissions:
+      contents: none
     needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
@@ -71,6 +77,8 @@ jobs:
         - linux: build_docs
 
   online:
+    permissions:
+      contents: none
     if: "!startsWith(github.event.ref, 'refs/tags/v')"
     needs: [docs]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
@@ -99,6 +107,8 @@ jobs:
         - linux: py39-online
 
   cron:
+    permissions:
+      contents: none
     if: |
       github.event_name == 'workflow_dispatch' || (
         github.event_name == 'pull_request' &&
@@ -123,6 +133,8 @@ jobs:
   publish:
     # Build wheels when pushing to any branch except main
     # publish.yml will only publish if tagged ^v.*
+    permissions:
+      contents: none
     if: |
       (
         github.event_name != 'pull_request' && (

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -11,8 +11,13 @@ on:
     #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
     - cron: '0 7 * * *'  # Every day at 07:00 UTC
 
+permissions:
+  contents: read
+
 jobs:
   dispatch_workflows:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - run: gh workflow run ci.yml --repo sunpy/sunpy --ref main

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -9,8 +9,14 @@ on:
 #            │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
     - cron: '0 5 * * *' # Every day at 05:00 UTC
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v3


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
