### PR TITLE
Check that adding .T to rotate fails a test

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1727,7 +1727,7 @@ class GenericMap(NDData):
                                     order=order, scale=scale,
                                     image_center=pixel_center,
                                     recenter=recenter, missing=missing,
-                                    method=method, clip=clip)
+                                    method=method, clip=clip).T
 
         if recenter:
             new_reference_pixel = pixel_array_center


### PR DESCRIPTION
We discovered on Element chat (thanks `eimason`, https://matrix.to/#/!MeRdFpEonLoCwhoHeT:matrix.org/$16581713051370OFAQS:openastronomy.org?via=matrix.org&via=openastronomy.org&via=cadair.com onwards) that a bug found it's way into sunpy 3.1.7 during the backport of #5803 in #6000.

This PR is a test to see if the error that was introduced fails at least one of our tests. If it doesn't, we should definitely add a test that fails with this change...