### PR TITLE
Add script to generate github markdown changelog

### DIFF
--- a/tools/generate_github_changelog.py
+++ b/tools/generate_github_changelog.py
@@ -1,4 +1,10 @@
+"""
+Script to render to terminal, the changelog entry for the latest version in markdown so it can be copied and pasted for a GitHub release.
+
+It requires pandoc to be installed on your system.
+"""
+
 import subprocess
 
-res = subprocess.run(['pandoc', '--wrap=none', '-t', 'markdown_strict', 'CHANGELOG.rst'], capture_output=True)
+res = subprocess.run(['pandoc', '--wrap=none', '-t', 'markdown_strict', str(Path(__file__).parent.parent / "CHANGELOG.rst")], capture_output=True)
 print(res.stdout.decode('ascii').split('\n# ')[0])

--- a/tools/generate_github_changelog.py
+++ b/tools/generate_github_changelog.py
@@ -6,5 +6,5 @@ It requires pandoc to be installed on your system.
 import subprocess
 from pathlib import Path
 
-res = subprocess.run(['pandoc', '--wrap=none', '-t', 'markdown_strict', str(Path(__file__).parent.parent / "CHANGELOG.rst")], capture_output=True)
+res = subprocess.run(['pandoc', '--wrap=none', '-t', 'gfm', str(Path(__file__).parent.parent / "CHANGELOG.rst")], capture_output=True)
 print(res.stdout.decode('ascii').split('\n# ')[0])

--- a/tools/generate_github_changelog.py
+++ b/tools/generate_github_changelog.py
@@ -1,0 +1,4 @@
+import subprocess
+
+res = subprocess.run(['pandoc', '--wrap=none', '-t', 'markdown_strict', 'CHANGELOG.rst'], capture_output=True)
+print(res.stdout.decode('ascii').split('\n# ')[0])

--- a/tools/generate_github_changelog.py
+++ b/tools/generate_github_changelog.py
@@ -3,8 +3,8 @@ Script to render to terminal, the changelog entry for the latest version in mark
 
 It requires pandoc to be installed on your system.
 """
-
 import subprocess
+from pathlib import Path
 
 res = subprocess.run(['pandoc', '--wrap=none', '-t', 'markdown_strict', str(Path(__file__).parent.parent / "CHANGELOG.rst")], capture_output=True)
 print(res.stdout.decode('ascii').split('\n# ')[0])


### PR DESCRIPTION
Fixes ish https://github.com/sunpy/sunpy/issues/6134. A bit of a ridiculous script on many levels, but it works to only print the most recent release changelog.