### PR TITLE
Use WCS API in `contains_coordinate`

### DIFF
--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -404,9 +404,11 @@ def contains_coordinate(smap, coordinates):
         returns a boolean arrary.
     """
     # Dimensions of smap
-    xs, ys = smap.dimensions
+    ys, xs = smap.wcs.array_shape * u.pix
     # Converting coordinates to pixels
-    xc, yc = smap.world_to_pixel(coordinates)
+    xc, yc = smap.wcs.world_to_pixel(coordinates)
+    xc = xc * u.pix
+    yc = yc * u.pix
     point5pix = 0.5 * u.pix
     return ((xc >= -point5pix) &
             (xc <= xs - point5pix) &

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -404,16 +404,13 @@ def contains_coordinate(smap, coordinates):
         returns a boolean arrary.
     """
     # Dimensions of smap
-    ys, xs = smap.wcs.array_shape * u.pix
+    ys, xs = smap.wcs.array_shape
     # Converting coordinates to pixels
     xc, yc = smap.wcs.world_to_pixel(coordinates)
-    xc = xc * u.pix
-    yc = yc * u.pix
-    point5pix = 0.5 * u.pix
-    return ((xc >= -point5pix) &
-            (xc <= xs - point5pix) &
-            (yc >= -point5pix) &
-            (yc <= ys - point5pix))
+    return ((xc >= -0.5) &
+            (xc <= xs - 0.5) &
+            (yc >= -0.5) &
+            (yc <= ys - 0.5))
 
 
 def _bresenham(*, x1, y1, x2, y2):


### PR DESCRIPTION
This PR makes a small change to the internals of `contains_coordinate` to use the API of `GenericMap.wcs` rather than that on `GenericMap` directly. The advantage of this is that functions like `contains_coordinate` and `extract_along_coord` can be used with objects with a `.wcs` property with two celestial axes (e.g. an `NDCube`) and not just `GenericMap`.
