### PR TITLE
Improvements to the TimeSeries guide

### DIFF
--- a/changelog/6345.doc.rst
+++ b/changelog/6345.doc.rst
@@ -1,1 +1,1 @@
-Edit and update the Map and TimeSeries guides.
+The :ref:`map_guide` and :ref:`timeseries_guide` have been reviewed and updated.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -1,6 +1,8 @@
-*********
-Map Guide
-*********
+.. _map_guide:
+
+**************
+Map data guide
+**************
 
 Map objects in **sunpy** are two-dimensional data associated with a coordinate system.
 This class offers many advantages over using packages such as `astropy.io.fits` to open 2D solar data in Python.

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -14,7 +14,7 @@ Therefore, a Map also contains a number of methods such as resizing or grabbing 
 See `~sunpy.map.mapbase.GenericMap` for summaries of all attributes and methods.
 
 :ref:`creating-maps` and :ref:`inspecting-maps` demonstrate how to create a Map object and view a summary of the data in the object.
-:ref:`map-data` describes how data is stored and accessed in a Map, and :ref:`plotting-maps` introduces some basics of visualizing Map data in SunPy.
+:ref:`map-data` describes how data is stored and accessed in a Map, and :ref:`plotting-maps` introduces some basics of visualizing Map data in **sunpy**.
 :ref:`map-sequences` and :ref:`composite-maps` detail how **sunpy** can handle multiple Maps from similar and different instruments.
 Lastly, :ref:`custom-maps` shows how you can create Maps from data sources not supported in **sunpy**.
 
@@ -43,7 +43,7 @@ To create a Map from a local FITS file try the following:
     >>> my_map = sunpy.map.Map('/mydirectory/mymap.fits')   # doctest: +SKIP
 
 **sunpy** automatically detects the type of file (e.g. FITS), the instrument associated with it (e.g. AIA, EIT, LASCO), and finds the FITS keywords it needs to interpret the coordinate system.
-If the type of FITS file is not recognized then SunPy will try some default FITS keywords and return a `~sunpy.map.GenericMap`, but results may vary.
+If the type of FITS file is not recognized then **sunpy** will try some default FITS keywords and return a `~sunpy.map.GenericMap`, but results may vary.
 **sunpy** can also create Maps using the JPEG 2000 files from `helioviewer.org <https://helioviewer.org/>`__.
 
 The :ref:`sphx_glr_generated_gallery_acquiring_data` section of the Example Gallery has several examples of retrieving data using the `~sunpy.net.Fido` tool.
@@ -203,7 +203,7 @@ To create a plot just type:
 
 This will open a Matplotlib plot on your screen.
 In addition, it is possible to grab the Matplotlib Axes object by using the `~sunpy.map.GenericMap.plot()` command.
-This makes it possible to use the SunPy plot as the foundation for a more complicated figure.
+This makes it possible to use the **sunpy** plot as the foundation for a more complicated figure.
 For more information about this and some examples see :ref:`plotting`.
 Check out the following foundational examples in the Example Gallery for plotting Maps:
 

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -6,7 +6,7 @@ Time series data guide
 
 Time series data are a fundamental part of many data analysis projects in heliophysics as well as other areas.
 **sunpy** provides a TimeSeries object to handle this type of data.
-Much like the `~sunpy.map.Map` object, `~sunpy.timeseries.TimeSeries` can load generic filetypes, and recognizes data from nine specific sources to provide instrument specific data loading and plotting capabilities.
+Much like the `~sunpy.map.Map` object, the `~sunpy.timeseries.TimeSeries` object can load generic filetypes, and recognizes data from nine specific sources to provide instrument specific data loading and plotting capabilities.
 For more information about TimeSeries, and what file types and data sources are supported, check out :doc:`/code_ref/timeseries`.
 
 :ref:`creating-timeseries` describes how to create a TimeSeries object from single or multiple observational sources.
@@ -22,7 +22,7 @@ Lastly, :ref:`ts-metadata` describes how to view and extract information from th
 ========================
 
 A TimeSeries object can be created from local files.
