### PR TITLE
Fix Matplotlib `get_cmap` deprecation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,11 +5,11 @@ exclude .gitignore
 exclude .mailmap
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yaml
+exclude .rtd-environment.yml
 exclude .test_package_pins.txt
 exclude .zenodo.json
 exclude asv.conf.json
 exclude CITATION.cff
-exclude readthedocs.yml
 
 prune .circleci
 prune .github

--- a/examples/example_template/example_template.py
+++ b/examples/example_template/example_template.py
@@ -9,6 +9,7 @@ The example uses <packages> to <do something> and <other package> to <do other
 thing>. Include links to referenced packages like this: `sunpy.map` to
 show the sunpy.map or like this `~sunpy.map`to show just 'map'.
 """
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -44,9 +45,9 @@ plt.ylabel('$y$')
 # time to introduce the next code block generates 2 separate figures.
 
 plt.figure()
-plt.imshow(z, cmap=plt.cm.get_cmap('hot'))
+plt.imshow(z, cmap=matplotlib.colormaps['hot'])
 plt.figure()
-plt.imshow(z, cmap=plt.cm.get_cmap('Spectral'), interpolation='none')
+plt.imshow(z, cmap=matplotlib.colormaps['Spectral'], interpolation='none')
 
 ##########################################################################
 # There's some subtle differences between rendered html rendered comment

--- a/examples/plotting/map_editcolormap.py
+++ b/examples/plotting/map_editcolormap.py
@@ -5,6 +5,7 @@ Editing the colormap and normalization of a Map
 
 How to edit the display of a map.
 """
+import matplotlib
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
@@ -20,9 +21,9 @@ aiamap = sunpy.map.Map(AIA_171_IMAGE)
 # All plot settings for a map are stored in the ``plot_settings`` attribute.
 # How a Map is displayed is determined by its colormap, which sets the colors
 # , and the normalization, which sets how data values are translated to colors.
-# Lets replace the colormap and normalization.
+# Let's replace the colormap and normalization.
 
-aiamap.plot_settings['cmap'] = plt.get_cmap('Greys_r')
+aiamap.plot_settings['cmap'] = matplotlib.colormaps['Greys_r']
 aiamap.plot_settings['norm'] = colors.LogNorm(100, aiamap.max())
 
 ###############################################################################

