### PR TITLE
Update Map Guide

### DIFF
--- a/changelog/6345.doc.rst
+++ b/changelog/6345.doc.rst
@@ -1,0 +1,1 @@
+Edit and update the Map and TimeSeries guides.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -1,20 +1,35 @@
-****
-Maps
-****
+*********
+Map Guide
+*********
 
-Maps in sunpy are are 2-dimensional data associated with a coordinate system. In
-this guide, we will cover some of the basic functionality of maps. Once you've
-read through this guide check out :doc:`/code_ref/map` for a more thorough look
-at sunpy maps. There you can see what instruments are currently supported or you
-can access the code reference for each instrument-specific map subclass.
+Map objects in SunPy are two-dimensional data associated with a coordinate system.
+This class offers many advantages over using, for example, `astropy.io.fits` to open
+2D solar data in Python. SunPy Maps recognize data from 19 sources
+(see :doc:`/code_ref/map` for a complete list) and can provide instrument-specific
+information when plotting and even correct/add metadata when it is missing from the
+original file.
 
-Creating maps
-=============
-To make things easy, sunpy can download several example files which are used
-throughout the docs. These files have names like
-``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE``. To
-create a `~sunpy.map.Map` from the the sample AIA image
-type the following into your Python shell::
+Part of the philosophy of the Map object is to provide most of the basic
+functionality that a scientist would want. Therefore, a Map also contains a number
+of methods such as resizing or grabbing a subview. See `~sunpy.map.mapbase.GenericMap`
+for summaries of all attributes and methods.
+
+:ref:`1. Creating Maps` and :ref:`2. Inspecting Maps` demonstrate how to create a Map object
+and view a summary of the data in the object. :ref:`3. Map Data` describes how data is stored
+and accessed in a Map, and :ref:`4. Plotting Maps` introduces some basics of visualizing Map
+data in SunPy. :ref:`5. Composite Maps` and :ref:`6. Map Sequences` detail how SunPy can handle
+multiple Maps from similar and different instruments. Lastly, :ref:`7. Creating Custom Maps`
+shows how you can create Maps from data sources not supported in SunPy.
+
+
+1. Creating Maps
+================
+
+To make things easy, SunPy can download sample data which are used
+throughout the docs (see :doc:`/examples/acquiring_data/2011_06_07_sampledata_overview`).
+These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE``.
+To create a `~sunpy.map.Map` from a sample AIA image,
+type the following into your Python shell: ::
 
     >>> import sunpy
     >>> import sunpy.map
@@ -22,34 +37,511 @@ type the following into your Python shell::
 
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
 
-The variable my_map is an `~sunpy.map.sources.AIAMap` object. To create one from a
-local FITS file try the following::
+The variable my_map is an `~sunpy.map.sources.AIAMap` object. To create a Map from a
+local FITS file try the following: ::
 
     >>> my_map = sunpy.map.Map('/mydirectory/mymap.fits')   # doctest: +SKIP
 
-sunpy should automatically detects the type of file (e.g. FITS), what instrument it is
-associated with (e.g. AIA, EIT, LASCO) and will automatically look in the
-appropriate places for the FITS keywords it needs to interpret the coordinate
-system. If the type of FITS file is not recognized then sunpy will try some
-default FITS keywords and return a `~sunpy.map.GenericMap` but results
-may vary. sunpy can also create maps from the jpg2000 files from
+SunPy automatically detects the type of file (e.g. FITS), the instrument
+associated with it (e.g. AIA, EIT, LASCO), and finds the FITS keywords it needs to
+interpret the coordinate system. If the type of FITS file is not recognized then SunPy will try some
+default FITS keywords and return a `~sunpy.map.GenericMap`, but results
+may vary. SunPy can also create Maps using the jpg2000 files from
 `helioviewer.org <https://helioviewer.org/>`_.
 