-For convenience, **sunpy** can download several example timeseries of observational data.
+For convenience, **sunpy** can download several example time series of observational data.
 These files have names like ``sunpy.data.sample.EVE_TIMESERIES`` and ``sunpy.data.sample.GOES_XRS_TIMESERIES``.
 To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries`, type the following into your interactive Python shell:
 
@@ -42,7 +42,7 @@ To create one from a local GOES/XRS FITS file try the following:
     >>> my_timeseries = ts.TimeSeries('/mydirectory/myts.fits', source='XRS')   # doctest: +SKIP
 
 **sunpy** will attempt to detect automatically the instrument source for most FITS files.
-However timeseries data are stored in a variety of file types (FITS, txt, csv, CDF), and so it is not always possible to detect the source.
+However time series data are stored in a variety of file types (FITS, txt, csv, CDF), and so it is not always possible to detect the source.
 **sunpy** ships with a number of known instrumental sources, and can also load CDF files that conform to the `Space Physics Guidelines for CDF <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`__.
 If you would like **sunpy** to include another instrumental source see the `Newcomers' Guide <https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html>`__.
 
@@ -221,8 +221,8 @@ If you want to truncate using slice-like values you can, for example taking ever
 
     >>> my_timeseries_trunc = my_timeseries.truncate(0, 100000, 2) # doctest: +REMOTE_DATA
 
-4.3 More complicated timeseries operations
-------------------------------------------
+4.3 More complicated time series operations
+-------------------------------------------
 If you want to do any more complicated analysis on a TimeSeries, we recommend converting it to a `pandas.DataFrame` object first.
 Although this conversion will use the unit information and metadata, pandas has a wide array of methods that can be used e.g. for resampling data.
 As an example to downsample you can do:
@@ -232,7 +232,7 @@ As an example to downsample you can do:
     >>> downsampled_dataframe = my_timeseries_trunc.to_dataframe().resample('10T').mean() # doctest: +REMOTE_DATA
 
 Here ``10T`` means sample every 10 minutes and 'mean' is the method used to combine the data in each 10 minute bin.
-See the `pandas` documentation for more details on other functionality they offer for timeseries analysis.
+See the `pandas` documentation for more details on other functionality they offer for time series analysis.
 
 4.4 Concatenating TimeSeries
 ----------------------------
@@ -468,7 +468,7 @@ You can easily get an overview of the metadata, this will show you a basic repre
     |-------------------------------------------------------------------------------------------------|
     <BLANKLINE>
 
-The data within a `~sunpy.timeseries.TimeSeriesMetaData` object is stored as a list of tuples, each tuple representing the metadata from a source file or timeseries.
+The data within a `~sunpy.timeseries.TimeSeriesMetaData` object is stored as a list of tuples, each tuple representing the metadata from a source file or time series.
 The tuple will contain a `~sunpy.time.TimeRange` telling us which rows the metadata applies to, a list of column name strings for which the metadata applies to and finally a `~sunpy.util.metadata.MetaDict` object for storing the key/value pairs of the metadata itself.
 Each time a TimeSeries is concatenated to the original a new set of rows and/or columns will be added to the `~pandas.DataFrame` and a new entry will be added into the metadata.
 Note that entries are ordered chronologically based on

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -11,7 +11,7 @@ For more information about TimeSeries, and what data sources are currently suppo
 
 :ref:`creating-timeseries` describes how to create a TimeSeries object from single or multiple observational sources.
 :ref:`inspecting-timeseries` describes how to examine the data and metadata.
-:ref:`plotting-timeseries` outlines the basics of how SunPy will plot a TimeSeries object.
+:ref:`plotting-timeseries` outlines the basics of how **sunpy** will plot a TimeSeries object.
 :ref:`manipulating-timeseries` describes how to modify data, truncate a TimeSeries, down and up sample data, concatenate data, and create an Astropy Table from a TimeSeries.
 :ref:`custom-timeseries` details how to create a TimeSeries object from a Pandas DataFrame or an Astropy Table.
 Lastly, :ref:`ts-metadata` describes how to view and extract information from the metadata.
