### PR TITLE
Add helper for creating Carrington header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1242,7 +1242,7 @@ Bug Fixes
   frame of the input map to the output coordinates. Previously only the observer
   coordinate, and no other frame attributes, were propagated. (`#4141 <https://github.com/sunpy/sunpy/pull/4141>`__)
 - Fix an off-by-one error in the reference pixel returned by
-  `sunpy.map.header_helper.make_fitswcs_header`. (`#4152 <https://github.com/sunpy/sunpy/pull/4152>`__)
+  :func:`sunpy.map.header_helper.make_fitswcs_header`. (`#4152 <https://github.com/sunpy/sunpy/pull/4152>`__)
 - `sunpy.map.GenericMap.reference_pixel` now uses zero-based indexing, in order
   to be consistent with the rest of the `sunpy.map` API. (`#4154 <https://github.com/sunpy/sunpy/pull/4154>`__)
 - Previously `sunpy.map.GenericMap.resample` with ``method='linear'`` was
@@ -1389,7 +1389,7 @@ Features
 - `~sunpy.map.GenericMap` objects now have a ``.cmap`` attribute, which returns the full `~matplotlib.colors.Colormap`.
   object. (`#3412 <https://github.com/sunpy/sunpy/pull/3412>`__)
 - `sunpy.io.write_file()` now accepts `~pathlib.Path` objects as filename inputs. (`#3469 <https://github.com/sunpy/sunpy/pull/3469>`__)
-- `sunpy.map.header_helper.make_fitswcs_header` now accepts a `tuple` representing the shape of an array as well as the actual array as the ``data`` argument. (`#3483 <https://github.com/sunpy/sunpy/pull/3483>`__)
+- :func:`sunpy.map.header_helper.make_fitswcs_header` now accepts a `tuple` representing the shape of an array as well as the actual array as the ``data`` argument. (`#3483 <https://github.com/sunpy/sunpy/pull/3483>`__)
 - Made a couple of module imports lazy to reduce the import time of sunpy.map by
   ~40%. (`#3495 <https://github.com/sunpy/sunpy/pull/3495>`__)
 - `sunpy.map.GenericMap.wcs` now uses the full FITS header to construct the WCS.
@@ -1410,13 +1410,13 @@ Bug Fixes
 ---------
 
 - Fixed accuracy issues with the calculations of Carrington longitude (`~sunpy.coordinates.sun.L0`) and Carrington rotation number (`~sunpy.coordinates.sun.carrington_rotation_number`). (`#3178 <https://github.com/sunpy/sunpy/pull/3178>`__)
-- Updated `sunpy.map.header_helper.make_fitswcs_header` to be more strict on the inputs it accepts. (`#3183 <https://github.com/sunpy/sunpy/pull/3183>`__)
-- Fix the calculation of ``rsun_ref`` in `~sunpy.map.header_helper.make_fitswcs_header` and and
+- Updated :func:`sunpy.map.header_helper.make_fitswcs_header` to be more strict on the inputs it accepts. (`#3183 <https://github.com/sunpy/sunpy/pull/3183>`__)
+- Fix the calculation of ``rsun_ref`` in :func:`~sunpy.map.header_helper.make_fitswcs_header` and and
   ensure that the default reference pixel is indexed from 1. (`#3184 <https://github.com/sunpy/sunpy/pull/3184>`__)
 - Fixed the missing transformation between two `~sunpy.coordinates.HeliographicCarrington` frames with different observation times. (`#3186 <https://github.com/sunpy/sunpy/pull/3186>`__)
 - `sunpy.map.sources.AIAMap` and `sunpy.map.sources.HMIMap` will no longer assume
   the existance of certain header keys. (`#3217 <https://github.com/sunpy/sunpy/pull/3217>`__)
-- `sunpy.map.header_helper.make_fitswcs_header` now supports specifying the map projection
+- :func:`sunpy.map.header_helper.make_fitswcs_header` now supports specifying the map projection
   rather than defaulting to ``TAN``. (`#3218 <https://github.com/sunpy/sunpy/pull/3218>`__)
 - Fix the behaviour of
   ``sunpy.coordinates.frames.Helioprojective.calculate_distance`` if the
@@ -1443,7 +1443,7 @@ Bug Fixes
 - Fixed bugs with `~sunpy.coordinates.wcs_utils.solar_frame_to_wcs_mapping` if the input frame does not include an observation time or an observer. (`#3305 <https://github.com/sunpy/sunpy/pull/3305>`__)
 - `~sunpy.coordinates.utils.GreatArc` now accounts for the start and end points of the arc having different observers. (`#3334 <https://github.com/sunpy/sunpy/pull/3334>`__)
 - Fixed situations where 2D coordinates provided to `~sunpy.coordinates.frames.HeliographicStonyhurst` and `~sunpy.coordinates.frames.HeliographicCarrington` were not converted to 3D as intended.  Furthermore, the stored data will always be the post-conversion, 3D version. (`#3351 <https://github.com/sunpy/sunpy/pull/3351>`__)
-- Fix off by one error in `sunpy.map.header_helper.make_fitswcs_header` where when using the
+- Fix off by one error in :func:`sunpy.map.header_helper.make_fitswcs_header` where when using the
   default ``reference_pixel=None`` keyword argument the pixel coordinate of the
   reference pixel was off by +1. (`#3356 <https://github.com/sunpy/sunpy/pull/3356>`__)
 - Updated both GOES XRS and LYRA dataretriever clients to use ``sunpy.util.scraper.Scraper``, to make sure that files are actually on the servers being queried. (`#3367 <https://github.com/sunpy/sunpy/pull/3367>`__)
@@ -1636,7 +1636,7 @@ Features
 - The default style for Map plots have changed to reflect the changes in Astropy
   3.2. (`#3054 <https://github.com/sunpy/sunpy/pull/3054>`__)
 - `sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst` can now account for light travel time when computing the (apparent) body position, as long as the observer location is provided. (`#3055 <https://github.com/sunpy/sunpy/pull/3055>`__)
-- Added a helper function (`sunpy.map.header_helper.make_fitswcs_header`) that allows users to create a meta header for custom created `sunpy.map.GenericMap`. (`#3083 <https://github.com/sunpy/sunpy/pull/3083>`__)
+- Added a helper function (:func:`sunpy.map.header_helper.make_fitswcs_header`) that allows users to create a meta header for custom created `sunpy.map.GenericMap`. (`#3083 <https://github.com/sunpy/sunpy/pull/3083>`__)
 - Map plotting now accepts the optional keyword ``clip_interval`` for specifying a percentile interval for clipping.  For example, if the interval (5%, 99%) is specified, the bounds of the z axis are chosen such that the lowest 5% of pixels and the highest 1% of pixels are excluded. (`#3100 <https://github.com/sunpy/sunpy/pull/3100>`__)
 - The new function `~sunpy.coordinates.get_horizons_coord` enables querying JPL HORIZONS for the locations of a wide range of solar-system bodies, including spacecraft. (`#3113 <https://github.com/sunpy/sunpy/pull/3113>`__)
 
@@ -1692,7 +1692,7 @@ Bug Fixes
   that `astropy.wcs.WCS` objects are correctly converted to
   `sunpy.coordinates.frames` objects irrespective of the ordering of the axes. (`#3116 <https://github.com/sunpy/sunpy/pull/3116>`__)
 - The `~sunpy.physics.differential_rotation.solar_rotate_coordinate` function returns a coordinate that accounts for the location of the new observer. (`#3123 <https://github.com/sunpy/sunpy/pull/3123>`__)
-- Add support for rotation parameters to `sunpy.map.header_helper.make_fitswcs_header`. (`#3139 <https://github.com/sunpy/sunpy/pull/3139>`__)
+- Add support for rotation parameters to :func:`sunpy.map.header_helper.make_fitswcs_header`. (`#3139 <https://github.com/sunpy/sunpy/pull/3139>`__)
 - Improve the implementation of `~sunpy.physics.differential_rotation.differential_rotate` the image warping when transforming Maps for differential rotation and change in observer position. (`#3149 <https://github.com/sunpy/sunpy/pull/3149>`__)
 - Fix a bug where new helioviewer sources potentially cause `~sunpy.net.helioviewer.HelioviewerClient.data_sources` to error. (`#3162 <https://github.com/sunpy/sunpy/pull/3162>`__)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,7 +43,7 @@ New Features
 
 - Added support for Python 3.10 (`#5568 <https://github.com/sunpy/sunpy/pull/5568>`__)
 - Added support for ``"%Y.%m.%d_%H:%M:%S_UTC"`` and ``"%Y.%m.%d_%H:%M:%S"`` time formats in `sunpy.time.parse_time`. (`#5647 <https://github.com/sunpy/sunpy/pull/5647>`__)
-- The ``rsun`` argument to :func:`~sunpy.map.get_observer_meta` is now
+- The ``rsun`` argument to :func:`~sunpy.map.header_helper.get_observer_meta` is now
   optional. (`#5655 <https://github.com/sunpy/sunpy/pull/5655>`__)
 - Added the :meth:`~sunpy.net.base_client.QueryResponseTable.total_size`, which
   estimates the total size of the results from a Fido query. If this is supported
