### PR TITLE
Deprecate GenericTimeSeries.index

### DIFF
--- a/changelog/6327.deprecation.rst
+++ b/changelog/6327.deprecation.rst
@@ -1,0 +1,3 @@
+Using `sunpy.timeseries.GenericTimeSeries.index` is deprecated.
+Use `~sunpy.timeseries.GenericTimeSeries.time` to get an astropy Time object,
+or ``ts.to_dataframe().index`` to get the times as a pandas ``DataTimeIndex``.

--- a/changelog/6327.feature.rst
+++ b/changelog/6327.feature.rst
@@ -1,0 +1,2 @@
+Added the `sunpy.timeseries.GenericTimeSeries.time` property to get the times
+of a timeseries as a `~astropy.time.Time` object.

--- a/docs/dev_guide/contents/example_gallery.rst
+++ b/docs/dev_guide/contents/example_gallery.rst
@@ -39,11 +39,10 @@ Contribution Guidelines
 
   * Always create a figure instance using ``plt.figure()`` prior to creating a plot.
 
-  * Only create an axes instance if it is explicitly needed later in the example
-    (e.g. when overplotting a coordinate on a map using ``ax.plot_coord``).
+  * Only create an axes instance if it is explicitly needed later in the example (e.g. when overplotting a coordinate on a map using ``ax.plot_coord``).
 
-  * If an axes instance is created, it should be explicitly passed as a keyword argument wherever possible
-    (e.g. in `~sunpy.map.GenericMap.plot` or `~sunpy.map.GenericMap.draw_grid`).
+  * If an axes instance is created, it should be explicitly passed as a keyword argument wherever possible (e.g. in `~sunpy.map.GenericMap.plot` or `~sunpy.map.GenericMap.draw_grid`).
 
-  * After each figure is created, call ``plt.show()``. While not explicitly needed for the gallery to render,
-    this ensures that, when run as a script, the gallery will display each figure sequentially.
+  * After each figure is created, call ``plt.show()``. While not explicitly needed for the gallery to render, this ensures that, when run as a script, the gallery will display each figure sequentially.
+
+  * If you need to use ``astropy.visualization.{quantity_support, time_support}``, import these functions at the top of the example, and call them directly before the first plot that needs them.

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -185,7 +185,7 @@ the header information as read from the source files. A word of caution: many
 data sources provide little to no meta data so this variable might be empty.
 The meta data is described in more detail later in this guide. Similarly there
 are properties for getting `~sunpy.timeseries.GenericTimeSeries.columns`
-as a list of strings, `~sunpy.timeseries.GenericTimeSeries.index`
+as a list of strings, `~sunpy.timeseries.GenericTimeSeries.time`
 values and `~sunpy.timeseries.GenericTimeSeries.time_range` of
 the data.  The actual data in a sunpy TimeSeries object is accessible through
 the `~sunpy.timeseries.GenericTimeSeries.data` attribute.  The

--- a/examples/acquiring_data/goes_xrs_example.py
+++ b/examples/acquiring_data/goes_xrs_example.py
@@ -30,9 +30,13 @@ available from each satellite. Similarly there are times when GOES 16 and 17 ove
 import matplotlib.pyplot as plt
 import numpy as np
 
+from astropy.visualization import time_support
+
 from sunpy import timeseries as ts
 from sunpy.net import Fido
 from sunpy.net import attrs as a
+
+time_support()
 
 #############################################################
 # Lets first define our start and end times and query using the
@@ -91,7 +95,7 @@ plt.show()
 
 goes_flare = goes_15.truncate("2015-06-21 09:35", "2015-06-21 10:30")
 fig, ax = plt.subplots()
-ax.plot(goes_flare.index, np.gradient(goes_flare.quantity("xrsb")))
+ax.plot(goes_flare.time, np.gradient(goes_flare.quantity("xrsb")))
 ax.set_ylabel("Flux (Wm$^{-2}$$s^{-1}$)")
 fig.autofmt_xdate()
 plt.show()

--- a/examples/acquiring_data/goes_xrs_example.py
+++ b/examples/acquiring_data/goes_xrs_example.py
@@ -36,8 +36,6 @@ from sunpy import timeseries as ts
 from sunpy.net import Fido
 from sunpy.net import attrs as a
 
-time_support()
-
 #############################################################
 # Lets first define our start and end times and query using the
 # `~sunpy.net.Fido`.
@@ -94,6 +92,8 @@ plt.show()
 # flares.
 
 goes_flare = goes_15.truncate("2015-06-21 09:35", "2015-06-21 10:30")
+
+time_support()
 fig, ax = plt.subplots()
 ax.plot(goes_flare.time, np.gradient(goes_flare.quantity("xrsb")))
 ax.set_ylabel("Flux (Wm$^{-2}$$s^{-1}$)")

