### PR TITLE
update sample url for prep of rename of repo url

### DIFF
--- a/changelog/6289.trivial.rst
+++ b/changelog/6289.trivial.rst
@@ -1,0 +1,2 @@
+The sample-data URL will be changing from ``https://github.com/sunpy/sample-data/raw/master/sunpy/v1/`` to ``https://github.com/sunpy/data/raw/main/sunpy/v1/``.
+GitHub will keep the redirect alive for sometime but will eventually expire it.

--- a/changelog/6289.trivial.rst
+++ b/changelog/6289.trivial.rst
@@ -1,3 +1,3 @@
 The primary sample-data URL will be changing from ``https://github.com/sunpy/sample-data/raw/master/sunpy/v1/`` to ``https://github.com/sunpy/data/raw/main/sunpy/v1/``.
-GitHub will keep the redirect alive for sometime but will eventually expire it.
+We expect GitHub to redirect from the old URL for sometime but will eventually expire it.
 The ``data.sunpy.org`` mirror will continue to be available.

--- a/changelog/6289.trivial.rst
+++ b/changelog/6289.trivial.rst
@@ -1,2 +1,3 @@
-The sample-data URL will be changing from ``https://github.com/sunpy/sample-data/raw/master/sunpy/v1/`` to ``https://github.com/sunpy/data/raw/main/sunpy/v1/``.
+The primary sample-data URL will be changing from ``https://github.com/sunpy/sample-data/raw/master/sunpy/v1/`` to ``https://github.com/sunpy/data/raw/main/sunpy/v1/``.
 GitHub will keep the redirect alive for sometime but will eventually expire it.
+The ``data.sunpy.org`` mirror will continue to be available.

--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -7,6 +7,7 @@ from sunpy.util.config import _is_writable_dir, get_and_create_sample_dir
 from sunpy.util.parfive_helpers import Downloader
 
 _BASE_URLS = (
+    'https://github.com/sunpy/data/raw/main/sunpy/v1/',
     'https://github.com/sunpy/sample-data/raw/master/sunpy/v1/',
     'http://data.sunpy.org/sunpy/v1/',
 )


### PR DESCRIPTION
So we can get ready for upstream changes aka https://github.com/sunpy/sample-data/issues/25