-Creating Custom Maps
-====================
-It is also possible to create maps using custom data (e.g. from a simulation or an observation
-from a data source that is not explicitly supported in sunpy.) To do this you need to provide
+The `Acquiring Data <https://docs.sunpy.org/en/stable/generated/gallery/index.html#acquiring-data>`_ section
+of the Example Gallery has several examples of retrieving data using the `~sunpy.net.Fido` tool. For more details,
+check out the :doc:`/guide/acquiring_data/fido` guide.
+
+
+2. Inspecting Maps
+==================
+
+A Map contains a number of data-associated attributes. To get a quick look at
+your Map simply type: ::
+
+    >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
+    >>> my_map  # doctest: +REMOTE_DATA
+
+This will show a representation of the data as well as some of its associated attributes.
+Typing the above command in a Jupyter Notebook will show a rich HTML view of the
+table along with two plots of your data. The HTML view can also be accessed
+using the `~sunpy.map.GenericMap.quicklook` function, which will open the view in your
+default browser.
+
+A number of other attributes are also available. For example, the
+`~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`,
+`~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`): ::
+
+    >>> map_date = my_map.date  # doctest: +REMOTE_DATA
+    >>> map_exptime = my_map.exposure_time  # doctest: +REMOTE_DATA
+    >>> map_center = my_map.center  # doctest: +REMOTE_DATA
+
+To get a list of all of the attributes check the documentation by typing: ::
+
+    >>> help(my_map)  # doctest: +SKIP
+
+Many attributes and functions of the map classes accept and return
+`~astropy.units.quantity.Quantity` or `~astropy.coordinates.SkyCoord` objects.
+Please refer to :ref:`units-coordinates-sunpy` for more details.
+
+The metadata for the map is accessed by: ::
+
+    >>> header = my_map.meta  # doctest: +REMOTE_DATA
+
+This references the metadata dictionary with the header information as read
+from the source file. If you need to modify Map metadata, see this `example <https://docs.sunpy.org/en/latest/generated/gallery/map/map_metadata_modification.html>`_ for a demonstration. 
+
+
+3. Map Data
+===========
+
+The data in a SunPy Map object is accessible through the
+`~sunpy.map.GenericMap.data` attribute.  The data is implemented as a
+NumPy `~numpy.ndarray`. For example, to get
+the 0th element in the array: ::
+
+    >>> my_map.data[0, 0]  # doctest: +REMOTE_DATA
+    -95.92475
+    >>> my_map.data[0][0]  # doctest: +REMOTE_DATA
+    -95.92475
+
+The first index is for the y direction while the second index is for the x direction.
+For more information about indexing, please refer to the
+`Numpy documentation <https://docs.scipy.org/doc/numpy-dev/user/quickstart.html#indexing-slicing-and-iterating>`_.
+
+Data attributes like `~numpy.ndarray.dtype` and
+`~sunpy.map.GenericMap.dimensions` are accessible through
+a GenericMap object: ::
+
+    >>> my_map.dimensions  # doctest: +REMOTE_DATA
+    PixelPair(x=<Quantity 1024. pix>, y=<Quantity 1024. pix>)
+    >>> my_map.dtype  # doctest: +REMOTE_DATA
+    dtype('float32')
+
+Here, the dimensions attribute is similar to the `~numpy.ndarray.shape`
+attribute, however returning an `~astropy.units.quantity.Quantity`.
+
+You can store the data of a `~sunpy.map.GenericMap` object
+in a separate `~numpy.ndarray` by either of the following actions: ::
+
+    >>> var = my_map.data  # doctest: +REMOTE_DATA
+    >>> var = my_map.data.copy()  # doctest: +REMOTE_DATA
+
+To create a complete copy of a Map object that is entirely independent of the original,
+use the built-in `copy.deepcopy` method: ::
+
+    >>> import copy   # doctest: +REMOTE_DATA
+    >>> my_map_deepcopy = copy.deepcopy(my_map)   # doctest: +REMOTE_DATA
+
+A deepcopy ensures that any changes in the original Map object are not reflected in the
+copied object and vice versa. Note that this copies the data of
+the Map object as well as all of the other attributes and methods.
+
+Some basic statistical functions are built into Map
+objects: ::
+
+    >>> my_map.min()  # doctest: +REMOTE_DATA
+    -129.78036
+    >>> my_map.mean()  # doctest: +REMOTE_DATA
+    427.02252
+
+All the other `~numpy.ndarray` functions and attributes
+can be accessed through the data array directly. For example: ::
+
+    >>> my_map.data.std()  # doctest: +REMOTE_DATA
+    826.41016
+
+
+4. Plotting Maps
+================
+
+The SunPy `~sunpy.map.GenericMap`
+object and its instrument-specific sub-classes has their
+own built-in plot methods so that it is easy to quickly view your Map.
+To create a plot just type: ::
+
+    >>> my_map.peek()   # doctest: +SKIP
+
+This will open a matplotlib plot on your screen.
+In addition, it is possible to grab the matplotlib axes object
+by using the `~sunpy.map.GenericMap.plot()` command.
+This makes it possible to use the SunPy plot as the foundation for a
+more complicated figure. For more information about this and some
+examples see :ref:`plotting`. Check out the following foundational
+examples in the Example Gallery for plotting Maps:
+
+* `Plotting a map <https://docs.sunpy.org/en/stable/generated/gallery/plotting/aia_example.html>`_
+
+* `Plotting points on a Map with WCSAxes <https://docs.sunpy.org/en/stable/generated/gallery/plotting/wcsaxes_plotting_example.html>`_
+
+* `Editing the colormap and normalization of a Map <https://docs.sunpy.org/en/stable/generated/gallery/plotting/map_editcolormap.html>`_
+
+* `Plotting a coordinate grid <https://docs.sunpy.org/en/stable/generated/gallery/plotting/grid_plotting.html>`_
+
+* `Saving and loading a Map with FITS <https://docs.sunpy.org/en/stable/generated/gallery/saving_and_loading_data/genericmap_in_fits.html>`_
+
+.. note::
+
+   If the `astropy.visualization.wcsaxes` package is not used (it is used by
+   default) the `~sunpy.map.GenericMap.plot()` and
+   `~sunpy.map.GenericMap.peek()` methods assume that the data is not rotated,
+   i.e. the solar y axis is oriented with the columns of the array. If this
+   condition is not met (in the metadata), when the map is plotted a warning
+   will be issued. You can create an oriented map by using
+   `~sunpy.map.GenericMap.rotate()` before you plot the Map.
+
+
+4.1 Plotting Keywords
+---------------------
+
+For Map plotting, `~matplotlib.pyplot.imshow` does most of the heavy
+lifting in the background while SunPy makes a number of choices for you
+(e.g. colortable, plot title). Changing these defaults
+is made possible through two simple interfaces. You can pass any
+`~matplotlib.pyplot.imshow` keyword into
+the plot command to override the defaults for that particular plot. For example, the following
+command changes the default colormap to use an inverse Grey color table: ::
+
+    >>> my_map.plot(cmap=plt.cm.Greys_r)   # doctest: +SKIP
+
+You can view or make changes to the default settings through the ``sunpy.map.GenericMap.plot_settings``
+dictionary. In the following example, we change the title and colormap of the plot: ::
+
+    >>>    my_map.plot_settings['title'] = "Plot Two"  # doctest: +REMOTE_DATA
+    >>>    my_map.plot_settings['cmap'] = plt.cm.Blues_r  # doctest: +REMOTE_DATA
+
+
+4.2 Colormaps and Normalization
+-------------------------------
+
+Image data is generally shown in false color in order to better identify it or
+to better visualize structures in the image. Matplotlib handles this colormapping
+process through the `~matplotlib.colors` module. First, the data array is mapped onto
+the range 0-1 using an instance of
+`~matplotlib.colors.Normalize` or a subclass. Then, the data is mapped to a
+color using a `~matplotlib.colors.Colormap`.
+
+SunPy provides colormaps for each mission as defined by the mission teams.
+The Map object chooses the appropriate colormap for you when it is created as
+long as it recognizes the instrument. To see what colormaps are available: ::
+
+    >>> import sunpy.visualization.colormaps as cm
+    >>> cm.cmlist.keys()
+    dict_keys(['goes-rsuvi94', 'goes-rsuvi131', 'goes-rsuvi171', 'goes-rsuvi195',
+    'goes-rsuvi284', 'goes-rsuvi304', 'sdoaia94', 'sdoaia131', 'sdoaia171',
+    ...
+
+The SunPy colormaps are registered with matplotlib so you can grab them like
+you would any other colormap: ::
+
+    >>> import matplotlib.pyplot as plt
+    >>> import sunpy.visualization.colormaps
+    >>> cmap = plt.get_cmap('sdoaia171')
+
+See `~sunpy.visualization.colormaps` for a plot of all available colormaps.
+
+If you want to override the built-in colormap, consider the following example
+which plots an AIA map using an EIT colormap: ::
+
+.. plot::
+    :include-source:
+
+    import sunpy.map
+    import sunpy.data.sample
+    import matplotlib.pyplot as plt
+
+    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
+    cmap = plt.get_cmap('sohoeit171')
+
+    fig = plt.figure()
+    smap.plot(cmap=cmap)
+    plt.colorbar()
+    plt.show()
+
+You can also change the colormap for the Map itself: ::
+
+    >>> smap.plot_settings['cmap'] = plt.get_cmap('sohoeit171')  # doctest: +SKIP
+
+The normalization is set automatically so that all the
+data from minimum to maximum is displayed as best as possible.
+Just like the colormap, the default normalization
+can be changed through the plot_settings dictionary or directly for the individual
+plot by passing a keyword argument.
+               
+Alternate normalizations are available from `matplotlib <https://matplotlib.org/stable/tutorials/colors/colormapnorms.html>`_
+and `Astropy <https://docs.astropy.org/en/stable/visualization/normalization.html>`_.
+The following example shows the difference between
+a linear and logarithmic normalization on an AIA image.
+
+.. plot::
+    :include-source:
+
+    import sunpy.map
+    import sunpy.data.sample
+    import matplotlib.pyplot as plt
+    import matplotlib.colors as colors
+
+    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
+
+    fig = plt.figure(figsize=(4, 9))
+
+    ax1 = fig.add_subplot(2, 1, 1, projection=smap)
+    smap.plot(norm=colors.Normalize(), title='Linear normalization')
+    plt.colorbar()
+
+    ax2 = fig.add_subplot(2, 1, 2, projection=smap)
+    smap.plot(norm=colors.LogNorm(), title='Logarithmic normalization')
+    plt.colorbar()
+
+    plt.show()
+
+Note how the colorbar does not change since these two plots share
+the same colormap. Meanwhile, the data values associated with each color do change because
+the normalization is different.
+
+
+4.3 Clipping and Masking Data
+-----------------------------
+
+It is often necessary to ignore certain
+data in an image. For example, a large data value could be due to
+cosmic ray hits and should be ignored. The most straightforward way to ignore
+this kind of data in plots, without altering the data, is to clip it. This can be achieved
+very easily by using the ``clip_interval`` keyword. For example: ::
+
+    >>> import astropy.units as u
+    >>> smap.plot(clip_interval=(1, 99.5)*u.percent)  #doctest: +SKIP
+
+This clips out the dimmest 1% of pixels and the brightest 0.5% of pixels.  With those outlier
+pixels clipped, the resulting image makes better use of the full range of colors.
+If you'd like to see what areas of your images got clipped, you can modify the colormap: ::
+
+    >>> cmap = map.cmap  # doctest: +SKIP
+    >>> cmap.set_over('blue')  # doctest: +SKIP
+    >>> cmap.set_under('green')  # doctest: +SKIP
+
+This will color the areas above and below in red and green respectively
+(similar to this `matplotlib example <https://matplotlib.org/examples/pylab_examples/image_masked.html>`_).
+You can use the following colorbar command to display these choices: ::
+
+    >>> plt.colorbar(extend='both')   # doctest: +SKIP
+
+Here is an example of this put to use on an AIA image.
+
+.. plot::
+    :include-source:
+
+    import astropy.units as u
+    import matplotlib.pyplot as plt
+
+    import sunpy.map
+    import sunpy.data.sample
+
+    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
+    cmap = smap.cmap.copy()
+    cmap.set_over('blue')
+    cmap.set_under('green')
+
+    fig = plt.figure(figsize=(12, 4))
+
+    ax1 = fig.add_subplot(1, 2, 1, projection=smap)
+    smap.plot(title='Without clipping')
+    plt.colorbar()
+
+    ax2 = fig.add_subplot(1, 2, 2, projection=smap)
+    smap.plot(clip_interval=(1, 99.5)*u.percent, title='With clipping')
+    plt.colorbar(extend='both')
+
+    plt.show()
+
+
+Masking is another approach to ignoring certain data. A mask is a boolean
+array that can give you fine-grained control over what is not being
+displayed. The `~numpy.ma.MaskedArray`
+is a subclass of a NumPy array with the
+addition of an associated boolean array which holds the mask.
+See the following two examples for applications of this technique:
+
+* `Masking out the solar disk <https://docs.sunpy.org/en/stable/generated/gallery/computer_vision_techniques/mask_disk.html>`_
+
+* `Finding and masking bright pixels <https://docs.sunpy.org/en/stable/generated/gallery/computer_vision_techniques/finding_masking_bright_pixels.html>`_
+
+
+5. Composite Maps
+=================
+
+The `~sunpy.map.Map` method can also handle a list of maps. If a series of maps
+are supplied as inputs, `~sunpy.map.Map` will return a list of maps as the output.
+If the 'composite' keyword is set to True, then a `~sunpy.map.CompositeMap` object is
+returned.  This is useful if the maps are of a different type (e.g. different
+instruments).  For example, to create a simple Composite Map: ::
+
+    >>> my_maps = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE, sunpy.data.sample.RHESSI_IMAGE, composite=True)  # doctest: +REMOTE_DATA
+
+A `~sunpy.map.CompositeMap` is different from a regular SunPy `~sunpy.map.GenericMap` object and therefore
+different associated methods. To list which maps are part of your Composite Map use: ::
+
+    >>> my_maps.list_maps()  # doctest: +REMOTE_DATA
+    [<class 'sunpy.map.sources.soho.EITMap'>, <class 'sunpy.map.sources.rhessi.RHESSIMap'>]
+
+The following two examples demonstrate how to create a composite map of AIA and HMI data
+and how to overlay HMI contours on an AIA map (without creating a composite map object):
+
+* `Creating a Composite map <https://docs.sunpy.org/en/stable/generated/gallery/map/composite_map_AIA_HMI.html>`_
+
+* `Overplotting HMI Contours on an AIA Image <https://docs.sunpy.org/en/stable/generated/gallery/map/hmi_contours_wcsaxes.html>`_
+
+For a more advanced tutorial on combining data from several maps, see `Creating a Full Sun Map with AIA and EUVI <https://docs.sunpy.org/en/stable/generated/gallery/map_transformations/reprojection_aia_euvi_mosaic.html>`_.
+
+
+6. Map Sequences
+================
+
+A `~sunpy.map.MapSequence` is an ordered list of maps.  By default, the maps are ordered by
+their observation date, from earliest to latest date. A `~sunpy.map.MapSequence` can be
+created by supplying multiple existing maps: ::
+
+    >>> map1 = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
+    >>> map2 = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE)  # doctest: +REMOTE_DATA
+    >>> mc = sunpy.map.Map([map1, map2], sequence=True)  # doctest: +REMOTE_DATA
+
+or by providing a directory full of image files: ::
+
+    >>> mc = sunpy.map.Map('path/to/my/files/*.fits', sequence=True)   #  doctest: +SKIP
+
+The earliest map in the MapSequence can be accessed by indexing the maps
+list: ::
+
+    >>> mc.maps[0]   # doctest: +SKIP
+
+MapSequences can hold maps that have different shapes.  To test if all the
+maps in a `~sunpy.map.MapSequence` have the same shape: ::
+
+    >>> mc.all_maps_same_shape()  # doctest: +REMOTE_DATA
+    True
+
+It is often useful to return the image data in a `~sunpy.map.MapSequence` as a single
+three dimensional NumPy `~numpy.ndarray`: ::
+
+    >>> mc.as_array()   # doctest: +SKIP
+
+Note that an array is returned only if all the maps have the same
+shape.  If this is not true, a ``ValueError`` is returned.  If all the
+maps have nx pixels in the x-direction, and ny pixels in the y-direction,
+and there are n maps in the MapSequence, the returned `~numpy.ndarray` array
+has shape (ny, nx, n).  The data of the first map in the `~sunpy.map.MapSequence`
+appears in the `~numpy.ndarray` in position ``[:, :, 0]``, the data of second map in
+position ``[:, :, 1]``, and so on.  The order of maps in the `~sunpy.map.MapSequence` is
+reproduced in the returned `~numpy.ndarray`.
+
+The metadata from each map can be obtained using: ::
+
+    >>> mc.all_meta()   # doctest: +SKIP
+
+This returns a list of map meta objects that have the same order as
+the maps in the `~sunpy.map.MapSequence`.
+
+
+6.1 Coalignment of Map Sequences
+--------------------------------
+
+A typical data preparation step when dealing with time series of images is to
+coalign images taken at different times so that features in different images
+remain in the same place.  A common approach to this problem is
+to take a representative template that contains the features you are interested
+in, and match that to your images.  The location of the best match tells you
+where the template is in your image.  The images are then shifted to the
+location of the best match.
+
+SunPy provides a function to coalign the maps inside the `~sunpy.map.MapSequence`.
+This function requires the installation of the
+`scikit-image library <https://scikit-image.org/>`_, a commonly used image processing library.
+To coalign a `~sunpy.map.MapSequence`, simply import
+the function and apply it to your `~sunpy.map.MapSequence`: ::
+
+    >>> from sunpy.image.coalignment import mapsequence_coalign_by_match_template
+    >>> coaligned = mapsequence_coalign_by_match_template(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
+
+This will return a new `~sunpy.map.MapSequence`, coaligned to a template extracted from the
+center of the first map in the `~sunpy.map.MapSequence`, with the map dimensions clipped as
+required.  The coalignment algorithm provides many more options for handling
+the coalignment of `~sunpy.map.MapSequence`. Type: ::
+
+    >>> help(mapsequence_coalign_by_match_template)   # doctest: +SKIP
+
+for a full list of options and functionality.
+
+If you want to calculate the shifts required to compensate for solar
+rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use: ::
+
+    >>> from sunpy.image.coalignment import calculate_match_template_shift
+    >>> shifts = calculate_match_template_shift(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
+
+This is the algorithm used by the coalignment function to calculate the shifts.
+See `~sunpy.image.coalignment.calculate_match_template_shift` to learn more about its features.
+Shifts calculated using calculate_match_template_shift can be passed directly
+to the coalignment function.
+
+For similar examples, see the `Combing, Co-aligning, and Reprojecting Images <https://docs.sunpy.org/en/stable/generated/gallery/index.html#combining-co-aligning-and-reprojecting-images>`_
+section of the Example Gallery.
+
+
+6.2 Compensating for solar rotation in Map Sequences
+----------------------------------------------------
+
+A typical preparation step when dealing with a time series of solar
+image data is to shift the images so that features do not appear
+to move across the field of view.  This requires accounting for
+the `differential rotation <https://en.wikipedia.org/wiki/Solar_rotation>`_ of the Sun
+(solar features at the equator rotate faster than features at
+the poles).
+
+SunPy provides a function to shift images in a `~sunpy.map.MapSequence` according to the solar
+differential rotation calculated at the latitude of the center of the
+field of view.  The function does not *differentially* rotate the image.  Instead,
+this function is useful for de-rotating images when the effects of
+differential rotation in the `~sunpy.map.MapSequence` can be ignored. For example, it is useful
+if the spatial extent of the image is small or the duration of the
+`~sunpy.map.MapSequence` is brief (deciding on what 'small' or 'brief' means depends on your
+application).
+
+To apply this form of solar de-rotation to a `~sunpy.map.MapSequence`, import the
+function and apply it to your `~sunpy.map.MapSequence`: ::
+
+    >>> from sunpy.physics.solar_rotation import mapsequence_solar_derotate
+    >>> derotated = mapsequence_solar_derotate(mc)  # doctest: +SKIP
+
+For more info see `~sunpy.physics.solar_rotation.mapsequence_solar_derotate`.
+
+If you want to calculate the shifts required to compensate for solar
+rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use: ::
+
+    >>> from sunpy.physics.solar_rotation import calculate_solar_rotate_shift
+    >>> shifts = calculate_solar_rotate_shift(mc)  # doctest: +SKIP
+
+Please consult the docstring of the `~sunpy.image.coalignment.mapsequence_coalign_by_match_template` function
+to learn more about the features of this function.
+
+See the `Differential Rotation of the Sun <https://docs.sunpy.org/en/stable/generated/gallery/index.html#differential-rotation-of-the-sun>`_
+section of the Example Gallery for examples using `~sunpy.coordinates.metaframes.RotatedSunFrame`.
+
+
+7. Creating Custom Maps
+=======================
+
+It is also possible to create Maps using custom data (e.g. from a simulation or an observation
+from a data source that is not explicitly supported in SunPy). To do this, you need to provide
 `sunpy.map.Map` with both the data array as well as appropriate
-meta information. The meta information is important as it informs the `sunpy.map.Map`
-of the correct coordinate information associated with the data array. The meta information should be provided to
+meta information. The meta information informs `sunpy.map.Map`
+of the correct coordinate information associated with the data array and should be provided to
 `sunpy.map.Map` in the form of a header as a `dict` or `~sunpy.util.MetaDict`.
+See this `example <https://docs.sunpy.org/en/latest/generated/gallery/map/map_from_numpy_array.html>`_ for a brief demonstration of generating a Map from a data array.
 
-The keys that are required for the header information follows the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`_. sunpy now provides a map header helper function to assist the user in creating a header that contains the correct meta information
-to generate a `sunpy.map.Map`.
-
-The helper functionality includes a `~sunpy.map.meta_keywords` function
-that will return a `dict` of all the current meta keywords and their descriptions currently used by
-`sunpy.map.Map` to make a map::
+The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`_.
+SunPy provides a Map header helper function to assist in creating a header that
+contains the correct meta information. This includes a `~sunpy.map.meta_keywords` function
+that will return a `dict` of all the current meta keywords and their descriptions.
 
     >>> from sunpy.map import meta_keywords
 
@@ -59,16 +551,19 @@ that will return a `dict` of all the current meta keywords and their description
      'crval1': 'Coordinate value at reference point on naxis1 **required'
      ...
 
-There is also functionality also includes a utility function
+There is also a utility function
 `~sunpy.map.make_fitswcs_header` that will return a header with the
-appropiate FITS keywords once the map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames`
-is passed. The `astropy.coordinates.SkyCoord` is defined by the user, and contains information on the reference frame,
-reference coordinate and observer location. The function returns a `sunpy.util.MetaDict`.
+appropiate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames`
+is provided. The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame,
+reference coordinate, and observer location. This function returns a `sunpy.util.MetaDict`.
 The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.
 
-The `~sunpy.map.make_fitswcs_header` function also takes optional keywords arguments including ``reference_pixel`` and ``scale`` which describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively. If neither of these are given their values default to the center of the data array and 1 arcsec, respectively.
+The `~sunpy.map.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale``
+that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial
+scale of the pixels, respectively. If neither of these are given their values default to the center of the data array and 1 arcsec,
+respectively.
 
-Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`::
+Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`: ::
 
 
     >>> import numpy as np
@@ -116,7 +611,7 @@ and the data array. Since the ``reference_pixel`` and keywords were not passed i
 values of ``crpix`` and ``cdelt`` were set to the default values.
 
 These keywords can be passed to the function in the form of an `astropy.units.Quantity` with associated units.
-Here's another example of passing ``reference_pixel`` and ``scale`` to the function::
+Here's another example of passing ``reference_pixel`` and ``scale`` to the function: ::
 
     >>> header = sunpy.map.make_fitswcs_header(data, coord,
     ...                                        reference_pixel=u.Quantity([5, 5]*u.pixel),
@@ -158,7 +653,7 @@ to the `~sunpy.map.make_fitswcs_header` and will then populate the returned Meta
 Furthermore, the following observation keywords can be passed to the `~sunpy.map.make_fitswcs_header`
 function and will be translated to the FITS standard: ``observtory``, ``instrument``,``telescope``, ``wavelength``, ``exposure``.
 
-An example of creating a header with these additional keywords::
+An example of creating a header with these additional keywords: ::
 
     >>> header = sunpy.map.make_fitswcs_header(data, coord,
     ...                                        reference_pixel = u.Quantity([5, 5]*u.pixel),
@@ -189,629 +684,7 @@ An example of creating a header with these additional keywords::
           ('detector', 'UV detector'),
           ('waveunit', 'angstrom')])
 
-From these header MetaDict's that are generated, we can now create a custom map::
+From these header MetaDict's that are generated, we can now create a custom map: ::
 
     >>> my_map = sunpy.map.Map(data, header) # doctest: +SKIP
     >>> my_map.peek() # doctest: +SKIP
-
-Inspecting maps
-===============
-A map contains a number of data-associated attributes. To get a quick look at
-your map simply type::
-
-    >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
-    >>> my_map  # doctest: +REMOTE_DATA
-    <sunpy.map.sources.sdo.AIAMap object at ...>
-    SunPy Map
-    ---------
-    Observatory:                 SDO
-    Instrument:          AIA 3
-    Detector:            AIA
-    Measurement:                 171.0 Angstrom
-    Wavelength:          171.0 Angstrom
-    Observation Date:    2011-06-07 06:33:02
-    Exposure Time:               0.234256 s
-    Dimension:           [1024. 1024.] pix
-    Coordinate System:   helioprojective
-    Scale:                       [2.402792 2.402792] arcsec / pix
-    Reference Pixel:     [511.5 511.5] pix
-    Reference Coord:     [3.22309951 1.38578135] arcsec
-    array([[ -95.92475  ,    7.076416 ,   -1.9656711, ..., -127.96519  ,
-            -127.96519  , -127.96519  ],
-           [ -96.97533  ,   -5.1167884,    0.       , ...,  -98.924576 ,
-            -104.04137  , -127.919716 ],
-           [ -93.99607  ,    1.0189276,   -4.0757103, ...,   -5.094638 ,
-             -37.95505  , -127.87541  ],
-           ...,
-           [-128.01454  , -128.01454  , -128.01454  , ..., -128.01454  ,
-            -128.01454  , -128.01454  ],
-           [-127.899666 , -127.899666 , -127.899666 , ..., -127.899666 ,
-            -127.899666 , -127.899666 ],
-           [-128.03072  , -128.03072  , -128.03072  , ..., -128.03072  ,
-            -128.03072  , -128.03072  ]], dtype=float32)
-
-This will show a representation of the data as well as some of its associated
-attributes. A number of other attributes are also available, for example the
-`~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`,
-`~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`)::
-
-    >>> map_date = my_map.date  # doctest: +REMOTE_DATA
-    >>> map_exptime = my_map.exposure_time  # doctest: +REMOTE_DATA
-    >>> map_center = my_map.center  # doctest: +REMOTE_DATA
-
-To get a list of all of the attributes check the documentation by typing::
-
-    >>> help(my_map)  # doctest: +SKIP
-
-Many attributes and functions of the map classes accept and return
-`~astropy.units.quantity.Quantity` or `~astropy.coordinates.SkyCoord` objects,
-please refer to :ref:`units-coordinates-sunpy` for more details.
-
-The meta data for the map is accessed by ::
-
-    >>> header = my_map.meta  # doctest: +REMOTE_DATA
-
-This references the meta data dictionary with the header information as read
-from the source file.
-
-Getting at the data
-===================
-The data in a sunpy Map object is accessible through the
-`~sunpy.map.GenericMap.data` attribute.  The data is implemented as a
-NumPy `~numpy.ndarray`, so for example, to get
-the 0th element in the array ::
-
-    >>> my_map.data[0, 0]  # doctest: +REMOTE_DATA
-    -95.92475
-    >>> my_map.data[0][0]  # doctest: +REMOTE_DATA
-    -95.92475
-
-One important fact to remember is that the first
-index is for the y direction while the second index is for the x direction.
-For more information about indexing please refer to the
-`Numpy documentation <https://docs.scipy.org/doc/numpy-dev/user/quickstart.html#indexing-slicing-and-iterating>`_.
-
-Data attributes like `~numpy.ndarray.dtype` and
-`~sunpy.map.GenericMap.dimensions` are accessible through
-the SunPyGenericMap object ::
-
-    >>> my_map.dimensions  # doctest: +REMOTE_DATA
-    PixelPair(x=<Quantity 1024. pix>, y=<Quantity 1024. pix>)
-    >>> my_map.dtype  # doctest: +REMOTE_DATA
-    dtype('float32')
-
-Here the dimensions attribute is similar to the `~numpy.ndarray.shape`
-attribute, however returning an `~astropy.units.quantity.Quantity`.
-
-If you'd like to use the data in a sunpy `~sunpy.map.GenericMap` object
-elsewhere, you can use either of the following::
-
-    >>> var = my_map.data  # doctest: +REMOTE_DATA
-    >>> var = my_map.data.copy()  # doctest: +REMOTE_DATA
-
-Python makes use of pointers so if you want to alter the data and keep the
-original data in the map intact make sure to copy it.
-
-To create a complete copy of a Map object that is entirely independent of the original,
-use the built-in `copy.deepcopy`
-method, like so::
-
-    >>> import copy   # doctest: +REMOTE_DATA
-    >>> my_map_deepcopy = copy.deepcopy(my_map)   # doctest: +REMOTE_DATA
-
-A deepcopy ensures that any changes in the original Map object are not reflected in the
-copied object and vice versa. Note that this is different from simply copying the data of
-the Map object - this copies all of the other attributes and methods as well.
-
-Some basic statistical functions on the data array are also passed through to Map
-objects::
-
-    >>> my_map.min()  # doctest: +REMOTE_DATA
-    -129.78036
-    >>> my_map.max()  # doctest: +REMOTE_DATA
-    192130.17
-    >>> my_map.mean()  # doctest: +REMOTE_DATA
-    427.02252
-
-but you can also access all the other `~numpy.ndarray` functions and attributes
-by accessing the data array directly. For example::
-
-    >>> my_map.data.std()  # doctest: +REMOTE_DATA
-    826.41016
-
-Plotting
-========
-As is true of all of the sunpy data objects, the sunpy `~sunpy.map.GenericMap`
-object (and all of its instrument-specific sub-classes) has its
-own built-in plot methods so that it is easy to quickly view your map.
-To create a plot just type::
-
-    >>> my_map.peek()   # doctest: +SKIP
-
-This will open a matplotlib plot on your screen.
-In addition, to enable users to modify the plot it is possible to grab the
-matplotlib axes object by using the `~sunpy.map.GenericMap.plot()` command.
-This makes it possible to use the sunpy plot as the foundation for a
-more complicated figure. For a bit more information about this and some
-examples see :ref:`plotting`.
-
-.. note::
-
-   If the `astropy.visualization.wcsaxes` package is not used (it is used by
-   default) the `~sunpy.map.GenericMap.plot()` and
-   `~sunpy.map.GenericMap.peek()` methods assume that the data is not rotated,
-   i.e. the solar y axis is oriented with the columns of the array. If this
-   condition is not met (in the metadata), when the map is plotted a warning
-   will be issued. You can create an oriented map by using
-   `~sunpy.map.GenericMap.rotate()` before you plot the Map.
-
-Plotting Keywords
------------------
-
-For Map `~matplotlib.pyplot.imshow` does most of the heavy
-lifting in the background while sunpy makes a number of choices for you so that
-you don't have to (e.g. colortable, plot title). Changing these defaults
-is made possible through two simple interfaces. You can pass any
-`~matplotlib.pyplot.imshow` keyword into
-the plot command to override the defaults for that particular plot. The following
-plot changes the default AIA color table to use an inverse Grey color table.
-
-.. plot::
-    :include-source:
-
-    import sunpy.map
-    import sunpy.data.sample
-    import matplotlib.pyplot as plt
-    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-    fig = plt.figure()
-    smap.plot(cmap=plt.cm.Greys_r)
-    plt.colorbar()
-    plt.show()
-
-You can view or make changes to the default settings through the ``sunpy.map.GenericMap.plot_settings``
-dictionary. In the following example we change the title of the plot by changing the
-``sunpy.map.GenericMap.plot_settings`` property.
-
-.. plot::
-    :include-source:
-
-    import sunpy.map
-    import sunpy.data.sample
-    import matplotlib.pyplot as plt
-    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-    smap.plot_settings['title'] = "My Second sunpy Plot"
-    smap.plot_settings['cmap'] = plt.cm.Blues_r
-    fig = plt.figure()
-    smap.plot()
-    plt.colorbar()
-    plt.show()
-
-
-Colormaps and Normalization
----------------------------
-
-Image data is generally shown in false color in order to better identify it or
-to better visualize structures in the image. Matplotlib handles this colormapping
-process through the `~matplotlib.colors` module. This process involves two steps:
-the data array is first mapped onto the range 0-1 using an instance of
-`~matplotlib.colors.Normalize` or a subclass; then this number is mapped to a
-color using an instance of a subclass of a `~matplotlib.colors.Colormap`.
-
-sunpy provides the colormaps for each mission as defined by the mission teams.
-The Map object chooses the appropriate colormap for you when it is created as
-long as it recognizes the instrument. To see what colormaps are available::
-
-    >>> import sunpy.visualization.colormaps as cm
-    >>> cm.cmlist.keys()
-    dict_keys(['goes-rsuvi94', 'goes-rsuvi131', 'goes-rsuvi171', 'goes-rsuvi195',
-    'goes-rsuvi284', 'goes-rsuvi304', 'sdoaia94', 'sdoaia131', 'sdoaia171',
-    ...
-
-The sunpy colormaps are registered with matplotlib so you can grab them like
-you would any other colormap::
-
-    >>> import matplotlib.pyplot as plt
-    >>> import sunpy.visualization.colormaps
-
-You need to import `sunpy.visualization.colormaps` or `sunpy.map` for this to work::
-
-    >>> cmap = plt.get_cmap('sdoaia171')
-
-
-The following plot shows off all of the colormaps.
-
-.. plot::
-
-    import matplotlib.pyplot as plt
-    import sunpy.visualization.colormaps as cm
-    cm.show_colormaps()
-
-These can be used with the standard commands to change the colormap. So for
-example if you wanted to plot an AIA image but use an EIT colormap, you would
-do so as follows.
-
-.. plot::
-    :include-source:
-
-    import sunpy.map
-    import sunpy.data.sample
-    import matplotlib.pyplot as plt
-
-    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-    cmap = plt.get_cmap('sohoeit171')
-
-    fig = plt.figure()
-    smap.plot(cmap=cmap)
-    plt.colorbar()
-    plt.show()
-
-or you can just change the colormap for the map itself as follows::
-
-    >>> smap.plot_settings['cmap'] = plt.get_cmap('sohoeit171')  # doctest: +SKIP
-
-The normalization is also set automatically and is chosen so that all the
-data from minimum to maximum is displayed as best as possible for most cases.
-This means that it is never necessary to touch the data such as applying a function
-such sqrt or log to the data to make your plot look good.
-There are many normalizations available from matplotlib such as `~matplotlib.colors.LogNorm`. Other
-`more exotic normalizations <https://docs.astropy.org/en/stable/visualization/index.html>`_ are also
-made available from Astropy.  Just like the colormap the default normalization
-can be changed through the plot_settings dictionary or directly for the individual
-plot by passing a keyword argument. The following example shows the difference between
-a linear and logarithmic normalization on an AIA image.
-
-.. plot::
-    :include-source:
-
-    import sunpy.map
-    import sunpy.data.sample
-    import matplotlib.pyplot as plt
-    import matplotlib.colors as colors
-
-    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-
-    fig = plt.figure(figsize=(4, 9))
-
-    ax1 = fig.add_subplot(2, 1, 1, projection=smap)
-    smap.plot(norm=colors.Normalize(), title='Linear normalization')
-    plt.colorbar()
-
-    ax2 = fig.add_subplot(2, 1, 2, projection=smap)
-    smap.plot(norm=colors.LogNorm(), title='Logarithmic normalization')
-    plt.colorbar()
-
-    plt.show()
-
-Note how the color in the colorbar does not change since these two maps share
-the same colormap while the data values associated with each color do because
-the normalization is different.
-
-Masking and Clipping Data
-=========================
-It is often necessary for the purposes of display or otherwise to ignore certain
-data in an image. For example, a large data value could be due to
-cosmic ray hits and should be ignored. The most straightforward way to ignore
-this kind of data in plots without altering the data is to clip it. This can be achieved
-very easily by using the ``clip_interval`` keyword. For example::
-
-    >>> import astropy.units as u
-    >>> smap.plot(clip_interval=(1, 99.5)*u.percent)  #doctest: +SKIP
-
-This clips out the dimmest 1% of pixels and the brightest 0.5% of pixels.  With those outlier
-pixels clipped, the resulting image makes better use of the full range of colors.
-If you'd like to see what areas of your images got clipped, you can modify the colormap::
-
-    >>> cmap = map.cmap  # doctest: +SKIP
-    >>> cmap.set_over('blue')  # doctest: +SKIP
-    >>> cmap.set_under('green')  # doctest: +SKIP
-
-This will color the areas above and below in red and green respectively
-(similar to this `example <https://matplotlib.org/examples/pylab_examples/image_masked.html>`_).
-You can use the following colorbar command to display these choices::
-
-    >>> plt.colorbar(extend='both')   # doctest: +SKIP
-
-Here is an example of this put to use on an AIA image.
-
-.. plot::
-    :include-source:
-
-    import astropy.units as u
-    import matplotlib.pyplot as plt
-
-    import sunpy.map
-    import sunpy.data.sample
-
-    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-    cmap = smap.cmap.copy()
-    cmap.set_over('blue')
-    cmap.set_under('green')
-
-    fig = plt.figure(figsize=(12, 4))
-
-    ax1 = fig.add_subplot(1, 2, 1, projection=smap)
-    smap.plot(title='Without clipping')
-    plt.colorbar()
-
-    ax2 = fig.add_subplot(1, 2, 2, projection=smap)
-    smap.plot(clip_interval=(1, 99.5)*u.percent, title='With clipping')
-    plt.colorbar(extend='both')
-
-    plt.show()
-
-Another approach to clipping data is to specify explicit values for the minimum and maximum pixel
-values using the plotting keywords ``vmin`` and ``vmax``.
-
-Clipping excludes data that has extreme values, but there can be other forms of bad data.
-A mask is a boolean
-array and so can give you much more fine-grained control over what is not being
-displayed.  A `~numpy.ma.MaskedArray`
-is a subclass of a numpy array so it has all of the same properties with the
-addition of an associated boolean array which holds the mask.
-See `this example <https://docs.sunpy.org/en/stable/generated/gallery/computer_vision_techniques/mask_disk.html>`_ in our gallery.
-
-.. the following is a good example which could be fixed and added later
-.. The following plot achieves the same goal as above but using a mask instead of clipping.
-
-..    import sunpy.map
-    import matplotlib.pyplot as plt
-    import matplotlib.colors as colors
-    cmap = smap.plot_settings['cmap']
-    cmap.set_bad('blue', 1.0)
-    smap = sunpy.map.Map('/Users/schriste/Downloads/old downloads/foxsi_ar_data/ssw_cutout_20121030_153001_AIA_94_.fts')
-    smap.mask =
-    smap.plot()
-    plt.colorbar(extend='both')
-    plt.show()
-
-.. Hinode XRT image. By inspecting the maximum versus the mean and standard deviation, it is clear that there are some overly bright pixels. This is likely due to cosmic ray hits which is throwing off the default plot making it too dark to see the solar emission.
-
-.. .. plot::
-
-..    import sunpy.map
-    import matplotlib.pyplot as plt
-    smap = sunpy.map.Map('/Users/schriste/Desktop/sunpy_test_img/XRT20141211_184221.9.fits')
-    fig = plt.figure()
-    smap.plot()
-    txt = r"min={min}, max={max}, $\mu$={mean}, $\sigma$={std}".format(min=int(smap.min()),
-                                                                       max=int(smap.max()),
-                                                                       mean=int(smap.mean()),
-                                                                       std=int(smap.std()))
-    plt.text(-600, 1500, txt, color='white')
-    plt.colorbar()
-    plt.show()
-
-.. Let's address this by clipping the largest values (in this case everything above 3 sigma). The following plot shows the result of this operation.
-
-.. .. plot::
-
-..     import sunpy.map
-    import matplotlib.pyplot as plt
-    import matplotlib.colors as colors
-    cmap = smap.plot_settings['cmap']
-    cmap.set_over('green', 1.0)
-    cmap.set_under('purple', 1.0)
-    norm = colors.Normalize(vmin=smap.min(), vmax=smap.mean() + 3 *smap.std())
-    smap = sunpy.map.Map('/Users/schriste/Desktop/sunpy_test_img/XRT20141211_184221.9.fits')
-    smap.plot(norm=norm)
-    plt.colorbar(extend='both')
-    plt.show()
-
-.. This makes it very visible that there are a number of hot pixels mostly concentrated in the upper half of this image. Now let's address this problem with masking instead of clipping.
-
-.. .. plot::
-
-..     import sunpy.map
-    import matplotlib.pyplot as plt
-    import matplotlib.colors as colors
-    import numpy.ma
-    smap = sunpy.map.Map('/Users/schriste/Desktop/sunpy_test_img/XRT20141211_184221.9.fits')
-    cmap = smap.plot_settings['cmap']
-    cmap.set_bad('blue', 1.0)
-    smap.data = numpy.ma.masked_greater(smap.data, smap.mean() + 3 *smap.std())
-    txt = r"min={min}, max={max}, $\mu$={mean}, $\sigma$={std}".format(min=int(smap.min()),
-                                                                       max=int(smap.max()),
-                                                                       mean=int(smap.mean()),
-                                                                       std=int(smap.std()))
-    plt.text(-600, 1500, txt, color='white')
-    norm = colors.Normalize()
-    smap.plot(norm = norm)
-    plt.colorbar(extend='both')
-
-.. This plot shows a very similar effect to clipping but note that the array properties such as max and min have changed. That's because numpy is now ignoring those masked values. With a masked array
-.. (compared to clipping) we can go ahead and make more detailed masking operations so that we are not masking the emission from the bright solar sources. The next plot masks only those bright pixels in the upper area of the plot leaving the bright solar sources which are concentrated in the lower part of the plot intact.
-
-.. .. plot::
-
-..     import sunpy.map
-    import matplotlib.pyplot as plt
-    import matplotlib.colors as colors
-    import numpy.ma
-    file = '/Users/schriste/Downloads/old downloads/foxsi_ar_data/sXRT20141211_184221.9.fits'
-    smap = sunpy.map.Map(file)
-    cmap = smap.plot_settings['cmap']
-    cmap.set_bad('blue', 1.0)
-    smap.data = numpy.ma.masked_greater(smap.data, smap.mean() + 3 *smap.std())
-    smap.data.mask[0:250,:] = False
-    txt = r"min={min}, max={max}, $\mu$={mean}, $\sigma$={std}".format(min=int(smap.min()),
-                                                                       max=int(smap.max()),
-                                                                       mean=int(smap.mean()),
-                                                                       std=int(smap.std()))
-    plt.text(-600, 1500, txt, color='white')
-    norm = colors.Normalize()
-    smap.plot(norm = norm)
-    plt.colorbar(extend='both')
-
-
-Composite Maps and Overlaying Maps
-==================================
-
-The `~sunpy.map.Map` method described above can also handle a list of maps. If a series of maps
-are supplied as inputs, `~sunpy.map.Map` will return a list of maps as the output.  However,
-if the 'composite' keyword is set to True, then a `~sunpy.map.CompositeMap` object is
-returned.  This is useful if the maps are of a different type (e.g. different
-instruments).  For example, to create a simple composite map::
-
-    >>> my_maps = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE, sunpy.data.sample.RHESSI_IMAGE, composite=True)  # doctest: +REMOTE_DATA
-
-A `~sunpy.map.CompositeMap` is different from a regular sunpy `~sunpy.map.GenericMap` object and therefore
-different associated methods. To list which maps are part of your composite map use::
-
-    >>> my_maps.list_maps()  # doctest: +REMOTE_DATA
-    [<class 'sunpy.map.sources.soho.EITMap'>, <class 'sunpy.map.sources.rhessi.RHESSIMap'>]
-
-The following code adds a new map (which must be instantiated first), sets
-its transparency to 25%, turns on contours from 50% to 90% for the second
-map, and then plots the result.
-
-.. plot::
-    :include-source:
-
-    import sunpy.data.sample
-    import sunpy.map
-    import matplotlib.pyplot as plt
-    my_maps = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE, sunpy.data.sample.RHESSI_IMAGE, composite=True)
-    my_maps.add_map(sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE))
-    my_maps.set_alpha(2, 0.5)
-    my_maps.set_levels(1, [50, 60, 70, 80, 90], percent = True)
-    my_maps.plot()
-    plt.show()
-
-This is not a particularly pretty plot but it shows what sunpy can do!
-
-Working with your map
-=====================
-Part of the philosophy of the map object is to provide most of the basic
-functionality that a scientist would want therefore a map also contains a number
-of map-specific methods such as resizing a map or grabbing a subview. To get
-a list of the methods available for a map type::
-
-    >>> help(my_map)  # doctest: +SKIP
-
-and check out the methods section!
-
-MapSequences
-============
-A `~sunpy.map.MapSequence` is an ordered list of maps.  By default, the maps are ordered by
-their observation date, from earlier maps to later maps. A `~sunpy.map.MapSequence` can be
-created by supplying multiple existing maps::
-
-    >>> map1 = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
-    >>> map2 = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE)  # doctest: +REMOTE_DATA
-    >>> mc = sunpy.map.Map([map1, map2], sequence=True)  # doctest: +REMOTE_DATA
-
-or by providing a directory full of image files::
-
-    >>> mc = sunpy.map.Map('path/to/my/files/*.fits', sequence=True)   #  doctest: +SKIP
-
-The earliest map in the MapSequence can be accessed by simply indexing the maps
-list::
-
-    >>> mc.maps[0]   # doctest: +SKIP
-
-MapSequences can hold maps that have different shapes.  To test if all the
-maps in a `~sunpy.map.MapSequence` have the same shape::
-
-    >>> mc.all_maps_same_shape()  # doctest: +REMOTE_DATA
-    True
-
-It is often useful to return the image data in a `~sunpy.map.MapSequence` as a single
-three dimensional Numpy `~numpy.ndarray`::
-
-    >>> mc.as_array()   # doctest: +SKIP
-
-Note that an array is returned only if all the maps have the same
-shape.  If this is not true, an error (ValueError) is returned.  If all the
-maps have nx pixels in the x-direction, and ny pixels in the y-direction,
-and there are n maps in the MapSequence, the `~numpy.ndarray` array that is
-returned has shape (ny, nx, n).  The data of the first map in the `~sunpy.map.MapSequence`
-appears in the `~numpy.ndarray` in position ``[:, :, 0]``, the data of second map in
-position ``[:, :, 1]``, and so on.  The order of maps in the `~sunpy.map.MapSequence` is
-reproduced in the returned `~numpy.ndarray`.
-
-The meta data from each map can be obtained using::
-
-    >>> mc.all_meta()   # doctest: +SKIP
-
-This returns a list of map meta objects that have the same order as
-the maps in the `~sunpy.map.MapSequence`.
-
-Coalignment of MapSequences
-===========================
-A typical data preparation step when dealing with time series of images is to
-coalign images taken at different times so that features in different images
-remain in the same place.  A common approach to this problem is
-to take a representative template that contains the features you are interested
-in, and match that to your images.  The location of the best match tells you
-where the template is in your image.  The images are then shifted to the
-location of the best match.  This aligns your images to the position of the
-features in your representative template.
-
-sunpy provides a function to coalign the maps inside the `~sunpy.map.MapSequence`.
-The implementation of this functionality requires the installation of the
-scikit-image library, a commonly used image processing library.
-To coalign a `~sunpy.map.MapSequence`, simply import
-the function and apply it to your `~sunpy.map.MapSequence`::
-
-    >>> from sunpy.image.coalignment import mapsequence_coalign_by_match_template
-    >>> coaligned = mapsequence_coalign_by_match_template(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
-
-This will return a new `~sunpy.map.MapSequence`, coaligned to a template extracted from the
-center of the first map in the `~sunpy.map.MapSequence`, with the map dimensions clipped as
-required.  The coalignment algorithm provides many more options for handling
-the coalignment of `~sunpy.map.MapSequence` type::
-
-    >>> help(mapsequence_coalign_by_match_template)   # doctest: +SKIP
-
-for a full list of options and functionality.
-
-If you just want to calculate the shifts required to compensate for solar
-rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use::
-
-    >>> from sunpy.image.coalignment import calculate_match_template_shift
-    >>> shifts = calculate_match_template_shift(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
-
-This is the function used to calculate the shifts in `~sunpy.map.MapSequence` coalignment
-function above.  Please see `~sunpy.image.coalignment.calculate_match_template_shift` to learn more about its features.
-Shifts calculated using calculate_match_template_shift can be passed directly
-to the coalignment function.
-
-
-Compensating for solar rotation in MapSequences
-===============================================
-Often a set of solar image data consists of fixing the pointing of a
-field of view for some time and observing.  Features on the Sun will
-rotate according to the Sun's rotation.
-
-A typical data preparation step when dealing with time series of these
-types of images is to shift the images so that features do not appear
-to move across the field of view.  This requires taking in to account
-the rotation of the Sun.  The Sun rotates differentially, depending on
-latitude, with features at the equator moving faster than features at
-the poles.
-
-sunpy provides a function to shift images in `~sunpy.map.MapSequence` following solar
-rotation.  This function shifts an image according to the solar
-differential rotation calculated at the latitude of the center of the
-field of view.  The image is not *differentially* rotated.  This
-function is useful for de-rotating images when the effects of
-differential rotation in the `~sunpy.map.MapSequence` can be ignored (for example, if
-the spatial extent of the image is small, or when the duration of the
-`~sunpy.map.MapSequence` is small; deciding on what 'small' means depends on your
-application).
-
-To apply this form of solar derotation to a `~sunpy.map.MapSequence`, simply import the
-function and apply it to your `~sunpy.map.MapSequence`::
-
-    >>> from sunpy.physics.solar_rotation import mapsequence_solar_derotate
-    >>> derotated = mapsequence_solar_derotate(mc)  # doctest: +SKIP
-
-For more info see `~sunpy.physics.solar_rotation.mapsequence_solar_derotate`.
-
-If you just want to calculate the shifts required to compensate for solar
-rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use::
-
-    >>> from sunpy.physics.solar_rotation import calculate_solar_rotate_shift
-    >>> shifts = calculate_solar_rotate_shift(mc)  # doctest: +SKIP
-
-Please consult the docstring of the `~sunpy.image.coalignment.mapsequence_coalign_by_match_template` function in order to learn about the features of this function.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -2,9 +2,9 @@
 Map Guide
 *********
 
-Map objects in SunPy are two-dimensional data associated with a coordinate system.
-This class offers many advantages over using, for example, `astropy.io.fits` to open 2D solar data in Python.
-SunPy Maps recognize data from 19 sources (see :doc:`/code_ref/map` for a complete list) and can provide instrument-specific information when plotting and even correct/add metadata when it is missing from the original file.
+Map objects in **sunpy** are two-dimensional data associated with a coordinate system.
+This class offers many advantages over using packages such as `astropy.io.fits` to open 2D solar data in Python.
+**sunpy** Maps recognize data from 19 sources (see :doc:`/code_ref/map` for a complete list) and can provide instrument-specific information when plotting and even correct or add metadata when it is missing from the original file.
 
 Part of the philosophy of the Map object is to provide most of the basic functionality that a scientist would want.
 Therefore, a Map also contains a number of methods such as resizing or grabbing a subview.
@@ -12,17 +12,19 @@ See `~sunpy.map.mapbase.GenericMap` for summaries of all attributes and methods.
 
 :ref:`creating-maps` and :ref:`inspecting-maps` demonstrate how to create a Map object and view a summary of the data in the object.
 :ref:`map-data` describes how data is stored and accessed in a Map, and :ref:`plotting-maps` introduces some basics of visualizing Map data in SunPy.
-:ref:`composite-maps` and :ref:`map-sequences` detail how SunPy can handle multiple Maps from similar and different instruments.
-Lastly, :ref:`custom-maps` shows how you can create Maps from data sources not supported in SunPy.
+:ref:`map-sequences` and :ref:`composite-maps` detail how **sunpy** can handle multiple Maps from similar and different instruments.
+Lastly, :ref:`custom-maps` shows how you can create Maps from data sources not supported in **sunpy**.
 
 .. _creating-maps:
 
 1. Creating Maps
 ================
 
-To make things easy, SunPy can download sample data which are used throughout the docs (see the `Sample data overview <https://docs.sunpy.org/en/latest/generated/gallery/acquiring_data/2011_06_07_sampledata_overview.html>`_).
+To make things easy, **sunpy** can download sample data which are used throughout the docs (see the :ref:`sphx_glr_generated_gallery_acquiring_data_2011_06_07_sampledata_overview.py`).
 These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE``.
-To create a `~sunpy.map.Map` from a sample AIA image, type the following into your Python shell: ::
+To create a `~sunpy.map.Map` from a sample AIA image, type the following into your Python shell:
+
+.. code-block:: python
 
     >>> import sunpy
     >>> import sunpy.map
@@ -30,17 +32,20 @@ To create a `~sunpy.map.Map` from a sample AIA image, type the following into yo
 
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
 
-The variable my_map is an `~sunpy.map.sources.AIAMap` object.
-To create a Map from a local FITS file try the following: ::
+The variable ``my_map`` is an `~sunpy.map.sources.AIAMap` object.
+To create a Map from a local FITS file try the following:
+
+.. code-block:: python
 
     >>> my_map = sunpy.map.Map('/mydirectory/mymap.fits')   # doctest: +SKIP
 
-SunPy automatically detects the type of file (e.g. FITS), the instrument associated with it (e.g. AIA, EIT, LASCO), and finds the FITS keywords it needs to interpret the coordinate system.
+**sunpy** automatically detects the type of file (e.g. FITS), the instrument associated with it (e.g. AIA, EIT, LASCO), and finds the FITS keywords it needs to interpret the coordinate system.
 If the type of FITS file is not recognized then SunPy will try some default FITS keywords and return a `~sunpy.map.GenericMap`, but results may vary.
-SunPy can also create Maps using the jpg2000 files from `helioviewer.org <https://helioviewer.org/>`_.
+**sunpy** can also create Maps using the JPEG 2000 files from `helioviewer.org <https://helioviewer.org/>`__.
 
-The `Acquiring Data <https://docs.sunpy.org/en/stable/generated/gallery/index.html#acquiring-data>`_ section of the Example Gallery has several examples of retrieving data using the `~sunpy.net.Fido` tool.
+The :ref:`sphx_glr_generated_gallery_acquiring_data` section of the Example Gallery has several examples of retrieving data using the `~sunpy.net.Fido` tool.
 For more details, check out the :doc:`/guide/acquiring_data/fido` guide.
+See :ref:`sphx_glr_generated_gallery_saving_and_loading_data_genericmap_in_fits.py` for a demonstration of saving a map as a FITS file and `~sunpy.map.GenericMap.save` for more details on saving.
 
 .. _inspecting-maps:
 
@@ -48,7 +53,9 @@ For more details, check out the :doc:`/guide/acquiring_data/fido` guide.
 ==================
 
 A Map contains a number of data-associated attributes.
-To get a quick look at your Map simply type: ::
+To get a quick look at your Map simply type:
+
+.. code-block:: python
 
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
     >>> my_map  # doctest: +REMOTE_DATA
@@ -83,37 +90,46 @@ To get a quick look at your Map simply type: ::
 
 This will show a representation of the data as well as some of its associated attributes.
 Typing the above command in a Jupyter Notebook will show a rich HTML view of the table along with two plots of your data.
-The HTML view can also be accessed using the `~sunpy.map.GenericMap.quicklook` function, which will open the view in your default browser.
+The HTML view can also be accessed using the :func:`~sunpy.map.GenericMap.quicklook` function, which will open the view in your default browser.
 
 A number of other attributes are also available.
-For example, the `~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`, `~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`): ::
+For example, the `~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`, `~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`).
+The full list can be found on `~sunpy.map.GenericMap`:
+
+.. code-block:: python
 
     >>> map_date = my_map.date  # doctest: +REMOTE_DATA
     >>> map_exptime = my_map.exposure_time  # doctest: +REMOTE_DATA
     >>> map_center = my_map.center  # doctest: +REMOTE_DATA
 