@@ -47,7 +47,7 @@ To create one from a local GOES/XRS FITS file try the following:
 **sunpy** will attempt to detect automatically the instrument source for most FITS files.
 However timeseries data are stored in a variety of file types (FITS, txt, csv, CDF) and formats, and so it is not always possible to detect the source.
 For this reason, it is good practice to explicitly state the source for the file.
-SunPy ships with a number of known instrumental sources.
+**sunpy** ships with a number of known instrumental sources.
 If you would like **sunpy** to include another instrumental source see the `Newcomers' Guide <https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html>`__.
 The `~sunpy.timeseries.TimeSeries` factory has the ability to make a list of TimeSeries objects using a list of filepaths, a folder or a glob, for example:
 
@@ -124,7 +124,7 @@ This references the `~sunpy.timeseries.TimeSeriesMetaData` object with the heade
 A word of caution: many data sources provide little to no meta data so this variable might be empty.
 The meta data is described in more detail later in this guide.
 Similarly there are properties for getting `~sunpy.timeseries.GenericTimeSeries.columns` as a list of strings, `~sunpy.timeseries.GenericTimeSeries.time` values and `~sunpy.timeseries.GenericTimeSeries.time_range` of the data.
-The actual data in a SunPy TimeSeries object is accessible through the `~sunpy.timeseries.GenericTimeSeries.data` attribute.
+The actual data in a **sunpy** TimeSeries object is accessible through the `~sunpy.timeseries.GenericTimeSeries.data` attribute.
 The data is implemented as a Pandas `~pandas.DataFrame`, so to get a look at what data you have available use:
 
 .. code-block:: python

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -32,8 +32,6 @@ To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries`, type the fol
     >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
     >>> my_timeseries = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES)  # doctest: +REMOTE_DATA
 
-.. doctest-skip-all
-
 This is calling the `~sunpy.timeseries.TimeSeries` factory to create a time series from a GOES XRS FITS file.
 
 The variable ``my_timeseries`` is a `~sunpy.timeseries.GenericTimeSeries` object.
@@ -62,8 +60,7 @@ Instead of creating a list of one TimeSeries object per file, you can create a s
 
 .. code-block:: python
 
-    >>> my_ts = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES, sunpy.data.sample.GOES_XRS_TIMESERIES,  # doctest: +REMOTE_DATA
-    >>>                       source='XRS', concatenate=True)  # doctest: +REMOTE_DATA
+    >>> my_ts = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES, sunpy.data.sample.GOES_XRS_TIMESERIES, source='XRS', concatenate=True)  # doctest: +REMOTE_DATA
 
 Again these must all be from the same source if the ``source`` keyword is explicitly specified.
 The `.GenericTimeSeries.concatenate` method can be used to make a single time series from multiple TimeSeries from different sources if they are already in the form of TimeSeries objects.
@@ -79,7 +76,7 @@ For a quick look at a TimeSeries, type:
 .. code-block:: python
 
     >>> my_timeseries  # doctest: +REMOTE_DATA
-    <sunpy.timeseries.sources.goes.XRSTimeSeries object at 0x000002168FDCE280>
+    <sunpy.timeseries.sources.goes.XRSTimeSeries object at ...>
     SunPy TimeSeries
     ----------------
     Observatory:		 GOES-15
@@ -104,7 +101,7 @@ For a quick look at a TimeSeries, type:
     2011-06-07 23:59:53.538999915  1.000000e-09  1.598500e-07
     2011-06-07 23:59:55.584999919  1.000000e-09  1.624800e-07
     2011-06-07 23:59:57.631999850  1.000000e-09  1.598500e-07
-
+    <BLANKLINE>
     [42177 rows x 2 columns]
 
 This shows a table of information taken from the metadata and a preview of your data.
@@ -115,6 +112,22 @@ The metadata for the time series is accessed by:
 .. code-block:: python
 
     >>> my_timeseries.meta # doctest: +REMOTE_DATA
+    |-------------------------------------------------------------------------------------------------|
+    |TimeRange                  | Columns         | Meta                                              |
+    |-------------------------------------------------------------------------------------------------|
+    |2011-06-06T23:59:59.961999 | xrsa            | simple: True                                      |
+    |            to             | xrsb            | bitpix: 8                                         |
+    |2011-06-07T23:59:57.631999 |                 | naxis: 0                                          |
+    |                           |                 | extend: True                                      |
+    |                           |                 | date: 26/06/2012                                  |
+    |                           |                 | numext: 3                                         |
+    |                           |                 | telescop: GOES 15                                 |
+    |                           |                 | instrume: X-ray Detector                          |
+    |                           |                 | object: Sun                                       |
+    |                           |                 | origin: SDAC/GSFC                                 |
+    |                           |                 | ...                                               |
+    |-------------------------------------------------------------------------------------------------|
+    <BLANKLINE>
 
 This references the `~sunpy.timeseries.TimeSeriesMetaData` object with the header information as read from the source files.
 A word of caution: many data sources provide little to no meta data so this variable might be empty.
@@ -126,6 +139,7 @@ To get a column of the data use the `~sunpy.timeseries.GenericTimeSeries.quantit
 .. code-block:: python
 
     >>> my_timeseries.quantity('xrsa') # doctest: +REMOTE_DATA