@@ -110,7 +110,7 @@ Bug Fixes
   If the maximum number of records are returned, a message is shown. (`#5738 <https://github.com/sunpy/sunpy/pull/5738>`__)
 - Reading a series of CDF files where at least one of them is empty no longer
   raises an error. A message for each empty file is logged at the DEBUG level. (`#5751 <https://github.com/sunpy/sunpy/pull/5751>`__)
-- :func:`sunpy.map.make_fitswcs_header` now includes a PC_ij matrix in the returned
+- :func:`sunpy.map.header_helper.make_fitswcs_header` now includes a PC_ij matrix in the returned
   header if no rotation is specified. (`#5763 <https://github.com/sunpy/sunpy/pull/5763>`__)
 - In the case where a map header has no PC_ij values, CROTA2 != 0, and
   CDELT1 != CDELT2, the calculation of the map rotation matrix has been fixed.
@@ -324,7 +324,7 @@ New Features
 - Add default color map and normalization for `~sunpy.map.sources.HMISynopticMap`
   The default color map is 'hmimag' and the default normalization is linear between
   -1.5e-3 and +1.5e3, the expected normalization for this particular color map. (`#5464 <https://github.com/sunpy/sunpy/pull/5464>`__)
-- The headers produced by :func:`~sunpy.map.make_fitswcs_header` now include ``NAXIS``, ``NAXIS1``, and ``NAXIS2`` keywords. (`#5470 <https://github.com/sunpy/sunpy/pull/5470>`__)
+- The headers produced by :func:`~sunpy.map.header_helper.make_fitswcs_header` now include ``NAXIS``, ``NAXIS1``, and ``NAXIS2`` keywords. (`#5470 <https://github.com/sunpy/sunpy/pull/5470>`__)
 - The `~astropy.wcs.WCS` instance returned by the `sunpy.map.GenericMap.wcs` property now includes the shape of the data array. (`#5470 <https://github.com/sunpy/sunpy/pull/5470>`__)
 - Added the method :meth:`sunpy.map.GenericMap.reproject_to` for reprojecting a `~sunpy.map.Map` to a different WCS.
   This method requires the optional package `reproject` to be installed. (`#5470 <https://github.com/sunpy/sunpy/pull/5470>`__)
@@ -386,7 +386,7 @@ Bug Fixes
   changes from e.g. degrees to arc-minutes. This could previously lead to
   situations where the axis label units were incorrect. (`#5432 <https://github.com/sunpy/sunpy/pull/5432>`__)
 - Implement automatic fallback to helioviewer mirrors if API is non-functional. (`#5440 <https://github.com/sunpy/sunpy/pull/5440>`__)
-- Fixed the incorrect value for the FITS WCS ``LONPOLE`` keyword when using :func:`~sunpy.map.make_fitswcs_header` for certain combinations of WCS projection and reference coordinate. (`#5448 <https://github.com/sunpy/sunpy/pull/5448>`__)
+- Fixed the incorrect value for the FITS WCS ``LONPOLE`` keyword when using :func:`~sunpy.map.header_helper.make_fitswcs_header` for certain combinations of WCS projection and reference coordinate. (`#5448 <https://github.com/sunpy/sunpy/pull/5448>`__)
 - The date returned by `~sunpy.map.GenericMap.date` for Solar Orbiter/EUI maps
   has been adjusted to be taken from the DATE-AVG keyword
   (the middle of the image acquisition period), instead of the DATE-OBS
@@ -400,7 +400,7 @@ Bug Fixes
 - Fixed a bug where the property `sunpy.map.GenericMap.rsun_meters` would always internally determine the observer location, even when it is not needed, particularly for Stonyhurst heliographic maps, which have no notion of an observer.
   Thus, when working with a Stonyhurst heliographic map, a user could get an irrelevant warning message about having to assume an observer location (Earth center). (`#5478 <https://github.com/sunpy/sunpy/pull/5478>`__)
 - Fixed the unintended insertion of (assumed) observer location information when accessing the property `sunpy.map.GenericMap.wcs` for Stonyhurst heliographic maps. (`#5478 <https://github.com/sunpy/sunpy/pull/5478>`__)
-- Fixed an incorrect value for the FITS WCS ``LONPOLE`` keyword when using :func:`~sunpy.map.make_fitswcs_header` for `~sunpy.coordinates.frames.Helioprojective` maps with certain values of latitude for the reference coordinate. (`#5490 <https://github.com/sunpy/sunpy/pull/5490>`__)
+- Fixed an incorrect value for the FITS WCS ``LONPOLE`` keyword when using :func:`~sunpy.map.header_helper.make_fitswcs_header` for `~sunpy.coordinates.frames.Helioprojective` maps with certain values of latitude for the reference coordinate. (`#5490 <https://github.com/sunpy/sunpy/pull/5490>`__)
 - A non-standard ``CROTA`` keyword included in a `sunpy.map.sources.EUIMap` FITS header is now renamed to the recommended ``CROTA2`` so a warning is no longer raised. (`#5493 <https://github.com/sunpy/sunpy/pull/5493>`__)
 - The plotting x-limits of :meth:`sunpy.timeseries.sources.NOAAIndicesTimeSeries.plot`
   are now adjusted to only include finite points in the timeseries data. (`#5496 <https://github.com/sunpy/sunpy/pull/5496>`__)
@@ -590,7 +590,7 @@ Bug Fixes
   This resulted in the unexpected use of transformation machinery when transforming a coordinate to its own coordinate frame. (`#5127 <https://github.com/sunpy/sunpy/pull/5127>`__)
 - Fixed a bug with failing downloads in 2010 with the `~sunpy.net.dataretriever.sources.noaa.SRSClient`. (`#5159 <https://github.com/sunpy/sunpy/pull/5159>`__)
 - If the property `sunpy.map.GenericMap.rsun_obs` needs to calculate the solar angular radius from header information, it now properly uses the ``rsun_ref`` keyword if it is present and does not emit any warning. (`#5172 <https://github.com/sunpy/sunpy/pull/5172>`__)
-- Added a "rsun_obs" keyword to the output of :func:`sunpy.map.make_fitswcs_header` if the coordinate argument has a "rsun" frame attribute. (`#5177 <https://github.com/sunpy/sunpy/pull/5177>`__)
+- Added a "rsun_obs" keyword to the output of :func:`sunpy.map.header_helper.make_fitswcs_header` if the coordinate argument has a "rsun" frame attribute. (`#5177 <https://github.com/sunpy/sunpy/pull/5177>`__)
 - Fixed small inaccuracies in the grid plotted by :meth:`~sunpy.map.GenericMap.draw_grid` for maps that specify a radius of the Sun that is different from the constant in `sunpy.sun.constants`. (`#5211 <https://github.com/sunpy/sunpy/pull/5211>`__)
 - Fixed :meth:`sunpy.map.GenericMap.draw_contours` so that the contours from a map can be plotted on axes with a different coordinate system. (`#5239 <https://github.com/sunpy/sunpy/pull/5239>`__)
 - When using the cylindrical representation of ``Heliocentric`` to work in the Heliocentric Radial coordinate frame, the ``psi`` component now goes from 0 to 360 degrees instead of -180 to 180 degrees. (`#5242 <https://github.com/sunpy/sunpy/pull/5242>`__)
@@ -598,7 +598,7 @@ Bug Fixes
 - :func:`sunpy.coordinates.solar_frame_to_wcs_mapping` now sets the observer auxiliary
   information when a `~sunpy.coordinates.HeliographicCarrington` frame with
   ``observer='self'`` is passed. (`#5264 <https://github.com/sunpy/sunpy/pull/5264>`__)
-- Calling :func:`sunpy.map.make_fitswcs_header` with a
+- Calling :func:`sunpy.map.header_helper.make_fitswcs_header` with a
   `~sunpy.coordinates.HeliographicCarrington` coordinate that with ``observer='self'``
   set now correctly sets the observer information in the header. (`#5264 <https://github.com/sunpy/sunpy/pull/5264>`__)
 - :meth:`sunpy.map.GenericMap.superpixel` now keeps the reference coordinate of the
@@ -1242,7 +1242,7 @@ Bug Fixes
   frame of the input map to the output coordinates. Previously only the observer
   coordinate, and no other frame attributes, were propagated. (`#4141 <https://github.com/sunpy/sunpy/pull/4141>`__)
 - Fix an off-by-one error in the reference pixel returned by
-  `sunpy.map.make_fitswcs_header`. (`#4152 <https://github.com/sunpy/sunpy/pull/4152>`__)
+  `sunpy.map.header_helper.make_fitswcs_header`. (`#4152 <https://github.com/sunpy/sunpy/pull/4152>`__)
 - `sunpy.map.GenericMap.reference_pixel` now uses zero-based indexing, in order
   to be consistent with the rest of the `sunpy.map` API. (`#4154 <https://github.com/sunpy/sunpy/pull/4154>`__)
 - Previously `sunpy.map.GenericMap.resample` with ``method='linear'`` was