-To get a list of all of the attributes check the documentation by typing: ::
+To get a list of all of the attributes check the documentation by typing:
+
+.. code-block:: python
 
     >>> help(my_map)  # doctest: +SKIP
 
 Many attributes and functions of the map classes accept and return `~astropy.units.quantity.Quantity` or `~astropy.coordinates.SkyCoord` objects.
 Please refer to :ref:`units-coordinates-sunpy` for more details.
 
-The metadata for the map is accessed by: ::
+The metadata for the map is accessed by:
+
+.. code-block:: python
 
     >>> header = my_map.meta  # doctest: +REMOTE_DATA
 
 This references the metadata dictionary with the header information as read from the source file.
-If you need to modify Map metadata, see `Map metadata modification <https://docs.sunpy.org/en/latest/generated/gallery/map/map_metadata_modification.html>`_ for a demonstration.
+To see if the metadata of a Map source has been modified, see :ref:`sphx_glr_generated_gallery_map_map_metadata_modification.py` for a demonstration.
 
 .. _map-data:
 
 3. Map Data
 ===========
 
-The data in a SunPy Map object is accessible through the `~sunpy.map.GenericMap.data` attribute.
+The data in a Map object is accessible through the `~sunpy.map.GenericMap.data` attribute.
 The data is implemented as a NumPy `~numpy.ndarray`.
-For example, to get the 0th element in the array: ::
+For example, to get the 0th element in the array:
+
+.. code-block:: python
 
     >>> my_map.data[0, 0]  # doctest: +REMOTE_DATA
     -95.92475
@@ -121,9 +137,11 @@ For example, to get the 0th element in the array: ::
     -95.92475
 
 The first index is for the y direction while the second index is for the x direction.
-For more information about indexing, please refer to the `Numpy documentation <https://docs.scipy.org/doc/numpy-dev/user/quickstart.html#indexing-slicing-and-iterating>`_.
+For more information about indexing, please refer to the `numpy documentation <https://numpy.org/doc/stable/user/basics.indexing.html#indexing-on-ndarrays>`__.
 
-Data attributes like `~numpy.ndarray.dtype` and `~sunpy.map.GenericMap.dimensions` are accessible through a GenericMap object: ::
+Data attributes like `~numpy.ndarray.dtype` and `~sunpy.map.GenericMap.dimensions` are accessible through a GenericMap object:
+
+.. code-block:: python
 
     >>> my_map.dimensions  # doctest: +REMOTE_DATA
     PixelPair(x=<Quantity 1024. pix>, y=<Quantity 1024. pix>)
@@ -132,12 +150,16 @@ Data attributes like `~numpy.ndarray.dtype` and `~sunpy.map.GenericMap.dimension
 
 Here, the dimensions attribute is similar to the `~numpy.ndarray.shape` attribute, however returning an `~astropy.units.quantity.Quantity`.
 
-You can store the data of a `~sunpy.map.GenericMap` object in a separate `~numpy.ndarray` by either of the following actions: ::
+You can store the data of a `~sunpy.map.GenericMap` object in a separate `~numpy.ndarray` by either of the following actions:
+
+.. code-block:: python
 
     >>> var = my_map.data  # doctest: +REMOTE_DATA
     >>> var = my_map.data.copy()  # doctest: +REMOTE_DATA
 
-To create a complete copy of a Map object that is entirely independent of the original, use the built-in `copy.deepcopy` method: ::
+To create a complete copy of a Map object that is entirely independent of the original, use the built-in `copy.deepcopy` method:
+
+.. code-block:: python
 
     >>> import copy   # doctest: +REMOTE_DATA
     >>> my_map_deepcopy = copy.deepcopy(my_map)   # doctest: +REMOTE_DATA
@@ -145,15 +167,21 @@ To create a complete copy of a Map object that is entirely independent of the or
 A deepcopy ensures that any changes in the original Map object are not reflected in the copied object and vice versa.
 Note that this copies the data of the Map object as well as all of the other attributes and methods.
 
-Some basic statistical functions are built into Map objects: ::
+Some basic statistical functions are built into Map objects:
+
+.. code-block:: python
 
     >>> my_map.min()  # doctest: +REMOTE_DATA
     -129.78036
+    >>> my_map.max()  # doctest: +REMOTE_DATA
+    192130.17
     >>> my_map.mean()  # doctest: +REMOTE_DATA
     427.02252
 
 All the other `~numpy.ndarray` functions and attributes can be accessed through the data array directly.
-For example: ::
+For example:
+
+.. code-block:: python
 
     >>> my_map.data.std()  # doctest: +REMOTE_DATA
     826.41016
@@ -163,8 +191,10 @@ For example: ::
 4. Plotting Maps
 ================
 
-The SunPy `~sunpy.map.GenericMap` object and its instrument-specific sub-classes has their own built-in plot methods so that it is easy to quickly view your Map.
-To create a plot just type: ::
+The `~sunpy.map.GenericMap` object has a built-in plot method such that it is easy to quickly view your map.
+To create a plot just type:
+
+.. code-block:: python
 
     >>> my_map.peek()   # doctest: +SKIP
 
@@ -174,27 +204,18 @@ This makes it possible to use the SunPy plot as the foundation for a more compli
 For more information about this and some examples see :ref:`plotting`.
 Check out the following foundational examples in the Example Gallery for plotting Maps:
 
-* `Plotting a map <https://docs.sunpy.org/en/stable/generated/gallery/plotting/aia_example.html>`_
+* :ref:`sphx_glr_generated_gallery_plotting_aia_example.py`
 
-* `Plotting points on a Map with WCSAxes <https://docs.sunpy.org/en/stable/generated/gallery/plotting/wcsaxes_plotting_example.html>`_
+* :ref:`sphx_glr_generated_gallery_plotting_wcsaxes_plotting_example.py`
 
-* `Editing the colormap and normalization of a Map <https://docs.sunpy.org/en/stable/generated/gallery/plotting/map_editcolormap.html>`_
+* :ref:`sphx_glr_generated_gallery_plotting_map_editcolormap.py`
 
-* `Plotting a coordinate grid <https://docs.sunpy.org/en/stable/generated/gallery/plotting/grid_plotting.html>`_
-
-* `Saving and loading a Map with FITS <https://docs.sunpy.org/en/stable/generated/gallery/saving_and_loading_data/genericmap_in_fits.html>`_
-
-.. note::
-
-   If the `astropy.visualization.wcsaxes` package is not used (it is used by default) the `~sunpy.map.GenericMap.plot()` and `~sunpy.map.GenericMap.peek()` methods assume that the data is not rotated, i.e. the solar y axis is oriented with the columns of the array.
-   If this condition is not met (in the metadata), when the map is plotted a warning will be issued.
-   You can create an oriented map by using `~sunpy.map.GenericMap.rotate()` before you plot the Map.
-
+* :ref:`sphx_glr_generated_gallery_plotting_grid_plotting.py`
 
 4.1 Plotting Keywords
 ---------------------
 
-For Map plotting, `~matplotlib.pyplot.imshow` does most of the heavy lifting in the background while SunPy makes a number of choices for you (e.g. colortable, plot title).
+For Map plotting, `~matplotlib.pyplot.imshow` does most of the heavy lifting in the background while **sunpy** makes a number of choices for you (e.g. colortable, plot title).
 Changing these defaults is made possible through two simple interfaces.
 You can pass any `~matplotlib.pyplot.imshow` keyword into the plot command to override the defaults for that particular plot.
 For example, the following plot changes the default colormap to use an inverse Grey color table.
@@ -212,7 +233,7 @@ For example, the following plot changes the default colormap to use an inverse G
     plt.show()
 
 You can view or make changes to the default settings through the ``sunpy.map.GenericMap.plot_settings`` dictionary.
-See `Editing the colormap and normalization of a Map <https://docs.sunpy.org/en/stable/generated/gallery/plotting/map_editcolormap.html>`_ for an example of this method.
+See :ref:`sphx_glr_generated_gallery_plotting_map_editcolormap.py` for an example of this method.
 
 
 4.2 Colormaps and Normalization
@@ -223,9 +244,11 @@ Matplotlib handles this colormapping process through the `~matplotlib.colors` mo
 First, the data array is mapped onto the range 0-1 using an instance of `~matplotlib.colors.Normalize` or a subclass.
 Then, the data is mapped to a color using a `~matplotlib.colors.Colormap`.
 
-SunPy provides colormaps for each mission as defined by the mission teams.
+**sunpy** provides colormaps for each mission as defined by the mission teams.
 The Map object chooses the appropriate colormap for you when it is created as long as it recognizes the instrument.
-To see what colormaps are available: ::
+To see what colormaps are available:
+
+.. code-block:: python
 
     >>> import sunpy.visualization.colormaps as cm
     >>> cm.cmlist.keys()
@@ -233,7 +256,9 @@ To see what colormaps are available: ::
     'goes-rsuvi284', 'goes-rsuvi304', 'sdoaia94', 'sdoaia131', 'sdoaia171',
     ...
 
-The SunPy colormaps are registered with matplotlib so you can grab them like you would any other colormap: ::
+The **sunpy** colormaps are registered with matplotlib so you can grab them like you would any other colormap:
+
+.. code-block:: python
 
     >>> import matplotlib.pyplot as plt
     >>> import sunpy.visualization.colormaps
@@ -258,14 +283,16 @@ If you want to override the built-in colormap, consider the following example wh
     plt.colorbar()
     plt.show()
 
-You can also change the colormap for the Map itself: ::
+You can also change the colormap for the Map itself:
+
+.. code-block:: python
 
     >>> smap.plot_settings['cmap'] = plt.get_cmap('sohoeit171')  # doctest: +SKIP
 
 The normalization is set automatically so that all the data from minimum to maximum is displayed as best as possible.
-Just like the colormap, the default normalization can be changed through the plot_settings dictionary or directly for the individual plot by passing a keyword argument.
+Just like the colormap, the default normalization can be changed through the ``plot_settings`` dictionary or directly for the individual plot by passing a keyword argument.
                
-Alternate normalizations are available from `matplotlib <https://matplotlib.org/stable/tutorials/colors/colormapnorms.html>`_ and `Astropy <https://docs.astropy.org/en/stable/visualization/normalization.html>`_.
+Alternate normalizations are available from `matplotlib <https://matplotlib.org/stable/tutorials/colors/colormapnorms.html>`__ and `astropy <https://docs.astropy.org/en/stable/visualization/normalization.html>`__.
 The following example shows the difference between a linear and logarithmic normalization on an AIA image.
 
 .. plot::
@@ -300,21 +327,27 @@ Meanwhile, the data values associated with each color do change because the norm
 It is often necessary to ignore certain data in an image.
 For example, a large data value could be due to cosmic ray hits and should be ignored.
 The most straightforward way to ignore this kind of data in plots, without altering the data, is to clip it.
-This can be achieved very easily by using the ``clip_interval`` keyword. For example: ::
+This can be achieved very easily by using the ``clip_interval`` keyword. For example:
+
+.. code-block:: python
 
     >>> import astropy.units as u
     >>> smap.plot(clip_interval=(1, 99.5)*u.percent)  #doctest: +SKIP
 
 This clips out the dimmest 1% of pixels and the brightest 0.5% of pixels.
 With those outlier pixels clipped, the resulting image makes better use of the full range of colors.
-If you'd like to see what areas of your images got clipped, you can modify the colormap: ::
+If you'd like to see what areas of your images got clipped, you can modify the colormap:
+
+.. code-block:: python
 
     >>> cmap = map.cmap  # doctest: +SKIP
     >>> cmap.set_over('blue')  # doctest: +SKIP
     >>> cmap.set_under('green')  # doctest: +SKIP
 
-This will color the areas above and below in red and green respectively (similar to this `matplotlib example <https://matplotlib.org/examples/pylab_examples/image_masked.html>`_).
-You can use the following colorbar command to display these choices: ::
+This will color the areas above and below in red and green respectively (similar to this `matplotlib example <https://matplotlib.org/examples/pylab_examples/image_masked.html>`__).
+You can use the following colorbar command to display these choices:
+
+.. code-block:: python
 
     >>> plt.colorbar(extend='both')   # doctest: +SKIP
 
@@ -352,157 +385,113 @@ A mask is a boolean array that can give you fine-grained control over what is no
 The `~numpy.ma.MaskedArray` is a subclass of a NumPy array with the addition of an associated boolean array which holds the mask.
 See the following two examples for applications of this technique:
 
-* `Masking out the solar disk <https://docs.sunpy.org/en/stable/generated/gallery/computer_vision_techniques/mask_disk.html>`_
+* :ref:`sphx_glr_generated_gallery_computer_vision_techniques_mask_disk.py`
 
-* `Finding and masking bright pixels <https://docs.sunpy.org/en/stable/generated/gallery/computer_vision_techniques/finding_masking_bright_pixels.html>`_
+* :ref:`sphx_glr_generated_gallery_computer_vision_techniques_finding_masking_bright_pixels.py`
+
+.. _map-sequences:
+
+5. Map Sequences
+================
+
+A `~sunpy.map.MapSequence` is an ordered list of maps.
+By default, the maps are ordered by their observation date, from earliest to latest date.
+A `~sunpy.map.MapSequence` can be created by supplying multiple existing maps:
+
+.. code-block:: python
+
+    >>> map1 = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
+    >>> map2 = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE)  # doctest: +REMOTE_DATA
+    >>> mc = sunpy.map.Map([map1, map2], sequence=True)  # doctest: +REMOTE_DATA
+
+or by providing a directory full of image files:
+
+.. code-block:: python
+
+    >>> mc = sunpy.map.Map('path/to/my/files/*.fits', sequence=True)   #  doctest: +SKIP
+
+The earliest map in the MapSequence can be accessed by indexing the maps list:
+
+.. code-block:: python
+
+    >>> mc.maps[0]   # doctest: +SKIP
+
+MapSequences can hold maps that have different shapes.
+To test if all the maps in a `~sunpy.map.MapSequence` have the same shape:
+
+.. code-block:: python
+
+    >>> mc.all_maps_same_shape()  # doctest: +REMOTE_DATA
+    True
+
+It is often useful to return the image data in a `~sunpy.map.MapSequence` as a single three dimensional NumPy `~numpy.ndarray`:
+
+.. code-block:: python
+
+    >>> mc_array = mc.as_array()   # doctest: +REMOTE_DATA
+
+Note that an array is returned only if all the maps have the same shape.
+If this is not true, a `ValueError` is returned.
+If all the maps have nx pixels in the x-direction, and ny pixels in the y-direction, and there are n maps in the MapSequence, the returned `~numpy.ndarray` array has shape (ny, nx, n).
+The data of the first map in the `~sunpy.map.MapSequence` appears in the `~numpy.ndarray` in position ``[:, :, 0]``, the data of second map in position ``[:, :, 1]``, and so on.
+The order of maps in the `~sunpy.map.MapSequence` is reproduced in the returned `~numpy.ndarray`.
+
+The metadata from each map can be obtained using:
+
+.. code-block:: python
+
+    >>> mc.all_meta()   # doctest: +SKIP
+
+This returns a list of map meta objects that have the same order as the maps in the `~sunpy.map.MapSequence`.
+
+For information on coaligning images and compensating for solar rotation in Map Sequences, see the `sunkit-image example gallery <https://docs.sunpy.org/projects/sunkit-image/en/stable/generated/gallery/index.html>`__ and the `sunkit_image.coalignment` module.
 
 .. _composite-maps:
 
-5. Composite Maps
-=================
+6. Composite Maps and Overlaying Maps
+=====================================
 
 The `~sunpy.map.Map` method can also handle a list of maps.
 If a series of maps are supplied as inputs, `~sunpy.map.Map` will return a list of maps as the output.
 If the 'composite' keyword is set to True, then a `~sunpy.map.CompositeMap` object is returned.
 This is useful if the maps are of a different type (e.g. different instruments).
-For example, to create a simple Composite Map: ::
+For example, to create a simple Composite Map:
+
+.. code-block:: python
 
     >>> my_maps = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE, sunpy.data.sample.RHESSI_IMAGE, composite=True)  # doctest: +REMOTE_DATA
 
-A `~sunpy.map.CompositeMap` is different from a regular SunPy `~sunpy.map.GenericMap` object and therefore different associated methods.
-To list which maps are part of your Composite Map use: ::
+A `~sunpy.map.CompositeMap` is different from a regular `~sunpy.map.GenericMap` object and therefore different associated methods.
+To list which maps are part of your Composite Map use:
+
+.. code-block:: python
 
     >>> my_maps.list_maps()  # doctest: +REMOTE_DATA
     [<class 'sunpy.map.sources.soho.EITMap'>, <class 'sunpy.map.sources.rhessi.RHESSIMap'>]
 
 The following two examples demonstrate how to create a composite map of AIA and HMI data and how to overlay HMI contours on an AIA map (without creating a composite map object):
 
-* `Creating a Composite map <https://docs.sunpy.org/en/stable/generated/gallery/map/composite_map_AIA_HMI.html>`_
+* :ref:`sphx_glr_generated_gallery_map_composite_map_AIA_HMI.py`
 
-* `Overplotting HMI Contours on an AIA Image <https://docs.sunpy.org/en/stable/generated/gallery/map/hmi_contours_wcsaxes.html>`_
+* :ref:`sphx_glr_generated_gallery_map_hmi_contours_wcsaxes.py`
 