+    <Quantity [1.e-09, 1.e-09, 1.e-09, ..., 1.e-09, 1.e-09, 1.e-09] W / m2>
 
 .. _plotting-timeseries:
 
@@ -180,6 +194,7 @@ For example:
     >>> values = my_timeseries.quantity('xrsa') * 2
     >>> my_timeseries = my_timeseries.add_column('xrsa*2', values)
     >>> my_timeseries.columns
+    ['xrsa', 'xrsb', 'xrsa*2']
 
 Adding a column is not done in place, but instead returns a new TimeSeries with the new column added.
 Note that the values will be converted into the column units if an Astropy `~astropy.units.quantity.Quantity` is given.
@@ -214,7 +229,7 @@ As an example to downsample you can do:
 
 .. code-block:: python
 
-    >>> downsampled_dataframe = my_timeseries_trunc.to_datafrmae().resample('10T').mean()
+    >>> downsampled_dataframe = my_timeseries_trunc.to_dataframe().resample('10T').mean()
 
 Here ``10T`` means sample every 10 minutes and 'mean' is the method used to combine the data in each 10 minute bin.
 See the `pandas` documentation for more details on other functionality they offer for timeseries analysis.
@@ -235,7 +250,7 @@ For example:
 
 .. code-block:: python
 
-    >>> concatenated_timeseries = goes_timeseries_1.concatenate(goes_timeseries_2)
+    >>> concatenated_timeseries = goes_timeseries_1.concatenate(goes_timeseries_2) # doctest: +SKIP
 
 This will result in a TimeSeries identical to if you used the factory to create it in one step.
 A limitation of the TimeSeries class is that often it is not easy to determine the source observatory/instrument of a file, generally because the file formats used vary depending on the scientific working groups, thus some sources need to be explicitly stated (as a keyword argument) and so it is not possible to concatenate files from multiple sources with the factory.