@@ -1389,7 +1389,7 @@ Features
 - `~sunpy.map.GenericMap` objects now have a ``.cmap`` attribute, which returns the full `~matplotlib.colors.Colormap`.
   object. (`#3412 <https://github.com/sunpy/sunpy/pull/3412>`__)
 - `sunpy.io.write_file()` now accepts `~pathlib.Path` objects as filename inputs. (`#3469 <https://github.com/sunpy/sunpy/pull/3469>`__)
-- `sunpy.map.make_fitswcs_header` now accepts a `tuple` representing the shape of an array as well as the actual array as the ``data`` argument. (`#3483 <https://github.com/sunpy/sunpy/pull/3483>`__)
+- `sunpy.map.header_helper.make_fitswcs_header` now accepts a `tuple` representing the shape of an array as well as the actual array as the ``data`` argument. (`#3483 <https://github.com/sunpy/sunpy/pull/3483>`__)
 - Made a couple of module imports lazy to reduce the import time of sunpy.map by
   ~40%. (`#3495 <https://github.com/sunpy/sunpy/pull/3495>`__)
 - `sunpy.map.GenericMap.wcs` now uses the full FITS header to construct the WCS.
@@ -1410,13 +1410,13 @@ Bug Fixes
 ---------
 
 - Fixed accuracy issues with the calculations of Carrington longitude (`~sunpy.coordinates.sun.L0`) and Carrington rotation number (`~sunpy.coordinates.sun.carrington_rotation_number`). (`#3178 <https://github.com/sunpy/sunpy/pull/3178>`__)
-- Updated `sunpy.map.make_fitswcs_header` to be more strict on the inputs it accepts. (`#3183 <https://github.com/sunpy/sunpy/pull/3183>`__)
-- Fix the calculation of ``rsun_ref`` in `~sunpy.map.make_fitswcs_header` and and
+- Updated `sunpy.map.header_helper.make_fitswcs_header` to be more strict on the inputs it accepts. (`#3183 <https://github.com/sunpy/sunpy/pull/3183>`__)
+- Fix the calculation of ``rsun_ref`` in `~sunpy.map.header_helper.make_fitswcs_header` and and
   ensure that the default reference pixel is indexed from 1. (`#3184 <https://github.com/sunpy/sunpy/pull/3184>`__)
 - Fixed the missing transformation between two `~sunpy.coordinates.HeliographicCarrington` frames with different observation times. (`#3186 <https://github.com/sunpy/sunpy/pull/3186>`__)
 - `sunpy.map.sources.AIAMap` and `sunpy.map.sources.HMIMap` will no longer assume
   the existance of certain header keys. (`#3217 <https://github.com/sunpy/sunpy/pull/3217>`__)
-- `sunpy.map.make_fitswcs_header` now supports specifying the map projection
+- `sunpy.map.header_helper.make_fitswcs_header` now supports specifying the map projection
   rather than defaulting to ``TAN``. (`#3218 <https://github.com/sunpy/sunpy/pull/3218>`__)
 - Fix the behaviour of
   ``sunpy.coordinates.frames.Helioprojective.calculate_distance`` if the
@@ -1443,7 +1443,7 @@ Bug Fixes
 - Fixed bugs with `~sunpy.coordinates.wcs_utils.solar_frame_to_wcs_mapping` if the input frame does not include an observation time or an observer. (`#3305 <https://github.com/sunpy/sunpy/pull/3305>`__)
 - `~sunpy.coordinates.utils.GreatArc` now accounts for the start and end points of the arc having different observers. (`#3334 <https://github.com/sunpy/sunpy/pull/3334>`__)
 - Fixed situations where 2D coordinates provided to `~sunpy.coordinates.frames.HeliographicStonyhurst` and `~sunpy.coordinates.frames.HeliographicCarrington` were not converted to 3D as intended.  Furthermore, the stored data will always be the post-conversion, 3D version. (`#3351 <https://github.com/sunpy/sunpy/pull/3351>`__)
-- Fix off by one error in `sunpy.map.make_fitswcs_header` where when using the
+- Fix off by one error in `sunpy.map.header_helper.make_fitswcs_header` where when using the
   default ``reference_pixel=None`` keyword argument the pixel coordinate of the
   reference pixel was off by +1. (`#3356 <https://github.com/sunpy/sunpy/pull/3356>`__)
 - Updated both GOES XRS and LYRA dataretriever clients to use ``sunpy.util.scraper.Scraper``, to make sure that files are actually on the servers being queried. (`#3367 <https://github.com/sunpy/sunpy/pull/3367>`__)
@@ -1636,7 +1636,7 @@ Features
 - The default style for Map plots have changed to reflect the changes in Astropy
   3.2. (`#3054 <https://github.com/sunpy/sunpy/pull/3054>`__)
 - `sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst` can now account for light travel time when computing the (apparent) body position, as long as the observer location is provided. (`#3055 <https://github.com/sunpy/sunpy/pull/3055>`__)
-- Added a helper function (`sunpy.map.make_fitswcs_header`) that allows users to create a meta header for custom created `sunpy.map.GenericMap`. (`#3083 <https://github.com/sunpy/sunpy/pull/3083>`__)
+- Added a helper function (`sunpy.map.header_helper.make_fitswcs_header`) that allows users to create a meta header for custom created `sunpy.map.GenericMap`. (`#3083 <https://github.com/sunpy/sunpy/pull/3083>`__)
 - Map plotting now accepts the optional keyword ``clip_interval`` for specifying a percentile interval for clipping.  For example, if the interval (5%, 99%) is specified, the bounds of the z axis are chosen such that the lowest 5% of pixels and the highest 1% of pixels are excluded. (`#3100 <https://github.com/sunpy/sunpy/pull/3100>`__)
 - The new function `~sunpy.coordinates.get_horizons_coord` enables querying JPL HORIZONS for the locations of a wide range of solar-system bodies, including spacecraft. (`#3113 <https://github.com/sunpy/sunpy/pull/3113>`__)
 
@@ -1692,7 +1692,7 @@ Bug Fixes
   that `astropy.wcs.WCS` objects are correctly converted to
   `sunpy.coordinates.frames` objects irrespective of the ordering of the axes. (`#3116 <https://github.com/sunpy/sunpy/pull/3116>`__)
 - The `~sunpy.physics.differential_rotation.solar_rotate_coordinate` function returns a coordinate that accounts for the location of the new observer. (`#3123 <https://github.com/sunpy/sunpy/pull/3123>`__)
-- Add support for rotation parameters to `sunpy.map.make_fitswcs_header`. (`#3139 <https://github.com/sunpy/sunpy/pull/3139>`__)
+- Add support for rotation parameters to `sunpy.map.header_helper.make_fitswcs_header`. (`#3139 <https://github.com/sunpy/sunpy/pull/3139>`__)
 - Improve the implementation of `~sunpy.physics.differential_rotation.differential_rotate` the image warping when transforming Maps for differential rotation and change in observer position. (`#3149 <https://github.com/sunpy/sunpy/pull/3149>`__)
 - Fix a bug where new helioviewer sources potentially cause `~sunpy.net.helioviewer.HelioviewerClient.data_sources` to error. (`#3162 <https://github.com/sunpy/sunpy/pull/3162>`__)
 

--- a/changelog/6415.feature.rst
+++ b/changelog/6415.feature.rst
@@ -1,1 +1,1 @@
-Added a new function :func:`sunpy.map.header_helper.carrington_header` to help with generating FITS-WCS headers in a Carrington coordinate system.
+Added a new function :func:`sunpy.map.header_helper.make_carrington_header` to help with generating FITS-WCS headers in a Carrington coordinate system.

--- a/changelog/6415.feature.rst
+++ b/changelog/6415.feature.rst
@@ -1,1 +1,1 @@
-Added a new function :func:`sunpy.map.header_helper.make_carrington_header` to help with generating FITS-WCS headers in a Carrington coordinate system.
+Added a new function :func:`sunpy.map.header_helper.make_heliographic_header` to help with generating FITS-WCS headers in Carrington or Stonyhurst coordinate systems that span the entire solar surface.

--- a/changelog/6415.feature.rst
+++ b/changelog/6415.feature.rst
@@ -1,0 +1,1 @@
+Added a new function :func:`sunpy.map.header_helper.carrington_header` to help with generating FITS-WCS headers in a Carrington coordinate system.

--- a/changelog/6499.feature.1.rst
+++ b/changelog/6499.feature.1.rst
@@ -1,3 +1,3 @@
-`~sunpy.map.header_helper.make_fitswcs_header` now includes the keyword argument ``unit`` for setting the
+:func:`~sunpy.map.header_helper.make_fitswcs_header` now includes the keyword argument ``unit`` for setting the
 ``BUNIT`` FITS keyword in the resulting header.
 This will take precedence over any unit information attached to ``data``.

