### PR TITLE
Sync .github/* in 4.0 branch with main

### DIFF
--- a/.github/workflows/asv-regular.yml
+++ b/.github/workflows/asv-regular.yml
@@ -41,11 +41,11 @@ jobs:
         # On main the release of v1.1 is the 2.0dev tag
         run: taskset -c 0 asv run --skip-existing-successful v2.0.dev..
       - name: Install SSH Client 🔑
-        uses: webfactory/ssh-agent@v0.5.3
+        uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ASV_CI_KEY }}
       - name: Push results
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: main
           folder: asv_results

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: gh workflow run ci.yml --repo sunpy/sunpy --ref main
-      - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 3.1
-      - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 3.0
+      - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 4.0
     env:
       GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
Although the `asv-regular.yml` and `scheduled_builds.yml` workflows are not run on the `4.0` branch should we still try to keep them in sync? Only `.github/workflows/ci.yml` is used on the release branches.