### PR TITLE
Only run scheduled tests every week

### DIFF
--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -9,7 +9,7 @@ on:
     #        │ │ ┌───────── day of the month (1 - 31)
     #        │ │ │ ┌───────── month (1 - 12 or JAN-DEC)
     #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
-    - cron: '0 7 * * *'  # Every day at 07:00 UTC
+    - cron: '0 7 * * 1'  # Every Monday at 07:00 UTC
 
 jobs:
   dispatch_workflows:


### PR DESCRIPTION
This reduces the frequency of our scheduled tests from daily to weekly. My motivation here is:

1. We do not respond to test failures on a daily basis (and don't have the developer resources to do so)
2. Running tests every day uses a lot of CI resources. These are £ free (currently), but have an environmental cost in all the energy it takes to run them.
3. I think I would be at least personally be more likely to actually take notice of any failures every week and act on them, compared to every day