@@ -243,13 +258,43 @@ To do this you can still use the `~sunpy.timeseries.GenericTimeSeries.concatenat
 
 .. code-block:: python
 
-    >>> concatenated_timeseries = goes_timeseries.concatenate(eve_timeseries)
+    >>> eve_ts = ts.TimeSeries(sunpy.data.sample.EVE_TIMESERIES, source='eve')
+    >>> goes_ts = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES)
+    >>> concatenated_timeseries = goes_ts.concatenate(eve_ts)
 
 Note that the more complex `~sunpy.timeseries.TimeSeriesMetaData` object now has 2 entries and shows details on both:
 
 .. code-block:: python
 
     >>> concatenated_timeseries.meta
+        |-------------------------------------------------------------------------------------------------|
+    |TimeRange                  | Columns         | Meta                                              |
+    |-------------------------------------------------------------------------------------------------|
+    |2011-06-06T23:59:59.961999 | xrsa            | simple: True                                      |
+    |            to             | xrsb            | bitpix: 8                                         |
+    |2011-06-07T23:59:57.631999 |                 | naxis: 0                                          |
+    |                           |                 | extend: True                                      |
+    |                           |                 | date: 26/06/2012                                  |
+    |                           |                 | numext: 3                                         |
+    |                           |                 | telescop: GOES 15                                 |
+    |                           |                 | instrume: X-ray Detector                          |
+    |                           |                 | object: Sun                                       |
+    |                           |                 | origin: SDAC/GSFC                                 |
+    |                           |                 | ...                                               |
+    |-------------------------------------------------------------------------------------------------|
+    |2011-06-07T00:00:00.000000 | XRS-B proxy     | data_list: 20110607_EVE_L0CS_DIODES_1m.txt        |
+    |            to             | XRS-A proxy     | created: Tue Jun  7 23:59:10 2011 UTC             |
+    |2011-06-07T23:59:00.000000 | SEM proxy       | origin: SDO/EVE Science Processing and Operations |
+    |                           | 0.1-7ESPquad    | units: W/m^2 for irradiance, dark is counts/(0.25s|
+    |                           | 17.1ESP         | source: SDO-EVE ESP and MEGS-P instruments, http:/|
+    |                           | 25.7ESP         | product: Level 0CS, 1-minute averaged SDO-EVE Sola|
+    |                           | 30.4ESP         | version: 2.1, code updated 2011-May-12            |
+    |                           | 36.6ESP         | missing data: -1.00e+00                           |
+    |                           | darkESP         | hhmm: hour and minute in UT                       |
+    |                           | 121.6MEGS-P     | xrs-b proxy: a model of the expected XRS-B 0.1-0.8|
+    |                           | ...             | ...                                               |
+    |-------------------------------------------------------------------------------------------------|
+    <BLANKLINE>
 
 The metadata object is described in more detail in the next section.
 
@@ -271,30 +316,30 @@ One of the most useful reasons for doing this is that Astropy `~sunpy.timeseries
 
     >>> table
     <Table length=21089>
-                 date               xrsa     xrsb
-                                   W / m2   W / m2
-            datetime64[ns]        float32  float32
-    ----------------------------- ------- ----------
-    2011-06-06T23:59:59.961999000     0.1 1.8871e-07
-    2011-06-07T00:00:04.058999000   1e-09 1.8609e-07
-    2011-06-07T00:00:08.151999000   1e-09 1.8609e-07
-    2011-06-07T00:00:12.248999000   1e-09 1.8609e-07
-    2011-06-07T00:00:16.344999000   1e-09 1.8084e-07
-    2011-06-07T00:00:20.441999000   1e-09 1.8084e-07
-    2011-06-07T00:00:24.534999000   1e-09 1.8084e-07
-    2011-06-07T00:00:28.631999000   1e-09 1.8346e-07
-    2011-06-07T00:00:32.728999000   1e-09 1.8346e-07
-                              ...     ...        ...
-    2011-06-07T23:59:20.768999000   1e-09  1.651e-07
-    2011-06-07T23:59:24.864999000   1e-09 1.5985e-07
-    2011-06-07T23:59:28.961999000   1e-09 1.5985e-07
-    2011-06-07T23:59:33.058999000   1e-09 1.6248e-07
-    2011-06-07T23:59:37.151999000   1e-09 1.6248e-07
-    2011-06-07T23:59:41.248999000   1e-09 1.5985e-07
-    2011-06-07T23:59:45.344999000   1e-09 1.5723e-07
-    2011-06-07T23:59:49.441999000   1e-09 1.6248e-07
-    2011-06-07T23:59:53.538999000   1e-09 1.5985e-07
-    2011-06-07T23:59:57.631999000   1e-09 1.5985e-07
+                 date               xrsa     xrsb     xrsa*2
+                                   W / m2   W / m2    W / m2
+            datetime64[ns]        float32  float32   float32
+    ----------------------------- ------- ---------- -------
+    2011-06-06T23:59:59.961999893   1e-09 1.8871e-07   2e-09
+    2011-06-07T00:00:04.058999896   1e-09 1.8609e-07   2e-09
+    2011-06-07T00:00:08.151999950   1e-09 1.8609e-07   2e-09
+    2011-06-07T00:00:12.248999953   1e-09 1.8609e-07   2e-09
+    2011-06-07T00:00:16.344999909   1e-09 1.8084e-07   2e-09
+    2011-06-07T00:00:20.441999912   1e-09 1.8084e-07   2e-09
+    2011-06-07T00:00:24.534999847   1e-09 1.8084e-07   2e-09
+    2011-06-07T00:00:28.631999850   1e-09 1.8346e-07   2e-09
+    2011-06-07T00:00:32.728999853   1e-09 1.8346e-07   2e-09
+                              ...     ...        ...     ...
+    2011-06-07T23:59:20.768999934   1e-09  1.651e-07   2e-09
+    2011-06-07T23:59:24.864999890   1e-09 1.5985e-07   2e-09
+    2011-06-07T23:59:28.961999893   1e-09 1.5985e-07   2e-09
+    2011-06-07T23:59:33.058999896   1e-09 1.6248e-07   2e-09
+    2011-06-07T23:59:37.151999950   1e-09 1.6248e-07   2e-09
+    2011-06-07T23:59:41.248999953   1e-09 1.5985e-07   2e-09
+    2011-06-07T23:59:45.344999909   1e-09 1.5723e-07   2e-09
+    2011-06-07T23:59:49.441999912   1e-09 1.6248e-07   2e-09
+    2011-06-07T23:59:53.538999915   1e-09 1.5985e-07   2e-09
+    2011-06-07T23:59:57.631999850   1e-09 1.5985e-07   2e-09
 
 and the more sophisticated browser view using the `~astropy.table.Table.show_in_browser` method:
 