-For a more advanced tutorial on combining data from several maps, see `Creating a Full Sun Map with AIA and EUVI <https://docs.sunpy.org/en/stable/generated/gallery/map_transformations/reprojection_aia_euvi_mosaic.html>`_.
-
-.. _map-sequences:
-
-6. Map Sequences
-================
-
-A `~sunpy.map.MapSequence` is an ordered list of maps.
-By default, the maps are ordered by their observation date, from earliest to latest date.
-A `~sunpy.map.MapSequence` can be created by supplying multiple existing maps: ::
-
-    >>> map1 = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
-    >>> map2 = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE)  # doctest: +REMOTE_DATA
-    >>> mc = sunpy.map.Map([map1, map2], sequence=True)  # doctest: +REMOTE_DATA
-
-or by providing a directory full of image files: ::
-
-    >>> mc = sunpy.map.Map('path/to/my/files/*.fits', sequence=True)   #  doctest: +SKIP
-
-The earliest map in the MapSequence can be accessed by indexing the maps list: ::
-
-    >>> mc.maps[0]   # doctest: +SKIP
-
-MapSequences can hold maps that have different shapes.
-To test if all the maps in a `~sunpy.map.MapSequence` have the same shape: ::
-
-    >>> mc.all_maps_same_shape()  # doctest: +REMOTE_DATA
-    True
-
-It is often useful to return the image data in a `~sunpy.map.MapSequence` as a single three dimensional NumPy `~numpy.ndarray`: ::
-
-    >>> mc.as_array()   # doctest: +SKIP
-
-Note that an array is returned only if all the maps have the same shape.
-If this is not true, a ``ValueError`` is returned.
-If all the maps have nx pixels in the x-direction, and ny pixels in the y-direction, and there are n maps in the MapSequence, the returned `~numpy.ndarray` array has shape (ny, nx, n).
-The data of the first map in the `~sunpy.map.MapSequence` appears in the `~numpy.ndarray` in position ``[:, :, 0]``, the data of second map in position ``[:, :, 1]``, and so on.
-The order of maps in the `~sunpy.map.MapSequence` is reproduced in the returned `~numpy.ndarray`.
-
-The metadata from each map can be obtained using: ::
-
-    >>> mc.all_meta()   # doctest: +SKIP
-
-This returns a list of map meta objects that have the same order as the maps in the `~sunpy.map.MapSequence`.
-
-
-6.1 Coalignment of Map Sequences
---------------------------------
-
-A typical data preparation step when dealing with time series of images is to coalign images taken at different times so that features in different images remain in the same place.
-A common approach to this problem is to take a representative template that contains the features you are interested in, and match that to your images.
-The location of the best match tells you where the template is in your image.
-The images are then shifted to the location of the best match.
-
-SunPy provides a function to coalign the maps inside the `~sunpy.map.MapSequence`.
-This function requires the installation of the `scikit-image library <https://scikit-image.org/>`_, a commonly used image processing library.
-To coalign a `~sunpy.map.MapSequence`, simply import the function and apply it to your `~sunpy.map.MapSequence`: ::
-
-    >>> from sunpy.image.coalignment import mapsequence_coalign_by_match_template
-    >>> coaligned = mapsequence_coalign_by_match_template(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
-
-This will return a new `~sunpy.map.MapSequence`, coaligned to a template extracted from the center of the first map in the `~sunpy.map.MapSequence`, with the map dimensions clipped as required.
-The coalignment algorithm provides many more options for handling the coalignment of `~sunpy.map.MapSequence`.
-Type: ::
-
-    >>> help(mapsequence_coalign_by_match_template)   # doctest: +SKIP
-
-for a full list of options and functionality.
-
-If you want to calculate the shifts required to compensate for solar rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use: ::
-
-    >>> from sunpy.image.coalignment import calculate_match_template_shift
-    >>> shifts = calculate_match_template_shift(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
-
-This is the algorithm used by the coalignment function to calculate the shifts.
-See `~sunpy.image.coalignment.calculate_match_template_shift` to learn more about its features.
-Shifts calculated using calculate_match_template_shift can be passed directly to the coalignment function.
-
-For similar examples, see the `Combining, Co-aligning, and Reprojecting Images <https://docs.sunpy.org/en/stable/generated/gallery/index.html#combining-co-aligning-and-reprojecting-images>`_ section of the Example Gallery.
-
-
-6.2 Compensating for solar rotation in Map Sequences
-----------------------------------------------------
-
-A typical preparation step when dealing with a time series of solar image data is to shift the images so that features do not appear to move across the field of view.
-This requires accounting for the `differential rotation <https://en.wikipedia.org/wiki/Solar_rotation>`_ of the Sun (solar features at the equator rotate faster than features at the poles).
-
-SunPy provides a function to shift images in a `~sunpy.map.MapSequence` according to the solar differential rotation calculated at the latitude of the center of the field of view.
-The function does not *differentially* rotate the image.
-Instead, this function is useful for de-rotating images when the effects of differential rotation in the `~sunpy.map.MapSequence` can be ignored.
-For example, it is useful if the spatial extent of the image is small or the duration of the `~sunpy.map.MapSequence` is brief (deciding on what 'small' or 'brief' means depends on your application).
-
-To apply this form of solar de-rotation to a `~sunpy.map.MapSequence`, import the function and apply it to your `~sunpy.map.MapSequence`: ::
-
-    >>> from sunpy.physics.solar_rotation import mapsequence_solar_derotate
-    >>> derotated = mapsequence_solar_derotate(mc)  # doctest: +SKIP
-
-For more info see `~sunpy.physics.solar_rotation.mapsequence_solar_derotate`.
-
-If you want to calculate the shifts required to compensate for solar rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use: ::
-
-    >>> from sunpy.physics.solar_rotation import calculate_solar_rotate_shift
-    >>> shifts = calculate_solar_rotate_shift(mc)  # doctest: +SKIP
-
-Please consult the docstring of the `~sunpy.image.coalignment.mapsequence_coalign_by_match_template` function to learn more about the features of this function.
-
-See the `Differential Rotation of the Sun <https://docs.sunpy.org/en/stable/generated/gallery/index.html#differential-rotation-of-the-sun>`_ section of the Example Gallery for examples using `~sunpy.coordinates.metaframes.RotatedSunFrame`.
-
+For a more advanced tutorial on combining data from several maps, see :ref:`sphx_glr_generated_gallery_map_transformations_reprojection_aia_euvi_mosaic.py`.
 
 .. _custom-maps:
 
 7. Creating Custom Maps
 =======================
 
-It is also possible to create Maps using custom data (e.g. from a simulation or an observation from a data source that is not explicitly supported in SunPy).
+It is also possible to create Maps using custom data (e.g. from a simulation or an observation from a data source that is not explicitly supported in **sunpy**).
 To do this, you need to provide `sunpy.map.Map` with both the data array as well as appropriate meta information.
 The meta information informs `sunpy.map.Map` of the correct coordinate information associated with the data array and should be provided to `sunpy.map.Map` in the form of a header as a `dict` or `~sunpy.util.MetaDict`.
-See this `example <https://docs.sunpy.org/en/latest/generated/gallery/map/map_from_numpy_array.html>`_ for a brief demonstration of generating a Map from a data array.
+See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a brief demonstration of generating a Map from a data array.
 
-The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`_.
-SunPy provides a Map header helper function to assist in creating a header that contains the correct meta information.
-This includes a `~sunpy.map.meta_keywords` function that will return a `dict` of all the current meta keywords and their descriptions.
+The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
+**sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
+This includes a `~sunpy.map.meta_keywords` function that will return a `dict` the meta keywords used when creating a Map.
+
+.. code-block:: python
 
     >>> from sunpy.map import meta_keywords
 
@@ -512,7 +501,7 @@ This includes a `~sunpy.map.meta_keywords` function that will return a `dict` of
      'crval1': 'Coordinate value at reference point on naxis1 **required'
      ...
 
-There is also a utility function `~sunpy.map.make_fitswcs_header` that will return a header with the appropiate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
+The utility function `~sunpy.map.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
 This function returns a `sunpy.util.MetaDict`.
 The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.
@@ -520,8 +509,9 @@ The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an
 The `~sunpy.map.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
 If neither of these are given their values default to the center of the data array and 1 arcsec, respectively.
 
-Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`: ::
+Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`:
 
+.. code-block:: python
 
     >>> import numpy as np
     >>> import astropy.units as u
@@ -561,12 +551,13 @@ Here's an example of creating a header from some generic data and an `astropy.co
     pc2_2: 1.0
     rsun_obs: 965.3829548285768
 
-
 From this we can see now that the function returned a `sunpy.util.MetaDict` that populated the standard FITS keywords with information provided by the passed `astropy.coordinates.SkyCoord`, and the data array.
 Since the ``reference_pixel`` and keywords were not passed in the example above, the values of ``crpix`` and ``cdelt`` were set to the default values.
 
 These keywords can be passed to the function in the form of an `astropy.units.Quantity` with associated units.
-Here's another example of passing ``reference_pixel`` and ``scale`` to the function: ::
+Here's another example of passing ``reference_pixel`` and ``scale`` to the function:
+
+.. code-block:: python
 
     >>> header = sunpy.map.make_fitswcs_header(data, coord,
     ...                                        reference_pixel=u.Quantity([5, 5]*u.pixel),
@@ -605,38 +596,51 @@ As we can see, a list of WCS and observer meta information is contained within t
 Any of the keywords listed in ``header_helper.meta_keywords`` can be passed to the `~sunpy.map.make_fitswcs_header` and will then populate the returned MetaDict header.
 Furthermore, the following observation keywords can be passed to the `~sunpy.map.make_fitswcs_header` function and will be translated to the FITS standard: ``observtory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
 
-An example of creating a header with these additional keywords: ::
+An example of creating a header with these additional keywords:
+
+.. code-block:: python
 
     >>> header = sunpy.map.make_fitswcs_header(data, coord,
     ...                                        reference_pixel = u.Quantity([5, 5]*u.pixel),
     ...                                        scale = u.Quantity([2, 2] *u.arcsec/u.pixel),
     ...                                        telescope = 'Test case', instrument = 'UV detector',
     ...                                        wavelength = 1000*u.angstrom)
-    >>> header  # doctest: +SKIP
-    MetaDict([('wcsaxes', 2),
-          ('crpix1', 5.0),
-          ('crpix2', 5.0),
-          ('cdelt1', <Quantity 2. arcsec2 / pix2>),
-          ('cdelt2', <Quantity 2. arcsec2 / pix2>),
-          ('cunit1', Unit("arcsec")),
-          ('cunit2', Unit("arcsec")),
-          ('ctype1', 'HPLN-TAN'),
-          ('ctype2', 'HPLT-TAN'),
-          ('crval1', 0.0),
-          ('crval2', 0.0),
-          ...
-          ('date-obs', '2013-10-28T00:00:00.000'),
-          ('hgln_obs', 0.0),
-          ('hglt_obs', 4.7711570596394015),
-          ('dsun_obs', 148644585949.4918),
-          ('rsun_ref', 695700.0),
-          ('rsun_obs', 965.3829548285768),
-          ('instrume', 'Test case'),
-          ('wavelnth', 1000),
-          ('detector', 'UV detector'),
-          ('waveunit', 'angstrom')])
+    >>> for key, value in header.items():
+    ...     print(f"{key}: {value}")
+    wcsaxes: 2
+    crpix1: 6.0
+    crpix2: 6.0
+    cdelt1: 2.0
+    cdelt2: 2.0
+    cunit1: arcsec
+    cunit2: arcsec
+    ctype1: HPLN-TAN
+    ctype2: HPLT-TAN
+    crval1: 0.0
+    crval2: 0.0
+    lonpole: 180.0
+    latpole: 0.0
+    mjdref: 0.0
+    date-obs: 2013-10-28T00:00:00.000
+    rsun_ref: 695700000.0
+    dsun_obs: 148644585949.49
+    hgln_obs: 0.0
+    hglt_obs: 4.7711570596394
+    instrume: UV detector
+    telescop: Test case
+    wavelnth: 1000.0
+    waveunit: Angstrom
+    naxis: 2
+    naxis1: 10
+    naxis2: 10
+    pc1_1: 1.0
+    pc1_2: -0.0
+    pc2_1: 0.0
+    pc2_2: 1.0
+    rsun_obs: 965.3829548285768
 
-From these header MetaDict's that are generated, we can now create a custom map: ::
+From these header MetaDict's that are generated, we can now create a custom map:
 
-    >>> my_map = sunpy.map.Map(data, header) # doctest: +SKIP
-    >>> my_map.peek() # doctest: +SKIP
+.. code-block:: python
+
+    >>> my_map = sunpy.map.Map(data, header)

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -3,34 +3,26 @@ Map Guide
 *********
 
 Map objects in SunPy are two-dimensional data associated with a coordinate system.
-This class offers many advantages over using, for example, `astropy.io.fits` to open
-2D solar data in Python. SunPy Maps recognize data from 19 sources
-(see :doc:`/code_ref/map` for a complete list) and can provide instrument-specific
-information when plotting and even correct/add metadata when it is missing from the
-original file.
+This class offers many advantages over using, for example, `astropy.io.fits` to open 2D solar data in Python.
+SunPy Maps recognize data from 19 sources (see :doc:`/code_ref/map` for a complete list) and can provide instrument-specific information when plotting and even correct/add metadata when it is missing from the original file.
 
-Part of the philosophy of the Map object is to provide most of the basic
-functionality that a scientist would want. Therefore, a Map also contains a number
-of methods such as resizing or grabbing a subview. See `~sunpy.map.mapbase.GenericMap`
-for summaries of all attributes and methods.
+Part of the philosophy of the Map object is to provide most of the basic functionality that a scientist would want.
+Therefore, a Map also contains a number of methods such as resizing or grabbing a subview.
+See `~sunpy.map.mapbase.GenericMap` for summaries of all attributes and methods.
 
-:ref:`creating-maps` and :ref:`inspecting-maps` demonstrate how to create a Map object
-and view a summary of the data in the object. :ref:`map-data` describes how data is stored
-and accessed in a Map, and :ref:`plotting-maps` introduces some basics of visualizing Map
-data in SunPy. :ref:`composite-maps` and :ref:`map-sequences` detail how SunPy can handle
-multiple Maps from similar and different instruments. Lastly, :ref:`custom-maps`
-shows how you can create Maps from data sources not supported in SunPy.
+:ref:`creating-maps` and :ref:`inspecting-maps` demonstrate how to create a Map object and view a summary of the data in the object.
+:ref:`map-data` describes how data is stored and accessed in a Map, and :ref:`plotting-maps` introduces some basics of visualizing Map data in SunPy.
+:ref:`composite-maps` and :ref:`map-sequences` detail how SunPy can handle multiple Maps from similar and different instruments.
+Lastly, :ref:`custom-maps` shows how you can create Maps from data sources not supported in SunPy.
 
 .. _creating-maps:
 
 1. Creating Maps
 ================
 
-To make things easy, SunPy can download sample data which are used
-throughout the docs (see the `Sample data overview <https://docs.sunpy.org/en/latest/generated/gallery/acquiring_data/2011_06_07_sampledata_overview.html>`_).
+To make things easy, SunPy can download sample data which are used throughout the docs (see the `Sample data overview <https://docs.sunpy.org/en/latest/generated/gallery/acquiring_data/2011_06_07_sampledata_overview.html>`_).
 These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE``.
-To create a `~sunpy.map.Map` from a sample AIA image,
-type the following into your Python shell: ::
+To create a `~sunpy.map.Map` from a sample AIA image, type the following into your Python shell: ::
 
     >>> import sunpy
     >>> import sunpy.map
@@ -38,42 +30,63 @@ type the following into your Python shell: ::
 
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
 
-The variable my_map is an `~sunpy.map.sources.AIAMap` object. To create a Map from a
-local FITS file try the following: ::
+The variable my_map is an `~sunpy.map.sources.AIAMap` object.
+To create a Map from a local FITS file try the following: ::
 
     >>> my_map = sunpy.map.Map('/mydirectory/mymap.fits')   # doctest: +SKIP
 
-SunPy automatically detects the type of file (e.g. FITS), the instrument
-associated with it (e.g. AIA, EIT, LASCO), and finds the FITS keywords it needs to
-interpret the coordinate system. If the type of FITS file is not recognized then SunPy will try some
-default FITS keywords and return a `~sunpy.map.GenericMap`, but results
-may vary. SunPy can also create Maps using the jpg2000 files from
-`helioviewer.org <https://helioviewer.org/>`_.
+SunPy automatically detects the type of file (e.g. FITS), the instrument associated with it (e.g. AIA, EIT, LASCO), and finds the FITS keywords it needs to interpret the coordinate system.
+If the type of FITS file is not recognized then SunPy will try some default FITS keywords and return a `~sunpy.map.GenericMap`, but results may vary.
+SunPy can also create Maps using the jpg2000 files from `helioviewer.org <https://helioviewer.org/>`_.
 
-The `Acquiring Data <https://docs.sunpy.org/en/stable/generated/gallery/index.html#acquiring-data>`_ section
-of the Example Gallery has several examples of retrieving data using the `~sunpy.net.Fido` tool. For more details,
-check out the :doc:`/guide/acquiring_data/fido` guide.
+The `Acquiring Data <https://docs.sunpy.org/en/stable/generated/gallery/index.html#acquiring-data>`_ section of the Example Gallery has several examples of retrieving data using the `~sunpy.net.Fido` tool.
+For more details, check out the :doc:`/guide/acquiring_data/fido` guide.
 
 .. _inspecting-maps:
 
 2. Inspecting Maps
 ==================
 
-A Map contains a number of data-associated attributes. To get a quick look at
-your Map simply type: ::
+A Map contains a number of data-associated attributes.
+To get a quick look at your Map simply type: ::
 
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
     >>> my_map  # doctest: +REMOTE_DATA
+    <sunpy.map.sources.sdo.AIAMap object at ...>
+    SunPy Map
+    ---------
+    Observatory:                 SDO
+    Instrument:          AIA 3
+    Detector:            AIA
+    Measurement:                 171.0 Angstrom
+    Wavelength:          171.0 Angstrom
+    Observation Date:    2011-06-07 06:33:02
+    Exposure Time:               0.234256 s
+    Dimension:           [1024. 1024.] pix
+    Coordinate System:   helioprojective
+    Scale:                       [2.402792 2.402792] arcsec / pix
+    Reference Pixel:     [511.5 511.5] pix
+    Reference Coord:     [3.22309951 1.38578135] arcsec
+    array([[ -95.92475  ,    7.076416 ,   -1.9656711, ..., -127.96519  ,
+            -127.96519  , -127.96519  ],
+           [ -96.97533  ,   -5.1167884,    0.       , ...,  -98.924576 ,
+            -104.04137  , -127.919716 ],
+           [ -93.99607  ,    1.0189276,   -4.0757103, ...,   -5.094638 ,
+             -37.95505  , -127.87541  ],
+           ...,
+           [-128.01454  , -128.01454  , -128.01454  , ..., -128.01454  ,
+            -128.01454  , -128.01454  ],
+           [-127.899666 , -127.899666 , -127.899666 , ..., -127.899666 ,
+            -127.899666 , -127.899666 ],
+           [-128.03072  , -128.03072  , -128.03072  , ..., -128.03072  ,
+            -128.03072  , -128.03072  ]], dtype=float32)
 
 This will show a representation of the data as well as some of its associated attributes.
-Typing the above command in a Jupyter Notebook will show a rich HTML view of the
-table along with two plots of your data. The HTML view can also be accessed
-using the `~sunpy.map.GenericMap.quicklook` function, which will open the view in your
-default browser.
+Typing the above command in a Jupyter Notebook will show a rich HTML view of the table along with two plots of your data.
+The HTML view can also be accessed using the `~sunpy.map.GenericMap.quicklook` function, which will open the view in your default browser.
 
-A number of other attributes are also available. For example, the
-`~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`,
-`~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`): ::
+A number of other attributes are also available.
+For example, the `~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`, `~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`): ::
 
     >>> map_date = my_map.date  # doctest: +REMOTE_DATA
     >>> map_exptime = my_map.exposure_time  # doctest: +REMOTE_DATA
@@ -83,26 +96,24 @@ To get a list of all of the attributes check the documentation by typing: ::
 
     >>> help(my_map)  # doctest: +SKIP
 
-Many attributes and functions of the map classes accept and return
-`~astropy.units.quantity.Quantity` or `~astropy.coordinates.SkyCoord` objects.
+Many attributes and functions of the map classes accept and return `~astropy.units.quantity.Quantity` or `~astropy.coordinates.SkyCoord` objects.
 Please refer to :ref:`units-coordinates-sunpy` for more details.
 
 The metadata for the map is accessed by: ::
 
     >>> header = my_map.meta  # doctest: +REMOTE_DATA
 
-This references the metadata dictionary with the header information as read
-from the source file. If you need to modify Map metadata, see `Map metadata modification <https://docs.sunpy.org/en/latest/generated/gallery/map/map_metadata_modification.html>`_ for a demonstration.
+This references the metadata dictionary with the header information as read from the source file.
+If you need to modify Map metadata, see `Map metadata modification <https://docs.sunpy.org/en/latest/generated/gallery/map/map_metadata_modification.html>`_ for a demonstration.
 
 .. _map-data:
 
 3. Map Data
 ===========
 
-The data in a SunPy Map object is accessible through the
-`~sunpy.map.GenericMap.data` attribute.  The data is implemented as a
-NumPy `~numpy.ndarray`. For example, to get
-the 0th element in the array: ::
+The data in a SunPy Map object is accessible through the `~sunpy.map.GenericMap.data` attribute.
+The data is implemented as a NumPy `~numpy.ndarray`.
+For example, to get the 0th element in the array: ::
 
     >>> my_map.data[0, 0]  # doctest: +REMOTE_DATA
     -95.92475
@@ -110,47 +121,39 @@ the 0th element in the array: ::
     -95.92475
 
 The first index is for the y direction while the second index is for the x direction.
-For more information about indexing, please refer to the
-`Numpy documentation <https://docs.scipy.org/doc/numpy-dev/user/quickstart.html#indexing-slicing-and-iterating>`_.
+For more information about indexing, please refer to the `Numpy documentation <https://docs.scipy.org/doc/numpy-dev/user/quickstart.html#indexing-slicing-and-iterating>`_.
 
-Data attributes like `~numpy.ndarray.dtype` and
-`~sunpy.map.GenericMap.dimensions` are accessible through
-a GenericMap object: ::
+Data attributes like `~numpy.ndarray.dtype` and `~sunpy.map.GenericMap.dimensions` are accessible through a GenericMap object: ::
 
     >>> my_map.dimensions  # doctest: +REMOTE_DATA
     PixelPair(x=<Quantity 1024. pix>, y=<Quantity 1024. pix>)
     >>> my_map.dtype  # doctest: +REMOTE_DATA
     dtype('float32')
 
-Here, the dimensions attribute is similar to the `~numpy.ndarray.shape`
-attribute, however returning an `~astropy.units.quantity.Quantity`.
+Here, the dimensions attribute is similar to the `~numpy.ndarray.shape` attribute, however returning an `~astropy.units.quantity.Quantity`.
 
-You can store the data of a `~sunpy.map.GenericMap` object
-in a separate `~numpy.ndarray` by either of the following actions: ::
+You can store the data of a `~sunpy.map.GenericMap` object in a separate `~numpy.ndarray` by either of the following actions: ::
 
     >>> var = my_map.data  # doctest: +REMOTE_DATA
     >>> var = my_map.data.copy()  # doctest: +REMOTE_DATA
 
-To create a complete copy of a Map object that is entirely independent of the original,
-use the built-in `copy.deepcopy` method: ::
+To create a complete copy of a Map object that is entirely independent of the original, use the built-in `copy.deepcopy` method: ::
 
     >>> import copy   # doctest: +REMOTE_DATA
     >>> my_map_deepcopy = copy.deepcopy(my_map)   # doctest: +REMOTE_DATA
 
-A deepcopy ensures that any changes in the original Map object are not reflected in the
-copied object and vice versa. Note that this copies the data of
-the Map object as well as all of the other attributes and methods.
+A deepcopy ensures that any changes in the original Map object are not reflected in the copied object and vice versa.
+Note that this copies the data of the Map object as well as all of the other attributes and methods.
 
-Some basic statistical functions are built into Map
-objects: ::
+Some basic statistical functions are built into Map objects: ::
 
     >>> my_map.min()  # doctest: +REMOTE_DATA
     -129.78036
     >>> my_map.mean()  # doctest: +REMOTE_DATA
     427.02252
 
-All the other `~numpy.ndarray` functions and attributes
-can be accessed through the data array directly. For example: ::
+All the other `~numpy.ndarray` functions and attributes can be accessed through the data array directly.
+For example: ::
 
     >>> my_map.data.std()  # doctest: +REMOTE_DATA
     826.41016
@@ -160,20 +163,16 @@ can be accessed through the data array directly. For example: ::
 4. Plotting Maps
 ================
 
-The SunPy `~sunpy.map.GenericMap`
-object and its instrument-specific sub-classes has their
-own built-in plot methods so that it is easy to quickly view your Map.
+The SunPy `~sunpy.map.GenericMap` object and its instrument-specific sub-classes has their own built-in plot methods so that it is easy to quickly view your Map.
 To create a plot just type: ::
 
     >>> my_map.peek()   # doctest: +SKIP
 
 This will open a matplotlib plot on your screen.
-In addition, it is possible to grab the matplotlib axes object
-by using the `~sunpy.map.GenericMap.plot()` command.
-This makes it possible to use the SunPy plot as the foundation for a
-more complicated figure. For more information about this and some
-examples see :ref:`plotting`. Check out the following foundational
-examples in the Example Gallery for plotting Maps:
+In addition, it is possible to grab the matplotlib axes object by using the `~sunpy.map.GenericMap.plot()` command.
+This makes it possible to use the SunPy plot as the foundation for a more complicated figure.
+For more information about this and some examples see :ref:`plotting`.
+Check out the following foundational examples in the Example Gallery for plotting Maps:
 
 * `Plotting a map <https://docs.sunpy.org/en/stable/generated/gallery/plotting/aia_example.html>`_
 
@@ -187,48 +186,46 @@ examples in the Example Gallery for plotting Maps:
 
 .. note::
 
-   If the `astropy.visualization.wcsaxes` package is not used (it is used by
-   default) the `~sunpy.map.GenericMap.plot()` and
-   `~sunpy.map.GenericMap.peek()` methods assume that the data is not rotated,
-   i.e. the solar y axis is oriented with the columns of the array. If this
-   condition is not met (in the metadata), when the map is plotted a warning
-   will be issued. You can create an oriented map by using
-   `~sunpy.map.GenericMap.rotate()` before you plot the Map.
+   If the `astropy.visualization.wcsaxes` package is not used (it is used by default) the `~sunpy.map.GenericMap.plot()` and `~sunpy.map.GenericMap.peek()` methods assume that the data is not rotated, i.e. the solar y axis is oriented with the columns of the array.
+   If this condition is not met (in the metadata), when the map is plotted a warning will be issued.
+   You can create an oriented map by using `~sunpy.map.GenericMap.rotate()` before you plot the Map.
 
 
 4.1 Plotting Keywords
 ---------------------
 
-For Map plotting, `~matplotlib.pyplot.imshow` does most of the heavy
-lifting in the background while SunPy makes a number of choices for you
-(e.g. colortable, plot title). Changing these defaults
-is made possible through two simple interfaces. You can pass any
-`~matplotlib.pyplot.imshow` keyword into
-the plot command to override the defaults for that particular plot. For example, the following
-command changes the default colormap to use an inverse Grey color table: ::
+For Map plotting, `~matplotlib.pyplot.imshow` does most of the heavy lifting in the background while SunPy makes a number of choices for you (e.g. colortable, plot title).
+Changing these defaults is made possible through two simple interfaces.
+You can pass any `~matplotlib.pyplot.imshow` keyword into the plot command to override the defaults for that particular plot.
+For example, the following plot changes the default colormap to use an inverse Grey color table.
 
-    >>> my_map.plot(cmap=plt.cm.Greys_r)   # doctest: +SKIP
+.. plot::
+    :include-source:
 
-You can view or make changes to the default settings through the ``sunpy.map.GenericMap.plot_settings``
-dictionary. In the following example, we change the title and colormap of the plot: ::
+    import sunpy.map
+    import sunpy.data.sample
+    import matplotlib.pyplot as plt
+    smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
+    fig = plt.figure()
+    smap.plot(cmap=plt.cm.Greys_r)
+    plt.colorbar()
+    plt.show()
 
-    >>>    my_map.plot_settings['title'] = "Plot Two"  # doctest: +REMOTE_DATA
-    >>>    my_map.plot_settings['cmap'] = plt.cm.Blues_r  # doctest: +REMOTE_DATA
+You can view or make changes to the default settings through the ``sunpy.map.GenericMap.plot_settings`` dictionary.
+See `Editing the colormap and normalization of a Map <https://docs.sunpy.org/en/stable/generated/gallery/plotting/map_editcolormap.html>`_ for an example of this method.
 
 
 4.2 Colormaps and Normalization
 -------------------------------
 
-Image data is generally shown in false color in order to better identify it or
-to better visualize structures in the image. Matplotlib handles this colormapping
-process through the `~matplotlib.colors` module. First, the data array is mapped onto
-the range 0-1 using an instance of
-`~matplotlib.colors.Normalize` or a subclass. Then, the data is mapped to a
-color using a `~matplotlib.colors.Colormap`.
+Image data is generally shown in false color in order to better identify it or to better visualize structures in the image.
+Matplotlib handles this colormapping process through the `~matplotlib.colors` module.
+First, the data array is mapped onto the range 0-1 using an instance of `~matplotlib.colors.Normalize` or a subclass.
+Then, the data is mapped to a color using a `~matplotlib.colors.Colormap`.
 
 SunPy provides colormaps for each mission as defined by the mission teams.
-The Map object chooses the appropriate colormap for you when it is created as
-long as it recognizes the instrument. To see what colormaps are available: ::
+The Map object chooses the appropriate colormap for you when it is created as long as it recognizes the instrument.
+To see what colormaps are available: ::
 
     >>> import sunpy.visualization.colormaps as cm
     >>> cm.cmlist.keys()
@@ -236,8 +233,7 @@ long as it recognizes the instrument. To see what colormaps are available: ::
     'goes-rsuvi284', 'goes-rsuvi304', 'sdoaia94', 'sdoaia131', 'sdoaia171',
     ...
 
-The SunPy colormaps are registered with matplotlib so you can grab them like
-you would any other colormap: ::
+The SunPy colormaps are registered with matplotlib so you can grab them like you would any other colormap: ::
 
     >>> import matplotlib.pyplot as plt
     >>> import sunpy.visualization.colormaps
@@ -245,8 +241,7 @@ you would any other colormap: ::
 
 See `~sunpy.visualization.colormaps` for a plot of all available colormaps.
 
-If you want to override the built-in colormap, consider the following example
-which plots an AIA map using an EIT colormap.
+If you want to override the built-in colormap, consider the following example which plots an AIA map using an EIT colormap.
 
 .. plot::
     :include-source:
@@ -267,16 +262,11 @@ You can also change the colormap for the Map itself: ::
 
     >>> smap.plot_settings['cmap'] = plt.get_cmap('sohoeit171')  # doctest: +SKIP
 
-The normalization is set automatically so that all the
-data from minimum to maximum is displayed as best as possible.
-Just like the colormap, the default normalization
-can be changed through the plot_settings dictionary or directly for the individual
-plot by passing a keyword argument.
+The normalization is set automatically so that all the data from minimum to maximum is displayed as best as possible.
+Just like the colormap, the default normalization can be changed through the plot_settings dictionary or directly for the individual plot by passing a keyword argument.
                
-Alternate normalizations are available from `matplotlib <https://matplotlib.org/stable/tutorials/colors/colormapnorms.html>`_
-and `Astropy <https://docs.astropy.org/en/stable/visualization/normalization.html>`_.
-The following example shows the difference between
-a linear and logarithmic normalization on an AIA image.
+Alternate normalizations are available from `matplotlib <https://matplotlib.org/stable/tutorials/colors/colormapnorms.html>`_ and `Astropy <https://docs.astropy.org/en/stable/visualization/normalization.html>`_.
+The following example shows the difference between a linear and logarithmic normalization on an AIA image.
 
 .. plot::
     :include-source:
@@ -300,33 +290,30 @@ a linear and logarithmic normalization on an AIA image.
 
     plt.show()
 
-Note how the colorbar does not change since these two plots share
-the same colormap. Meanwhile, the data values associated with each color do change because
-the normalization is different.
+Note how the colorbar does not change since these two plots share the same colormap.
+Meanwhile, the data values associated with each color do change because the normalization is different.
 
 
 4.3 Clipping and Masking Data
 -----------------------------
 
-It is often necessary to ignore certain
-data in an image. For example, a large data value could be due to
-cosmic ray hits and should be ignored. The most straightforward way to ignore
-this kind of data in plots, without altering the data, is to clip it. This can be achieved
-very easily by using the ``clip_interval`` keyword. For example: ::
+It is often necessary to ignore certain data in an image.
+For example, a large data value could be due to cosmic ray hits and should be ignored.
+The most straightforward way to ignore this kind of data in plots, without altering the data, is to clip it.
+This can be achieved very easily by using the ``clip_interval`` keyword. For example: ::
 
     >>> import astropy.units as u
     >>> smap.plot(clip_interval=(1, 99.5)*u.percent)  #doctest: +SKIP
 
-This clips out the dimmest 1% of pixels and the brightest 0.5% of pixels.  With those outlier
-pixels clipped, the resulting image makes better use of the full range of colors.
+This clips out the dimmest 1% of pixels and the brightest 0.5% of pixels.
+With those outlier pixels clipped, the resulting image makes better use of the full range of colors.
 If you'd like to see what areas of your images got clipped, you can modify the colormap: ::
 
     >>> cmap = map.cmap  # doctest: +SKIP
     >>> cmap.set_over('blue')  # doctest: +SKIP
     >>> cmap.set_under('green')  # doctest: +SKIP
 
-This will color the areas above and below in red and green respectively
-(similar to this `matplotlib example <https://matplotlib.org/examples/pylab_examples/image_masked.html>`_).
+This will color the areas above and below in red and green respectively (similar to this `matplotlib example <https://matplotlib.org/examples/pylab_examples/image_masked.html>`_).
 You can use the following colorbar command to display these choices: ::
 
     >>> plt.colorbar(extend='both')   # doctest: +SKIP
@@ -360,11 +347,9 @@ Here is an example of this put to use on an AIA image.
     plt.show()
 
 
-Masking is another approach to ignoring certain data. A mask is a boolean
-array that can give you fine-grained control over what is not being
-displayed. The `~numpy.ma.MaskedArray`
-is a subclass of a NumPy array with the
-addition of an associated boolean array which holds the mask.
+Masking is another approach to ignoring certain data.
+A mask is a boolean array that can give you fine-grained control over what is not being displayed.
+The `~numpy.ma.MaskedArray` is a subclass of a NumPy array with the addition of an associated boolean array which holds the mask.
 See the following two examples for applications of this technique:
 
 * `Masking out the solar disk <https://docs.sunpy.org/en/stable/generated/gallery/computer_vision_techniques/mask_disk.html>`_
@@ -376,22 +361,21 @@ See the following two examples for applications of this technique:
 5. Composite Maps
 =================
 
-The `~sunpy.map.Map` method can also handle a list of maps. If a series of maps
-are supplied as inputs, `~sunpy.map.Map` will return a list of maps as the output.
-If the 'composite' keyword is set to True, then a `~sunpy.map.CompositeMap` object is
-returned.  This is useful if the maps are of a different type (e.g. different
-instruments).  For example, to create a simple Composite Map: ::
+The `~sunpy.map.Map` method can also handle a list of maps.
+If a series of maps are supplied as inputs, `~sunpy.map.Map` will return a list of maps as the output.
+If the 'composite' keyword is set to True, then a `~sunpy.map.CompositeMap` object is returned.
+This is useful if the maps are of a different type (e.g. different instruments).
+For example, to create a simple Composite Map: ::
 
     >>> my_maps = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE, sunpy.data.sample.RHESSI_IMAGE, composite=True)  # doctest: +REMOTE_DATA
 
-A `~sunpy.map.CompositeMap` is different from a regular SunPy `~sunpy.map.GenericMap` object and therefore
-different associated methods. To list which maps are part of your Composite Map use: ::
+A `~sunpy.map.CompositeMap` is different from a regular SunPy `~sunpy.map.GenericMap` object and therefore different associated methods.
+To list which maps are part of your Composite Map use: ::
 
     >>> my_maps.list_maps()  # doctest: +REMOTE_DATA
     [<class 'sunpy.map.sources.soho.EITMap'>, <class 'sunpy.map.sources.rhessi.RHESSIMap'>]
 
