### PR TITLE
PR check list for the dev_guide

### DIFF
--- a/changelog/6346.doc.rst
+++ b/changelog/6346.doc.rst
@@ -1,0 +1,1 @@
+Adds a pull request check list to the Developer's Guide.

--- a/docs/dev_guide/contents/cheatsheet.rst
+++ b/docs/dev_guide/contents/cheatsheet.rst
@@ -1,42 +1,46 @@
 .. _cheatsheet:
 
-******************************
-SunPy Pull Request Cheat Sheet
-******************************
+***********************
+Pull Request Check List
+***********************
 
-The pull request (PR) cheat sheet below is a rough outline of the steps that should be taken when making a contribution to SunPy on Github.
+The pull request (commonly referred to as a PR) check list below is an outline of the steps that should be taken when making a contribution to a SunPy repository on Github.
 
-1. Review and test changes locally on your machine
-    a. Double check that an Issue or PR does not exist for the changes you are making
-    b. If you are contributing code, review the `Coding Standards page <https://docs.sunpy.org/en/latest/dev_guide/contents/code_standards.html>`_
-    c. See the `Developer's Guide <https://docs.sunpy.org/en/latest/dev_guide/index.html>`_ for guidelines regarding code tests, documentation, and other types of contributions
-    d. Have you tested your changes with the latest version of SunPy? If not, update your local copy of SunPy from your `remote repository <https://docs.github.com/en/get-started/using-git/getting-changes-from-a-remote-repository>`_ on Github
-2. Push your changes to Github
-    a. `Create a new branch <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository>`_ of sunpy/main in your fork of SunPy
-    b. Give this branch a name that reflects the changes you are making
-    c. Make multiple commits that describe the changes
-    d. `Push your changes <https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository>`_ to the new branch
-3. `Compare your branch <https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/comparing-commits>`_ with sunpy/main
-    a. Resolve any conflicts that occur
-4. Create a pull request
-    a. `Create a pull request <https://docs.github.com/en/get-started/quickstart/hello-world#opening-a-pull-request>`_ from the branch you have updated
-    b. Add a description to the PR that describes the changes you have made
-    c. `Link <https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls>`_ to any relevant Issues or PRs in your description
-5. Add a changelog to your PR
-    a. A `changelog <https://github.com/sunpy/sunpy/tree/main/changelog#changelog>`_ is a short record of the type of changes made in your PR
-6. SunPy maintainers will `review your PR <https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html>`_
-    a. Fix any errors that others highlight and push the changes to your branch
-    b. Discuss possible changes/improvements in the comments
-    c. Review the `Continuous Integration (CI) <https://docs.sunpy.org/en/latest/dev_guide/contents/ci_jobs.html>`_ tests and fix any errors that are found
-        i. If you are confused by an error that the CI is giving you just ask about in your PR
-7. Ask questions if you get stuck or confused at any point
-    a. Open-source projects are about communication and collaboration
-    b. Join the SunPy Matrix Chat channel (link at the bottom of this page)
+New to Git and Github?
+Check out the :ref:`newcomers` and `Git Cheat Sheets <https://training.github.com/>`__.
 
-Making a change to the SunPy website? See `these guidelines <https://github.com/sunpy/sunpy.org#sunpyorg-website>`_ for making website changes.
+If you would prefer a visual Git interface, you can try `Github Desktop <https://desktop.github.com/>`__ or `GitKraken <https://www.gitkraken.com/>`__.
 
-New to Git/Github? Check out the `Newcomers' Guide <https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html>`_ and `Git Cheat Sheets <https://training.github.com/>`_.
+#. Review and test changes locally on your machine (see :ref:`testing`).
+    #. Double check that a pull request does not exist for the changes you are making.
+       Ideally, check that there is an issue that details what you want to change and why.
+    #. If you are contributing code, review the :ref:`coding-standards` page.
+    #. See the :ref:`dev_guide` for guidelines regarding code tests, documentation, and other types of contributions.
+    #. Have you tested your changes with the latest version of ``sunpy``?
+       If not, update your local copy from your `remote repository <https://docs.github.com/en/get-started/using-git/getting-changes-from-a-remote-repository>`__ on Github.
+#. Push your changes to Github.
+    #. `Create a new branch <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository>`__ in your fork of ``sunpy``.
+    #. Give this branch a name that reflects the changes you are making.
+    #. Create commits that describe the changes.
+    #. `Push your changes <https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository>`__ to the new branch on your remote fork.
+#. `Compare your branch <https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/comparing-commits>`__ with ``sunpy/main``.
+    #. Resolve any conflicts that occur ideally with a `git rebase <https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase>`__.
+#. Create a pull request.
+    #. `Create a pull request <https://docs.github.com/en/get-started/quickstart/hello-world#opening-a-pull-request>`__ from the branch you have created/updated.
+    #. Add a description to the pull request that describes the changes you have made.
+       Remember to delete the preamble within the message box.
+    #. `Link <https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls>`__ to any relevant issues, pull requests, or comments in your description.
+#. Add a changelog to your pull request.
+    #. A `changelog <https://github.com/sunpy/sunpy/tree/main/changelog#changelog>`__ is a short record of the type of changes made in your pull request.
+       Other users are the intended audience, and you can have multiple logs per pull request.
+#. Maintainers will review your pull request :ref:`pr_review`.
+    #. Tweak anything that others highlight and push the changes to your branch.
+       You can also commit suggestions either in bulk or single commits via the Github user interface.
+    #. Discuss possible changes or improvements in the comments with the reviewers.
+    #. Review the Continuous Integration (CI) :ref:`ci_jobs` tests and fix any errors or warnings that are found.
+        #. If you are confused by an error that the continuous integration is giving you, submit a comment in your pull request.
+#. Ask questions if you get stuck or confused at any point!
+    #. Open-source projects are about communication and collaboration.
+    #. `Join the SunPy Matrix Chat channel <https://matrix.to/#/+sunpy:openastronomy.org>`__.
 