--- a/examples/plotting/sunpy_matplotlib_colormap.py
+++ b/examples/plotting/sunpy_matplotlib_colormap.py
@@ -5,6 +5,7 @@ Using the sunpy Colormaps with matplotlib
 
 How you can use the sunpy colormaps with matplotlib.
 """
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -14,7 +15,7 @@ import sunpy.visualization.colormaps as cm
 # When the sunpy colormaps are imported, the sunpy colormaps are registered
 # with matplotlib. It is now possible to access the colormaps with the following command.
 
-sdoaia171 = plt.get_cmap('sdoaia171')
+sdoaia171 = matplotlib.colormaps['sdoaia171']
 
 ###############################################################################
 # You can get the list of all sunpy colormaps with:

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -14,7 +14,6 @@ from collections import namedtuple
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import cm
 from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.figure import Figure
 
@@ -356,8 +355,8 @@ class GenericMap(NDData):
 
         # Use a grayscale colormap with histogram equalization (and red for bad values)
         # Make a copy of the colormap to avoid modifying the matplotlib instance when
-        # doing set_bad()
-        cmap = copy.copy(cm.get_cmap('gray'))
+        # doing set_bad() (copy not needed when min mpl is 3.5, as already a copy)
+        cmap = copy.copy(sunpy_cm._get_mpl_cmap('gray'))
         cmap.set_bad(color='red')
         norm = ImageNormalize(stretch=HistEqStretch(finite_data))
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -34,6 +34,7 @@ from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyMetadataWarning
 from sunpy.util.metadata import ModifiedItem
+from sunpy.visualization.colormaps.cm import _get_mpl_cmap
 from .conftest import make_simple_map
 from .strategies import matrix_meta
 
@@ -261,7 +262,7 @@ def test_units(generic_map):
 
 
 def test_cmap(generic_map):
-    assert generic_map.cmap == plt.get_cmap('gray')
+    assert generic_map.cmap == _get_mpl_cmap('gray')
 
 
 def test_coordinate_frame(aia171_test_map):

--- a/sunpy/visualization/colormaps/cm.py
+++ b/sunpy/visualization/colormaps/cm.py
@@ -180,7 +180,7 @@ cmlist = {
     'solar orbiterhri_lya1216': solohri_lya1216,
 }
 
-# Register the colormaps with matplotlib so plt.get_cmap('sdoaia171') works
+# Register the colormaps with matplotlib so matplotlib.colormaps['sdoaia171'] works
 for name, cmap in cmlist.items():
     _register_cmap(name=name, cmap=cmap)
 

--- a/sunpy/visualization/colormaps/color_tables.py
+++ b/sunpy/visualization/colormaps/color_tables.py
@@ -304,25 +304,27 @@ def hmi_mag_color_table():
     --------
     >>> # Example usage for NRT data:
     >>> import sunpy.map
-    >>> import matplotlib.pyplot as plt
+    >>> import matplotlib
     >>> hmi = sunpy.map.Map('fblos.fits')  # doctest: +SKIP
-    >>> hmi.plot_settings['cmap'] = plt.get_cmap('hmimag')  # doctest: +SKIP
+    >>> hmi.plot_settings['cmap'] = matplotlib.colormaps['hmimag']  # doctest: +SKIP
     >>> hmi.peek(vmin=-1500.0, vmax=1500.0)  # doctest: +SKIP
 
     >>> # OR (for a basic plot with pixel values on the axes)
     >>> import numpy as np
+    >>> import matplotlib
     >>> import matplotlib.pyplot as plt
     >>> import sunpy.map
     >>> hmi = sunpy.map.Map('fblos.fits')  # doctest: +SKIP
-    >>> plt.imshow(np.clip(hmi.data, -1500.0, 1500.0), cmap=plt.get_cmap('hmimag'), origin='lower')  # doctest: +SKIP
+    >>> plt.imshow(np.clip(hmi.data, -1500.0, 1500.0), cmap=matplotlib.colormaps['hmimag'], origin='lower')  # doctest: +SKIP
     >>> plt.show()  # doctest: +SKIP
 
     >>> # Example usage for science (Level 1.0) data:
     >>> import numpy as np
+    >>> import matplotlib
     >>> import sunpy.map
     >>> hmi = sunpy.map.Map('hmi.m_45s.2014.05.11_12_00_45_TAI.magnetogram.fits')  # doctest: +SKIP
     >>> hmir = hmi.rotate()  # doctest: +SKIP
-    >>> hmir.plot_settings['cmap'] = plt.get_cmap('hmimag')  # doctest: +SKIP
+    >>> hmir.plot_settings['cmap'] = matplotlib.colormaps['hmimag']  # doctest: +SKIP
     >>> hmir.peek(vmin=-1500.0, vmax=1500.0)  # doctest: +SKIP
 
     References

--- a/sunpy/visualization/colormaps/tests/test_cm.py
+++ b/sunpy/visualization/colormaps/tests/test_cm.py
@@ -1,4 +1,3 @@
-import matplotlib.pyplot as plt
 import pytest
 
 import astropy.units as u
@@ -6,12 +5,13 @@ import astropy.units as u
 import sunpy.visualization.colormaps as cm
 import sunpy.visualization.colormaps.color_tables as ct
 from sunpy.tests.helpers import figure_test
+from sunpy.visualization.colormaps.cm import _get_mpl_cmap
 
 
 # Checks that colormaps are imported by MPL
 def test_get_cmap():
     for cmap in cm.cmlist.keys():
-        assert cm.cmlist[cmap] == plt.get_cmap(cmap)
+        assert cm.cmlist[cmap] == _get_mpl_cmap(cmap)
 
 
 def test_invalid_show_cmaps():


### PR DESCRIPTION
Additional fix for https://github.com/sunpy/sunpy/pull/6379