@@ -346,17 +391,10 @@ This `~pandas.DataFrame` can then be used to construct a TimeSeries:
 .. code-block:: python
 
     >>> import sunpy.timeseries as ts
-    >>> ts_custom = ts.TimeSeries(data)
-
-Furthermore, we could specify the metadata/header and units of this time series by sending them as arguments to the factory:
-
-.. code-block:: python
-
     >>> import astropy.units as u
-
-    >>> meta = {'key':'value'}
-    >>> units = {'intensity', u.W/u.m**2}
-    >>> ts_custom = ts.TimeSeries(data, meta, units)
+    >>> header = {'key': 'value'}
+    >>> units = {'intensity': u.W/u.m**2}
+    >>> ts_custom = ts.TimeSeries(data, header, units)
 
 5.2 Creating Custom TimeSeries from an Astropy Table
 ----------------------------------------------------
@@ -416,9 +454,9 @@ You can easily get an overview of the metadata, this will show you a basic repre
     |-------------------------------------------------------------------------------------------------|
     |TimeRange                  | Columns         | Meta                                              |
     |-------------------------------------------------------------------------------------------------|
-    |2011-06-06 23:59:59.961999 | xrsa            | simple: True                                      |
+    |2011-06-06T23:59:59.961999 | xrsa            | simple: True                                      |
     |            to             | xrsb            | bitpix: 8                                         |
-    |2011-06-07 23:59:57.631999 |                 | naxis: 0                                          |
+    |2011-06-07T23:59:57.631999 |                 | naxis: 0                                          |
     |                           |                 | extend: True                                      |
     |                           |                 | date: 26/06/2012                                  |
     |                           |                 | numext: 3                                         |

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -191,9 +191,9 @@ For example:
 
 .. code-block:: python
 
-    >>> values = my_timeseries.quantity('xrsa') * 2
-    >>> my_timeseries = my_timeseries.add_column('xrsa*2', values)
-    >>> my_timeseries.columns
+    >>> values = my_timeseries.quantity('xrsa') * 2 # doctest: +REMOTE_DATA
+    >>> my_timeseries = my_timeseries.add_column('xrsa*2', values) # doctest: +REMOTE_DATA
+    >>> my_timeseries.columns # doctest: +REMOTE_DATA
     ['xrsa', 'xrsb', 'xrsa*2']
 
 Adding a column is not done in place, but instead returns a new TimeSeries with the new column added.
