### PR TITLE
Fix filtering of empty VSO results w/ numpy 1.23

### DIFF
--- a/changelog/6318.bugfix.rst
+++ b/changelog/6318.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed an error when Fido returns zero results from the VSO
+and some results from at least one other data source. This
+(now fixed) error is only present when using numpy version >= 1.23.

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -315,11 +315,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         # client generated results, we drop the empty VSO results for tidiness.
         # This is because the VSO _can_handle_query is very broad because we
         # don't know the full list of supported values we can search for (yet).
-        if len(results) > 1:
-            vso_results = list(filter(lambda r: isinstance(r, vso.VSOQueryResponseTable), results))
-            for vres in vso_results:
-                if len(vres) == 0:
-                    results.remove(vres)
+        results = [r for r in results if not isinstance(r, vso.VSOQueryResponseTable) or len(r) > 0]
 
         return UnifiedResponse(*results)
 


### PR DESCRIPTION
Should fix https://github.com/sunpy/sunpy/issues/6300, by avoiding use of `.remove()`. I think the new code is a bit nicer anyway.