### PR TITLE
Fix CFF file author naming format

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: '1.1.0'
-message: 'Please cite the following works when using this software.'
+message: 'Please cite the following work when using this software.'
 authors:
-  - family-names: 'The SunPy Community'
+  - name: 'The SunPy Community'
   - family-names: 'Barnes'
     given-names: 'Will T.'
   - family-names: 'Bobra'


### PR DESCRIPTION
This fixes the formatting of "The SunPy Community" in the citation when it's presented in the GitHub sidebar. Compare "Cite this repository" inside sidebar of https://github.com/ConorMacBride/sunpy to https://github.com/sunpy/sunpy