-Prefer a visual Git interface? Try `Github Desktop <https://desktop.github.com/>`_.
-
-This guide is partially based on Astropy's `Development Workflow <https://docs.astropy.org/en/latest/development/workflow/development_workflow.html>`_.
+This guide is partially based on Astropy's `Development Workflow <https://docs.astropy.org/en/latest/development/workflow/development_workflow.html>`__.

--- a/docs/dev_guide/contents/cheatsheet.rst
+++ b/docs/dev_guide/contents/cheatsheet.rst
@@ -1,0 +1,42 @@
+.. _cheatsheet:
+
+******************************
+SunPy Pull Request Cheat Sheet
+******************************
+
+The pull request (PR) cheat sheet below is a rough outline of the steps that should be taken when making a contribution to SunPy on Github.
+
+1. Review and test changes locally on your machine
+    a. Double check that an Issue or PR does not exist for the changes you are making
+    b. If you are contributing code, review the `Coding Standards page <https://docs.sunpy.org/en/latest/dev_guide/contents/code_standards.html>`_
+    c. See the `Developer's Guide <https://docs.sunpy.org/en/latest/dev_guide/index.html>`_ for guidelines regarding code tests, documentation, and other types of contributions
+    d. Have you tested your changes with the latest version of SunPy? If not, update your local copy of SunPy from your `remote repository <https://docs.github.com/en/get-started/using-git/getting-changes-from-a-remote-repository>`_ on Github
+2. Push your changes to Github
+    a. `Create a new branch <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository>`_ of sunpy/main in your fork of SunPy
+    b. Give this branch a name that reflects the changes you are making
+    c. Make multiple commits that describe the changes
+    d. `Push your changes <https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository>`_ to the new branch
+3. `Compare your branch <https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/comparing-commits>`_ with sunpy/main
+    a. Resolve any conflicts that occur
+4. Create a pull request
+    a. `Create a pull request <https://docs.github.com/en/get-started/quickstart/hello-world#opening-a-pull-request>`_ from the branch you have updated
+    b. Add a description to the PR that describes the changes you have made
+    c. `Link <https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls>`_ to any relevant Issues or PRs in your description
+5. Add a changelog to your PR
+    a. A `changelog <https://github.com/sunpy/sunpy/tree/main/changelog#changelog>`_ is a short record of the type of changes made in your PR
+6. SunPy maintainers will `review your PR <https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html>`_
+    a. Fix any errors that others highlight and push the changes to your branch
+    b. Discuss possible changes/improvements in the comments
+    c. Review the `Continuous Integration (CI) <https://docs.sunpy.org/en/latest/dev_guide/contents/ci_jobs.html>`_ tests and fix any errors that are found
+        i. If you are confused by an error that the CI is giving you just ask about in your PR
+7. Ask questions if you get stuck or confused at any point
+    a. Open-source projects are about communication and collaboration
+    b. Join the SunPy Matrix Chat channel (link at the bottom of this page)
+
+Making a change to the SunPy website? See `these guidelines <https://github.com/sunpy/sunpy.org#sunpyorg-website>`_ for making website changes.
+
+New to Git/Github? Check out the `Newcomers' Guide <https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html>`_ and `Git Cheat Sheets <https://training.github.com/>`_.
+
+Prefer a visual Git interface? Try `Github Desktop <https://desktop.github.com/>`_.
+
+This guide is partially based on Astropy's `Development Workflow <https://docs.astropy.org/en/latest/development/workflow/development_workflow.html>`_.

--- a/docs/dev_guide/contents/pr_checklist.rst
+++ b/docs/dev_guide/contents/pr_checklist.rst
@@ -1,4 +1,4 @@
-.. _cheatsheet:
+.. _pr_checklist:
 
 ***********************
 Pull Request Check List

--- a/docs/dev_guide/index.rst
+++ b/docs/dev_guide/index.rst
@@ -25,6 +25,7 @@ This section contains the various guidelines to be followed by anyone working on
             :maxdepth: 3
 
             contents/newcomers
+	    contents/cheatsheet
 
     .. grid-item-card::
         :class-card: card

--- a/docs/dev_guide/index.rst
+++ b/docs/dev_guide/index.rst
@@ -25,7 +25,7 @@ This section contains the various guidelines to be followed by anyone working on
             :maxdepth: 3
 
             contents/newcomers
-            contents/cheatsheet
+            contents/pr_checklist
 
     .. grid-item-card::
         :class-card: card


### PR DESCRIPTION
This PR adds a “pull request cheat sheet” to the SunPy Developer’s Guide (address Issue #5944). At the moment, it is grouped with the “Getting started” part of the guide, but I think it could also fit under “Conventions”. Here is a link to the [cheat sheet](https://github.com/mwhv2/sunpy-git/blob/cheatsheet/docs/dev_guide/contents/cheatsheet.rst) on my branch where the formatting is a bit easier to review.

There are seven general steps that the guide highlights, and each step has additional notes that provide more information about that step of the process. I have tried to provide links that either explain how a particular step is done or describe what is being done.

Another possible step to add is deleting the branch after the PR has been merged. Since I am still getting used to Github, I am not sure if this is common/best practice. What are everyone’s thoughts on this?

Let me know if I missed any steps of the process, or if other information should be included.
