### PR TITLE
Make all kwargs to `reproject_to` kwarg only

### DIFF
--- a/changelog/6406.deprecation.rst
+++ b/changelog/6406.deprecation.rst
@@ -1,0 +1,1 @@
+The ``algorithm``, ``return_footprint`` and any keyword arguments passed through to the underlying `reproject` functions now must be passed as keyword arguments.

--- a/changelog/6406.deprecation.rst
+++ b/changelog/6406.deprecation.rst
@@ -1,1 +1,1 @@
-The ``algorithm``, ``return_footprint`` and any keyword arguments passed through to the underlying `reproject` functions now must be passed as keyword arguments.
+Passing the ``algorithm``, ``return_footprint`` arguments as positional arguments is deprecated. Pass them as keyword arguments (e.g. ``..., return_footprint=True, ...``) instead.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2644,7 +2644,7 @@ class GenericMap(NDData):
 
         return axes
 
-    @deprecate_positional_args_since("4.1", keyword_only=True)
+    @deprecate_positional_args_since("4.1")
     def reproject_to(self, target_wcs, *, algorithm='interpolation', return_footprint=False,
                      **reproject_args):
         """

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -49,6 +49,7 @@ from sunpy.util.decorators import (
     add_common_docstring,
     cached_property_based_on,
     check_arithmetic_compatibility,
+    deprecate_positional_args_since,
 )
 from sunpy.util.exceptions import warn_deprecated, warn_metadata, warn_user
 from sunpy.util.functools import seconddispatch
@@ -2643,6 +2644,7 @@ class GenericMap(NDData):
 
         return axes
 
+    @deprecate_positional_args_since("4.1", keyword_only=True)
     def reproject_to(self, target_wcs, *, algorithm='interpolation', return_footprint=False,
                      **reproject_args):
         """

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2643,7 +2643,7 @@ class GenericMap(NDData):
 
         return axes
 
-    def reproject_to(self, target_wcs, algorithm='interpolation', return_footprint=False,
+    def reproject_to(self, target_wcs, *, algorithm='interpolation', return_footprint=False,
                      **reproject_args):
         """
         Reproject the map to a different world coordinate system (WCS)

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -13,6 +13,7 @@ from astropy.wcs import WCS
 
 import sunpy.map
 from sunpy.tests.helpers import figure_test
+from sunpy.util.exceptions import SunpyDeprecationWarning
 
 
 @pytest.fixture
@@ -119,3 +120,11 @@ def test_return_footprint(aia171_test_map, hpc_header):
 def test_invalid_inputs(aia171_test_map, hpc_header):
     with pytest.raises(ValueError, match="The specified algorithm must be one of"):
         aia171_test_map.reproject_to(hpc_header, algorithm='something')
+
+
+def test_deprecated_positional_args(aia171_test_map, hpc_header):
+    with pytest.warns(SunpyDeprecationWarning, match=r"Pass algorithm=interpolation as keyword args"):
+        aia171_test_map.reproject_to(hpc_header, 'interpolation')
+
+    with pytest.warns(SunpyDeprecationWarning, match=r"Pass algorithm=interpolation, return_footprint=True as keyword args"):
+        aia171_test_map.reproject_to(hpc_header, 'interpolation', True)


### PR DESCRIPTION
While working on fixing compatibility with reproject_to in ndcube I have come to the conclusion that we really should be kwarg only here, so that the ordering of the arguments inside or outside of `**reproject_args` is not relevant to our API compatibility.