### PR TITLE
Update license year

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2019 The SunPy developers
+Copyright (c) 2013-2022 The SunPy developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
It isn't 2019 anymore.

I have updated the wiki pages for releases to add this as a check.