--- a/examples/plotting/solar_cycle_example.py
+++ b/examples/plotting/solar_cycle_example.py
@@ -17,7 +17,6 @@ from sunpy.net import Fido
 from sunpy.net import attrs as a
 from sunpy.time import TimeRange
 
-time_support()
 ###############################################################################
 # The U.S. Dept. of Commerce, NOAA, Space Weather Prediction Center (SWPC)
 # provides recent solar cycle indices which includes different sunspot numbers,
@@ -46,7 +45,6 @@ noaa_predict = ts.TimeSeries(f_noaa_predict, source='noaapredictindices')
 # The predictions provide both a high and low values, which we plot below as
 # ranges.
 
-# Enable support for plotting astropy times
 time_support()
 plt.figure()
 plt.plot(noaa.time, noaa.quantity('sunspot RI'), label='Sunspot Number')

--- a/examples/plotting/solar_cycle_example.py
+++ b/examples/plotting/solar_cycle_example.py
@@ -10,12 +10,14 @@ import matplotlib.pyplot as plt
 
 import astropy.units as u
 from astropy.time import Time, TimeDelta
+from astropy.visualization import time_support
 
 import sunpy.timeseries as ts
 from sunpy.net import Fido
 from sunpy.net import attrs as a
 from sunpy.time import TimeRange
 
+time_support()
 ###############################################################################
 # The U.S. Dept. of Commerce, NOAA, Space Weather Prediction Center (SWPC)
 # provides recent solar cycle indices which includes different sunspot numbers,
@@ -44,11 +46,13 @@ noaa_predict = ts.TimeSeries(f_noaa_predict, source='noaapredictindices')
 # The predictions provide both a high and low values, which we plot below as
 # ranges.
 
+# Enable support for plotting astropy times
+time_support()
 plt.figure()
