### PR TITLE
Deprecate timeseries peek() positional arguments

### DIFF
--- a/changelog/6310.deprecation.rst
+++ b/changelog/6310.deprecation.rst
@@ -1,0 +1,3 @@
+Passing positional arguments to all ``timeseries`` ``peek()`` methods
+is now deprecated, and will raise an error in sunpy 5.1. Pass the arguments
+with keywords (e.g. ``title='my plot title'``) instead.

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -53,7 +53,7 @@ number of source-specific plot customisations in ``peek()`` and ``plot()`` metho
 See the changelog for more details on what has changed.
 
 In order to harmonise different ``peek()`` and ``plot()`` signatures, all non-keyword arguments to these methods are deprecated.
-To avoid a warning pas all arguments with keywords (e.g. ``plot(title='my plot title')``) instead.
+To avoid a warning pass all arguments with keywords (e.g. ``plot(title='my plot title')``) instead.
 
 ``parfive`` 2.0.0 release
 =========================

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -49,8 +49,11 @@ the `sunpy.visualization.drawing` module and renamed :func:`sunpy.visualization.
 Changes to timeseries plotting
 ==============================
 In order to make plotting a timeseries as source-independent as possible, we have removed a
-number of source-specific plot customisations in ``peek()`` and ``plot()`` methods. See the
-changelog for more details on what has changed.
+number of source-specific plot customisations in ``peek()`` and ``plot()`` methods.
+See the changelog for more details on what has changed.
+
+In order to harmonise different ``peek()`` and ``plot()`` signatures, all non-keyword arguments to these methods are deprecated.
+To avoid a warning pas all arguments with keywords (e.g. ``plot(title='my plot title')``) instead.
 
 ``parfive`` 2.0.0 release
 =========================

--- a/examples/acquiring_data/search_cdaweb.py
+++ b/examples/acquiring_data/search_cdaweb.py
@@ -38,4 +38,4 @@ print(downloaded_files)
 # Python library to read the CDF file.
 solo_mag = TimeSeries(downloaded_files, concatenate=True)
 print(solo_mag.columns)
-solo_mag.peek(['B_RTN_0', 'B_RTN_1', 'B_RTN_2'])
+solo_mag.peek(columns=['B_RTN_0', 'B_RTN_1', 'B_RTN_2'])

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -13,6 +13,7 @@ from astropy.time import TimeDelta
 import sunpy.io
 from sunpy.time import parse_time
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
+from sunpy.util.decorators import deprecate_positional_args_since
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
 
@@ -88,7 +89,8 @@ class ESPTimeSeries(GenericTimeSeries):
         return axes
 
     @peek_show
-    def peek(self, title="EVE/ESP Level 1", columns=None, **kwargs):
+    @deprecate_positional_args_since("4.1")
+    def peek(self, *, title="EVE/ESP Level 1", columns=None, **kwargs):
         """
         Displays the EVE ESP Level 1 timeseries data by calling
         `~sunpy.timeseries.sources.eve.ESPTimeSeries.plot`.
@@ -195,7 +197,8 @@ class EVESpWxTimeSeries(GenericTimeSeries):
     _url = "http://lasp.colorado.edu/home/eve/"
 
     @peek_show
-    def peek(self, columns=None, **kwargs):
+    @deprecate_positional_args_since("4.1")
+    def peek(self, *, columns=None, **kwargs):
         """
         Plots the time series in a new figure.
 

--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -13,6 +13,7 @@ from astropy.time import TimeDelta
 import sunpy.io
 from sunpy.time import parse_time
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
+from sunpy.util.decorators import deprecate_positional_args_since
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
 
@@ -95,7 +96,8 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
         return axes
 
     @peek_show
-    def peek(self, title=None, columns=None, **kwargs):
+    @deprecate_positional_args_since("4.1")
+    def peek(self, *, title=None, columns=None, **kwargs):
         """
         Displays the GBM timeseries by calling
         `~sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries.plot`.

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -13,6 +13,7 @@ import sunpy.io
 from sunpy import config
 from sunpy.time import parse_time
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
+from sunpy.util.decorators import deprecate_positional_args_since
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
 
@@ -94,7 +95,8 @@ class LYRATimeSeries(GenericTimeSeries):
         return axes
 
     @peek_show
-    def peek(self, title=None, columns=None, names=3, **kwargs):
+    @deprecate_positional_args_since("4.1")
+    def peek(self, *, title=None, columns=None, names=3, **kwargs):
         """
         Displays the LYRA data by calling `~sunpy.timeseries.sources.lyra.LYRATimeSeries.plot`.
 

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -10,6 +10,7 @@ import pandas as pd
 import astropy.units as u
 
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
+from sunpy.util.decorators import deprecate_positional_args_since
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
 
@@ -110,7 +111,8 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         return axes
 
     @peek_show
-    def peek(self, title="Solar Cycle Progression", plot_type='sunspot SWO', columns=None, **kwargs):
+    @deprecate_positional_args_since("4.1")
+    def peek(self, *, title="Solar Cycle Progression", plot_type='sunspot SWO', columns=None, **kwargs):
         """
         Displays the NOAA Indices as a function of time by calling
         `~sunpy.timeseries.sources.noaa.NOAAPredictIndicesTimeSeries.plot`.

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -15,6 +15,7 @@ import sunpy.io
 from sunpy import config
 from sunpy.time import parse_time
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
+from sunpy.util.decorators import deprecate_positional_args_since
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
 
@@ -88,7 +89,8 @@ class NoRHTimeSeries(GenericTimeSeries):
         return axes
 
     @peek_show
-    def peek(self, title="Nobeyama Radioheliograph", columns=None, **kwargs):
+    @deprecate_positional_args_since("4.1")
+    def peek(self, *, title="Nobeyama Radioheliograph", columns=None, **kwargs):
         """
         Displays the NoRH lightcurve TimeSeries by calling
         `~sunpy.timeseries.sources.norh.NoRHTimeSeries.plot`.

--- a/sunpy/timeseries/sources/tests/test_eve.py
+++ b/sunpy/timeseries/sources/tests/test_eve.py
@@ -1,9 +1,11 @@
+import re
+
 import pytest
 
 import sunpy.timeseries
 from sunpy.data.test import get_test_filepath
 from sunpy.tests.helpers import figure_test
-from sunpy.util.exceptions import SunpyUserWarning
+from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyUserWarning
 
 esp_filepath = get_test_filepath('eve_l1_esp_2011046_00_truncated.fits')
 eve_filepath = get_test_filepath('EVE_L0CS_DIODES_1m_truncated.txt')
@@ -34,6 +36,11 @@ def test_esp_plot_column(esp_test_ts):
     assert '0.1-7nm' in axes[0].get_ylabel()
     assert '18nm' in axes[1].get_ylabel()
     assert '36nm' in axes[2].get_ylabel()
+
+
+def test_esp_peek_keyword_deprecation(esp_test_ts):
+    with pytest.warns(SunpyDeprecationWarning, match=re.escape('Pass title= as keyword args')):
+        esp_test_ts.peek('')
 
 
 @figure_test

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -551,6 +551,11 @@ def test_timeseries_array():
         assert isinstance(ts, sunpy.timeseries.GenericTimeSeries)
 
 
+def test_deprecated_positional_peek_args(many_ts):
+    # Check that all positional arguments to peek() are deprecated
+    with pytest.warns(SunpyDeprecationWarning, match='passing these as positional arguments will result in an error'):
+        many_ts.peek(many_ts.columns[0:1])
+
 # TODO:
 # _validate_units
 # _validate_meta

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -25,6 +25,7 @@ from sunpy import config
 from sunpy.time import TimeRange
 from sunpy.timeseries import TimeSeriesMetaData
 from sunpy.util.datatype_factory_base import NoMatchError
+from sunpy.util.decorators import deprecate_positional_args_since
 from sunpy.util.exceptions import warn_deprecated, warn_user
 from sunpy.util.metadata import MetaDict
 from sunpy.util.util import _figure_to_base64
@@ -764,7 +765,8 @@ class GenericTimeSeries:
             ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
 
     @peek_show
-    def peek(self, columns=None, *, title=None, **kwargs):
+    @deprecate_positional_args_since("4.1")
+    def peek(self, *, columns=None, title=None, **kwargs):
         """
         Displays a graphical overview of the data in this object for user evaluation.
         For the creation of plots, users should instead use the

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -263,6 +263,13 @@ class add_common_docstring:
 
 def deprecate_positional_args_since(since, keyword_only=False):
     """
+    Decorator for methods that issues warnings for positional arguments
+    Using the keyword-only argument syntax in pep 3102, arguments after the
+    * will issue a warning when passed as a positional argument.
+
+    Note that when you apply this, you also have to put at * in the signature
+    to create new keyword only parameters!
+
     Parameters
     ----------
     since : str
@@ -270,9 +277,7 @@ def deprecate_positional_args_since(since, keyword_only=False):
     """
     def deprecate_positional_args(f):
         """
-        Decorator for methods that issues warnings for positional arguments
-        Using the keyword-only argument syntax in pep 3102, arguments after the
-        * will issue a warning when passed as a positional argument.
+
 
         Parameters
         ----------


### PR DESCRIPTION
This includes a decorator to deprecate passing some peek arguments as positional arguments. I still need to roll this out to all the other peek methods, but opening as a draft to avoid anyone else duplicating this work.

Fixes https://github.com/sunpy/sunpy/issues/6307