--- a/changelog/6499.feature.1.rst
+++ b/changelog/6499.feature.1.rst
@@ -1,3 +1,3 @@
-`~sunpy.map.make_fitswcs_header` now includes the keyword argument ``unit`` for setting the
+`~sunpy.map.header_helper.make_fitswcs_header` now includes the keyword argument ``unit`` for setting the
 ``BUNIT`` FITS keyword in the resulting header.
 This will take precedence over any unit information attached to ``data``.

--- a/changelog/6499.feature.2.rst
+++ b/changelog/6499.feature.2.rst
@@ -1,2 +1,2 @@
-If the ``data`` argument to `~sunpy.map.header_helper.make_fitswcs_header` is an `~astropy.units.Quantity`,
+If the ``data`` argument to :func:`~sunpy.map.header_helper.make_fitswcs_header` is an `~astropy.units.Quantity`,
 the associated unit will be used to set the ``BUNIT`` FITS keyword in the resulting header.

--- a/changelog/6499.feature.2.rst
+++ b/changelog/6499.feature.2.rst
@@ -1,2 +1,2 @@
-If the ``data`` argument to `~sunpy.map.make_fitswcs_header` is an `~astropy.units.Quantity`,
+If the ``data`` argument to `~sunpy.map.header_helper.make_fitswcs_header` is an `~astropy.units.Quantity`,
 the associated unit will be used to set the ``BUNIT`` FITS keyword in the resulting header.

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -101,7 +101,6 @@ which data and metadata pairs match its instrument.
     :inherited-members:
 
 
-
 Writing a new Instrument Map Class
 ==================================
 

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -72,7 +72,7 @@ All sunpy Maps are derived from `sunpy.map.GenericMap`, all the methods and attr
     :skip: make_fitswcs_header
     :skip: meta_keywords
     :skip: get_observer_meta
-    :skip: carrington_header
+    :skip: make_carrington_header
 
 Header helpers
 ==============

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -72,7 +72,7 @@ All sunpy Maps are derived from `sunpy.map.GenericMap`, all the methods and attr
     :skip: make_fitswcs_header
     :skip: meta_keywords
     :skip: get_observer_meta
-    :skip: make_carrington_header
+    :skip: make_heliographic_header
 
 Header helpers
 ==============

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -69,6 +69,20 @@ All sunpy Maps are derived from `sunpy.map.GenericMap`, all the methods and attr
     :no-main-docstr:
     :inherited-members:
     :include-all-objects:
+    :skip: make_fitswcs_header
+    :skip: meta_keywords
+    :skip: get_observer_meta
+    :skip: carrington_header
+
+Header helpers
+==============
+
+The header_helper sub-module contains helper functions for generating FITS-WCS headers from Python objects.
+
+.. automodapi:: sunpy.map.header_helper
+    :no-main-docstr:
+    :inherited-members:
+    :include-all-objects:
 
 .. _map-sources:
 
@@ -85,6 +99,7 @@ which data and metadata pairs match its instrument.
 .. automodapi:: sunpy.map.sources
     :no-main-docstr:
     :inherited-members:
+
 
 
 Writing a new Instrument Map Class

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -492,7 +492,7 @@ See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a bri
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
 **sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
-This includes a `~sunpy.map.header_helper.meta_keywords` function that will return a `dict` of the meta keywords used when creating a Map.
+This includes a :func:`~sunpy.map.header_helper.meta_keywords` function that will return a `dict` of the meta keywords used when creating a Map.
 
 .. code-block:: python
 
@@ -504,12 +504,12 @@ This includes a `~sunpy.map.header_helper.meta_keywords` function that will retu
      'crval1': 'Coordinate value at reference point on naxis1 **required'
      ...
 
-The utility function `~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
+The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
 This function returns a `sunpy.util.MetaDict`.
 The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.
 
-The `~sunpy.map.header_helper.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
+The :func:`~sunpy.map.header_helper.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
 If neither of these are given their values default to the center of the data array and 1 arcsec, respectively.
 
 Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`:
@@ -598,8 +598,8 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
     rsun_obs: 965.3829548285768
 
 As we can see, a list of WCS and observer meta information is contained within the generated headers, however we may want to include other meta information including the observatory name, the wavelength and waveunit of the observation.
-Any of the keywords listed in ``header_helper.meta_keywords`` can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` and will then populate the returned MetaDict header.
-Furthermore, the following observation keywords can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` function: ``observtory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
+Any of the keywords in the dictionary returned by :func:`~sunpy.map.header_helper.meta_keywords` can be passed to the :func:`~sunpy.map.header_helper.make_fitswcs_header` and will then populate the returned MetaDict header.
+Furthermore, the following observation keywords can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` function: ``observatory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
 
 An example of creating a header with these additional keywords:
 

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -492,11 +492,11 @@ See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a bri
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
 **sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
-This includes a `~sunpy.map.meta_keywords` function that will return a `dict` the meta keywords used when creating a Map.
+This includes a `~sunpy.map.header_helper.meta_keywords` function that will return a `dict` the meta keywords used when creating a Map.
 
 .. code-block:: python
 
-    >>> from sunpy.map import meta_keywords
+    >>> from sunpy.map.header_helper import meta_keywords
 
     >>> meta_keywords() # doctest: +SKIP
     {'cunit1': 'Units of the coordinate increments along naxis1 e.g. arcsec **required',
@@ -504,12 +504,12 @@ This includes a `~sunpy.map.meta_keywords` function that will return a `dict` th
      'crval1': 'Coordinate value at reference point on naxis1 **required'
      ...
 
-The utility function `~sunpy.map.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
+The utility function `~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
 This function returns a `sunpy.util.MetaDict`.
 The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.
 
-The `~sunpy.map.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
+The `~sunpy.map.header_helper.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
 If neither of these are given their values default to the center of the data array and 1 arcsec, respectively.
 
 Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`:
@@ -517,13 +517,15 @@ Here's an example of creating a header from some generic data and an `astropy.co
 .. code-block:: python
 
     >>> import numpy as np
-    >>> import astropy.units as u
-    >>> from sunpy.coordinates import frames
     >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>>
+    >>> from sunpy.coordinates import frames
+    >>> from sunpy.map.header_helper import make_fitswcs_header
 
     >>> data = np.arange(0,100).reshape(10,10)
     >>> coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime = '2013-10-28', observer = 'earth', frame = frames.Helioprojective)
-    >>> header = sunpy.map.make_fitswcs_header(data, coord)
+    >>> header = make_fitswcs_header(data, coord)
     >>> for key, value in header.items():
     ...     print(f"{key}: {value}")
     wcsaxes: 2
@@ -562,7 +564,7 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
 
 .. code-block:: python
 