@@ -211,7 +211,7 @@ For example, to trim our GOES data into a period of interest use:
 
     >>> from sunpy.time import TimeRange
     >>> tr = TimeRange('2012-06-01 05:00', '2012-06-01 06:30')
-    >>> my_timeseries_trunc = my_timeseries.truncate(tr)
+    >>> my_timeseries_trunc = my_timeseries.truncate(tr) # doctest: +REMOTE_DATA
 
 This takes a number of different arguments, such as the start and end dates (as datetime or string objects) or a `~sunpy.time.TimeRange` as used above.
 Note that the truncated TimeSeries will have a truncated `~sunpy.timeseries.TimeSeriesMetaData` object, which may include dropping metadata entries for data totally cut out from the TimeSeries.
@@ -219,7 +219,7 @@ If you want to truncate using slice-like values you can, for example taking ever
 
 .. code-block:: python
 
-    >>> my_timeseries_trunc = my_timeseries.truncate(0, 100000, 2)
+    >>> my_timeseries_trunc = my_timeseries.truncate(0, 100000, 2) # doctest: +REMOTE_DATA
 
 4.3 More complicated timeseries operations
 ------------------------------------------
@@ -229,7 +229,7 @@ As an example to downsample you can do:
 
 .. code-block:: python
 
-    >>> downsampled_dataframe = my_timeseries_trunc.to_dataframe().resample('10T').mean()
+    >>> downsampled_dataframe = my_timeseries_trunc.to_dataframe().resample('10T').mean() # doctest: +REMOTE_DATA
 
 Here ``10T`` means sample every 10 minutes and 'mean' is the method used to combine the data in each 10 minute bin.
 See the `pandas` documentation for more details on other functionality they offer for timeseries analysis.
@@ -258,15 +258,15 @@ To do this you can still use the `~sunpy.timeseries.GenericTimeSeries.concatenat
 
 .. code-block:: python
 
-    >>> eve_ts = ts.TimeSeries(sunpy.data.sample.EVE_TIMESERIES, source='eve')
-    >>> goes_ts = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES)
-    >>> concatenated_timeseries = goes_ts.concatenate(eve_ts)
+    >>> eve_ts = ts.TimeSeries(sunpy.data.sample.EVE_TIMESERIES, source='eve') # doctest: +REMOTE_DATA
+    >>> goes_ts = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES) # doctest: +REMOTE_DATA
+    >>> concatenated_timeseries = goes_ts.concatenate(eve_ts) # doctest: +REMOTE_DATA
 
 Note that the more complex `~sunpy.timeseries.TimeSeriesMetaData` object now has 2 entries and shows details on both:
 
 .. code-block:: python
 
-    >>> concatenated_timeseries.meta
+    >>> concatenated_timeseries.meta # doctest: +REMOTE_DATA
         |-------------------------------------------------------------------------------------------------|
     |TimeRange                  | Columns         | Meta                                              |
     |-------------------------------------------------------------------------------------------------|
@@ -307,14 +307,14 @@ For example:
 
 .. code-block:: python
 
-    >>> table = my_timeseries_trunc.to_table()
+    >>> table = my_timeseries_trunc.to_table() # doctest: +REMOTE_DATA
 
 Note that this `~astropy.table.Table` will contain a mixin column for containing the Astropy `~astropy.time.Time` object representing the index, it will also add the relevant units to the columns.
 One of the most useful reasons for doing this is that Astropy `~sunpy.timeseries.GenericTimeSeries.to_table` objects have some very nice options for viewing the data, including the basic console view:
 
 .. code-block:: python
 
-    >>> table
+    >>> table # doctest: +REMOTE_DATA
     <Table length=21089>
                  date               xrsa     xrsb     xrsa*2
                                    W / m2   W / m2    W / m2
@@ -444,13 +444,13 @@ The metadata can be accessed by:
 
 .. code-block:: python
 
-    >>> meta = my_timeseries.meta
+    >>> meta = my_timeseries.meta # doctest: +REMOTE_DATA
 
 You can easily get an overview of the metadata, this will show you a basic representation of the metadata entries that are relevant to this TimeSeries.
 
 .. code-block:: python
 
-    >>> meta
+    >>> meta # doctest: +REMOTE_DATA
     |-------------------------------------------------------------------------------------------------|
     |TimeRange                  | Columns         | Meta                                              |
     |-------------------------------------------------------------------------------------------------|
@@ -482,7 +482,7 @@ For example:
 
 .. code-block:: python
 
-    >>> meta_str = meta.to_string(depth = 20, width=99)
+    >>> meta_str = meta.to_string(depth=20, width=99) # doctest: +REMOTE_DATA
 
 Similar to the TimeSeries, the metadata has some properties for convenient access to the global metadata details, including `~sunpy.timeseries.TimeSeriesMetaData.columns` as a list of strings,  and `~sunpy.timeseries.TimeSeriesMetaData.time_range` of the data.
 Beyond this, there are properties to get lists of details for all the entries in the `~sunpy.timeseries.TimeSeriesMetaData` object, including `~sunpy.timeseries.TimeSeriesMetaData.timeranges`, `~sunpy.timeseries.TimeSeriesMetaData.columns` (as a list of string column names) and `~sunpy.timeseries.TimeSeriesMetaData.metas`.
@@ -495,8 +495,8 @@ For example:
 
 .. code-block:: python
 
-    >>> tsmd_return = my_timeseries.meta.find(colname='xrsa', time='2012-06-01 00:00:33.904999')
-    >>> tsmd_return.metas
+    >>> tsmd_return = my_timeseries.meta.find(colname='xrsa', time='2012-06-01 00:00:33.904999') # doctest: +REMOTE_DATA
+    >>> tsmd_return.metas # doctest: +REMOTE_DATA
     []
 
 Note, the colname and time filters are optional, but omitting both filters just returns an identical `~sunpy.timeseries.TimeSeriesMetaData` object to the TimeSeries original.
@@ -507,8 +507,8 @@ The result can be converted into a simple list of strings using the `~sunpy.time
 
 .. code-block:: python
 
