### PR TITLE
Allow GenericMap to automatically set EUI map colormap

### DIFF
--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -34,7 +34,6 @@ class EUIMap(GenericMap):
     def __init__(self, data, header, **kwargs):
         super().__init__(data, header, **kwargs)
         self._nickname = self.detector
-        self.plot_settings['cmap'] = self._get_cmap_name()
         self.plot_settings['norm'] = ImageNormalize(
             stretch=source_stretch(self.meta, LinearStretch()), clip=False)
 


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/6198. GenericMap has a try... except... block when setting the colormap that prevents the error in that issue being raised.

Not sure the best way to test this without adding a jp2 file to the test data? Personally I'm happy this without a test, but also understand if another dev wants one.