-    >>> header = sunpy.map.make_fitswcs_header(data, coord,
+    >>> header = make_fitswcs_header(data, coord,
     ...                                        reference_pixel=u.Quantity([5, 5]*u.pixel),
     ...                                        scale=u.Quantity([2, 2] *u.arcsec/u.pixel))
     >>> for key, value in header.items():
@@ -596,14 +598,14 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
     rsun_obs: 965.3829548285768
 
 As we can see, a list of WCS and observer meta information is contained within the generated headers, however we may want to include other meta information including the observatory name, the wavelength and waveunit of the observation.
-Any of the keywords listed in ``header_helper.meta_keywords`` can be passed to the `~sunpy.map.make_fitswcs_header` and will then populate the returned MetaDict header.
-Furthermore, the following observation keywords can be passed to the `~sunpy.map.make_fitswcs_header` function and will be translated to the FITS standard: ``observtory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
+Any of the keywords listed in ``header_helper.meta_keywords`` can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` and will then populate the returned MetaDict header.
+Furthermore, the following observation keywords can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` function and will be translated to the FITS standard: ``observtory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
 
 An example of creating a header with these additional keywords:
 
 .. code-block:: python
 
-    >>> header = sunpy.map.make_fitswcs_header(data, coord,
+    >>> header = make_fitswcs_header(data, coord,
     ...                                        reference_pixel = u.Quantity([5, 5]*u.pixel),
     ...                                        scale = u.Quantity([2, 2] *u.arcsec/u.pixel),
     ...                                        telescope = 'Test case', instrument = 'UV detector',

--- a/docs/guide/data_types/maps.rst
+++ b/docs/guide/data_types/maps.rst
@@ -492,7 +492,7 @@ See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a bri
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
 **sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
-This includes a `~sunpy.map.header_helper.meta_keywords` function that will return a `dict` the meta keywords used when creating a Map.
+This includes a `~sunpy.map.header_helper.meta_keywords` function that will return a `dict` of the meta keywords used when creating a Map.
 
 .. code-block:: python
 
@@ -519,7 +519,7 @@ Here's an example of creating a header from some generic data and an `astropy.co
     >>> import numpy as np
     >>> from astropy.coordinates import SkyCoord
     >>> import astropy.units as u
-    >>>
+
     >>> from sunpy.coordinates import frames
     >>> from sunpy.map.header_helper import make_fitswcs_header
 
@@ -599,7 +599,7 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
 
 As we can see, a list of WCS and observer meta information is contained within the generated headers, however we may want to include other meta information including the observatory name, the wavelength and waveunit of the observation.
 Any of the keywords listed in ``header_helper.meta_keywords`` can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` and will then populate the returned MetaDict header.
-Furthermore, the following observation keywords can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` function and will be translated to the FITS standard: ``observtory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
+Furthermore, the following observation keywords can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` function: ``observtory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
 
 An example of creating a header with these additional keywords:
 

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -110,7 +110,7 @@ In particular:
 - `sunpy.map.GenericMap.reference_pixel` now returns a zero-based reference pixel.
   This is one pixel less than the previously returned value.
   Note that this means the ``reference_pixel`` now does **not** have the same value as the FITS ``CRPIX`` values, which are one-based indices.
-- `sunpy.map.header_helper.make_fitswcs_header` now correctly interprets the ``reference_pixel`` argument as being zero-based, in previous releases it incorrectly interpreted the ``reference_pixel`` as one-based.
+- :func:`sunpy.map.header_helper.make_fitswcs_header` now correctly interprets the ``reference_pixel`` argument as being zero-based, in previous releases it incorrectly interpreted the ``reference_pixel`` as one-based.
 
 .. _whatsnew-2.0-standards:
 

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -110,7 +110,7 @@ In particular:
 - `sunpy.map.GenericMap.reference_pixel` now returns a zero-based reference pixel.
   This is one pixel less than the previously returned value.
   Note that this means the ``reference_pixel`` now does **not** have the same value as the FITS ``CRPIX`` values, which are one-based indices.
-- `sunpy.map.make_fitswcs_header` now correctly interprets the ``reference_pixel`` argument as being zero-based, in previous releases it incorrectly interpreted the ``reference_pixel`` as one-based.
+- `sunpy.map.header_helper.make_fitswcs_header` now correctly interprets the ``reference_pixel`` argument as being zero-based, in previous releases it incorrectly interpreted the ``reference_pixel`` as one-based.
 
 .. _whatsnew-2.0-standards:
 

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -35,6 +35,11 @@ It is now easy to extract data values from a `~sunpy.map.GenericMap` along a cur
 This is done by applying `Bresenham's line algorithm <http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm>`__ between the consecutive coordinates, in pixel space, and then indexing the data array of the map at those points.
 See :ref:`sphx_glr_generated_gallery_units_and_coordinates_map_slit_extraction.py` for an example.
 
+Easier reprojecting to Carrington and Stonyhurst coordinates
+============================================================
+`sunpy.map.header_helper` has a new `~sunpy.map.header_helper.make_heliographic_header` function that simplifies creating map headers that span the whole solar surface in Carrington or Stonyhurst coordinates.
+When used in combination with `sunpy.map.GenericMap.reproject_to` this greatly simplifies reprojecting helioprojective maps into heliographic full-Sun maps.
+
 Drawing the solar equator and prime meridian
 ============================================
 You can now use the `sunpy.visualization.drawing` module to draw the solar equator and prime meridian (zero Carrington longitude) on Astropy WCS axes.

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -37,7 +37,7 @@ See :ref:`sphx_glr_generated_gallery_units_and_coordinates_map_slit_extraction.p
 
 Easier reprojecting to Carrington and Stonyhurst coordinates
 ============================================================
-`sunpy.map.header_helper` has a new `~sunpy.map.header_helper.make_heliographic_header` function that simplifies creating map headers that span the whole solar surface in Carrington or Stonyhurst coordinates.
+``sunpy.map.header_helper`` has a new `~sunpy.map.header_helper.make_heliographic_header` function that simplifies creating map headers that span the whole solar surface in Carrington or Stonyhurst coordinates.
 When used in combination with `sunpy.map.GenericMap.reproject_to` this greatly simplifies reprojecting helioprojective maps into heliographic full-Sun maps.
 
 Drawing the solar equator and prime meridian

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -40,6 +40,8 @@ Easier reprojecting to Carrington and Stonyhurst coordinates
 ``sunpy.map.header_helper`` has a new `~sunpy.map.header_helper.make_heliographic_header` function that simplifies creating map headers that span the whole solar surface in Carrington or Stonyhurst coordinates.
 When used in combination with `sunpy.map.GenericMap.reproject_to` this greatly simplifies reprojecting helioprojective maps into heliographic full-Sun maps.
 
+.. minigallery:: sunpy.map.header_helper.make_heliographic_header
+
 Drawing the solar equator and prime meridian
 ============================================
 You can now use the `sunpy.visualization.drawing` module to draw the solar equator and prime meridian (zero Carrington longitude) on Astropy WCS axes.

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -37,8 +37,8 @@ See :ref:`sphx_glr_generated_gallery_units_and_coordinates_map_slit_extraction.p
 
 Easier reprojecting to Carrington and Stonyhurst coordinates
 ============================================================
-``sunpy.map.header_helper`` has a new `~sunpy.map.header_helper.make_heliographic_header` function that simplifies creating map headers that span the whole solar surface in Carrington or Stonyhurst coordinates.
-When used in combination with `sunpy.map.GenericMap.reproject_to` this greatly simplifies reprojecting helioprojective maps into heliographic full-Sun maps.
+``sunpy.map.header_helper`` has a new :func:`~sunpy.map.header_helper.make_heliographic_header` function that simplifies creating map headers that span the whole solar surface in Carrington or Stonyhurst coordinates.
+When used in combination with :meth:`sunpy.map.GenericMap.reproject_to` this greatly simplifies reprojecting helioprojective maps into heliographic full-Sun maps.
 
 .. minigallery:: sunpy.map.make_heliographic_header
 

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -40,7 +40,7 @@ Easier reprojecting to Carrington and Stonyhurst coordinates
 ``sunpy.map.header_helper`` has a new `~sunpy.map.header_helper.make_heliographic_header` function that simplifies creating map headers that span the whole solar surface in Carrington or Stonyhurst coordinates.
 When used in combination with `sunpy.map.GenericMap.reproject_to` this greatly simplifies reprojecting helioprojective maps into heliographic full-Sun maps.
 
-.. minigallery:: sunpy.map.header_helper.make_heliographic_header
+.. minigallery:: sunpy.map.make_heliographic_header
 
 Drawing the solar equator and prime meridian
 ============================================

--- a/examples/map/map_from_numpy_array.py
+++ b/examples/map/map_from_numpy_array.py
@@ -20,8 +20,9 @@ from sunpy.coordinates import frames
 data = np.arange(0, 100).reshape(10, 10)
 
 ##############################################################################
-# Next we need to create the metadata. This is made easier using the `~sunpy.map.header_helper.make_fitswcs_header`
-# function which will create a header object for you. First define the reference coordinate
+# Next we need to create the metadata. This is made easier using the
+# :func:`~sunpy.map.header_helper.make_fitswcs_header` function which will
+# create a header object for you. First define the reference coordinate
 # which requires a time and an observer location.
 
 coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime='2013-10-28 08:24',

--- a/examples/map/map_from_numpy_array.py
+++ b/examples/map/map_from_numpy_array.py
@@ -20,7 +20,7 @@ from sunpy.coordinates import frames
 data = np.arange(0, 100).reshape(10, 10)
 
 ##############################################################################
-# Next we need to create the metadata. This is made easier using the `~sunpy.map.make_fitswcs_header`
+# Next we need to create the metadata. This is made easier using the `~sunpy.map.header_helper.make_fitswcs_header`
 # function which will create a header object for you. First define the reference coordinate
 # which requires a time and an observer location.
 

--- a/examples/map_transformations/reprojection_aia_euvi_mosaic.py
+++ b/examples/map_transformations/reprojection_aia_euvi_mosaic.py
@@ -70,7 +70,7 @@ plt.show()
 ######################################################################
 # The next step is to calculate the output coordinate system for the combined
 # map. We select a heliographic Stonyhurst frame, and a Plate Carree (CAR)
-# projection, and generate a header using `sunpy.map.make_fitswcs_header` and
+# projection, and generate a header using `sunpy.map.header_helper.make_fitswcs_header` and
 # then construct a World Coordinate System (WCS) object for that header.
 
 shape_out = (180, 360)  # This is set deliberately low to reduce memory consumption

--- a/examples/map_transformations/reprojection_carrington.py
+++ b/examples/map_transformations/reprojection_carrington.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 
 import sunpy.data.sample
 import sunpy.map
-from sunpy.map import make_heliographic_header
+from sunpy.map.header_helper import make_heliographic_header
 
 ###############################################################################
 # We will start with using sunpy's sample data for this example.

--- a/examples/map_transformations/reprojection_carrington.py
+++ b/examples/map_transformations/reprojection_carrington.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 
 import sunpy.data.sample
 import sunpy.map
-from sunpy.map.header_helper import make_carrington_header
+from sunpy.map.header_helper import make_heliographic_header
 
 ###############################################################################
 # We will start with using sunpy's sample data for this example.
@@ -25,12 +25,12 @@ aia_map.plot()
 
 ###############################################################################
 # Reproject works by transforming an input image to a desired World Coordinate
-# System (WCS) projection. Here we use :func:`sunpy.map.header_helper.make_carrington_header`
+# System (WCS) projection. Here we use :func:`sunpy.map.header_helper.make_heliographic_header`
 # to create a FITS WCS header based on a heliographic Carrington reference
 # coordinate.
 
 shape = (720, 1440)
-carr_header = make_carrington_header(aia_map.date, aia_map.observer_coordinate, shape)
+carr_header = make_heliographic_header(aia_map.date, aia_map.observer_coordinate, shape, 'carrington')
 
 ###############################################################################
 # With the new header, re-project the data into the new coordinate system.

--- a/examples/map_transformations/reprojection_carrington.py
+++ b/examples/map_transformations/reprojection_carrington.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 
 import sunpy.data.sample
 import sunpy.map
-from sunpy.map.header_helper import make_heliographic_header
+from sunpy.map import make_heliographic_header
 
 ###############################################################################
 # We will start with using sunpy's sample data for this example.

--- a/examples/map_transformations/reprojection_carrington.py
+++ b/examples/map_transformations/reprojection_carrington.py
@@ -30,7 +30,7 @@ aia_map.plot()
 # coordinate.
 
 shape = (720, 1440)
-carr_header = make_heliographic_header(aia_map.date, aia_map.observer_coordinate, shape, 'carrington')
+carr_header = make_heliographic_header(aia_map.date, aia_map.observer_coordinate, shape, frame='carrington')
 
 ###############################################################################
 # With the new header, re-project the data into the new coordinate system.

--- a/examples/map_transformations/reprojection_different_observers.py
+++ b/examples/map_transformations/reprojection_different_observers.py
@@ -64,7 +64,7 @@ plt.legend([limb_aia[0], limb_euvi[0]],
 
 ######################################################################
 # We now need to construct an output WCS. We build a custom header using
-# :func:`sunpy.map.make_fitswcs_header` but we use a lot of the ``map_aia``
+# :func:`sunpy.map.header_helper.make_fitswcs_header` but we use a lot of the ``map_aia``
 # properties to do it.
 
 out_header = sunpy.map.make_fitswcs_header(

--- a/examples/map_transformations/reprojection_heliographic_stonyhurst.py
+++ b/examples/map_transformations/reprojection_heliographic_stonyhurst.py
@@ -1,9 +1,9 @@
 """
-===========================
-Creating a Heliographic Map
-===========================
+========================
+Creating Carrington Maps
+========================
 
-In this example we use the `reproject` generate an image in heliographic coordinates from an AIA image.
+In this example we use the `reproject` generate a map in heliographic Carrington coordinates from a full-disk AIA image.
 
 You will need `reproject <https://reproject.readthedocs.io/en/stable/>`__ v0.6 or higher installed.
 """
@@ -11,11 +11,9 @@ You will need `reproject <https://reproject.readthedocs.io/en/stable/>`__ v0.6 o
 
 import matplotlib.pyplot as plt
 
-import astropy.units as u
-from astropy.coordinates import SkyCoord
-
 import sunpy.data.sample
 import sunpy.map
+import sunpy.map.header_helper
 
 ###############################################################################
 # We will start with using sunpy's sample data for this example.
@@ -28,20 +26,12 @@ plt.show()
 
 ###############################################################################
 # Reproject works by transforming an input image to a desired World Coordinate
-# System (WCS) projection. Here we use :func:`sunpy.map.make_fitswcs_header`
-# to create a FITS WCS header based on a Stonyhurst heliographic reference
-# coordinate and the CAR (plate carrée) projection.
+# System (WCS) projection. Here we use :func:`sunpy.map.header_helper.carrington_header`
+# to create a FITS WCS header based on a heliographic Carrington reference
+# coordinate.
 
-shape_out = (720, 1440)
-frame_out = SkyCoord(0, 0, unit=u.deg,
-                     frame="heliographic_stonyhurst",
-                     obstime=aia_map.date,
-                     rsun=aia_map.coordinate_frame.rsun)
-header = sunpy.map.make_fitswcs_header(shape_out,
-                                       frame_out,
-                                       scale=(360 / shape_out[1],
-                                              180 / shape_out[0]) * u.deg / u.pix,
-                                       projection_code="CAR")
+shape_out = (1440, 720)
+carr_header = sunpy.map.header_helper.carrington_header(aia_map.date, aia_map.observer_coordinate, shape_out=shape_out)
 
 ###############################################################################
 # With the new header, re-project the data into the new coordinate system.
@@ -49,7 +39,7 @@ header = sunpy.map.make_fitswcs_header(shape_out,
 # the fast :func:`reproject.reproject_interp` algorithm, but a different
 # algorithm can be specified (e.g., :func:`reproject.reproject_adaptive`).
 
-outmap = aia_map.reproject_to(header)
+outmap = aia_map.reproject_to(carr_header)
 
 ###############################################################################
 # Plot the result.

--- a/examples/map_transformations/reprojection_heliographic_stonyhurst.py
+++ b/examples/map_transformations/reprojection_heliographic_stonyhurst.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 
 import sunpy.data.sample
 import sunpy.map
-from sunpy.map.header_helper import carrington_header
+from sunpy.map.header_helper import make_carrington_header
 
 ###############################################################################
 # We will start with using sunpy's sample data for this example.
@@ -25,12 +25,12 @@ aia_map.plot()
 
 ###############################################################################
 # Reproject works by transforming an input image to a desired World Coordinate
-# System (WCS) projection. Here we use :func:`sunpy.map.header_helper.carrington_header`
+# System (WCS) projection. Here we use :func:`sunpy.map.header_helper.make_carrington_header`
 # to create a FITS WCS header based on a heliographic Carrington reference
 # coordinate.
 
 shape = (720, 1440)
-carr_header = carrington_header(aia_map.date, aia_map.observer_coordinate, shape)
+carr_header = make_carrington_header(aia_map.date, aia_map.observer_coordinate, shape)
 
 ###############################################################################
 # With the new header, re-project the data into the new coordinate system.

--- a/examples/map_transformations/reprojection_heliographic_stonyhurst.py
+++ b/examples/map_transformations/reprojection_heliographic_stonyhurst.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 
 import sunpy.data.sample
 import sunpy.map
-import sunpy.map.header_helper
+from sunpy.map.header_helper import carrington_header
 
 ###############################################################################
 # We will start with using sunpy's sample data for this example.
@@ -22,7 +22,6 @@ aia_map = sunpy.map.Map(sunpy.data.sample.AIA_193_IMAGE)
 
 plt.figure()
 aia_map.plot()
-plt.show()
 
 ###############################################################################
 # Reproject works by transforming an input image to a desired World Coordinate
@@ -30,8 +29,8 @@ plt.show()
 # to create a FITS WCS header based on a heliographic Carrington reference
 # coordinate.
 
-shape_out = (1440, 720)
-carr_header = sunpy.map.header_helper.carrington_header(aia_map.date, aia_map.observer_coordinate, shape_out=shape_out)
+shape = (720, 1440)
+carr_header = carrington_header(aia_map.date, aia_map.observer_coordinate, shape)
 
 ###############################################################################
 # With the new header, re-project the data into the new coordinate system.

--- a/examples/units_and_coordinates/radec_to_hpc_map.py
+++ b/examples/units_and_coordinates/radec_to_hpc_map.py
@@ -18,8 +18,9 @@ For many solar studies we may want to plot this data in some Sun-centered coordi
 such as `~sunpy.coordinates.frames.Helioprojective`. In this example we read the data and
 header information from the LOFAR FITS file and then create a new header with updated WCS
 information to create a `~sunpy.map.Map` with a HPC coordinate frame. We will make use of the
-`astropy.coordinates` and `sunpy.coordinates` submodules together with `~sunpy.map.header_helper.make_fitswcs_header`
-to create a new header and generate a `~sunpy.map.Map`.
+`astropy.coordinates` and `sunpy.coordinates` submodules together with
+:func:`~sunpy.map.header_helper.make_fitswcs_header` to create a new header and generate a
+`~sunpy.map.Map`.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -110,13 +111,14 @@ P1 = sun.P(obstime)
 
 ##########################################################################
 # Now we can use this information to create a new header using the helper
-# function `~sunpy.map.header_helper.make_fitswcs_header()`. This will create a MetaDict
-# which we contain all the necessay WCS information to create a `~sunpy.map.Map`.
-# We provide a reference coordinate (in HPC), the spatial
-# scale of the observation (i.e. ``cdelt1`` and ``cdelt2``), and the rotation angle (P1).
-# Note that here, 1 is subtracted from the crpix1 and crpix2 values, this is because
-# the ``reference_pixel`` keyword in ~sunpy.map.header_helper.make_fitswcs_header` is zero indexed rather
-# than the fits convention of 1 indexed.
+# function :func:`~sunpy.map.header_helper.make_fitswcs_header`. This will
+# create a MetaDict which we contain all the necessary WCS information to
+# create a `~sunpy.map.Map`. We provide a reference coordinate (in HPC),
+# the spatial scale of the observation (i.e., ``cdelt1`` and ``cdelt2``),
+# and the rotation angle (P1). Note that here, 1 is subtracted from the
+# ``crpix1`` and ``crpix2`` values, this is because the ``reference_pixel``
+# keyword in :func:~sunpy.map.header_helper.make_fitswcs_header` is zero
+# indexed rather than the fits convention of 1 indexed.
 
 new_header = sunpy.map.make_fitswcs_header(data, reference_coord_arcsec,
                                            reference_pixel=u.Quantity([header['crpix1']-1,

--- a/examples/units_and_coordinates/radec_to_hpc_map.py
+++ b/examples/units_and_coordinates/radec_to_hpc_map.py
@@ -18,7 +18,7 @@ For many solar studies we may want to plot this data in some Sun-centered coordi
 such as `~sunpy.coordinates.frames.Helioprojective`. In this example we read the data and
 header information from the LOFAR FITS file and then create a new header with updated WCS
 information to create a `~sunpy.map.Map` with a HPC coordinate frame. We will make use of the
-`astropy.coordinates` and `sunpy.coordinates` submodules together with `~sunpy.map.make_fitswcs_header`
+`astropy.coordinates` and `sunpy.coordinates` submodules together with `~sunpy.map.header_helper.make_fitswcs_header`
 to create a new header and generate a `~sunpy.map.Map`.
 """
 import matplotlib.pyplot as plt
@@ -110,12 +110,12 @@ P1 = sun.P(obstime)
 
 ##########################################################################
 # Now we can use this information to create a new header using the helper
-# function `~sunpy.map.make_fitswcs_header()`. This will create a MetaDict
+# function `~sunpy.map.header_helper.make_fitswcs_header()`. This will create a MetaDict
 # which we contain all the necessay WCS information to create a `~sunpy.map.Map`.
 # We provide a reference coordinate (in HPC), the spatial
 # scale of the observation (i.e. ``cdelt1`` and ``cdelt2``), and the rotation angle (P1).
 # Note that here, 1 is subtracted from the crpix1 and crpix2 values, this is because
-# the ``reference_pixel`` keyword in ~sunpy.map.make_fitswcs_header` is zero indexed rather
+# the ``reference_pixel`` keyword in ~sunpy.map.header_helper.make_fitswcs_header` is zero indexed rather
 # than the fits convention of 1 indexed.
 
 new_header = sunpy.map.make_fitswcs_header(data, reference_coord_arcsec,

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -441,6 +441,5 @@ def make_heliographic_header(date, observer_coordinate, shape, frame, *, project
             (180 / np.pi) / (int(shape[0]) / 2)
         ] * u.deg / u.pix
 
-    # Header helper expects shape to be in [y, x] order, but scale in [x, y]...
     header = make_fitswcs_header(shape, frame_out, scale=scale, projection_code=projection_code)
     return header

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -417,6 +417,8 @@ def make_heliographic_header(date, observer_coordinate, shape, *, frame, project
     >>> header = make_heliographic_header(date, observer, [90, 180], frame='carrington')
     >>> header
     MetaDict([('wcsaxes', 2), ('crpix1', 90.5), ('crpix2', 45.5), ('cdelt1', 2.0), ('cdelt2', 2.0), ('cunit1', 'deg'), ('cunit2', 'deg'), ('ctype1', 'CRLN-CAR'), ('ctype2', 'CRLT-CAR'), ('crval1', 0.0), ('crval2', 0.0), ('lonpole', 0.0), ('latpole', 90.0), ('mjdref', 0.0), ('date-obs', '2020-01-01T12:00:00.000'), ('rsun_ref', 695700000.0), ('dsun_obs', 147096975776.97), ('hgln_obs', 0.0), ('hglt_obs', -3.0011725838606), ('naxis', 2), ('naxis1', 180), ('naxis2', 90), ('pc1_1', 1.0), ('pc1_2', -0.0), ('pc2_1', 0.0), ('pc2_2', 1.0), ('rsun_obs', 975.5398432033492)])
+
+    .. minigallery:: sunpy.map.make_heliographic_header
     """
     valid_codes = {"CAR", "CEA"}
     if projection_code not in valid_codes:

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -380,7 +380,7 @@ _map_meta_keywords = {
 
 def make_heliographic_header(date, observer_coordinate, shape, *, frame, projection_code="CAR"):
     """
-    Construct a FITS-WCS header for a heliographic (Carrington or Stonyhurst) coordinate frame.
+    Construct a FITS-WCS header for a full-Sun heliographic (Carrington or Stonyhurst) coordinate frame.
 
     The date-time and observer coordinate of the new coordinate frame
     are taken from the input map. The resulting WCS covers the full surface
@@ -402,6 +402,10 @@ def make_heliographic_header(date, observer_coordinate, shape, *, frame, project
     Returns
     -------
     `~sunpy.util.MetaDict`
+
+    See Also
+    --------
+    sunpy.map.header_helper.make_fitswcs_header : A more generic header helper that can be used if more customisation is required.
 
     Examples
     --------

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -378,7 +378,7 @@ _map_meta_keywords = {
 }
 
 
-def make_heliographic_header(date, observer_coordinate, shape, frame, *, projection_code="CAR"):
+def make_heliographic_header(date, observer_coordinate, shape, *, frame, projection_code="CAR"):
     """
     Construct a FITS-WCS header for a heliographic (Carrington or Stonyhurst) coordinate frame.
 
@@ -410,7 +410,7 @@ def make_heliographic_header(date, observer_coordinate, shape, frame, *, project
     >>>
     >>> date = '2020-01-01 12:00:00'
     >>> observer = get_earth(date)
-    >>> header = make_heliographic_header(date, observer, [90, 180], 'carrington')
+    >>> header = make_heliographic_header(date, observer, [90, 180], frame='carrington')
     >>> header
     MetaDict([('wcsaxes', 2), ('crpix1', 90.5), ('crpix2', 45.5), ('cdelt1', 2.0), ('cdelt2', 2.0), ('cunit1', 'deg'), ('cunit2', 'deg'), ('ctype1', 'CRLN-CAR'), ('ctype2', 'CRLT-CAR'), ('crval1', 0.0), ('crval2', 0.0), ('lonpole', 0.0), ('latpole', 90.0), ('mjdref', 0.0), ('date-obs', '2020-01-01T12:00:00.000'), ('rsun_ref', 695700000.0), ('dsun_obs', 147096975776.97), ('hgln_obs', 0.0), ('hglt_obs', -3.0011725838606), ('naxis', 2), ('naxis1', 180), ('naxis2', 90), ('pc1_1', 1.0), ('pc1_2', -0.0), ('pc2_1', 0.0), ('pc2_2', 1.0), ('rsun_obs', 975.5398432033492)])
     """

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -8,7 +8,7 @@ from sunpy import log
 from sunpy.coordinates import frames, sun
 from sunpy.util import MetaDict
 
-__all__ = ['meta_keywords', 'make_fitswcs_header', 'get_observer_meta', 'carrington_header']
+__all__ = ['meta_keywords', 'make_fitswcs_header', 'get_observer_meta', 'make_carrington_header']
 
 
 def meta_keywords():
@@ -378,7 +378,7 @@ _map_meta_keywords = {
 }
 
 
-def carrington_header(date, observer_coordinate, shape, *, projection_code="CAR"):
+def make_carrington_header(date, observer_coordinate, shape, *, projection_code="CAR"):
     """
     Construct a FITS-WCS header for a Carrington coordinate frame.
     The date-time and observer coordinate of the new coordinate frame

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -428,6 +428,7 @@ def make_heliographic_header(date, observer_coordinate, shape, *, frame, project
         frame=f"heliographic_{frame}",
         obstime=date,
         observer=observer_coordinate,
+        rsun=getattr(observer_coordinate, "rsun", None),
     )
 
     if projection_code == "CAR":

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -233,7 +233,7 @@ def test_invalid_inputs(map_data, hcc_coord, hpc_coord_notime, hpc_coord):
 @pytest.mark.parametrize('shape', [[90, 180], [240, 100]])
 @pytest.mark.parametrize('projection_code', ['CAR', 'CEA'])
 def test_make_heliographic_header(aia171_test_map, shape, projection_code, frame):
-    header = make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape, frame, projection_code=projection_code)
+    header = make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape, frame=frame, projection_code=projection_code)
     carr_map = aia171_test_map.reproject_to(header)
 
     # Check upper right and lower left coordinates are as expected
@@ -250,7 +250,7 @@ def test_make_heliographic_header(aia171_test_map, shape, projection_code, frame
 
 def test_make_heliographic_header_invalid_inputs(aia171_test_map):
     with pytest.raises(ValueError, match='projection_code must be one of'):
-        make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, [90, 180], 'carrington', projection_code='blah')
+        make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, [90, 180], frame='carrington', projection_code='blah')
 
     with pytest.raises(ValueError, match='frame must be one of'):
-        make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, [90, 180], 'blah')
+        make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, [90, 180], frame='blah')

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -229,10 +229,10 @@ def test_invalid_inputs(map_data, hcc_coord, hpc_coord_notime, hpc_coord):
 
 
 # Second case here chosen to produce non-square pixels
-@pytest.mark.parametrize('shape_out', [[180, 90], [100, 240]])
+@pytest.mark.parametrize('shape', [[90, 180], [240, 100]])
 @pytest.mark.parametrize('projection_code', ['CAR', 'CEA'])
-def test_carrington_header(aia171_test_map, shape_out, projection_code):
-    header = carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape_out=shape_out, projection_code=projection_code)
+def test_carrington_header(aia171_test_map, shape, projection_code):
+    header = carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape=shape, projection_code=projection_code)
     carr_map = aia171_test_map.reproject_to(header)
 
     # Check upper right and lower left coordinates are as expected
@@ -240,6 +240,6 @@ def test_carrington_header(aia171_test_map, shape_out, projection_code):
     assert ll_coord.lon == 180 * u.deg
     assert ll_coord.lat == -90 * u.deg
 
-    ur_coord = carr_map.pixel_to_world((shape_out[0] - 0.5) * u.pix, (shape_out[1] - 0.5) * u.pix)
+    ur_coord = carr_map.pixel_to_world((shape[1] - 0.5) * u.pix, (shape[0] - 0.5) * u.pix)
     assert ur_coord.lon == 180 * u.deg
     assert ur_coord.lat == 90 * u.deg

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -8,7 +8,7 @@ from astropy.wcs import WCS
 import sunpy.map
 from sunpy.coordinates import frames, sun
 from sunpy.map import make_fitswcs_header
-from sunpy.map.header_helper import make_carrington_header
+from sunpy.map.header_helper import make_heliographic_header
 from sunpy.util.metadata import MetaDict
 
 
@@ -228,23 +228,29 @@ def test_invalid_inputs(map_data, hcc_coord, hpc_coord_notime, hpc_coord):
         header = make_fitswcs_header(map_data, hpc_coord, scale=u.Quantity([0, 0]*u.arcsec))
 
 
+@pytest.mark.parametrize('frame', ['carrington', 'stonyhurst'])
 # Second case here chosen to produce non-square pixels
 @pytest.mark.parametrize('shape', [[90, 180], [240, 100]])
 @pytest.mark.parametrize('projection_code', ['CAR', 'CEA'])
-def test_make_carrington_header(aia171_test_map, shape, projection_code):
-    header = make_carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape=shape, projection_code=projection_code)
+def test_make_heliographic_header(aia171_test_map, shape, projection_code, frame):
+    header = make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape, frame, projection_code=projection_code)
     carr_map = aia171_test_map.reproject_to(header)
 
     # Check upper right and lower left coordinates are as expected
     ll_coord = carr_map.pixel_to_world(-0.5 * u.pix, -0.5 * u.pix)
-    assert ll_coord.lon == 180 * u.deg
+    assert ll_coord.lon in [-180 * u.deg, 180*u.deg]
     assert ll_coord.lat == -90 * u.deg
+    assert ll_coord.frame.name == f"heliographic_{frame}"
 
     ur_coord = carr_map.pixel_to_world((shape[1] - 0.5) * u.pix, (shape[0] - 0.5) * u.pix)
-    assert ur_coord.lon == 180 * u.deg
+    assert ur_coord.lon in [-180 * u.deg, 180*u.deg]
     assert ur_coord.lat == 90 * u.deg
+    assert ur_coord.frame.name == f"heliographic_{frame}"
 
 
-def test_make_carrington_header_invalid_proj_code(aia171_test_map):
+def test_make_heliographic_header_invalid_inputs(aia171_test_map):
     with pytest.raises(ValueError, match='projection_code must be one of'):
-        make_carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape=[90, 180], projection_code='blah')
+        make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, [90, 180], 'carrington', projection_code='blah')
+
+    with pytest.raises(ValueError, match='frame must be one of'):
+        make_heliographic_header(aia171_test_map.date, aia171_test_map.observer_coordinate, [90, 180], 'blah')

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -243,3 +243,8 @@ def test_carrington_header(aia171_test_map, shape, projection_code):
     ur_coord = carr_map.pixel_to_world((shape[1] - 0.5) * u.pix, (shape[0] - 0.5) * u.pix)
     assert ur_coord.lon == 180 * u.deg
     assert ur_coord.lat == 90 * u.deg
