### PR TITLE
Implement a cgi alive test when determining what VSO endpoint to use

### DIFF
--- a/changelog/6362.trivial.rst
+++ b/changelog/6362.trivial.rst
@@ -1,0 +1,4 @@
+When determining which VSO servers to use for queries, `.VSOClient` will now
+attempt to check if the cgi endpoint referenced by the WDSL file is accessible,
+and try the next endpoint if it can't be reached. This should mean that a small
+category of connection issues with the VSO are now automatically bypassed.

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -297,7 +297,7 @@ def fail_to_open_nso_cgi(disallowed_url, url, **kwargs):
     return urlopen(url, **kwargs)
 
 
-@pytest.mark.online
+@pytest.mark.remote_data
 def test_fallback_if_cgi_offline(mocker):
     """
     This test takes the cgi endpoint URL out of the WDSL, and then disables it,

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -61,7 +61,7 @@ def check_connection(url):
         return urlopen(url, timeout=15).getcode() == 200
     except (socket.error, socket.timeout, HTTPError, URLError) as e:
         warn_user(f"Connection to {url} failed with error {e}. Retrying with different url and port.")
-        return None
+        return False
 
 
 def check_cgi_connection(url):
@@ -76,10 +76,10 @@ def check_cgi_connection(url):
         if e.code == 411:
             return True
         warn_user(f"Connection to {url} failed with error {e}. Retrying with different url and port.")
-        return None
+        return False
     except (socket.error, socket.timeout, URLError) as e:
         warn_user(f"Connection to {url} failed with error {e}. Retrying with different url and port.")
-        return None
+        return False
 
 
 def get_online_vso_url():

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -55,7 +55,6 @@ class _Str(str):
     meta = None
 
 
-# ----------------------------------------
 def check_connection(url):
     try:
         return urlopen(url, timeout=15).getcode() == 200

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -39,14 +39,11 @@ from .table_response import VSOQueryResponseTable
 from .zeep_plugins import SunPyLoggingZeepPlugin
 
 DEFAULT_URL_PORT = [
-    {'url': 'http://docs.virtualsolar.org/WSDL/VSOi_rpc_literal.wsdl',
-     'port': 'nsoVSOi'},
-    {'url': 'https://sdac.virtualsolar.org/API/VSOi_rpc_literal.wsdl',
-     'port': 'sdacVSOi'},
+    {'url': 'http://docs.virtualsolar.org/WSDL/VSOi_rpc_literal.wsdl', 'port': 'nsoVSOi'},
+    {'url': 'https://sdac.virtualsolar.org/API/VSOi_rpc_literal.wsdl', 'port': 'sdacVSOi'},
     # This connects to the same cgi as the first WSDL file, but if that file
     # isn't accessible and the SDAC cgi is unreachable, this might still work.
-    {'url': 'https://sdac.virtualsolar.org/API/VSOi_rpc_literal.wsdl',
-     'port': 'nsoVSOi'},
+    {'url': 'https://sdac.virtualsolar.org/API/VSOi_rpc_literal.wsdl', 'port': 'nsoVSOi'},
 ]
 
 

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -58,7 +58,7 @@ class _Str(str):
 def check_connection(url):
     try:
         return urlopen(url, timeout=15).getcode() == 200
-    except (socket.error, socket.timeout, HTTPError, URLError) as e:
+    except (OSError, HTTPError, URLError) as e:
         warn_user(f"Connection to {url} failed with error {e}. Retrying with different url and port.")
         return False
 
@@ -76,7 +76,7 @@ def check_cgi_connection(url):
             return True
         warn_user(f"Connection to {url} failed with error {e}. Retrying with different url and port.")
         return False
-    except (socket.error, socket.timeout, URLError) as e:
+    except (OSError, URLError) as e:
         warn_user(f"Connection to {url} failed with error {e}. Retrying with different url and port.")
         return False
 


### PR DESCRIPTION
fixes #6361 

I have no idea how to test this, as we are testing that a url in a remote file is accessible. I guess the only way would be to trick the function into downloading a pre-faked WSDL file.