### PR TITLE
Overrride EUI waveunit

### DIFF
--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -59,9 +59,10 @@ class EUIMap(GenericMap):
 
     @property
     def waveunit(self):
-        # EUI JP2000 files don't have this in their metadata,
-        # the FITS files are ok, so we check if it exists, and if not,
-        # the metadata spec wavelengths are always in Angstrom
+        # EUI JP2000 files do not have the WAVEUNIT key in the metadata.
+        # However, the FITS files do.
+        # The EUI metadata spec says the WAVELNTH key is always expressed
+        # in Angstroms so we assume this if the WAVEUNIT is missing.
         return super().waveunit or u.Angstrom
 
     @property

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -59,9 +59,10 @@ class EUIMap(GenericMap):
 
     @property
     def waveunit(self):
-        # EUI maps don't have this in their metadata, but according to their
-        # metadata spec wavelengths are always in Angstrom
-        return u.Angstrom
+        # EUI JP2000 files don't have this in their metadata,
+        # the FITS files are ok, so we check if it exists, and if not,
+        # the metadata spec wavelengths are always in Angstrom
+        return super().waveunit or u.Angstrom
 
     @property
     def _supported_observer_coordinates(self):

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -58,6 +58,12 @@ class EUIMap(GenericMap):
         return parse_time(t, scale=timesys.lower())
 
     @property
+    def waveunit(self):
+        # EUI maps don't have this in their metadata, but according to their
+        # metadata spec wavelengths are always in Angstrom
+        return u.Angstrom
+
+    @property
     def _supported_observer_coordinates(self):
         return [(('hcix_obs', 'hciy_obs', 'hciz_obs'),
                  {'x': self.meta.get('hcix_obs'),


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/6198 - see https://issues.cosmos.esa.int/solarorbiterwiki/display/SOSP/Metadata+Definition+for+Solar+Orbiter+Science+Data for the ESA documentation that says this should be Angstrom.

I checked loading a .jp2 file with this PR, and it correctly loads the right colormap 🎉 