-plt.plot(noaa.index, noaa.quantity('sunspot RI'), label='Sunspot Number')
-plt.plot(noaa_predict.index, noaa_predict.quantity('sunspot'),
+plt.plot(noaa.time, noaa.quantity('sunspot RI'), label='Sunspot Number')
+plt.plot(noaa_predict.time, noaa_predict.quantity('sunspot'),
          color='grey', label='Near-term Prediction')
-plt.fill_between(noaa_predict.index, noaa_predict.quantity('sunspot low'),
+plt.fill_between(noaa_predict.time, noaa_predict.quantity('sunspot low'),
                  noaa_predict.quantity('sunspot high'), alpha=0.3, color='grey')
 plt.ylim(bottom=0)
 plt.ylabel('Sunspot Number')

--- a/examples/time_series/timeseriesmetadata_example.py
+++ b/examples/time_series/timeseriesmetadata_example.py
@@ -85,8 +85,8 @@ print(large_trunc_ts.meta.to_string(2))
 large_trunc_ts.meta.find(time=parse_time('2010-11-04 09:01:16'))
 large_trunc_ts.meta.find(time='2010-11-04 09:01:16', colname='xrsb')
 
-# You can get the time of a row a from the TimeSeries object's index:
-large_trunc_ts.meta.find(time=large_trunc_ts.index[10])
+# You can get the time of a row a from the TimeSeries object's times:
+large_trunc_ts.meta.find(time=large_trunc_ts.time[10])
 
 # There is also a get method:
 large_trunc_ts.meta.get('telescop')

--- a/sunpy/timeseries/sources/tests/test_goes.py
+++ b/sunpy/timeseries/sources/tests/test_goes.py
@@ -99,7 +99,7 @@ def test_goes_remote():
 def test_goes_leap_seconds():
     with pytest.warns(SunpyUserWarning, match="There is one leap second timestamp present in: goes_13_leap_second"):
         ts = sunpy.timeseries.TimeSeries(goes13_leap_second_filepath)
-    assert str(ts.time[-1]) == '2015-06-30T23:59:59.999000000'
+    assert ts.time[-1].isot == '2015-06-30T23:59:59.999'
 
 
 def test_goes_plot_column(goes_test_ts):

--- a/sunpy/timeseries/sources/tests/test_goes.py
+++ b/sunpy/timeseries/sources/tests/test_goes.py
@@ -75,13 +75,13 @@ def test_new_goes16():
 def test_goes_netcdf_time_parsing15():
     # testing to make sure the time is correctly parsed (to ignore leap seconds)
     ts_goes = sunpy.timeseries.TimeSeries(new_goes15_filepath, source="XRS")
-    assert ts_goes.index[0].strftime("%Y-%m-%d %H:%M:%S.%f") == '2013-10-28 00:00:01.385000'
+    assert ts_goes.time[0].strftime("%Y-%m-%d %H:%M:%S.%f") == '2013-10-28 00:00:01.385'
 
 
 def test_goes_netcdf_time_parsing17():
     # testing to make sure the time is correctly parsed (to ignore leap seconds)
     ts_goes = sunpy.timeseries.TimeSeries(new_goes17_filepath, source="XRS")
-    assert ts_goes.index[0].strftime("%Y-%m-%d %H:%M:%S.%f") == '2020-10-16 00:00:00.476771'
+    assert ts_goes.time[0].strftime("%Y-%m-%d %H:%M:%S.%f") == '2020-10-16 00:00:00.477'
 
 
 @pytest.mark.remote_data
@@ -99,7 +99,7 @@ def test_goes_remote():
 def test_goes_leap_seconds():
     with pytest.warns(SunpyUserWarning, match="There is one leap second timestamp present in: goes_13_leap_second"):
         ts = sunpy.timeseries.TimeSeries(goes13_leap_second_filepath)
-    assert str(ts.index[-1]) == '2015-06-30 23:59:59.999000'
+    assert str(ts.time[-1]) == '2015-06-30T23:59:59.999000000'
 
 
 def test_goes_plot_column(goes_test_ts):

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -11,7 +11,7 @@ from pandas.testing import assert_frame_equal
 import astropy.units as u
 from astropy.table import Table
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.time import TimeDelta
+from astropy.time import Time, TimeDelta
 
 import sunpy
 import sunpy.timeseries
@@ -496,6 +496,10 @@ def test_equality_different_ts_types(generic_ts, eve_test_ts):
 def test_ts_index(generic_ts):
     with pytest.warns(SunpyDeprecationWarning, match='.index is deprecatd'):
         assert (generic_ts.index == generic_ts.to_dataframe().index).all()
+
+
+def test_ts_time(generic_ts):
+    assert isinstance(generic_ts.time, Time)
 
 
 def test_ts_shape(generic_ts):

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -18,7 +18,7 @@ import sunpy.timeseries
 from sunpy.tests.helpers import figure_test
 from sunpy.time import TimeRange, parse_time
 from sunpy.timeseries import TimeSeriesMetaData
-from sunpy.util import SunpyUserWarning
+from sunpy.util import SunpyDeprecationWarning, SunpyUserWarning
 from sunpy.util.metadata import MetaDict
 
 # Test fixtures are in ../conftest.py
@@ -494,7 +494,8 @@ def test_equality_different_ts_types(generic_ts, eve_test_ts):
 
 
 def test_ts_index(generic_ts):
-    assert (generic_ts.index == generic_ts.to_dataframe().index).all()
+    with pytest.warns(SunpyDeprecationWarning, match='.index is deprecatd'):
+        assert (generic_ts.index == generic_ts.to_dataframe().index).all()
 
 
 def test_ts_shape(generic_ts):

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -18,13 +18,14 @@ import pandas as pd
 import astropy
 import astropy.units as u
 from astropy.table import Column, Table
+from astropy.time import Time
 from astropy.visualization import hist
 
 from sunpy import config
 from sunpy.time import TimeRange
 from sunpy.timeseries import TimeSeriesMetaData
 from sunpy.util.datatype_factory_base import NoMatchError
-from sunpy.util.exceptions import warn_user
+from sunpy.util.exceptions import warn_deprecated, warn_user
 from sunpy.util.metadata import MetaDict
 from sunpy.util.util import _figure_to_base64
 from sunpy.visualization import peek_show
@@ -176,7 +177,16 @@ class GenericTimeSeries:
         """
         The time index of the data.
         """
-        return self._data.index
+        warn_deprecated('.index is deprecatd. Use .time instead to get an astropy.time.Time object, '
+                        'or ts.to_dataframe().index to get a pandas DateTimeIndex.')
+        return self.to_dataframe().index
+
+    @property
+    def time(self):
+        """
+        The timestamps of the data.
+        """
+        return Time(self._data.index)
 
     @property
     def shape(self):

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -186,7 +186,10 @@ class GenericTimeSeries:
         """
         The timestamps of the data.
         """
-        return Time(self._data.index)
+        t = Time(self._data.index)
+        # Set time format to enable plotting with astropy.visualisation.time_support()
+        t.format = 'iso'
+        return t
 
     @property
     def shape(self):


### PR DESCRIPTION
The goal here is to deprecate `.index`, which returns a pandas date-time array, and replace it with `.time` which returns astropy times. This new API is the same as `astropy.timeseries.TimeSeries`.

This is pulled out of https://github.com/sunpy/sunpy/pull/5834/files for easier review.