### PR TITLE
Prevent double CI on branch and open PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - 'main'
+      - '*.*'
       - '!*backport*'
     tags:
       - 'v*'


### PR DESCRIPTION
It happens sometimes. 

I plan to roll this out to each repo with actions. 