+
+
+def test_carrington_header_invalid_proj_code(aia171_test_map):
+    with pytest.raises(ValueError, match='projection_code must be one of'):
+        carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape=[90, 180], projection_code='blah')

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -8,6 +8,7 @@ from astropy.wcs import WCS
 import sunpy.map
 from sunpy.coordinates import frames, sun
 from sunpy.map import make_fitswcs_header
+from sunpy.map.header_helper import carrington_header
 from sunpy.util.metadata import MetaDict
 
 
@@ -225,3 +226,20 @@ def test_invalid_inputs(map_data, hcc_coord, hpc_coord_notime, hpc_coord):
         header = make_fitswcs_header(map_data, hpc_coord, scale=u.Quantity([0, 0]))
     with pytest.raises(u.UnitsError):
         header = make_fitswcs_header(map_data, hpc_coord, scale=u.Quantity([0, 0]*u.arcsec))
+
+
+# Second case here chosen to produce non-square pixels
+@pytest.mark.parametrize('shape_out', [[180, 90], [100, 240]])
+@pytest.mark.parametrize('projection_code', ['CAR', 'CEA'])
+def test_carrington_header(aia171_test_map, shape_out, projection_code):
+    header = carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape_out=shape_out, projection_code=projection_code)
+    carr_map = aia171_test_map.reproject_to(header)
+
+    # Check upper right and lower left coordinates are as expected
+    ll_coord = carr_map.pixel_to_world(-0.5 * u.pix, -0.5 * u.pix)
+    assert ll_coord.lon == 180 * u.deg
+    assert ll_coord.lat == -90 * u.deg
+
+    ur_coord = carr_map.pixel_to_world((shape_out[0] - 0.5) * u.pix, (shape_out[1] - 0.5) * u.pix)
+    assert ur_coord.lon == 180 * u.deg
+    assert ur_coord.lat == 90 * u.deg

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -8,7 +8,7 @@ from astropy.wcs import WCS
 import sunpy.map
 from sunpy.coordinates import frames, sun
 from sunpy.map import make_fitswcs_header