-The following two examples demonstrate how to create a composite map of AIA and HMI data
-and how to overlay HMI contours on an AIA map (without creating a composite map object):
+The following two examples demonstrate how to create a composite map of AIA and HMI data and how to overlay HMI contours on an AIA map (without creating a composite map object):
 
 * `Creating a Composite map <https://docs.sunpy.org/en/stable/generated/gallery/map/composite_map_AIA_HMI.html>`_
 
@@ -404,9 +388,9 @@ For a more advanced tutorial on combining data from several maps, see `Creating 
 6. Map Sequences
 ================
 
-A `~sunpy.map.MapSequence` is an ordered list of maps.  By default, the maps are ordered by
-their observation date, from earliest to latest date. A `~sunpy.map.MapSequence` can be
-created by supplying multiple existing maps: ::
+A `~sunpy.map.MapSequence` is an ordered list of maps.
+By default, the maps are ordered by their observation date, from earliest to latest date.
+A `~sunpy.map.MapSequence` can be created by supplying multiple existing maps: ::
 
     >>> map1 = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
     >>> map2 = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE)  # doctest: +REMOTE_DATA
@@ -416,139 +400,109 @@ or by providing a directory full of image files: ::
 
     >>> mc = sunpy.map.Map('path/to/my/files/*.fits', sequence=True)   #  doctest: +SKIP
 
-The earliest map in the MapSequence can be accessed by indexing the maps
-list: ::
+The earliest map in the MapSequence can be accessed by indexing the maps list: ::
 
     >>> mc.maps[0]   # doctest: +SKIP
 
-MapSequences can hold maps that have different shapes.  To test if all the
-maps in a `~sunpy.map.MapSequence` have the same shape: ::
+MapSequences can hold maps that have different shapes.
+To test if all the maps in a `~sunpy.map.MapSequence` have the same shape: ::
 
     >>> mc.all_maps_same_shape()  # doctest: +REMOTE_DATA
     True
 
-It is often useful to return the image data in a `~sunpy.map.MapSequence` as a single
-three dimensional NumPy `~numpy.ndarray`: ::
+It is often useful to return the image data in a `~sunpy.map.MapSequence` as a single three dimensional NumPy `~numpy.ndarray`: ::
 
     >>> mc.as_array()   # doctest: +SKIP
 
-Note that an array is returned only if all the maps have the same
-shape.  If this is not true, a ``ValueError`` is returned.  If all the
-maps have nx pixels in the x-direction, and ny pixels in the y-direction,
-and there are n maps in the MapSequence, the returned `~numpy.ndarray` array
-has shape (ny, nx, n).  The data of the first map in the `~sunpy.map.MapSequence`
-appears in the `~numpy.ndarray` in position ``[:, :, 0]``, the data of second map in
-position ``[:, :, 1]``, and so on.  The order of maps in the `~sunpy.map.MapSequence` is
-reproduced in the returned `~numpy.ndarray`.
+Note that an array is returned only if all the maps have the same shape.
+If this is not true, a ``ValueError`` is returned.
+If all the maps have nx pixels in the x-direction, and ny pixels in the y-direction, and there are n maps in the MapSequence, the returned `~numpy.ndarray` array has shape (ny, nx, n).
+The data of the first map in the `~sunpy.map.MapSequence` appears in the `~numpy.ndarray` in position ``[:, :, 0]``, the data of second map in position ``[:, :, 1]``, and so on.
+The order of maps in the `~sunpy.map.MapSequence` is reproduced in the returned `~numpy.ndarray`.
 
 The metadata from each map can be obtained using: ::
 
     >>> mc.all_meta()   # doctest: +SKIP
 
-This returns a list of map meta objects that have the same order as
-the maps in the `~sunpy.map.MapSequence`.
+This returns a list of map meta objects that have the same order as the maps in the `~sunpy.map.MapSequence`.
 
 
 6.1 Coalignment of Map Sequences
 --------------------------------
 
-A typical data preparation step when dealing with time series of images is to
-coalign images taken at different times so that features in different images
-remain in the same place.  A common approach to this problem is
-to take a representative template that contains the features you are interested
-in, and match that to your images.  The location of the best match tells you
-where the template is in your image.  The images are then shifted to the
-location of the best match.
+A typical data preparation step when dealing with time series of images is to coalign images taken at different times so that features in different images remain in the same place.
+A common approach to this problem is to take a representative template that contains the features you are interested in, and match that to your images.
+The location of the best match tells you where the template is in your image.
+The images are then shifted to the location of the best match.
 
 SunPy provides a function to coalign the maps inside the `~sunpy.map.MapSequence`.
-This function requires the installation of the
-`scikit-image library <https://scikit-image.org/>`_, a commonly used image processing library.
-To coalign a `~sunpy.map.MapSequence`, simply import
-the function and apply it to your `~sunpy.map.MapSequence`: ::
+This function requires the installation of the `scikit-image library <https://scikit-image.org/>`_, a commonly used image processing library.
+To coalign a `~sunpy.map.MapSequence`, simply import the function and apply it to your `~sunpy.map.MapSequence`: ::
 
     >>> from sunpy.image.coalignment import mapsequence_coalign_by_match_template
     >>> coaligned = mapsequence_coalign_by_match_template(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
 
-This will return a new `~sunpy.map.MapSequence`, coaligned to a template extracted from the
-center of the first map in the `~sunpy.map.MapSequence`, with the map dimensions clipped as
-required.  The coalignment algorithm provides many more options for handling
-the coalignment of `~sunpy.map.MapSequence`. Type: ::
+This will return a new `~sunpy.map.MapSequence`, coaligned to a template extracted from the center of the first map in the `~sunpy.map.MapSequence`, with the map dimensions clipped as required.
+The coalignment algorithm provides many more options for handling the coalignment of `~sunpy.map.MapSequence`.
+Type: ::
 
     >>> help(mapsequence_coalign_by_match_template)   # doctest: +SKIP
 
 for a full list of options and functionality.
 
-If you want to calculate the shifts required to compensate for solar
-rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use: ::
+If you want to calculate the shifts required to compensate for solar rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use: ::
 
     >>> from sunpy.image.coalignment import calculate_match_template_shift
     >>> shifts = calculate_match_template_shift(mc)  # doctest: +REMOTE_DATA,+IGNORE_WARNINGS
 
 This is the algorithm used by the coalignment function to calculate the shifts.
 See `~sunpy.image.coalignment.calculate_match_template_shift` to learn more about its features.
-Shifts calculated using calculate_match_template_shift can be passed directly
-to the coalignment function.
+Shifts calculated using calculate_match_template_shift can be passed directly to the coalignment function.
 
-For similar examples, see the `Combing, Co-aligning, and Reprojecting Images <https://docs.sunpy.org/en/stable/generated/gallery/index.html#combining-co-aligning-and-reprojecting-images>`_
-section of the Example Gallery.
+For similar examples, see the `Combining, Co-aligning, and Reprojecting Images <https://docs.sunpy.org/en/stable/generated/gallery/index.html#combining-co-aligning-and-reprojecting-images>`_ section of the Example Gallery.
 
 
 6.2 Compensating for solar rotation in Map Sequences
 ----------------------------------------------------
 
-A typical preparation step when dealing with a time series of solar
-image data is to shift the images so that features do not appear
-to move across the field of view.  This requires accounting for
-the `differential rotation <https://en.wikipedia.org/wiki/Solar_rotation>`_ of the Sun
-(solar features at the equator rotate faster than features at
-the poles).
+A typical preparation step when dealing with a time series of solar image data is to shift the images so that features do not appear to move across the field of view.
+This requires accounting for the `differential rotation <https://en.wikipedia.org/wiki/Solar_rotation>`_ of the Sun (solar features at the equator rotate faster than features at the poles).
 
-SunPy provides a function to shift images in a `~sunpy.map.MapSequence` according to the solar
-differential rotation calculated at the latitude of the center of the
-field of view.  The function does not *differentially* rotate the image.  Instead,
-this function is useful for de-rotating images when the effects of
-differential rotation in the `~sunpy.map.MapSequence` can be ignored. For example, it is useful
-if the spatial extent of the image is small or the duration of the
-`~sunpy.map.MapSequence` is brief (deciding on what 'small' or 'brief' means depends on your
-application).
+SunPy provides a function to shift images in a `~sunpy.map.MapSequence` according to the solar differential rotation calculated at the latitude of the center of the field of view.
+The function does not *differentially* rotate the image.
+Instead, this function is useful for de-rotating images when the effects of differential rotation in the `~sunpy.map.MapSequence` can be ignored.
+For example, it is useful if the spatial extent of the image is small or the duration of the `~sunpy.map.MapSequence` is brief (deciding on what 'small' or 'brief' means depends on your application).
 
-To apply this form of solar de-rotation to a `~sunpy.map.MapSequence`, import the
-function and apply it to your `~sunpy.map.MapSequence`: ::
+To apply this form of solar de-rotation to a `~sunpy.map.MapSequence`, import the function and apply it to your `~sunpy.map.MapSequence`: ::
 
     >>> from sunpy.physics.solar_rotation import mapsequence_solar_derotate
     >>> derotated = mapsequence_solar_derotate(mc)  # doctest: +SKIP
 
 For more info see `~sunpy.physics.solar_rotation.mapsequence_solar_derotate`.
 
-If you want to calculate the shifts required to compensate for solar
-rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use: ::
+If you want to calculate the shifts required to compensate for solar rotation relative to the first map in the `~sunpy.map.MapSequence` without applying them, use: ::
 
     >>> from sunpy.physics.solar_rotation import calculate_solar_rotate_shift
     >>> shifts = calculate_solar_rotate_shift(mc)  # doctest: +SKIP
 
-Please consult the docstring of the `~sunpy.image.coalignment.mapsequence_coalign_by_match_template` function
-to learn more about the features of this function.
+Please consult the docstring of the `~sunpy.image.coalignment.mapsequence_coalign_by_match_template` function to learn more about the features of this function.
 
-See the `Differential Rotation of the Sun <https://docs.sunpy.org/en/stable/generated/gallery/index.html#differential-rotation-of-the-sun>`_
-section of the Example Gallery for examples using `~sunpy.coordinates.metaframes.RotatedSunFrame`.
+See the `Differential Rotation of the Sun <https://docs.sunpy.org/en/stable/generated/gallery/index.html#differential-rotation-of-the-sun>`_ section of the Example Gallery for examples using `~sunpy.coordinates.metaframes.RotatedSunFrame`.
+
 
 .. _custom-maps:
 
 7. Creating Custom Maps
 =======================
 
-It is also possible to create Maps using custom data (e.g. from a simulation or an observation
-from a data source that is not explicitly supported in SunPy). To do this, you need to provide
-`sunpy.map.Map` with both the data array as well as appropriate
-meta information. The meta information informs `sunpy.map.Map`
-of the correct coordinate information associated with the data array and should be provided to
-`sunpy.map.Map` in the form of a header as a `dict` or `~sunpy.util.MetaDict`.
+It is also possible to create Maps using custom data (e.g. from a simulation or an observation from a data source that is not explicitly supported in SunPy).
+To do this, you need to provide `sunpy.map.Map` with both the data array as well as appropriate meta information.
+The meta information informs `sunpy.map.Map` of the correct coordinate information associated with the data array and should be provided to `sunpy.map.Map` in the form of a header as a `dict` or `~sunpy.util.MetaDict`.
 See this `example <https://docs.sunpy.org/en/latest/generated/gallery/map/map_from_numpy_array.html>`_ for a brief demonstration of generating a Map from a data array.
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`_.
-SunPy provides a Map header helper function to assist in creating a header that
-contains the correct meta information. This includes a `~sunpy.map.meta_keywords` function
-that will return a `dict` of all the current meta keywords and their descriptions.
+SunPy provides a Map header helper function to assist in creating a header that contains the correct meta information.
+This includes a `~sunpy.map.meta_keywords` function that will return a `dict` of all the current meta keywords and their descriptions.
 
     >>> from sunpy.map import meta_keywords
 
@@ -558,17 +512,13 @@ that will return a `dict` of all the current meta keywords and their description
      'crval1': 'Coordinate value at reference point on naxis1 **required'
      ...
 
-There is also a utility function
-`~sunpy.map.make_fitswcs_header` that will return a header with the
-appropiate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames`
-is provided. The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame,
-reference coordinate, and observer location. This function returns a `sunpy.util.MetaDict`.
+There is also a utility function `~sunpy.map.make_fitswcs_header` that will return a header with the appropiate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
+The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
+This function returns a `sunpy.util.MetaDict`.
 The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.
 
-The `~sunpy.map.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale``
-that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial
-scale of the pixels, respectively. If neither of these are given their values default to the center of the data array and 1 arcsec,
-respectively.
+The `~sunpy.map.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
+If neither of these are given their values default to the center of the data array and 1 arcsec, respectively.
 
 Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`: ::
 
@@ -612,10 +562,8 @@ Here's an example of creating a header from some generic data and an `astropy.co
     rsun_obs: 965.3829548285768
 
 
-From this we can see now that the function returned a `sunpy.util.MetaDict` that populated
-the standard FITS keywords with information provided by the passed `astropy.coordinates.SkyCoord`,
-and the data array. Since the ``reference_pixel`` and keywords were not passed in the example above, the
-values of ``crpix`` and ``cdelt`` were set to the default values.
+From this we can see now that the function returned a `sunpy.util.MetaDict` that populated the standard FITS keywords with information provided by the passed `astropy.coordinates.SkyCoord`, and the data array.
+Since the ``reference_pixel`` and keywords were not passed in the example above, the values of ``crpix`` and ``cdelt`` were set to the default values.
 
 These keywords can be passed to the function in the form of an `astropy.units.Quantity` with associated units.
 Here's another example of passing ``reference_pixel`` and ``scale`` to the function: ::
@@ -653,12 +601,9 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
     pc2_2: 1.0
     rsun_obs: 965.3829548285768
 
-As we can see, a list of WCS and observer meta information is contained within the generated headers,
-however we may want to include other meta information including the observatory name, the wavelength and
-waveunit of the observation. Any of the keywords listed in ``header_helper.meta_keywords`` can be passed
-to the `~sunpy.map.make_fitswcs_header` and will then populate the returned MetaDict header.
-Furthermore, the following observation keywords can be passed to the `~sunpy.map.make_fitswcs_header`
-function and will be translated to the FITS standard: ``observtory``, ``instrument``,``telescope``, ``wavelength``, ``exposure``.
+As we can see, a list of WCS and observer meta information is contained within the generated headers, however we may want to include other meta information including the observatory name, the wavelength and waveunit of the observation.
+Any of the keywords listed in ``header_helper.meta_keywords`` can be passed to the `~sunpy.map.make_fitswcs_header` and will then populate the returned MetaDict header.
+Furthermore, the following observation keywords can be passed to the `~sunpy.map.make_fitswcs_header` function and will be translated to the FITS standard: ``observtory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
 
 An example of creating a header with these additional keywords: ::
 

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -292,7 +292,7 @@ You can also change the colormap for the Map itself:
 
 The normalization is set automatically so that all the data from minimum to maximum is displayed as best as possible.
 Just like the colormap, the default normalization can be changed through the ``plot_settings`` dictionary or directly for the individual plot by passing a keyword argument.
-               
+
 Alternate normalizations are available from `matplotlib <https://matplotlib.org/stable/tutorials/colors/colormapnorms.html>`__ and `astropy <https://docs.astropy.org/en/stable/visualization/normalization.html>`__.
 The following example shows the difference between a linear and logarithmic normalization on an AIA image.
 

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -14,19 +14,20 @@ functionality that a scientist would want. Therefore, a Map also contains a numb
 of methods such as resizing or grabbing a subview. See `~sunpy.map.mapbase.GenericMap`
 for summaries of all attributes and methods.
 
-:ref:`1. Creating Maps` and :ref:`2. Inspecting Maps` demonstrate how to create a Map object
-and view a summary of the data in the object. :ref:`3. Map Data` describes how data is stored
-and accessed in a Map, and :ref:`4. Plotting Maps` introduces some basics of visualizing Map
-data in SunPy. :ref:`5. Composite Maps` and :ref:`6. Map Sequences` detail how SunPy can handle
-multiple Maps from similar and different instruments. Lastly, :ref:`7. Creating Custom Maps`
+:ref:`creating-maps` and :ref:`inspecting-maps` demonstrate how to create a Map object
+and view a summary of the data in the object. :ref:`map-data` describes how data is stored
+and accessed in a Map, and :ref:`plotting-maps` introduces some basics of visualizing Map
+data in SunPy. :ref:`composite-maps` and :ref:`map-sequences` detail how SunPy can handle
+multiple Maps from similar and different instruments. Lastly, :ref:`custom-maps`
 shows how you can create Maps from data sources not supported in SunPy.
 
+.. _creating-maps:
 
 1. Creating Maps
 ================
 
 To make things easy, SunPy can download sample data which are used
-throughout the docs (see :doc:`/examples/acquiring_data/2011_06_07_sampledata_overview`).
+throughout the docs (see the `Sample data overview <https://docs.sunpy.org/en/latest/generated/gallery/acquiring_data/2011_06_07_sampledata_overview.html>`_).
 These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE``.
 To create a `~sunpy.map.Map` from a sample AIA image,
 type the following into your Python shell: ::
@@ -53,6 +54,7 @@ The `Acquiring Data <https://docs.sunpy.org/en/stable/generated/gallery/index.ht
 of the Example Gallery has several examples of retrieving data using the `~sunpy.net.Fido` tool. For more details,
 check out the :doc:`/guide/acquiring_data/fido` guide.
 
+.. _inspecting-maps:
 
 2. Inspecting Maps
 ==================
@@ -90,8 +92,9 @@ The metadata for the map is accessed by: ::
     >>> header = my_map.meta  # doctest: +REMOTE_DATA
 
 This references the metadata dictionary with the header information as read
-from the source file. If you need to modify Map metadata, see this `example <https://docs.sunpy.org/en/latest/generated/gallery/map/map_metadata_modification.html>`_ for a demonstration. 
+from the source file. If you need to modify Map metadata, see `Map metadata modification <https://docs.sunpy.org/en/latest/generated/gallery/map/map_metadata_modification.html>`_ for a demonstration.
 
+.. _map-data:
 
 3. Map Data
 ===========
@@ -152,6 +155,7 @@ can be accessed through the data array directly. For example: ::
     >>> my_map.data.std()  # doctest: +REMOTE_DATA
     826.41016
 
+.. _plotting-maps:
 
 4. Plotting Maps
 ================
@@ -242,7 +246,7 @@ you would any other colormap: ::
 See `~sunpy.visualization.colormaps` for a plot of all available colormaps.
 
 If you want to override the built-in colormap, consider the following example
-which plots an AIA map using an EIT colormap: ::
+which plots an AIA map using an EIT colormap.
 
 .. plot::
     :include-source:
@@ -367,6 +371,7 @@ See the following two examples for applications of this technique:
 
 * `Finding and masking bright pixels <https://docs.sunpy.org/en/stable/generated/gallery/computer_vision_techniques/finding_masking_bright_pixels.html>`_
 
+.. _composite-maps:
 
 5. Composite Maps
 =================
@@ -394,6 +399,7 @@ and how to overlay HMI contours on an AIA map (without creating a composite map 
 
 For a more advanced tutorial on combining data from several maps, see `Creating a Full Sun Map with AIA and EUVI <https://docs.sunpy.org/en/stable/generated/gallery/map_transformations/reprojection_aia_euvi_mosaic.html>`_.
 
+.. _map-sequences:
 
 6. Map Sequences
 ================
@@ -526,6 +532,7 @@ to learn more about the features of this function.
 See the `Differential Rotation of the Sun <https://docs.sunpy.org/en/stable/generated/gallery/index.html#differential-rotation-of-the-sun>`_
 section of the Example Gallery for examples using `~sunpy.coordinates.metaframes.RotatedSunFrame`.
 
+.. _custom-maps:
 
 7. Creating Custom Maps
 =======================

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -4,7 +4,8 @@ Map Guide
 
 Map objects in **sunpy** are two-dimensional data associated with a coordinate system.
 This class offers many advantages over using packages such as `astropy.io.fits` to open 2D solar data in Python.
-**sunpy** Maps recognize data from 19 sources (see :doc:`/code_ref/map` for a complete list) and can provide instrument-specific information when plotting and even correct or add metadata when it is missing from the original file.
+**sunpy** Maps be used with any image with two spatial axes that has FITS standard compliant metadata.
+There are also 19 sources (see :doc:`/code_ref/map` for a complete list) that provide instrument-specific information when plotting and in some cases interpret missing metadata when it is missing from the original file.
 
 Part of the philosophy of the Map object is to provide most of the basic functionality that a scientist would want.
 Therefore, a Map also contains a number of methods such as resizing or grabbing a subview.
@@ -90,7 +91,7 @@ To get a quick look at your Map simply type:
 
 This will show a representation of the data as well as some of its associated attributes.
 Typing the above command in a Jupyter Notebook will show a rich HTML view of the table along with two plots of your data.
-The HTML view can also be accessed using the :func:`~sunpy.map.GenericMap.quicklook` function, which will open the view in your default browser.
+The HTML view can also be accessed using the :func:`~sunpy.map.GenericMap.quicklook` method, which will open the view in your default browser.
 
 A number of other attributes are also available.
 For example, the `~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`, `~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`).
@@ -126,7 +127,7 @@ To see if the metadata of a Map source has been modified, see :ref:`sphx_glr_gen
 ===========
 
 The data in a Map object is accessible through the `~sunpy.map.GenericMap.data` attribute.
-The data is implemented as a NumPy `~numpy.ndarray`.
+The data is stored as a NumPy `~numpy.ndarray`.
 For example, to get the 0th element in the array:
 
 .. code-block:: python
@@ -157,7 +158,7 @@ You can store the data of a `~sunpy.map.GenericMap` object in a separate `~numpy
     >>> var = my_map.data  # doctest: +REMOTE_DATA
     >>> var = my_map.data.copy()  # doctest: +REMOTE_DATA
 
-To create a complete copy of a Map object that is entirely independent of the original, use the built-in `copy.deepcopy` method:
+To create a complete copy of a Map object that is entirely independent of the original, use the built-in `copy.deepcopy` function:
 
 .. code-block:: python
 
@@ -198,8 +199,8 @@ To create a plot just type:
 
     >>> my_map.peek()   # doctest: +SKIP
 
-This will open a matplotlib plot on your screen.
-In addition, it is possible to grab the matplotlib axes object by using the `~sunpy.map.GenericMap.plot()` command.
+This will open a Matplotlib plot on your screen.
+In addition, it is possible to grab the Matplotlib Axes object by using the `~sunpy.map.GenericMap.plot()` command.
 This makes it possible to use the SunPy plot as the foundation for a more complicated figure.
 For more information about this and some examples see :ref:`plotting`.
 Check out the following foundational examples in the Example Gallery for plotting Maps:
@@ -232,8 +233,8 @@ For example, the following plot changes the default colormap to use an inverse G
     plt.colorbar()
     plt.show()
 
-You can view or make changes to the default settings through the ``sunpy.map.GenericMap.plot_settings`` dictionary.
-See :ref:`sphx_glr_generated_gallery_plotting_map_editcolormap.py` for an example of this method.
+You can also view or make changes to the default settings through the ``sunpy.map.GenericMap.plot_settings`` dictionary.
+See :ref:`sphx_glr_generated_gallery_plotting_map_editcolormap.py` for an example of this workflow for changing plot settings.
 
 
 4.2 Colormaps and Normalization
@@ -256,7 +257,7 @@ To see what colormaps are available:
     'goes-rsuvi284', 'goes-rsuvi304', 'sdoaia94', 'sdoaia131', 'sdoaia171',
     ...
 
-The **sunpy** colormaps are registered with matplotlib so you can grab them like you would any other colormap:
+The **sunpy** colormaps are registered with Matplotlib so you can grab them like you would any other colormap:
 
 .. code-block:: python
 
@@ -431,7 +432,7 @@ It is often useful to return the image data in a `~sunpy.map.MapSequence` as a s
     >>> mc_array = mc.as_array()   # doctest: +REMOTE_DATA
 
 Note that an array is returned only if all the maps have the same shape.
-If this is not true, a `ValueError` is returned.
+If this is not true, a `ValueError` is raised.
 If all the maps have nx pixels in the x-direction, and ny pixels in the y-direction, and there are n maps in the MapSequence, the returned `~numpy.ndarray` array has shape (ny, nx, n).
 The data of the first map in the `~sunpy.map.MapSequence` appears in the `~numpy.ndarray` in position ``[:, :, 0]``, the data of second map in position ``[:, :, 1]``, and so on.
 The order of maps in the `~sunpy.map.MapSequence` is reproduced in the returned `~numpy.ndarray`.

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -3,7 +3,7 @@ TimeSeries Guide
 ****************
 
 Time series data are a fundamental part of many data analysis projects in heliophysics as well as other areas.
-SunPy provides a TimeSeries object to handle this type of data.
+**sunpy** provides a TimeSeries object to handle this type of data.
 Much like the `~sunpy.map.Map` object, `~sunpy.timeseries` recognizes data from nine sources and provides instrument-specific information when plotting and similar metadata handling.
 For more information about TimeSeries, and what data sources are currently supported, check out :doc:`/code_ref/timeseries`.
 
@@ -14,24 +14,21 @@ For more information about TimeSeries, and what data sources are currently suppo
 :ref:`custom-timeseries` details how to create a TimeSeries object from a Pandas DataFrame or an Astropy Table.
 Lastly, :ref:`ts-metadata` describes how to view and extract information from the metadata.
 
-.. warning::
-
-   The TimeSeries supersedes the previous LightCurve object but does not implement data download methods.
-   To download TimeSeries data files use `sunpy.net`.
-
 .. _creating-timeseries:
 
 1. Creating a TimeSeries
 ========================
 
 A TimeSeries object can be created from local files.
-For convenience, SunPy can download several example timeseries of observational data.
+For convenience, **sunpy** can download several example timeseries of observational data.
 These files have names like ``sunpy.data.sample.EVE_TIMESERIES`` and ``sunpy.data.sample.GOES_XRS_TIMESERIES``.
-To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries`, type the following into your interactive Python shell: ::
+To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries`, type the following into your interactive Python shell:
+
+.. code-block:: python
 
     >>> import sunpy.timeseries as ts
     >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
-    >>> my_timeseries = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES, source='XRS')  # doctest: +REMOTE_DATA
+    >>> my_timeseries = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES)  # doctest: +REMOTE_DATA
 
 .. doctest-skip-all
 
@@ -39,16 +36,20 @@ This is calling the `~sunpy.timeseries.TimeSeries` factory to create a time seri
 Note that if you have not downloaded the data already you should get an error and some instruction on how to download the sample data.
 
 The variable ``my_timeseries`` is a :ref:`timeseries` object.
-To create one from a local GOES/XRS FITS file try the following: ::
+To create one from a local GOES/XRS FITS file try the following:
+
+.. code-block:: python
 
     >>> my_timeseries = ts.TimeSeries('/mydirectory/myts.fits', source='XRS')   # doctest: +SKIP
 
-SunPy will attempt to detect automatically the instrument source for most FITS files.
-However timeseries data are stored in a variety of file types (FITS, txt, csv) and formats, and so it is not always possible to detect the source.
+**sunpy** will attempt to detect automatically the instrument source for most FITS files.
+However timeseries data are stored in a variety of file types (FITS, txt, csv, CDF) and formats, and so it is not always possible to detect the source.
 For this reason, it is good practice to explicitly state the source for the file.
 SunPy ships with a number of known instrumental sources.
-If you would like SunPy to include another instrumental source please follow the `SunPy contribution guide <https://sunpy.org/contribute>`__.
-The `~sunpy.timeseries.TimeSeries` factory has the ability to make a list of TimeSeries objects using a list of filepaths, a folder or a glob, for example: ::
+If you would like **sunpy** to include another instrumental source see the `Newcomers' Guide <https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html>`__.
+The `~sunpy.timeseries.TimeSeries` factory has the ability to make a list of TimeSeries objects using a list of filepaths, a folder or a glob, for example:
+
+.. code-block:: python
 
     >>> my_ts_list = ts.TimeSeries('filepath1', 'filepath2', source='XRS')   # doctest: +SKIP
     >>> my_ts_list = ts.TimeSeries('/goesdirectory/', source='XRS')   # doctest: +SKIP
