### PR TITLE
Fix the ordering of the API docs

### DIFF
--- a/docs/code_ref/index.rst
+++ b/docs/code_ref/index.rst
@@ -7,6 +7,7 @@ API Reference
 .. toctree::
    :maxdepth: 2
 
+   sunpy
    coordinates/index
    data
    database
@@ -16,7 +17,6 @@ API Reference
    net
    physics
    sun
-   sunpy
    time
    timeseries
    util

--- a/docs/code_ref/sunpy.rst
+++ b/docs/code_ref/sunpy.rst
@@ -1,4 +1,4 @@
-sunpy
-*****
+sunpy (`sunpy`)
+***************
 
 .. automodapi:: sunpy


### PR DESCRIPTION
I don't know why we don't have the top level package at the top?