### PR TITLE
Don't run CI if only a changelog has changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    paths-ignore:
+        - 'changelog/**'
     branches:
       - '*'
       - '!*backport*'

--- a/changelog/6386.trivial.rst
+++ b/changelog/6386.trivial.rst
@@ -1,0 +1,1 @@
+CI is no longer run on commits when only a changelog is modified.


### PR DESCRIPTION
It's pretty common to make a PR, and then add a changelog in a second commit (since you need the PR number before you make a changelog).

This PR stops the CI from running on a commit that's just a changelog being added, to prevent our CI being clogged up by unneeded runs.