-from sunpy.map.header_helper import carrington_header
+from sunpy.map.header_helper import make_carrington_header
 from sunpy.util.metadata import MetaDict
 
 
@@ -231,8 +231,8 @@ def test_invalid_inputs(map_data, hcc_coord, hpc_coord_notime, hpc_coord):
 # Second case here chosen to produce non-square pixels
 @pytest.mark.parametrize('shape', [[90, 180], [240, 100]])
 @pytest.mark.parametrize('projection_code', ['CAR', 'CEA'])
-def test_carrington_header(aia171_test_map, shape, projection_code):
-    header = carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape=shape, projection_code=projection_code)
+def test_make_carrington_header(aia171_test_map, shape, projection_code):
+    header = make_carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape=shape, projection_code=projection_code)
     carr_map = aia171_test_map.reproject_to(header)
 
     # Check upper right and lower left coordinates are as expected
@@ -245,6 +245,6 @@ def test_carrington_header(aia171_test_map, shape, projection_code):
     assert ur_coord.lat == 90 * u.deg
 
 
-def test_carrington_header_invalid_proj_code(aia171_test_map):
+def test_make_carrington_header_invalid_proj_code(aia171_test_map):
     with pytest.raises(ValueError, match='projection_code must be one of'):
-        carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape=[90, 180], projection_code='blah')
+        make_carrington_header(aia171_test_map.date, aia171_test_map.observer_coordinate, shape=[90, 180], projection_code='blah')


### PR DESCRIPTION
This adds a helper function to make it easier to create a FITSWCS header for a Carrington coordinate frame. Even though we already have the header helper function, reprojecting to whole Sun maps is a common enough use case that I think it deserves its own function.

To see how the API is simpler, look at the diff between the example I've renamed and modified to use a Carrington (instead of Stonyhurst) system. I am also imagining there is room for creating other commonly used headers. The one that jumps to mind at the moment is a something to reproject into a polar system like this: http://swhv.oma.be/user_manual/projection_2.png

There was some discussion about whether to put this in `sunkit-image` (https://github.com/sunpy/sunkit-image/pull/93), but @Cadair suggested this *might* belong in core, and I'm inclined to agree.

I would appreciate some either positive or negative feedback on whether this should be added as new API!

If feedback is posistive this still needs:
- A changelog entry
- A what's new entry
- Some more tests? Suggestions welcome...