### PR TITLE
Fixed bug that prevents RotatedSunFrame instances from being pickled

### DIFF
--- a/changelog/6342.bugfix.rst
+++ b/changelog/6342.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug that prevented `~sunpy.coordinates.metaframes.RotatedSunFrame` instances from being pickled.

--- a/sunpy/coordinates/metaframes.py
+++ b/sunpy/coordinates/metaframes.py
@@ -216,6 +216,13 @@ class RotatedSunFrame(SunPyBaseCoordinateFrame):
         """
         return self.base.obstime + self.duration
 
+    def __reduce__(self):
+        return (_rotatedsunframe_reducer, (self.base,), self.__dict__)
+
+
+def _rotatedsunframe_reducer(base):
+    return RotatedSunFrame.__new__(RotatedSunFrame, base=base)
+
 
 # For Astropy 4.3+, we need to manually remove the `obstime` frame attribute from RotatedSunFrame
 if 'obstime' in RotatedSunFrame.frame_attributes:

--- a/sunpy/coordinates/tests/test_metaframes.py
+++ b/sunpy/coordinates/tests/test_metaframes.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 from hypothesis import given, settings
 
@@ -276,3 +278,11 @@ def test_tranformation_to_nonobserver_frame(indirect_fixture):
     hgs_coord = rot_frame.transform_to(hgs_frame)
 
     assert hgs_coord.obstime == hgs_frame.obstime
+
+
+def test_pickle_rotatedsunframe():
+    base_coord = SkyCoord(1*u.deg, 2*u.deg, obstime="2003-04-05", rsun=600*u.Mm,
+                          frame='heliographic_stonyhurst')
+    rotated_coord = RotatedSunFrame(base=base_coord, duration=7*u.day)
+    pickled_coord = pickle.loads(pickle.dumps(rotated_coord))
+    assert pickled_coord == rotated_coord


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/6279

This fix is based on
https://github.com/astropy/astropy/pull/13305

This fix makes it so that RotatedSunFrame objects
can be pickled and unpickled.
