### PR TITLE
Check nddata rather than genericmap in arithmetic compatibility check

### DIFF
--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -10,6 +10,7 @@ from inspect import Parameter, signature
 from functools import wraps
 
 import astropy.units as u
+from astropy.nddata import NDData
 
 from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyPendingDeprecationWarning, warn_deprecated
 
@@ -383,13 +384,10 @@ def check_arithmetic_compatibility(func):
     """
     @wraps(func)
     def inner(instance, value):
-        # Import here to avoid circular imports
-        from sunpy.map import GenericMap
-
         # This is explicit because it is expected that users will try to do this. This raises
         # a different error because it is expected that this type of operation will be supported
         # in future releases.
-        if isinstance(value, GenericMap):
+        if isinstance(value, NDData):
             return NotImplemented
         try:
             # We want to support operations between numbers and array-like objects. This includes


### PR DESCRIPTION
This checks that the object you're doing an arithmetic operation with is not an NDData rather than just not a GenericMap. This ensures, for example, that you can't add a Map and an NDCube