@@ -62,7 +63,9 @@ For this reason, all the files should be from that same source for the `~sunpy.t
 
 You can create a single time series from multiple files for a given source using the keyword argument ``concatenate=True``, such as:
 
-    >>> my_timeseries = ts.TimeSeries('/mydirectory/myts1.fits', '/mydirectory/myts2.fits', source='XRS', concatenate=True)  # doctest: +SKIP
+.. code-block:: python
+
+    >>> my_ts = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES, sunpy.data.sample.GOES_XRS_TIMESERIES, source='XRS', concatenate=True)  # doctest: +REMOTE_DATA
 
 Note these must all be from the same source if using `~sunpy.timeseries.GenericTimeSeries.concatenate` from within the TimeSeries factory.
 However, if time series `~sunpy.timeseries.GenericTimeSeries.concatenate` method can be used to make a single time series from multiple TimeSeries from different sources once they are already in the form of TimeSeries objects.
@@ -72,28 +75,63 @@ However, if time series `~sunpy.timeseries.GenericTimeSeries.concatenate` method
 2. Inspecting TimeSeries & Accessing the Data
 =============================================
 
-A time series holds both data as well as meta data and units data.
-For a quick look at a TimeSeries, type: ::
+A time series holds both data as well as metadata and unit data.
+For a quick look at a TimeSeries, type:
 
-    >>> my_timeseries  # doctest: +SKIP
+.. code-block:: python
 
-This will show a table of information taken from the metadata and a preview of your data.
+    >>> my_timeseries  # doctest: +REMOTE_DATA
+    <sunpy.timeseries.sources.goes.XRSTimeSeries object at 0x000002168FDCE280>
+    SunPy TimeSeries
+    ----------------
+    Observatory:		 GOES-15
+    Instrument:		 <a href=https://www.swpc.noaa.gov/products/goes-x-ray-flux target="_blank">X-ray Detector</a>
+    Channel(s):		 xrsa<br>xrsb
+    Start Date:		 2011-06-07 00:00:00
+    End Date:		 2011-06-07 23:59:58
+    Center Date:		 2011-06-07 11:59:58
+    Resolution:		 2.048 s
+    Samples per Channel:		 42177
+    Data Range(s):		 xrsa   3.64E-06<br>xrsb   2.54E-05
+    Units:		 W / m2
+                                           xrsa          xrsb
+    2011-06-06 23:59:59.961999893  1.000000e-09  1.887100e-07
+    2011-06-07 00:00:02.008999944  1.000000e-09  1.834600e-07
+    2011-06-07 00:00:04.058999896  1.000000e-09  1.860900e-07
+    2011-06-07 00:00:06.104999900  1.000000e-09  1.808400e-07
+    2011-06-07 00:00:08.151999950  1.000000e-09  1.860900e-07
+    ...                                     ...           ...
+    2011-06-07 23:59:49.441999912  1.000000e-09  1.624800e-07
+    2011-06-07 23:59:51.488999844  1.000000e-09  1.624800e-07
+    2011-06-07 23:59:53.538999915  1.000000e-09  1.598500e-07
+    2011-06-07 23:59:55.584999919  1.000000e-09  1.624800e-07
+    2011-06-07 23:59:57.631999850  1.000000e-09  1.598500e-07
+
+    [42177 rows x 2 columns]
+
+This shows a table of information taken from the metadata and a preview of your data.
 If you execute this command in a Jupyter Notebook, a rich HTML version of this quick look will be shown that includes plots of the data.
-Alternatively, the `~sunpy.timeseries.GenericTimeSeries.quicklook` command will show the HTML view in your default browser.
-The meta data for the time series is accessed by: ::
+Alternatively, the :func:`~sunpy.timeseries.GenericTimeSeries.quicklook` command will show the HTML view in your default browser.
+The metadata for the time series is accessed by:
+
+.. code-block:: python
 
     >>> header = my_timeseries.meta
 
 This references the `~sunpy.timeseries.TimeSeriesMetaData` object with the header information as read from the source files.
 A word of caution: many data sources provide little to no meta data so this variable might be empty.
 The meta data is described in more detail later in this guide.
-Similarly there are properties for getting `~sunpy.timeseries.GenericTimeSeries.columns` as a list of strings, `~sunpy.timeseries.GenericTimeSeries.index` values and `~sunpy.timeseries.GenericTimeSeries.time_range` of the data.
+Similarly there are properties for getting `~sunpy.timeseries.GenericTimeSeries.columns` as a list of strings, `~sunpy.timeseries.GenericTimeSeries.time` values and `~sunpy.timeseries.GenericTimeSeries.time_range` of the data.
 The actual data in a SunPy TimeSeries object is accessible through the `~sunpy.timeseries.GenericTimeSeries.data` attribute.
-The data is implemented as a Pandas `~pandas.DataFrame`, so to get a look at what data you have available use: ::
+The data is implemented as a Pandas `~pandas.DataFrame`, so to get a look at what data you have available use:
+
+.. code-block:: python
 
     >>> my_timeseries.data  # doctest: +SKIP
 
-You can also get a quick overview of that data using: ::
+You can also get a quick overview of that data using:
+
+.. code-block:: python
 
     >>> my_timeseries.data.info()
     <class 'pandas.core.frame.DataFrame'>
@@ -105,30 +143,40 @@ You can also get a quick overview of that data using: ::
     memory usage: 659.0 KB
 
 Time series are columnar data so to get at a particular datum you need to first index the column, then the element you want.
-To get the names of the available columns: ::
+To get the names of the available columns:
+
+.. code-block:: python
 
     >>> my_timeseries.data.columns
     Index(['xrsa', 'xrsb'], dtype='object')
 
-You can access the 0th element in the column ``xrsa`` with: ::
+You can access the 0th element in the column ``xrsa`` with:
+
+.. code-block:: python
 
     >>> my_timeseries.data['xrsa'][0]
     1e-09
 
-You can also grab all of the data at a particular time: ::
+You can also grab all of the data at a particular time:
+
+.. code-block:: python
 
     >>> my_timeseries.data['xrsa']['2011-06-07 00:00:02.008999']
     1e-09
 
 This will return a list of entries with times that match the accuracy of the time you provide.
-You can consider the data as x or y values: ::
+You can consider the data as x or y values:
+
+.. code-block:: python
 
     >>> x = my_timeseries.data.index
     >>> y = my_timeseries.data.values
 
-You can read more about indexing at the `Pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`_.
+You can read more about indexing at the `Pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`__.
 
-A TimeSeries can also return an Astropy `~astropy.units.quantity.Quantity` for a given column using the `~sunpy.timeseries.GenericTimeSeries.quantity` method, this uses the values stored in the data and units stored in the units dictionary to determine the `~astropy.units.quantity.Quantity`: ::
+A TimeSeries can also return an Astropy `~astropy.units.quantity.Quantity` for a given column using the `~sunpy.timeseries.GenericTimeSeries.quantity` method, this uses the values stored in the data and units stored in the units dictionary to determine the `~astropy.units.quantity.Quantity`:
+
+.. code-block:: python
 
     >>> quantity = my_timeseries.quantity('xrsa')
 
@@ -137,7 +185,7 @@ A TimeSeries can also return an Astropy `~astropy.units.quantity.Quantity` for a
 3. Plotting TimeSeries
 ======================
 
-The SunPy TimeSeries object has its own built-in plot methods so that it is easy to quickly view your time series.
+The **sunpy** TimeSeries object has its own built-in plot methods so that it is easy to quickly view your time series.
 To create a plot just type:
 
 .. plot::
@@ -153,7 +201,7 @@ This will open a Matplotlib plot on your screen.
 If you want to save this to a PNG file you can do so from the Matplotlib GUI.
 
 In addition, to enable users to modify the plot it is possible to use the `~sunpy.timeseries.GenericTimeSeries.plot` command.
-This makes it possible to use the SunPy plot as the foundation for a more complicated figure:
+This makes it possible to use the **sunpy** plot as the foundation for a more complicated figure:
 
 .. plot::
    :include-source:
@@ -177,24 +225,33 @@ This makes it possible to use the SunPy plot as the foundation for a more compli
 4.1 Modifying the Data
 ----------------------
 
-Since the timeseries data is stored as a Pandas `~pandas.DataFrame` you can easily modify the data directly using all of the usual Pandas methods: for example, you can modify a single cells value using: ::
+Since the timeseries data is stored as a Pandas `~pandas.DataFrame` you can use all of the usual Pandas methods.
+For example, you can modify a single value using:
+
+.. code-block:: python
 
     >>> my_timeseries.data['xrsa'][0] = 0.1
 
-Or similarly using a datetime values (as string or datetime object): ::
+Or similarly using a datetime values (as string or datetime object):
+
+.. code-block:: python
 
     >>> my_timeseries.data['xrsa']['2012-06-01 23:59:45.061999'] = 1
 
-You can even change all the values for a given time: ::
+You can even change all the values for a given time:
+
+.. code-block:: python
 
     >>> my_timeseries.data['xrsa']['2012-06-01 00:00'] = 1
 
 Note, you will need to be careful to consider units when modifying the TimeSeries data directly.
-For further details about editing Pandas DataFames you can read the `Pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`_.
+For further details about editing Pandas DataFames you can read the `Pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`__.
 
 Additionally the TimeSeries provides the `~sunpy.timeseries.GenericTimeSeries.add_column` method which will either add a new column or update a current column if the colname is already present.
 This can take numpy array or preferably an Astropy `~astropy.units.quantity.Quantity` value.
-For example: ::
+For example:
+
+.. code-block:: python
 
     >>> values = u.Quantity(my_timeseries.data['xrsa'].values[:-2], my_timeseries.units['xrsa']) * 20.5
     >>> my_timeseries.add_column('new col', values)
@@ -208,7 +265,9 @@ Caution should be taken when adding a new column because this column won't have 
 
 It is often useful to truncate an existing TimeSeries object to retain a specific time range.
 This is easily achieved by using the `~sunpy.timeseries.GenericTimeSeries.truncate` method.
-For example, to trim our GOES data into a period of interest use: ::
+For example, to trim our GOES data into a period of interest use:
+
+.. code-block:: python
 
     >>> from sunpy.time import TimeRange
     >>> tr = TimeRange('2012-06-01 05:00','2012-06-01 06:30')
@@ -216,7 +275,9 @@ For example, to trim our GOES data into a period of interest use: ::
 
 This takes a number of different arguments, such as the start and end dates (as datetime or string objects) or a `~sunpy.time.TimeRange` as used above.
 Note that the truncated TimeSeries will have a truncated `~sunpy.timeseries.TimeSeriesMetaData` object, which may include dropping metadata entries for data totally cut out from the TimeSeries.
-If you want to truncate using slice-like values you can, for example taking every 2nd value from 0 to 10000 can be done using: ::
+If you want to truncate using slice-like values you can, for example taking every 2nd value from 0 to 10000 can be done using:
+
+.. code-block:: python
 
     >>> my_timeseries_trunc = my_timeseries.truncate(0,100000,2)
 
@@ -226,17 +287,21 @@ Caution should be used when removing values from the data manually, the TimeSeri
 --------------------------------------------------
 
 Because the data is stored in a Pandas `~pandas.DataFrame` object you can manipulate it using normal Pandas methods, such as the `~pandas.DataFrame.resample` method.
-To downsample you can use: ::
+To downsample you can use:
+
+.. code-block:: python
 
     >>> downsampled_dataframe = my_timeseries_trunc.data.resample('10T').mean()
 
 Note, here ``10T`` means sample every 10 minutes and 'mean' is the method used to combine the data.
 Alternatively the sum method is often used.
-You can also upsample, such as: ::
+You can also upsample, such as:
+
+.. code-block:: python
 
     >>> upsampled_data = my_timeseries_trunc.data.resample('30S').ffill()
 
-Note, here we upsample to 30 second intervals using ``30S`` and use the pandas fill-forward method.
+Note, here we upsample to 30 second intervals using ``30S`` and use the Pandas fill-forward method.
 Alternatively the back-fill method could be used.
 Caution should be used when resampling the data, the TimeSeries can't guarantee Astropy Units are correctly preserved when you interact with the data directly.
 
@@ -245,23 +310,31 @@ Caution should be used when resampling the data, the TimeSeries can't guarantee 
 
 It's common to want to combine a number of TimeSeries together into a single TimeSeries.
 In the simplest scenario this is to combine data from a single source over several time ranges, for example if you wanted to combine the daily GOES data to get a week or more of constant data in one TimeSeries.
-This can be performed using the TimeSeries factory with the ``concatenate=True`` keyword argument: ::
+This can be performed using the TimeSeries factory with the ``concatenate=True`` keyword argument:
+
+.. code-block:: python
 
     >>> concatenated_timeseries = sunpy.timeseries.TimeSeries(filepath1, filepath2, source='XRS', concatenate=True)  # doctest: +SKIP
 
 Note, you can list any number of files, or a folder or use a glob to select the input files to be concatenated.
 It is possible to concatenate two TimeSeries after creating them with the factory using the `~sunpy.timeseries.GenericTimeSeries.concatenate` method.
-For example: ::
+For example:
+
+.. code-block:: python
 
     >>> concatenated_timeseries = goes_timeseries_1.concatenate(goes_timeseries_2)  # doctest: +SKIP
 
 This will result in a TimeSeries identical to if you used the factory to create it in one step.
 A limitation of the TimeSeries class is that often it is not easy to determine the source observatory/instrument of a file, generally because the file formats used vary depending on the scientific working groups, thus some sources need to be explicitly stated (as a keyword argument) and so it is not possible to concatenate files from multiple sources with the factory.
-To do this you can still use the `~sunpy.timeseries.GenericTimeSeries.concatenate` method, which will create a new TimeSeries with all the rows and columns of the source and concatenated TimeSeries in one: ::
+To do this you can still use the `~sunpy.timeseries.GenericTimeSeries.concatenate` method, which will create a new TimeSeries with all the rows and columns of the source and concatenated TimeSeries in one:
+
+.. code-block:: python
 
     >>> concatenated_timeseries = goes_timeseries.concatenate(eve_timeseries)  # doctest: +SKIP
 
-Note that the more complex `~sunpy.timeseries.TimeSeriesMetaData` object now has 2 entries and shows details on both: ::
+Note that the more complex `~sunpy.timeseries.TimeSeriesMetaData` object now has 2 entries and shows details on both:
+
+.. code-block:: python
 
     >>> concatenated_timeseries.meta  # doctest: +SKIP
 
@@ -272,12 +345,16 @@ The metadata object is described in more detail in the next section.
 -----------------------------------------------
 
 If you want to take the data from your TimeSeries and use it as a `~astropy.table.Table` this can be done using the `~sunpy.timeseries.GenericTimeSeries.to_table` method.
-For example: ::
+For example:
+
+.. code-block:: python
 
     >>> table = my_timeseries_trunc.to_table()
 
 Note that this `~astropy.table.Table` will contain a mixin column for containing the Astropy `~astropy.time.Time` object representing the index, it will also add the relevant units to the columns.
-One of the most useful reasons for doing this is that Astropy `~sunpy.timeseries.GenericTimeSeries.to_table` objects have some very nice options for viewing the data, including the basic console view: ::
+One of the most useful reasons for doing this is that Astropy `~sunpy.timeseries.GenericTimeSeries.to_table` objects have some very nice options for viewing the data, including the basic console view:
+
+.. code-block:: python
 
     >>> table
     <Table length=21089>
@@ -306,7 +383,9 @@ One of the most useful reasons for doing this is that Astropy `~sunpy.timeseries
     2011-06-07T23:59:53.538999000   1e-09 1.5985e-07
     2011-06-07T23:59:57.631999000   1e-09 1.5985e-07
 
-and the more sophisticated browser view using the `~astropy.table.Table.show_in_browser` method: ::
+and the more sophisticated browser view using the `~astropy.table.Table.show_in_browser` method:
+
+.. code-block:: python
 
     >>> table.show_in_browser(jsviewer=True)  # doctest: +SKIP
 
@@ -325,37 +404,45 @@ You can use the factory to create a `~sunpy.timeseries.GenericTimeSeries` from a
 
 A TimeSeries object must be supplied with some data when it is created.
 The data can either be in your current Python session, in a local file, or in a remote file.
-Let's create some data and pass it into a TimeSeries object: ::
+Let's create some data and pass it into a TimeSeries object:
+
+.. code-block:: python
 
     >>> import numpy as np
     >>> intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
 
-The first line imports the numpy module used to create and store the data.
-The second line creates a basic numpy array of values representing a sine wave.
+This creates a basic numpy array of values representing a sine wave.
 We can use this array along with a suitable time storing object (such as Astropy `~astropy.time` or a list of `datetime` objects) to make a Pandas `~pandas.DataFrame`.
-A suitable list of times must contain the same number of values as the data, this can be created using: ::
+A suitable list of times must contain the same number of values as the data, this can be created using:
+
+.. code-block:: python
 
     >>> import datetime
     >>> base = datetime.datetime.today()
     >>> times = [base - datetime.timedelta(minutes=x) for x in range(24*60, 0, -1)]
 
-The Pandas `~pandas.DataFrame` will use the dates list as the index: ::
+The Pandas `~pandas.DataFrame` will use the dates list as the index:
+
+.. code-block:: python
 
     >>> from pandas import DataFrame
     >>> data = DataFrame(intensity, index=times, columns=['intensity'])
 
-This `~pandas.DataFrame` can then be used to construct a TimeSeries: ::
+This `~pandas.DataFrame` can then be used to construct a TimeSeries:
+
+.. code-block:: python
 
     >>> import sunpy.timeseries as ts
     >>> ts_custom = ts.TimeSeries(data)
 
-Furthermore we could specify the metadata/header and units of this time series by sending them as arguments to the factory: ::
+Furthermore, we could specify the metadata/header and units of this time series by sending them as arguments to the factory:
 
-    >>> from collections import OrderedDict
+.. code-block:: python
+
     >>> import astropy.units as u
 
-    >>> meta = OrderedDict({'key':'value'})
-    >>> units = OrderedDict([('intensity', u.W/u.m**2)])
+    >>> meta = {'key':'value'}
+    >>> units = {'intensity', u.W/u.m**2}
     >>> ts_custom = ts.TimeSeries(data, meta, units)
 
 5.2 Creating Custom TimeSeries from an Astropy Table
@@ -363,7 +450,9 @@ Furthermore we could specify the metadata/header and units of this time series b
 
 A Pandas `~pandas.DataFrame` is the underlying object used to store the data within a TimeSeries, so the above example is the most lightweight to create a custom TimeSeries, but being scientific data it will often be more convenient to use an Astropy `~astropy.table.Table` and let the factory convert this.
 An advantage of this method is it allows you to include metadata and Astropy `~astropy.units.quantity.Quantity` values, which are both supported in tables, without additional arguments.
-For example: ::
+For example:
+
+.. code-block:: python
 
     >>> import datetime
     >>> from astropy.time import Time
@@ -379,9 +468,11 @@ For example: ::
     >>> ts_table = ts.TimeSeries(table)
 
 Note that due to the properties of the `~astropy.time.Time` object, this will be a mixin column which since it is a single object, limits the versatility of the `~astropy.table.Table` a little.
-For more on mixin columns see the `Astropy docs <https://docs.astropy.org/en/stable/table/mixin_columns.html>`_.
+For more on mixin columns see the `Astropy docs <https://docs.astropy.org/en/stable/table/mixin_columns.html>`__.
 The units will be taken from the table quantities for each column, the metadata will simply be the table.meta dictionary.
-You can also explicitly add metadata and units, these will be added to the relevant dictionaries using the dictionary update method, with the explicit user-given values taking precedence.
+You can also explicitly add metadata and units, these will be added to the relevant dictionaries using the dictionary update method, with the explicit user-given values taking precedence:
+
+.. code-block:: python
 
     >>> from sunpy.util.metadata import MetaDict
     >>> from collections import OrderedDict
@@ -398,11 +489,15 @@ You can also explicitly add metadata and units, these will be added to the relev
 
 TimeSeries store metadata in a `~sunpy.timeseries.TimeSeriesMetaData` object, this object is designed to be able to store multiple basic `~sunpy.util.metadata.MetaDict` (case-insensitive ordered dictionary) objects and able to identify the relevant metadata for a given cell in the data.
 This enables a single TimeSeries to be created by combining/concatenating multiple TimeSeries source files together into one and to keep a reliable track of all the metadata relevant to each cell, column or row.
-The metadata can be accessed by: ::
+The metadata can be accessed by:
+
+.. code-block:: python
 
     >>> meta = my_timeseries.meta
 
-You can easily get an overview of the metadata, this will show you a basic representation of the metadata entries that are relevant to this TimeSeries. ::
+You can easily get an overview of the metadata, this will show you a basic representation of the metadata entries that are relevant to this TimeSeries.
+
+.. code-block:: python
 
     >>> meta
     |-------------------------------------------------------------------------------------------------|
@@ -428,11 +523,13 @@ Each time a TimeSeries is concatenated to the original a new set of rows and/or 
 Note that entries are ordered chronologically based on
 `~sunpy.time.timerange.TimeRange.start` and generally it's expected that no two
 TimeSeries will overlap on both columns and time range.
-For example it is not good practice for alternate row values in a single column to be relevant to different metadata entries as this would make it impossible to uniquely identify the metadata relevant to each cell.
+For example, it is not good practice for alternate row values in a single column to be relevant to different metadata entries as this would make it impossible to uniquely identify the metadata relevant to each cell.
 
 If you want the string that's printed then you can use the `~sunpy.timeseries.TimeSeriesMetaData.to_string` method.
 This has the advantage of having optional keyword arguments that allows you to set the depth (number of rows for each entry) and width (total number of characters wide) to better fit your output.
-For example: ::
+For example:
+
+.. code-block:: python
 
     >>> meta_str = meta.to_string(depth = 20, width=99)
 
@@ -443,7 +540,9 @@ Note that when truncating a `~sunpy.timeseries.TimeSeriesMetaData` object you wi
 You can also `~sunpy.timeseries.TimeSeriesMetaData.append` a new entry (as a tuple or list), which will add the entry in the correct chronological position.
 It is frequently necessary to locate the metadata for a given column, row or cell which can be uniquely identified by both, to do this you can use the `~sunpy.timeseries.TimeSeriesMetaData.find` method, by adding colname and/or time/row keyword arguments you get a `~sunpy.timeseries.TimeSeriesMetaData` object returned which contains only the relevant entries.
 You can then use the `~sunpy.timeseries.TimeSeriesMetaData.metas` property to get a list of just the relevant `~sunpy.util.metadata.MetaDict` objects.
-For example: ::
+For example:
+
+.. code-block:: python
 
     >>> tsmd_return = my_timeseries.meta.find(colname='xrsa', time='2012-06-01 00:00:33.904999')
     >>> tsmd_return.metas
@@ -453,16 +552,20 @@ Note, the colname and time filters are optional, but omitting both filters just 
 A common use case for the metadata is to find out the instrument/s that gathered the data and in this case you can use the `~sunpy.timeseries.TimeSeriesMetaData.get` method.
 This method takes a single key string or list of key strings with the optional filters and will search for any matching values.
 This method returns another `~sunpy.timeseries.TimeSeriesMetaData` object, but removes all unwanted key/value pairs.
-The result can be converted into a simple list of strings using the `~sunpy.timeseries.TimeSeriesMetaData.values` method: ::
+The result can be converted into a simple list of strings using the `~sunpy.timeseries.TimeSeriesMetaData.values` method:
+
+.. code-block:: python
 
     >>> tsmd_return = my_timeseries.meta.get('telescop', colname='xrsa')
     >>> tsmd_return.values()
     ['GOES 15']
 
 Note `~sunpy.timeseries.TimeSeriesMetaData.values` removes duplicate strings and sorts the returned list.
-You can update the values for these entries efficiently using the `~sunpy.timeseries.TimeSeriesMetaData.update` method which takes a dictionary argument and updates the values to each of the dictionaries that match the given colname and time filters, for example: ::
+You can update the values for these entries efficiently using the `~sunpy.timeseries.TimeSeriesMetaData.update` method which takes a dictionary argument and updates the values to each of the dictionaries that match the given colname and time filters, for example:
+
+.. code-block:: python
 
     >>> my_timeseries.meta.update({'telescop': 'G15'}, colname='xrsa', overwrite=True)
 
-Here we have to specify the overwrite=False keyword parameter to allow us to overwrite values for keys already present in the `~sunpy.util.metadata.MetaDict` objects, this helps protect the integrity of the original metadata and without this set (or with it set to False) you can still add new key/value pairs.
+Here we have to specify the ``overwrite=False`` keyword parameter to allow us to overwrite values for keys already present in the `~sunpy.util.metadata.MetaDict` objects, this helps protect the integrity of the original metadata and without this set (or with it set to False) you can still add new key/value pairs.
 Note that the `~sunpy.util.metadata.MetaDict` objects are both case-insensitive for key strings and have ordered entries, where possible the order is preserved when updating values.

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -2,40 +2,32 @@
 TimeSeries Guide
 ****************
 
-Time series data are a fundamental part of many data analysis projects
-in heliophysics as well as other areas. SunPy provides a TimeSeries
-object to handle this type of data. Much like the `~sunpy.map.Map` object,
-`~sunpy.timeseries` recognizes data from nine sources and provides
-instrument-specific information when plotting and similar metadata handling.
-For more information about TimeSeries, and what data sources are currently supported,
-check out :doc:`/code_ref/timeseries`.
+Time series data are a fundamental part of many data analysis projects in heliophysics as well as other areas.
+SunPy provides a TimeSeries object to handle this type of data.
+Much like the `~sunpy.map.Map` object, `~sunpy.timeseries` recognizes data from nine sources and provides instrument-specific information when plotting and similar metadata handling.
+For more information about TimeSeries, and what data sources are currently supported, check out :doc:`/code_ref/timeseries`.
 
 :ref:`creating-timeseries` describes how to create a TimeSeries object from single or multiple observational sources.
 :ref:`inspecting-timeseries` describes how to examine the data and metadata.
 :ref:`plotting-timeseries` outlines the basics of how SunPy will plot a TimeSeries object.
-:ref:`manipulating-timeseries` describes how to modify data, truncate a TimeSeries, down and up sample data,
-concatenate data, and create an Astropy Table from a TimeSeries.
-:ref:`custom-timeseries` details how to create a TimeSeries object from
-a Pandas DataFrame or an Astropy Table.
-Lastly, :ref:`ts-metadata` describes how to view and
-extract information from the metadata.
+:ref:`manipulating-timeseries` describes how to modify data, truncate a TimeSeries, down and up sample data, concatenate data, and create an Astropy Table from a TimeSeries.
+:ref:`custom-timeseries` details how to create a TimeSeries object from a Pandas DataFrame or an Astropy Table.
+Lastly, :ref:`ts-metadata` describes how to view and extract information from the metadata.
 
 .. warning::
 
-   The TimeSeries supersedes the previous LightCurve object but does not
-   implement data download methods. To download TimeSeries data files use
-   `sunpy.net`.
+   The TimeSeries supersedes the previous LightCurve object but does not implement data download methods.
+   To download TimeSeries data files use `sunpy.net`.
 
 .. _creating-timeseries:
 
 1. Creating a TimeSeries
 ========================
 
-A TimeSeries object can be created from local files.  For convenience, SunPy can
-download several example timeseries of observational data. These files have names like
-``sunpy.data.sample.EVE_TIMESERIES`` and ``sunpy.data.sample.GOES_XRS_TIMESERIES``.
-To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries`, type the
-following into your interactive Python shell: ::
+A TimeSeries object can be created from local files.
+For convenience, SunPy can download several example timeseries of observational data.
+These files have names like ``sunpy.data.sample.EVE_TIMESERIES`` and ``sunpy.data.sample.GOES_XRS_TIMESERIES``.
+To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries`, type the following into your interactive Python shell: ::
 
     >>> import sunpy.timeseries as ts
     >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
@@ -43,79 +35,61 @@ following into your interactive Python shell: ::
 
 .. doctest-skip-all
 
-This is calling the `~sunpy.timeseries.TimeSeries` factory to create a time
-series from a GOES XRS FITS file. Note that if you have not downloaded the data
-already you should get an error and some instruction on how to download the
-sample data.
+This is calling the `~sunpy.timeseries.TimeSeries` factory to create a time series from a GOES XRS FITS file.
+Note that if you have not downloaded the data already you should get an error and some instruction on how to download the sample data.
 
-The variable ``my_timeseries`` is a :ref:`timeseries` object. To create one from
-a local GOES/XRS FITS file try the following: ::
+The variable ``my_timeseries`` is a :ref:`timeseries` object.
+To create one from a local GOES/XRS FITS file try the following: ::
 
     >>> my_timeseries = ts.TimeSeries('/mydirectory/myts.fits', source='XRS')   # doctest: +SKIP
 
