### PR TITLE
Fixed a bug when working with an observer defined in HEEQ

### DIFF
--- a/changelog/6311.bugfix.rst
+++ b/changelog/6311.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed bugs when working with a coordinate frame where the observer is specified in `~sunpy.coordinates.frames.HeliographicStonyhurst` and Cartesian representation, which is equivalent to Heliocentric Earth Equatorial (HEEQ).
+Now, the observer will always be converted to spherical representation.

--- a/changelog/6311.bugfix.rst
+++ b/changelog/6311.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed bugs when working with a coordinate frame where the observer is specified in `~sunpy.coordinates.frames.HeliographicStonyhurst` and Cartesian representation, which is equivalent to Heliocentric Earth Equatorial (HEEQ).
-Now, the observer will always be converted to spherical representation.
+Fixed bugs when working with a coordinate frame where the observer is specified in `~sunpy.coordinates.frames.HeliographicStonyhurst` with a Cartesian representation, which is equivalent to Heliocentric Earth Equatorial (HEEQ).
+Now, the observer will always be converted to spherical representation when the coordinate frame is created.

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -110,7 +110,15 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
             if isinstance(value, BaseCoordinateFrame) and not isinstance(value, self._frame):
                 value = SkyCoord(value)
 
-            return super().convert_input(value)
+            result, converted = super().convert_input(value)
+
+            # If already in the correct frame, make sure it has the default representation
+            if (not converted and isinstance(result, BaseCoordinateFrame) and
+                    not issubclass(result.representation_type, result.default_representation)):
+                result = result.replicate(representation_type=result.default_representation)
+                converted = True
+
+            return result, converted
 
     def _convert_string_to_coord(self, out, obstime):
         """

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -2,7 +2,7 @@
 import pytest
 
 import astropy.units as u
-from astropy.coordinates import ICRS, HeliocentricMeanEcliptic, get_body_barycentric
+from astropy.coordinates import ICRS, HeliocentricMeanEcliptic, SphericalRepresentation, get_body_barycentric
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 
@@ -112,6 +112,17 @@ def test_observer_not_hgs_astropy(oca):
     result, converted = oca.convert_input(observer)
 
     assert isinstance(result, HeliographicStonyhurst)
+    assert result.obstime == observer.obstime
+    assert converted
+
+
+def test_observer_not_default_representation(oca):
+    observer = HeliographicStonyhurst((1, 0, 0) * u.AU, representation_type='cartesian',
+                                      obstime='2001-01-01')
+    result, converted = oca.convert_input(observer)
+
+    assert isinstance(result, HeliographicStonyhurst)
+    assert issubclass(result.representation_type, SphericalRepresentation)
     assert result.obstime == observer.obstime
     assert converted
 

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -9,6 +9,7 @@ from astropy.time import Time
 from sunpy.coordinates import frames, get_earth
 from sunpy.coordinates.frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy
 from sunpy.coordinates.frames import (
+    Heliocentric,
     HeliocentricInertial,
     HeliographicCarrington,
     HeliographicStonyhurst,
@@ -204,3 +205,12 @@ def test_obstime_hack():
     assert_quantity_allclose(obs.lon, earth.lon)
     assert_quantity_allclose(obs.lat, earth.lat)
     assert_quantity_allclose(obs.radius, earth.radius)
+
+
+@pytest.mark.parametrize('frame_class', [Heliocentric, HeliographicCarrington, Helioprojective])
+def test_observer_in_heeq(frame_class):
+    # An observer provided in HGS Cartesian (i.e., HEEQ) should be converted to HGS spherical
+    obs_heeq = HeliographicStonyhurst((3, 4, 12)*u.AU, representation_type='cartesian')
+    frame = frame_class(observer=obs_heeq)
+    assert issubclass(frame.observer.representation_type, SphericalRepresentation)
+    assert_quantity_allclose(frame.observer.radius, 13*u.AU)


### PR DESCRIPTION
As [reported by @samaloney](https://github.com/samaloney/stixpy/pull/39#discussion_r908321543), trying to work with an observer defined in `HeliographicStonyhurst` with a Cartesian representation (i.e., equivalent to HEEQ) causes transformations to error.  This is due to the observer-equality check assuming that an `HeliographicStonyhurst` observer is already be in spherical representation.  There are other places in our code that also assume that the observer is already in spherical representation.

This PR fixes those bugs by converting a `HeliographicStonyhurst` observer to the default representation (i.e., spherical).