-    >>> tsmd_return = my_timeseries.meta.get('telescop', colname='xrsa')
-    >>> tsmd_return.values()
+    >>> tsmd_return = my_timeseries.meta.get('telescop', colname='xrsa') # doctest: +REMOTE_DATA
+    >>> tsmd_return.values() # doctest: +REMOTE_DATA
     ['GOES 15']
 
 Note `~sunpy.timeseries.TimeSeriesMetaData.values` removes duplicate strings and sorts the returned list.
@@ -516,7 +516,7 @@ You can update the values for these entries efficiently using the `~sunpy.timese
 
 .. code-block:: python
 
-    >>> my_timeseries.meta.update({'telescop': 'G15'}, colname='xrsa', overwrite=True)
+    >>> my_timeseries.meta.update({'telescop': 'G15'}, colname='xrsa', overwrite=True) # doctest: +REMOTE_DATA
 
 Here we have to specify the ``overwrite=False`` keyword parameter to allow us to overwrite values for keys already present in the `~sunpy.util.metadata.MetaDict` objects, this helps protect the integrity of the original metadata and without this set (or with it set to False) you can still add new key/value pairs.
 Note that the `~sunpy.util.metadata.MetaDict` objects are both case-insensitive for key strings and have ordered entries, where possible the order is preserved when updating values.

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -1,6 +1,8 @@
-****************
-TimeSeries Guide
-****************
+.. _timeseries_guide:
+
+*********************
+Timeseries data guide
+*********************
 
 Time series data are a fundamental part of many data analysis projects in heliophysics as well as other areas.
 **sunpy** provides a TimeSeries object to handle this type of data.


### PR DESCRIPTION
There are some minor changes to the map guide, but this is mainly an update to the TimeSeries guide. The main changes is stripping out any mentions of using `.data`. We are actively discouraging this because at some point in the future we will no longer use a `pandas.DataFrame` object to store the data internally, so we want users to use `.to_dataframe()` instead which is API we can carry on supporting even if we change the internal data storage.

@mwhv2 would be great if you could review my changes to make sure I haven't mangled what you wrote too much!