-SunPy will attempt to detect automatically the instrument source for most FITS
-files. However timeseries data are stored in a variety of file types (FITS, txt,
-csv) and formats, and so it is not always possible to detect the source. For
-this reason, it is good practice to explicitly state the source for the file.
-SunPy ships with a number of known instrumental sources.  If you would like
-SunPy to include another instrumental source please follow the
-`SunPy contribution guide <https://sunpy.org/contribute>`__.
-The `~sunpy.timeseries.TimeSeries` factory has the ability to make a list of
-TimeSeries objects using a list of filepaths, a folder or a glob, for example: ::
+SunPy will attempt to detect automatically the instrument source for most FITS files.
+However timeseries data are stored in a variety of file types (FITS, txt, csv) and formats, and so it is not always possible to detect the source.
+For this reason, it is good practice to explicitly state the source for the file.
+SunPy ships with a number of known instrumental sources.
+If you would like SunPy to include another instrumental source please follow the `SunPy contribution guide <https://sunpy.org/contribute>`__.
+The `~sunpy.timeseries.TimeSeries` factory has the ability to make a list of TimeSeries objects using a list of filepaths, a folder or a glob, for example: ::
 
     >>> my_ts_list = ts.TimeSeries('filepath1', 'filepath2', source='XRS')   # doctest: +SKIP
     >>> my_ts_list = ts.TimeSeries('/goesdirectory/', source='XRS')   # doctest: +SKIP
     >>> my_ts_list = ts.TimeSeries(glob, source='XRS')   # doctest: +SKIP
 
-Note that this functionality will only work with files from the same single
-source, generating a source specific child of the `~sunpy.timeseries.GenericTimeSeries`
-class such as the `~sunpy.timeseries.sources.goes.XRSTimeSeries` above. For this
-reason, all the files should be from that same source for the `~sunpy.timeseries.TimeSeries`
-factory to work as intended.
+Note that this functionality will only work with files from the same single source, generating a source specific child of the `~sunpy.timeseries.GenericTimeSeries` class such as the `~sunpy.timeseries.sources.goes.XRSTimeSeries` above.
+For this reason, all the files should be from that same source for the `~sunpy.timeseries.TimeSeries` factory to work as intended.
 
 1.1 Creating a Single TimeSeries from Multiple Files
 ----------------------------------------------------
 
-You can create a single time series from multiple files for a given source using
-the keyword argument ``concatenate=True``, such as:
+You can create a single time series from multiple files for a given source using the keyword argument ``concatenate=True``, such as:
 
     >>> my_timeseries = ts.TimeSeries('/mydirectory/myts1.fits', '/mydirectory/myts2.fits', source='XRS', concatenate=True)  # doctest: +SKIP
 
-Note these must all be from the same source if using
-`~sunpy.timeseries.GenericTimeSeries.concatenate` from within the TimeSeries
-factory. However, if time series `~sunpy.timeseries.GenericTimeSeries.concatenate` method
-can be used to make a single time series from multiple TimeSeries from different
-sources once they are already in the form of TimeSeries objects.
+Note these must all be from the same source if using `~sunpy.timeseries.GenericTimeSeries.concatenate` from within the TimeSeries factory.
+However, if time series `~sunpy.timeseries.GenericTimeSeries.concatenate` method can be used to make a single time series from multiple TimeSeries from different sources once they are already in the form of TimeSeries objects.
 
 .. _inspecting-timeseries:
 
 2. Inspecting TimeSeries & Accessing the Data
 =============================================
 
-A time series holds both data as well as meta data and units data. For a quick look at
-a TimeSeries, type: ::
+A time series holds both data as well as meta data and units data.
+For a quick look at a TimeSeries, type: ::
 
     >>> my_timeseries  # doctest: +SKIP
 
 This will show a table of information taken from the metadata and a preview of your data.
-If you execute this command in a Jupyter Notebook, a rich HTML version of this quick look
-will be shown that includes plots of the data. Alternatively, the `~sunpy.timeseries.GenericTimeSeries.quicklook`
-command will show the HTML view in your default browser.
+If you execute this command in a Jupyter Notebook, a rich HTML version of this quick look will be shown that includes plots of the data.
+Alternatively, the `~sunpy.timeseries.GenericTimeSeries.quicklook` command will show the HTML view in your default browser.
 The meta data for the time series is accessed by: ::
 
     >>> header = my_timeseries.meta
 
-This references the `~sunpy.timeseries.TimeSeriesMetaData` object with
-the header information as read from the source files. A word of caution: many
-data sources provide little to no meta data so this variable might be empty.
-The meta data is described in more detail later in this guide. Similarly there
-are properties for getting `~sunpy.timeseries.GenericTimeSeries.columns`
-as a list of strings, `~sunpy.timeseries.GenericTimeSeries.index`
-values and `~sunpy.timeseries.GenericTimeSeries.time_range` of
-the data.  The actual data in a SunPy TimeSeries object is accessible through
-the `~sunpy.timeseries.GenericTimeSeries.data` attribute.  The
-data is implemented as a Pandas `~pandas.DataFrame`, so to get a look at what
-data you have available use: ::
+This references the `~sunpy.timeseries.TimeSeriesMetaData` object with the header information as read from the source files.
+A word of caution: many data sources provide little to no meta data so this variable might be empty.
+The meta data is described in more detail later in this guide.
+Similarly there are properties for getting `~sunpy.timeseries.GenericTimeSeries.columns` as a list of strings, `~sunpy.timeseries.GenericTimeSeries.index` values and `~sunpy.timeseries.GenericTimeSeries.time_range` of the data.
+The actual data in a SunPy TimeSeries object is accessible through the `~sunpy.timeseries.GenericTimeSeries.data` attribute.
+The data is implemented as a Pandas `~pandas.DataFrame`, so to get a look at what data you have available use: ::
 
     >>> my_timeseries.data  # doctest: +SKIP
 
@@ -130,9 +104,8 @@ You can also get a quick overview of that data using: ::
     dtypes: float32(2)
     memory usage: 659.0 KB
 
-Time series are columnar data so to get at a particular datum you need to
-first index the column, then the element you want. To get the names of the
-available columns: ::
+Time series are columnar data so to get at a particular datum you need to first index the column, then the element you want.
+To get the names of the available columns: ::
 
     >>> my_timeseries.data.columns
     Index(['xrsa', 'xrsb'], dtype='object')
@@ -147,19 +120,15 @@ You can also grab all of the data at a particular time: ::
     >>> my_timeseries.data['xrsa']['2011-06-07 00:00:02.008999']
     1e-09
 
-This will return a list of entries with times that match the accuracy of the time
-you provide. You can consider the data as x or y values: ::
+This will return a list of entries with times that match the accuracy of the time you provide.
+You can consider the data as x or y values: ::
 
     >>> x = my_timeseries.data.index
     >>> y = my_timeseries.data.values
 
-You can read more about indexing at the `Pandas documentation website
-<https://pandas.pydata.org/pandas-docs/stable/>`_.
+You can read more about indexing at the `Pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`_.
 
-A TimeSeries can also return an Astropy `~astropy.units.quantity.Quantity` for a
-given column using the `~sunpy.timeseries.GenericTimeSeries.quantity`
-method, this uses the values stored in the data and units stored in the units
-dictionary to determine the `~astropy.units.quantity.Quantity`: ::
+A TimeSeries can also return an Astropy `~astropy.units.quantity.Quantity` for a given column using the `~sunpy.timeseries.GenericTimeSeries.quantity` method, this uses the values stored in the data and units stored in the units dictionary to determine the `~astropy.units.quantity.Quantity`: ::
 
     >>> quantity = my_timeseries.quantity('xrsa')
 
@@ -168,9 +137,8 @@ dictionary to determine the `~astropy.units.quantity.Quantity`: ::
 3. Plotting TimeSeries
 ======================
 
-The SunPy TimeSeries object has its own built-in plot methods so that
-it is easy to quickly view your time series. To create a plot just
-type:
+The SunPy TimeSeries object has its own built-in plot methods so that it is easy to quickly view your time series.
+To create a plot just type:
 
 .. plot::
     :include-source:
@@ -181,12 +149,11 @@ type:
     ts = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES, source='XRS')
     ts.peek()
 
-This will open a Matplotlib plot on your screen. If you want to save this to a PNG
-file you can do so from the Matplotlib GUI.
+This will open a Matplotlib plot on your screen.
+If you want to save this to a PNG file you can do so from the Matplotlib GUI.
 
-In addition, to enable users to modify the plot it is possible to use the
-`~sunpy.timeseries.GenericTimeSeries.plot` command.  This makes it possible to
-use the SunPy plot as the foundation for a more complicated figure:
+In addition, to enable users to modify the plot it is possible to use the `~sunpy.timeseries.GenericTimeSeries.plot` command.
+This makes it possible to use the SunPy plot as the foundation for a more complicated figure:
 
 .. plot::
    :include-source:
@@ -210,9 +177,7 @@ use the SunPy plot as the foundation for a more complicated figure:
 4.1 Modifying the Data
 ----------------------
 
-Since the timeseries data is stored as a Pandas `~pandas.DataFrame`
-you can easily modify the data directly using all of the usual Pandas methods:
-for example, you can modify a single cells value using: ::
+Since the timeseries data is stored as a Pandas `~pandas.DataFrame` you can easily modify the data directly using all of the usual Pandas methods: for example, you can modify a single cells value using: ::
 
     >>> my_timeseries.data['xrsa'][0] = 0.1
 
@@ -224,102 +189,79 @@ You can even change all the values for a given time: ::
 
     >>> my_timeseries.data['xrsa']['2012-06-01 00:00'] = 1
 
-Note, you will need to be careful to consider units when modifying the
-TimeSeries data directly. For further details about editing Pandas DataFames you
-can read the `Pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`_.
+Note, you will need to be careful to consider units when modifying the TimeSeries data directly.
+For further details about editing Pandas DataFames you can read the `Pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`_.
 
-Additionally the TimeSeries provides the `~sunpy.timeseries.GenericTimeSeries.add_column`
-method which will either add a new column or update a current column if the
-colname is already present. This can take numpy array or preferably an Astropy
-`~astropy.units.quantity.Quantity` value.  For example: ::
+Additionally the TimeSeries provides the `~sunpy.timeseries.GenericTimeSeries.add_column` method which will either add a new column or update a current column if the colname is already present.
+This can take numpy array or preferably an Astropy `~astropy.units.quantity.Quantity` value.
+For example: ::
 
     >>> values = u.Quantity(my_timeseries.data['xrsa'].values[:-2], my_timeseries.units['xrsa']) * 20.5
     >>> my_timeseries.add_column('new col', values)
     <sunpy.timeseries.sources.goes.XRSTimeSeries object at ...>
 
-Note that the values will be converted into the column units if an Astropy
-`~astropy.units.quantity.Quantity` is given. Caution should be taken when adding
-a new column because this column won't have any associated MetaData entry,
-similarly if you use an array of values it won't add an entry into the units
-`~collections.OrderedDict`.
+Note that the values will be converted into the column units if an Astropy `~astropy.units.quantity.Quantity` is given.
+Caution should be taken when adding a new column because this column won't have any associated MetaData entry, similarly if you use an array of values it won't add an entry into the units `~collections.OrderedDict`.
 
 4.2 Truncating a TimeSeries
 ---------------------------
 
-It is often useful to truncate an existing TimeSeries object to retain a
-specific time range.  This is easily achieved by using the `~sunpy.timeseries.GenericTimeSeries.truncate`
-method. For example, to trim our GOES data into a period of interest use: ::
+It is often useful to truncate an existing TimeSeries object to retain a specific time range.
+This is easily achieved by using the `~sunpy.timeseries.GenericTimeSeries.truncate` method.
+For example, to trim our GOES data into a period of interest use: ::
 
     >>> from sunpy.time import TimeRange
     >>> tr = TimeRange('2012-06-01 05:00','2012-06-01 06:30')
     >>> my_timeseries_trunc = my_timeseries.truncate(tr)
 
-This takes a number of different arguments, such as the start and end dates (as
-datetime or string objects) or a `~sunpy.time.TimeRange` as used above. Note
-that the truncated TimeSeries will have a truncated `~sunpy.timeseries.TimeSeriesMetaData`
-object, which may include dropping metadata entries for data totally cut out
-from the TimeSeries.  If you want to truncate using slice-like values you can,
-for example taking every 2nd value from 0 to 10000 can be done using: ::
+This takes a number of different arguments, such as the start and end dates (as datetime or string objects) or a `~sunpy.time.TimeRange` as used above.
+Note that the truncated TimeSeries will have a truncated `~sunpy.timeseries.TimeSeriesMetaData` object, which may include dropping metadata entries for data totally cut out from the TimeSeries.
+If you want to truncate using slice-like values you can, for example taking every 2nd value from 0 to 10000 can be done using: ::
 
     >>> my_timeseries_trunc = my_timeseries.truncate(0,100000,2)
 
-Caution should be used when removing values from the data manually, the
-TimeSeries can't guarantee Astropy units are correctly preserved when you
-interact with the data directly.
+Caution should be used when removing values from the data manually, the TimeSeries can't guarantee Astropy units are correctly preserved when you interact with the data directly.
 
 4.3 Down and Up Sampling a TimeSeries Using Pandas
 --------------------------------------------------
 
-Because the data is stored in a Pandas `~pandas.DataFrame` object you
-can manipulate it using normal Pandas methods, such as the `~pandas.DataFrame.resample`
-method.  To downsample you can use: ::
+Because the data is stored in a Pandas `~pandas.DataFrame` object you can manipulate it using normal Pandas methods, such as the `~pandas.DataFrame.resample` method.
+To downsample you can use: ::
 
     >>> downsampled_dataframe = my_timeseries_trunc.data.resample('10T').mean()
 
-Note, here ``10T`` means sample every 10 minutes and 'mean' is the method used
-to combine the data. Alternatively the sum method is often used.
+Note, here ``10T`` means sample every 10 minutes and 'mean' is the method used to combine the data.
+Alternatively the sum method is often used.
 You can also upsample, such as: ::
 
     >>> upsampled_data = my_timeseries_trunc.data.resample('30S').ffill()
 
-Note, here we upsample to 30 second intervals using ``30S`` and use the pandas
-fill-forward method. Alternatively the back-fill method could be used.  Caution
-should be used when resampling the data, the TimeSeries can't guarantee Astropy
-Units are correctly preserved when you interact with the data directly.
+Note, here we upsample to 30 second intervals using ``30S`` and use the pandas fill-forward method.
+Alternatively the back-fill method could be used.
+Caution should be used when resampling the data, the TimeSeries can't guarantee Astropy Units are correctly preserved when you interact with the data directly.
 
 4.4 Concatenating TimeSeries
 ----------------------------
 
-It's common to want to combine a number of TimeSeries together into a single
-TimeSeries.  In the simplest scenario this is to combine data from a single
-source over several time ranges, for example if you wanted to combine the daily
-GOES data to get a week or more of constant data in one TimeSeries.  This can be
-performed using the TimeSeries factory with the ``concatenate=True``
-keyword argument: ::
+It's common to want to combine a number of TimeSeries together into a single TimeSeries.
+In the simplest scenario this is to combine data from a single source over several time ranges, for example if you wanted to combine the daily GOES data to get a week or more of constant data in one TimeSeries.
+This can be performed using the TimeSeries factory with the ``concatenate=True`` keyword argument: ::
 
     >>> concatenated_timeseries = sunpy.timeseries.TimeSeries(filepath1, filepath2, source='XRS', concatenate=True)  # doctest: +SKIP
 
-Note, you can list any number of files, or a folder or use a glob to select the
-input files to be concatenated.  It is possible to concatenate two TimeSeries
-after creating them with the factory using the `~sunpy.timeseries.GenericTimeSeries.concatenate`
-method.  For example: ::
+Note, you can list any number of files, or a folder or use a glob to select the input files to be concatenated.
+It is possible to concatenate two TimeSeries after creating them with the factory using the `~sunpy.timeseries.GenericTimeSeries.concatenate` method.
+For example: ::
 
     >>> concatenated_timeseries = goes_timeseries_1.concatenate(goes_timeseries_2)  # doctest: +SKIP
 
-This will result in a TimeSeries identical to if you used the factory to create
-it in one step.  A limitation of the TimeSeries class is that often it is not
-easy to determine the source observatory/instrument of a file, generally
-because the file formats used vary depending on the scientific working groups,
-thus some sources need to be explicitly stated (as a keyword argument) and so it
-is not possible to concatenate files from multiple sources with the factory.
-To do this you can still use the `~sunpy.timeseries.GenericTimeSeries.concatenate`
-method, which will create a new TimeSeries with all the rows and columns of the
-source and concatenated TimeSeries in one: ::
+This will result in a TimeSeries identical to if you used the factory to create it in one step.
+A limitation of the TimeSeries class is that often it is not easy to determine the source observatory/instrument of a file, generally because the file formats used vary depending on the scientific working groups, thus some sources need to be explicitly stated (as a keyword argument) and so it is not possible to concatenate files from multiple sources with the factory.
+To do this you can still use the `~sunpy.timeseries.GenericTimeSeries.concatenate` method, which will create a new TimeSeries with all the rows and columns of the source and concatenated TimeSeries in one: ::
 
     >>> concatenated_timeseries = goes_timeseries.concatenate(eve_timeseries)  # doctest: +SKIP
 
-Note that the more complex `~sunpy.timeseries.TimeSeriesMetaData`
-object now has 2 entries and shows details on both: ::
+Note that the more complex `~sunpy.timeseries.TimeSeriesMetaData` object now has 2 entries and shows details on both: ::
 
     >>> concatenated_timeseries.meta  # doctest: +SKIP
 
@@ -329,18 +271,13 @@ The metadata object is described in more detail in the next section.
 4.5 Creating an Astropy Table from a TimeSeries
 -----------------------------------------------
 
-If you want to take the data from your TimeSeries and use it as a `~astropy.table.Table`
-this can be done using the `~sunpy.timeseries.GenericTimeSeries.to_table`
-method.  For example: ::
+If you want to take the data from your TimeSeries and use it as a `~astropy.table.Table` this can be done using the `~sunpy.timeseries.GenericTimeSeries.to_table` method.
+For example: ::
 
     >>> table = my_timeseries_trunc.to_table()
 
-Note that this `~astropy.table.Table` will contain a mixin column for
-containing the Astropy `~astropy.time.Time` object representing the index,
-it will also add the relevant units to the columns. One of the most useful
-reasons for doing this is that Astropy `~sunpy.timeseries.GenericTimeSeries.to_table`
-objects have some very nice options for viewing the data, including the basic
-console view: ::
+Note that this `~astropy.table.Table` will contain a mixin column for containing the Astropy `~astropy.time.Time` object representing the index, it will also add the relevant units to the columns.
+One of the most useful reasons for doing this is that Astropy `~sunpy.timeseries.GenericTimeSeries.to_table` objects have some very nice options for viewing the data, including the basic console view: ::
 
     >>> table
     <Table length=21089>
@@ -369,41 +306,34 @@ console view: ::
     2011-06-07T23:59:53.538999000   1e-09 1.5985e-07
     2011-06-07T23:59:57.631999000   1e-09 1.5985e-07
 
-and the more sophisticated browser view using the `~astropy.table.Table.show_in_browser`
-method: ::
+and the more sophisticated browser view using the `~astropy.table.Table.show_in_browser` method: ::
 
     >>> table.show_in_browser(jsviewer=True)  # doctest: +SKIP
 
-For further details about editing Astropy tables you can read the `Astropy
-documentation website <https://docs.astropy.org/en/stable/table/>`_.
+For further details about editing Astropy tables you can read the `Astropy documentation website <https://docs.astropy.org/en/stable/table/>`_.
 
 .. _custom-timeseries:
 
 5. Creating Custom TimeSeries
 =============================
 
-Sometimes you will have data that you want to create into a TimeSeries. You can
-use the factory to create a `~sunpy.timeseries.GenericTimeSeries`
-from a variety of data sources currently including `pandas.DataFrame` and
-`astropy.table.Table`.
+Sometimes you will have data that you want to create into a TimeSeries.
+You can use the factory to create a `~sunpy.timeseries.GenericTimeSeries` from a variety of data sources currently including `pandas.DataFrame` and `astropy.table.Table`.
 
 5.1 Creating a TimeSeries from a Pandas DataFrame
 -------------------------------------------------
 
-A TimeSeries object must be supplied with some data when it is
-created.  The data can either be in your current Python session, in a
-local file, or in a remote file.  Let's create some data and pass
-it into a TimeSeries object: ::
+A TimeSeries object must be supplied with some data when it is created.
+The data can either be in your current Python session, in a local file, or in a remote file.
+Let's create some data and pass it into a TimeSeries object: ::
 
     >>> import numpy as np
     >>> intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
 
 The first line imports the numpy module used to create and store the data.
 The second line creates a basic numpy array of values representing a sine wave.
-We can use this array along with a suitable time storing object (such as Astropy
-`~astropy.time` or a list of `datetime` objects) to make a Pandas
-`~pandas.DataFrame`.  A suitable list of times must contain the same
-number of values as the data, this can be created using: ::
+We can use this array along with a suitable time storing object (such as Astropy `~astropy.time` or a list of `datetime` objects) to make a Pandas `~pandas.DataFrame`.
+A suitable list of times must contain the same number of values as the data, this can be created using: ::
 
     >>> import datetime
     >>> base = datetime.datetime.today()
@@ -419,8 +349,7 @@ This `~pandas.DataFrame` can then be used to construct a TimeSeries: ::
     >>> import sunpy.timeseries as ts
     >>> ts_custom = ts.TimeSeries(data)
 
-Furthermore we could specify the metadata/header and units of this time series
-by sending them as arguments to the factory: ::
+Furthermore we could specify the metadata/header and units of this time series by sending them as arguments to the factory: ::
 
     >>> from collections import OrderedDict
     >>> import astropy.units as u
@@ -432,13 +361,9 @@ by sending them as arguments to the factory: ::
 5.2 Creating Custom TimeSeries from an Astropy Table
 ----------------------------------------------------
 
-A Pandas `~pandas.DataFrame` is the underlying object used to store
-the data within a TimeSeries, so the above example is the most lightweight to
-create a custom TimeSeries, but being scientific data it will often be more
-convenient to use an Astropy `~astropy.table.Table` and let the factory
-convert this.  An advantage of this method is it allows you to include metadata
-and Astropy `~astropy.units.quantity.Quantity` values, which are both supported
-in tables, without additional arguments.  For example: ::
+A Pandas `~pandas.DataFrame` is the underlying object used to store the data within a TimeSeries, so the above example is the most lightweight to create a custom TimeSeries, but being scientific data it will often be more convenient to use an Astropy `~astropy.table.Table` and let the factory convert this.
+An advantage of this method is it allows you to include metadata and Astropy `~astropy.units.quantity.Quantity` values, which are both supported in tables, without additional arguments.
+For example: ::
 
     >>> import datetime
     >>> from astropy.time import Time
@@ -453,14 +378,10 @@ in tables, without additional arguments.  For example: ::
     >>> table.add_index('time')
     >>> ts_table = ts.TimeSeries(table)
 
-Note that due to the properties of the `~astropy.time.Time` object, this will be
-a mixin column which since it is a single object, limits the versatility of
-the `~astropy.table.Table` a little. For more on mixin columns see the `Astropy
-docs <https://docs.astropy.org/en/stable/table/mixin_columns.html>`_.  The units
-will be taken from the table quantities for each column, the metadata will
-simply be the table.meta dictionary.  You can also explicitly add metadata and
-units, these will be added to the relevant dictionaries using the dictionary
-update method, with the explicit user-given values taking precedence.
+Note that due to the properties of the `~astropy.time.Time` object, this will be a mixin column which since it is a single object, limits the versatility of the `~astropy.table.Table` a little.
+For more on mixin columns see the `Astropy docs <https://docs.astropy.org/en/stable/table/mixin_columns.html>`_.
+The units will be taken from the table quantities for each column, the metadata will simply be the table.meta dictionary.
+You can also explicitly add metadata and units, these will be added to the relevant dictionaries using the dictionary update method, with the explicit user-given values taking precedence.
 
     >>> from sunpy.util.metadata import MetaDict
     >>> from collections import OrderedDict
@@ -475,18 +396,13 @@ update method, with the explicit user-given values taking precedence.
 6. A Detailed Look at the Metadata
 ==================================
 
-TimeSeries store metadata in a `~sunpy.timeseries.TimeSeriesMetaData`
-object, this object is designed to be able to store multiple basic `~sunpy.util.metadata.MetaDict`
-(case-insensitive ordered dictionary) objects and able to identify the relevant
-metadata for a given cell in the data. This enables a single TimeSeries to be
-created by combining/concatenating multiple TimeSeries source files together
-into one and to keep a reliable track of all the metadata relevant to each cell,
-column or row.  The metadata can be accessed by: ::
+TimeSeries store metadata in a `~sunpy.timeseries.TimeSeriesMetaData` object, this object is designed to be able to store multiple basic `~sunpy.util.metadata.MetaDict` (case-insensitive ordered dictionary) objects and able to identify the relevant metadata for a given cell in the data.
+This enables a single TimeSeries to be created by combining/concatenating multiple TimeSeries source files together into one and to keep a reliable track of all the metadata relevant to each cell, column or row.
+The metadata can be accessed by: ::
 
     >>> meta = my_timeseries.meta
 
-You can easily get an overview of the metadata, this will show you a basic
-representation of the metadata entries that are relevant to this TimeSeries. ::
+You can easily get an overview of the metadata, this will show you a basic representation of the metadata entries that are relevant to this TimeSeries. ::
 
     >>> meta
     |-------------------------------------------------------------------------------------------------|
@@ -506,85 +422,47 @@ representation of the metadata entries that are relevant to this TimeSeries. ::
     |-------------------------------------------------------------------------------------------------|
     <BLANKLINE>
 
-The data within a `~sunpy.timeseries.TimeSeriesMetaData` object is
-stored as a list of tuples, each tuple representing the metadata from a source
-file or timeseries. The tuple will contain a `~sunpy.time.TimeRange` telling us
-which rows the metadata applies to, a list of column name strings for which the
-metadata applies to and finally a `~sunpy.util.metadata.MetaDict` object for
-storing the key/value pairs of the metadata itself.  Each time a TimeSeries is
-concatenated to the original a new set of rows and/or columns will be added to
-the `~pandas.DataFrame` and a new entry will be added into the
-metadata.  Note that entries are ordered chronologically based on
+The data within a `~sunpy.timeseries.TimeSeriesMetaData` object is stored as a list of tuples, each tuple representing the metadata from a source file or timeseries.
+The tuple will contain a `~sunpy.time.TimeRange` telling us which rows the metadata applies to, a list of column name strings for which the metadata applies to and finally a `~sunpy.util.metadata.MetaDict` object for storing the key/value pairs of the metadata itself.
+Each time a TimeSeries is concatenated to the original a new set of rows and/or columns will be added to the `~pandas.DataFrame` and a new entry will be added into the metadata.
+Note that entries are ordered chronologically based on
 `~sunpy.time.timerange.TimeRange.start` and generally it's expected that no two
-TimeSeries will overlap on both columns and time range.  For example it is not
-good practice for alternate row values in a single column to be relevant to
-different metadata entries as this would make it impossible to uniquely identify
-the metadata relevant to each cell.
+TimeSeries will overlap on both columns and time range.
+For example it is not good practice for alternate row values in a single column to be relevant to different metadata entries as this would make it impossible to uniquely identify the metadata relevant to each cell.
 
-If you want the string that's printed then you can use the
-`~sunpy.timeseries.TimeSeriesMetaData.to_string` method.  This has the
-advantage of having optional keyword arguments that allows you to set the depth
-(number of rows for each entry) and width (total number of characters wide)
-to better fit your output.  For example: ::
+If you want the string that's printed then you can use the `~sunpy.timeseries.TimeSeriesMetaData.to_string` method.
+This has the advantage of having optional keyword arguments that allows you to set the depth (number of rows for each entry) and width (total number of characters wide) to better fit your output.
+For example: ::
 
     >>> meta_str = meta.to_string(depth = 20, width=99)
 
-Similar to the TimeSeries, the metadata has some properties for convenient
-access to the global metadata details, including
-`~sunpy.timeseries.TimeSeriesMetaData.columns` as a list of
-strings,  and `~sunpy.timeseries.TimeSeriesMetaData.time_range` of the data.
-Beyond this, there are properties to get lists of details for all the entries in
-the `~sunpy.timeseries.TimeSeriesMetaData` object, including
-`~sunpy.timeseries.TimeSeriesMetaData.timeranges`,
-`~sunpy.timeseries.TimeSeriesMetaData.columns` (as a list of string
-column names) and `~sunpy.timeseries.TimeSeriesMetaData.metas`.
-Similar to TimeSeries objects you can `~sunpy.timeseries.TimeSeriesMetaData.concatenate`
-`~sunpy.timeseries.TimeSeriesMetaData`
-objects, but generally you won't need to do this as it is done automatically
-when actioned on the TimeSeries.
-Note that when truncating a `~sunpy.timeseries.TimeSeriesMetaData`
-object you will remove any entries outside of the given `~sunpy.time.TimeRange`.
-You can also `~sunpy.timeseries.TimeSeriesMetaData.append` a new entry
-(as a tuple or list), which will add the entry in the correct chronological
-position.  It is frequently necessary to locate the metadata for a given column,
-row or cell which can be uniquely identified by both, to do this you can use the
-`~sunpy.timeseries.TimeSeriesMetaData.find` method, by adding colname
-and/or time/row keyword arguments you get a `~sunpy.timeseries.TimeSeriesMetaData`
-object returned which contains only the relevant entries. You can then use the
-`~sunpy.timeseries.TimeSeriesMetaData.metas` property to get a list of
-just the relevant `~sunpy.util.metadata.MetaDict` objects.  For example: ::
+Similar to the TimeSeries, the metadata has some properties for convenient access to the global metadata details, including `~sunpy.timeseries.TimeSeriesMetaData.columns` as a list of strings,  and `~sunpy.timeseries.TimeSeriesMetaData.time_range` of the data.
+Beyond this, there are properties to get lists of details for all the entries in the `~sunpy.timeseries.TimeSeriesMetaData` object, including `~sunpy.timeseries.TimeSeriesMetaData.timeranges`, `~sunpy.timeseries.TimeSeriesMetaData.columns` (as a list of string column names) and `~sunpy.timeseries.TimeSeriesMetaData.metas`.
+Similar to TimeSeries objects you can `~sunpy.timeseries.TimeSeriesMetaData.concatenate` `~sunpy.timeseries.TimeSeriesMetaData` objects, but generally you won't need to do this as it is done automatically when actioned on the TimeSeries.
+Note that when truncating a `~sunpy.timeseries.TimeSeriesMetaData` object you will remove any entries outside of the given `~sunpy.time.TimeRange`.
+You can also `~sunpy.timeseries.TimeSeriesMetaData.append` a new entry (as a tuple or list), which will add the entry in the correct chronological position.
+It is frequently necessary to locate the metadata for a given column, row or cell which can be uniquely identified by both, to do this you can use the `~sunpy.timeseries.TimeSeriesMetaData.find` method, by adding colname and/or time/row keyword arguments you get a `~sunpy.timeseries.TimeSeriesMetaData` object returned which contains only the relevant entries.
+You can then use the `~sunpy.timeseries.TimeSeriesMetaData.metas` property to get a list of just the relevant `~sunpy.util.metadata.MetaDict` objects.
+For example: ::
 
     >>> tsmd_return = my_timeseries.meta.find(colname='xrsa', time='2012-06-01 00:00:33.904999')
     >>> tsmd_return.metas
     []
 
-Note, the colname and time filters are optional, but omitting both filters just
-returns an identical `~sunpy.timeseries.TimeSeriesMetaData` object to
-the TimeSeries original. A common use case for the metadata is to find out the
-instrument/s that gathered the data and in this case you can use the
-`~sunpy.timeseries.TimeSeriesMetaData.get` method.  This method takes a
-single key string or list of key strings with the optional filters and will
-search for any matching values. This method returns another `~sunpy.timeseries.TimeSeriesMetaData`
-object, but removes all unwanted key/value pairs.  The result can be converted
-into a simple list of strings using the `~sunpy.timeseries.TimeSeriesMetaData.values`
-method: ::
+Note, the colname and time filters are optional, but omitting both filters just returns an identical `~sunpy.timeseries.TimeSeriesMetaData` object to the TimeSeries original.
+A common use case for the metadata is to find out the instrument/s that gathered the data and in this case you can use the `~sunpy.timeseries.TimeSeriesMetaData.get` method.
+This method takes a single key string or list of key strings with the optional filters and will search for any matching values.
+This method returns another `~sunpy.timeseries.TimeSeriesMetaData` object, but removes all unwanted key/value pairs.
+The result can be converted into a simple list of strings using the `~sunpy.timeseries.TimeSeriesMetaData.values` method: ::
 
     >>> tsmd_return = my_timeseries.meta.get('telescop', colname='xrsa')
     >>> tsmd_return.values()
     ['GOES 15']
 
-Note `~sunpy.timeseries.TimeSeriesMetaData.values` removes duplicate
-strings and sorts the returned list.  You can update the values for these
-entries efficiently using the `~sunpy.timeseries.TimeSeriesMetaData.update`
-method which takes a dictionary argument and updates the values to each of the
-dictionaries that match the given colname and time filters, for example: ::
+Note `~sunpy.timeseries.TimeSeriesMetaData.values` removes duplicate strings and sorts the returned list.
+You can update the values for these entries efficiently using the `~sunpy.timeseries.TimeSeriesMetaData.update` method which takes a dictionary argument and updates the values to each of the dictionaries that match the given colname and time filters, for example: ::
 
     >>> my_timeseries.meta.update({'telescop': 'G15'}, colname='xrsa', overwrite=True)
 
-Here we have to specify the overwrite=False keyword parameter to allow us to
-overwrite values for keys already present in the `~sunpy.util.metadata.MetaDict`
-objects, this helps protect the integrity of the original metadata and without
-this set (or with it set to False) you can still add new key/value pairs.
-Note that the `~sunpy.util.metadata.MetaDict` objects are both case-insensitive
-for key strings and have ordered entries, where possible the order is preserved
-when updating values.
+Here we have to specify the overwrite=False keyword parameter to allow us to overwrite values for keys already present in the `~sunpy.util.metadata.MetaDict` objects, this helps protect the integrity of the original metadata and without this set (or with it set to False) you can still add new key/value pairs.
+Note that the `~sunpy.util.metadata.MetaDict` objects are both case-insensitive for key strings and have ordered entries, where possible the order is preserved when updating values.

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -10,14 +10,14 @@ instrument-specific information when plotting and similar metadata handling.
 For more information about TimeSeries, and what data sources are currently supported,
 check out :doc:`/code_ref/timeseries`.
 
-:ref:`1. Creating a TimeSeries` describes how to create a TimeSeries object from single or multiple observational sources.
-:ref:`2. Inspecting TimeSeries & Accessing the Data` describes how to examine the data and metadata.
-:ref:`3. Plotting TimeSeries` outlines the basics of how SunPy will plot a TimeSeries object.
-:ref:`4. Manipulating TimeSeries` describes how to modify data, truncate a TimeSeries, down and up sample data,
+:ref:`creating-timeseries` describes how to create a TimeSeries object from single or multiple observational sources.
+:ref:`inspecting-timeseries` describes how to examine the data and metadata.
+:ref:`plotting-timeseries` outlines the basics of how SunPy will plot a TimeSeries object.
+:ref:`manipulating-timeseries` describes how to modify data, truncate a TimeSeries, down and up sample data,
 concatenate data, and create an Astropy Table from a TimeSeries.
-:ref:`5. Creating Custom TimeSeries` details how to create a TimeSeries object from
+:ref:`custom-timeseries` details how to create a TimeSeries object from
 a Pandas DataFrame or an Astropy Table.
-Lastly, :ref:`6. A Detailed Look at the Metadata` describes how to view and
+Lastly, :ref:`ts-metadata` describes how to view and
 extract information from the metadata.
 
 .. warning::
@@ -25,6 +25,8 @@ extract information from the metadata.
    The TimeSeries supersedes the previous LightCurve object but does not
    implement data download methods. To download TimeSeries data files use
    `sunpy.net`.
+
+.. _creating-timeseries:
 
 1. Creating a TimeSeries
 ========================
@@ -85,6 +87,7 @@ factory. However, if time series `~sunpy.timeseries.GenericTimeSeries.concatenat
 can be used to make a single time series from multiple TimeSeries from different
 sources once they are already in the form of TimeSeries objects.
 
+.. _inspecting-timeseries:
 
 2. Inspecting TimeSeries & Accessing the Data
 =============================================
@@ -96,7 +99,7 @@ a TimeSeries, type: ::
 
 This will show a table of information taken from the metadata and a preview of your data.
 If you execute this command in a Jupyter Notebook, a rich HTML version of this quick look
-will be shown that includes plots of the data. Alternatively, the `~sunpy.timeseries.GenericTimeSeries.quicklook` 
+will be shown that includes plots of the data. Alternatively, the `~sunpy.timeseries.GenericTimeSeries.quicklook`
 command will show the HTML view in your default browser.
 The meta data for the time series is accessed by: ::
 
@@ -160,6 +163,8 @@ dictionary to determine the `~astropy.units.quantity.Quantity`: ::
 
     >>> quantity = my_timeseries.quantity('xrsa')
 
+.. _plotting-timeseries:
+
 3. Plotting TimeSeries
 ======================
 
@@ -197,6 +202,7 @@ use the SunPy plot as the foundation for a more complicated figure:
    # Modify the figure here
    fig.savefig('figure.png')
 
+.. _manipulating-timeseries:
 
 4. Manipulating TimeSeries
 ==========================
@@ -371,6 +377,7 @@ method: ::
 For further details about editing Astropy tables you can read the `Astropy
 documentation website <https://docs.astropy.org/en/stable/table/>`_.
 
+.. _custom-timeseries:
 
 5. Creating Custom TimeSeries
 =============================
@@ -463,6 +470,7 @@ update method, with the explicit user-given values taking precedence.
     >>> units = OrderedDict([('intensity', u.W/u.m**2)])
     >>> ts_table = ts.TimeSeries(table, meta, units)
 
+.. _ts-metadata:
 
 6. A Detailed Look at the Metadata
 ==================================

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -1,19 +1,24 @@
-***********
-TimeSeries
-***********
+****************
+TimeSeries Guide
+****************
 
 Time series data are a fundamental part of many data analysis projects
-in heliophysics as well as other areas. sunpy therefore provides a TimeSeries
-object to handle this type of data. This new object supersedes the now
-deprecated Lightcurve datatype. Once you've read through this guide check out
-the :doc:`/code_ref/timeseries` for a more thorough look at sunpy TimeSeries
-and to see what data sources it currently supports.
+in heliophysics as well as other areas. SunPy provides a TimeSeries
+object to handle this type of data. Much like the `~sunpy.map.Map` object,
+`~sunpy.timeseries` recognizes data from nine sources and provides
+instrument-specific information when plotting and similar metadata handling.
+For more information about TimeSeries, and what data sources are currently supported,
+check out :doc:`/code_ref/timeseries`.
 
-Sections 1 and 2 below describe how to create TimeSeries objects.  Section 3
-describes how to inspect the TimeSeries object to examine the data itself and
-the metadata.  Section 4 describes how to plot a TimeSeries object, Section 5
-describes how a TimeSeries object can be manipulated, and Section 6 describes
-in detail the TimeSeries metadata.
+:ref:`1. Creating a TimeSeries` describes how to create a TimeSeries object from single or multiple observational sources.
+:ref:`2. Inspecting TimeSeries & Accessing the Data` describes how to examine the data and metadata.
+:ref:`3. Plotting TimeSeries` outlines the basics of how SunPy will plot a TimeSeries object.
+:ref:`4. Manipulating TimeSeries` describes how to modify data, truncate a TimeSeries, down and up sample data,
+concatenate data, and create an Astropy Table from a TimeSeries.
+:ref:`5. Creating Custom TimeSeries` details how to create a TimeSeries object from
+a Pandas DataFrame or an Astropy Table.
+Lastly, :ref:`6. A Detailed Look at the Metadata` describes how to view and
+extract information from the metadata.
 
 .. warning::
 
@@ -21,13 +26,13 @@ in detail the TimeSeries metadata.
    implement data download methods. To download TimeSeries data files use
    `sunpy.net`.
 
-1. Creating a TimeSeries from an observational data source
-==========================================================
+1. Creating a TimeSeries
+========================
 
-A TimeSeries object can be created from local files.  For convenience, sunpy can
+A TimeSeries object can be created from local files.  For convenience, SunPy can
 download several example timeseries of observational data. These files have names like
 ``sunpy.data.sample.EVE_TIMESERIES`` and ``sunpy.data.sample.GOES_XRS_TIMESERIES``.
-To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries` type the
+To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries`, type the
 following into your interactive Python shell: ::
 
     >>> import sunpy.timeseries as ts
@@ -46,13 +51,13 @@ a local GOES/XRS FITS file try the following: ::
 
     >>> my_timeseries = ts.TimeSeries('/mydirectory/myts.fits', source='XRS')   # doctest: +SKIP
 
-sunpy will attempt to detect automatically the instrument source for most FITS
+SunPy will attempt to detect automatically the instrument source for most FITS
 files. However timeseries data are stored in a variety of file types (FITS, txt,
 csv) and formats, and so it is not always possible to detect the source. For
 this reason, it is good practice to explicitly state the source for the file.
-sunpy ships with a number of known instrumental sources.  If you would like
-sunpy to include another instrumental source please follow the
-`sunpy contribution guide <https://sunpy.org/contribute>`__.
+SunPy ships with a number of known instrumental sources.  If you would like
+SunPy to include another instrumental source please follow the
+`SunPy contribution guide <https://sunpy.org/contribute>`__.
 The `~sunpy.timeseries.TimeSeries` factory has the ability to make a list of
 TimeSeries objects using a list of filepaths, a folder or a glob, for example: ::
 
@@ -67,7 +72,7 @@ reason, all the files should be from that same source for the `~sunpy.timeseries
 factory to work as intended.
 
 1.1 Creating a Single TimeSeries from Multiple Files
-====================================================
+----------------------------------------------------
 
 You can create a single time series from multiple files for a given source using
 the keyword argument ``concatenate=True``, such as:
@@ -80,103 +85,20 @@ factory. However, if time series `~sunpy.timeseries.GenericTimeSeries.concatenat
 can be used to make a single time series from multiple TimeSeries from different
 sources once they are already in the form of TimeSeries objects.
 
-2. Creating Custom TimeSeries
-=============================
 
-Sometimes you will have data that you want to create into a TimeSeries. You can
-use the factory to create a `~sunpy.timeseries.GenericTimeSeries`
-from a variety of data sources currently including `pandas.DataFrame` and
-`astropy.table.Table`.
+2. Inspecting TimeSeries & Accessing the Data
+=============================================
 
-2.1 Creating a TimeSeries from a Pandas DataFrame
-=================================================
+A time series holds both data as well as meta data and units data. For a quick look at
+a TimeSeries, type: ::
 
-A TimeSeries object must be supplied with some data when it is
-created.  The data can either be in your current Python session, in a
-local file, or in a remote file.  Let's create some data and pass
-it into a TimeSeries object: ::
+    >>> my_timeseries  # doctest: +SKIP
 
-    >>> import numpy as np
-    >>> intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
-
-The first line imports the numpy module used to create and store the data.
-The second line creates a basic numpy array of values representing a sine wave.
-We can use this array along with a suitable time storing object (such as Astropy
-`~astropy.time` or a list of `datetime` objects) to make a Pandas
-`~pandas.DataFrame`.  A suitable list of times must contain the same
-number of values as the data, this can be created using: ::
-
-    >>> import datetime
-    >>> base = datetime.datetime.today()
-    >>> times = [base - datetime.timedelta(minutes=x) for x in range(24*60, 0, -1)]
-
-The Pandas `~pandas.DataFrame` will use the dates list as the index: ::
-
-    >>> from pandas import DataFrame
-    >>> data = DataFrame(intensity, index=times, columns=['intensity'])
-
-This `~pandas.DataFrame` can then be used to construct a TimeSeries: ::
-
-    >>> import sunpy.timeseries as ts
-    >>> ts_custom = ts.TimeSeries(data)
-
-Furthermore we could specify the metadata/header and units of this time series
-by sending them as arguments to the factory: ::
-
-    >>> from collections import OrderedDict
-    >>> import astropy.units as u
-
-    >>> meta = OrderedDict({'key':'value'})
-    >>> units = OrderedDict([('intensity', u.W/u.m**2)])
-    >>> ts_custom = ts.TimeSeries(data, meta, units)
-
-2.2 Creating Custom TimeSeries from an Astropy Table
-====================================================
-
-A Pandas `~pandas.DataFrame` is the underlying object used to store
-the data within a TimeSeries, so the above example is the most lightweight to
-create a custom TimeSeries, but being scientific data it will often be more
-convenient to use an Astropy `~astropy.table.Table` and let the factory
-convert this.  An advantage of this method is it allows you to include metadata
-and Astropy `~astropy.units.quantity.Quantity` values, which are both supported
-in tables, without additional arguments.  For example: ::
-
-    >>> import datetime
-    >>> from astropy.time import Time
-    >>> import astropy.units as u
-    >>> from astropy.table import Table
-
-    >>> base = datetime.datetime.today()
-    >>> times = [base - datetime.timedelta(minutes=x) for x in range(24*60, 0, -1)]
-    >>> intensity = u.Quantity(np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60)))), u.W/u.m**2)
-    >>> tbl_meta = {'t_key':'t_value'}
-    >>> table = Table([times, intensity], names=['time', 'intensity'], meta=tbl_meta)
-    >>> table.add_index('time')
-    >>> ts_table = ts.TimeSeries(table)
-
-Note that due to the properties of the `~astropy.time.Time` object, this will be
-a mixin column which since it is a single object, limits the versatility of
-the `~astropy.table.Table` a little. For more on mixin columns see the `Astropy
-docs <https://docs.astropy.org/en/stable/table/mixin_columns.html>`_.  The units
-will be taken from the table quantities for each column, the metadata will
-simply be the table.meta dictionary.  You can also explicitly add metadata and
-units, these will be added to the relevant dictionaries using the dictionary
-update method, with the explicit user-given values taking precedence.
-
-    >>> from sunpy.util.metadata import MetaDict
-    >>> from collections import OrderedDict
-    >>> import astropy.units as u
-
-    >>> meta = MetaDict({'key':'value'})
-    >>> units = OrderedDict([('intensity', u.W/u.m**2)])
-    >>> ts_table = ts.TimeSeries(table, meta, units)
-
-
-3. Inspecting TimeSeries & Getting at the Data
-===============================================
-
-A time series holds both data as well as meta data and units data. The meta data
-for the time series is accessed by: ::
+This will show a table of information taken from the metadata and a preview of your data.
+If you execute this command in a Jupyter Notebook, a rich HTML version of this quick look
+will be shown that includes plots of the data. Alternatively, the `~sunpy.timeseries.GenericTimeSeries.quicklook` 
+command will show the HTML view in your default browser.
+The meta data for the time series is accessed by: ::
 
     >>> header = my_timeseries.meta
 
@@ -185,9 +107,9 @@ the header information as read from the source files. A word of caution: many
 data sources provide little to no meta data so this variable might be empty.
 The meta data is described in more detail later in this guide. Similarly there
 are properties for getting `~sunpy.timeseries.GenericTimeSeries.columns`
-as a list of strings, `~sunpy.timeseries.GenericTimeSeries.time`
+as a list of strings, `~sunpy.timeseries.GenericTimeSeries.index`
 values and `~sunpy.timeseries.GenericTimeSeries.time_range` of
-the data.  The actual data in a sunpy TimeSeries object is accessible through
+the data.  The actual data in a SunPy TimeSeries object is accessible through
 the `~sunpy.timeseries.GenericTimeSeries.data` attribute.  The
 data is implemented as a Pandas `~pandas.DataFrame`, so to get a look at what
 data you have available use: ::
@@ -228,7 +150,7 @@ you provide. You can consider the data as x or y values: ::
     >>> x = my_timeseries.data.index
     >>> y = my_timeseries.data.values
 
-You can read more about indexing at the `pandas documentation website
+You can read more about indexing at the `Pandas documentation website
 <https://pandas.pydata.org/pandas-docs/stable/>`_.
 
 A TimeSeries can also return an Astropy `~astropy.units.quantity.Quantity` for a
@@ -238,10 +160,10 @@ dictionary to determine the `~astropy.units.quantity.Quantity`: ::
 
     >>> quantity = my_timeseries.quantity('xrsa')
 
-4. Plotting
-===========
+3. Plotting TimeSeries
+======================
 
-The sunpy TimeSeries object has its own built-in plot methods so that
+The SunPy TimeSeries object has its own built-in plot methods so that
 it is easy to quickly view your time series. To create a plot just
 type:
 
@@ -259,7 +181,7 @@ file you can do so from the Matplotlib GUI.
 
 In addition, to enable users to modify the plot it is possible to use the
 `~sunpy.timeseries.GenericTimeSeries.plot` command.  This makes it possible to
-use the sunpy plot as the foundation for a more complicated figure:
+use the SunPy plot as the foundation for a more complicated figure:
 
 .. plot::
    :include-source:
@@ -276,11 +198,11 @@ use the sunpy plot as the foundation for a more complicated figure:
    fig.savefig('figure.png')
 
 
-5 Manipulating TimeSeries
-=========================
+4. Manipulating TimeSeries
+==========================
 
-5.1 Modifying the Data
-======================
+4.1 Modifying the Data
+----------------------
 
 Since the timeseries data is stored as a Pandas `~pandas.DataFrame`
 you can easily modify the data directly using all of the usual Pandas methods:
@@ -298,7 +220,7 @@ You can even change all the values for a given time: ::
 
 Note, you will need to be careful to consider units when modifying the
 TimeSeries data directly. For further details about editing Pandas DataFames you
-can read the `pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`_.
+can read the `Pandas documentation website <https://pandas.pydata.org/pandas-docs/stable/>`_.
 
 Additionally the TimeSeries provides the `~sunpy.timeseries.GenericTimeSeries.add_column`
 method which will either add a new column or update a current column if the
@@ -315,8 +237,8 @@ a new column because this column won't have any associated MetaData entry,
 similarly if you use an array of values it won't add an entry into the units
 `~collections.OrderedDict`.
 
-5.2 Truncating a TimeSeries
-===========================
+4.2 Truncating a TimeSeries
+---------------------------
 
 It is often useful to truncate an existing TimeSeries object to retain a
 specific time range.  This is easily achieved by using the `~sunpy.timeseries.GenericTimeSeries.truncate`
@@ -339,8 +261,8 @@ Caution should be used when removing values from the data manually, the
 TimeSeries can't guarantee Astropy units are correctly preserved when you
 interact with the data directly.
 
-5.3 Down and Up Sampling a TimeSeries Using Pandas
-==================================================
+4.3 Down and Up Sampling a TimeSeries Using Pandas
+--------------------------------------------------
 
 Because the data is stored in a Pandas `~pandas.DataFrame` object you
 can manipulate it using normal Pandas methods, such as the `~pandas.DataFrame.resample`
@@ -359,8 +281,8 @@ fill-forward method. Alternatively the back-fill method could be used.  Caution
 should be used when resampling the data, the TimeSeries can't guarantee Astropy
 Units are correctly preserved when you interact with the data directly.
 
-5.4 Concatenating TimeSeries
-============================
+4.4 Concatenating TimeSeries
+----------------------------
 
 It's common to want to combine a number of TimeSeries together into a single
 TimeSeries.  In the simplest scenario this is to combine data from a single
@@ -398,8 +320,8 @@ object now has 2 entries and shows details on both: ::
 The metadata object is described in more detail in the next section.
 
 
-5.5 Creating an Astropy Table from a TimeSeries
-===============================================
+4.5 Creating an Astropy Table from a TimeSeries
+-----------------------------------------------
 
 If you want to take the data from your TimeSeries and use it as a `~astropy.table.Table`
 this can be done using the `~sunpy.timeseries.GenericTimeSeries.to_table`
@@ -446,8 +368,100 @@ method: ::
 
     >>> table.show_in_browser(jsviewer=True)  # doctest: +SKIP
 
-For further details about editing Astropy tables you can read the `astropy
+For further details about editing Astropy tables you can read the `Astropy
 documentation website <https://docs.astropy.org/en/stable/table/>`_.
+
+
+5. Creating Custom TimeSeries
+=============================
+
+Sometimes you will have data that you want to create into a TimeSeries. You can
+use the factory to create a `~sunpy.timeseries.GenericTimeSeries`
+from a variety of data sources currently including `pandas.DataFrame` and
+`astropy.table.Table`.
+
+5.1 Creating a TimeSeries from a Pandas DataFrame
+-------------------------------------------------
+
+A TimeSeries object must be supplied with some data when it is
+created.  The data can either be in your current Python session, in a
+local file, or in a remote file.  Let's create some data and pass
+it into a TimeSeries object: ::
+
+    >>> import numpy as np
+    >>> intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
+
+The first line imports the numpy module used to create and store the data.
+The second line creates a basic numpy array of values representing a sine wave.
+We can use this array along with a suitable time storing object (such as Astropy
+`~astropy.time` or a list of `datetime` objects) to make a Pandas
+`~pandas.DataFrame`.  A suitable list of times must contain the same
+number of values as the data, this can be created using: ::
+
+    >>> import datetime
+    >>> base = datetime.datetime.today()
+    >>> times = [base - datetime.timedelta(minutes=x) for x in range(24*60, 0, -1)]
+
+The Pandas `~pandas.DataFrame` will use the dates list as the index: ::
+
+    >>> from pandas import DataFrame
+    >>> data = DataFrame(intensity, index=times, columns=['intensity'])
+
+This `~pandas.DataFrame` can then be used to construct a TimeSeries: ::
+
+    >>> import sunpy.timeseries as ts
+    >>> ts_custom = ts.TimeSeries(data)
+
+Furthermore we could specify the metadata/header and units of this time series
+by sending them as arguments to the factory: ::
+
+    >>> from collections import OrderedDict
+    >>> import astropy.units as u
+
+    >>> meta = OrderedDict({'key':'value'})
+    >>> units = OrderedDict([('intensity', u.W/u.m**2)])
+    >>> ts_custom = ts.TimeSeries(data, meta, units)
+
+5.2 Creating Custom TimeSeries from an Astropy Table
+----------------------------------------------------
+
+A Pandas `~pandas.DataFrame` is the underlying object used to store
+the data within a TimeSeries, so the above example is the most lightweight to
+create a custom TimeSeries, but being scientific data it will often be more
+convenient to use an Astropy `~astropy.table.Table` and let the factory
+convert this.  An advantage of this method is it allows you to include metadata
+and Astropy `~astropy.units.quantity.Quantity` values, which are both supported
+in tables, without additional arguments.  For example: ::
+
+    >>> import datetime
+    >>> from astropy.time import Time
+    >>> import astropy.units as u
+    >>> from astropy.table import Table
+
+    >>> base = datetime.datetime.today()
+    >>> times = [base - datetime.timedelta(minutes=x) for x in range(24*60, 0, -1)]
+    >>> intensity = u.Quantity(np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60)))), u.W/u.m**2)
+    >>> tbl_meta = {'t_key':'t_value'}
+    >>> table = Table([times, intensity], names=['time', 'intensity'], meta=tbl_meta)
+    >>> table.add_index('time')
+    >>> ts_table = ts.TimeSeries(table)
+
+Note that due to the properties of the `~astropy.time.Time` object, this will be
+a mixin column which since it is a single object, limits the versatility of
+the `~astropy.table.Table` a little. For more on mixin columns see the `Astropy
+docs <https://docs.astropy.org/en/stable/table/mixin_columns.html>`_.  The units
+will be taken from the table quantities for each column, the metadata will
+simply be the table.meta dictionary.  You can also explicitly add metadata and
+units, these will be added to the relevant dictionaries using the dictionary
+update method, with the explicit user-given values taking precedence.
+
+    >>> from sunpy.util.metadata import MetaDict
+    >>> from collections import OrderedDict
+    >>> import astropy.units as u
+
+    >>> meta = MetaDict({'key':'value'})
+    >>> units = OrderedDict([('intensity', u.W/u.m**2)])
+    >>> ts_table = ts.TimeSeries(table, meta, units)
 
 
 6. A Detailed Look at the Metadata


### PR DESCRIPTION
This PR is a somewhat substantial edit to the current Map guide and addresses #5573. The Map Guide has been reformatted so it, and the TimeSeries Guide, walk through similar steps in introducing a user to the class. Following the current TimeSeries guide format, I have numbered the sections/subsections of the guide, so it is clearer which sections elaborate on a more general topic. Much of the content in the guide is still here, but some sections have been rewritten to be more concise.

I’ve renamed the pages to Map Guide and TimeSeries Guide. There are different pages called Maps (`sunpy.map`) and Map (`sunpy.map.Map`) in the docs already that describe different aspects of the map class (same for TimeSeries). Calling this guide “Maps” I found confusing.

I think the examples in the Example Gallery are fantastic. So, if an example in this guide could be replaced with a link to an equally descriptive example, I have done this. I have also tried to reference relevant examples in each section that elaborate on the topic.

A small number of changes have been made to the TimeSeries Guide so it is consistent with the Map Guide. I have made this a draft PR since there is a lot to look through.

As a side note, I am advocate of learning by doing. I think it might be helpful to link to a shortened Jupyter notebook-version of this guide on Binder (same for TimeSeries Guide). Is that possible?
