### PR TITLE
Download sample data files on demand

### DIFF
--- a/changelog/6426.deprecation.rst
+++ b/changelog/6426.deprecation.rst
@@ -1,0 +1,2 @@
+:func:`sunpy.data.download_sample_data` is now deprecated.
+Use :func:`sunpy.data.sample.download_all` instead.

--- a/changelog/6426.feature.rst
+++ b/changelog/6426.feature.rst
@@ -1,0 +1,2 @@
+Sample data files provided through `sunpy.data.sample` are now downloaded individually on demand rather than being all downloaded upon import of that module.
+To download all sample data files, call :func:`sunpy.data.sample.download_all`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ warnings.filterwarnings("error", category=AstropyDeprecationWarning)
 ori_level = sunpy.log.level
 sunpy.log.setLevel("DEBUG")
 import sunpy.data.sample  # NOQA
+sunpy.data.sample.download_all()
 sunpy.log.setLevel(ori_level)
 
 # For the linkcheck

--- a/docs/guide/tour.rst
+++ b/docs/guide/tour.rst
@@ -9,8 +9,8 @@ functionality available.
 
 Sample Data
 ===========
-This tour makes use of a number of sample data files which you will need to
-download. This will happen when the sample data is imported for the first time.
+This tour makes use of a number of sample data files that will need to be downloaded.
+This downloading will happen automatically when using the module `sunpy.data.sample`.
 
 Maps
 ====

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -7,8 +7,5 @@ Each example is a short and self contained how-to guide for performing a specifi
 
 Sample data
 ===========
-Some of these examples require the SunPy sample data, which you can download by running::
-
-     >>> import sunpy.data.sample
-
-Once downloaded the data will be stored in your user directory and you will not need to download it again.
+Some of these examples require the SunPy sample data, which are downloaded as needed via the module `sunpy.data.sample`.
+If you want to download all of the sample data files in advance, call :func:`sunpy.data.sample.download_all`.

--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 
 from sunpy import log
 from sunpy.util.config import _is_writable_dir, get_and_create_sample_dir
+from sunpy.util.decorators import deprecated
 from sunpy.util.parfive_helpers import Downloader
 
 _BASE_URLS = (
@@ -122,6 +123,19 @@ def _handle_final_errors(results):
         )
 
 
+def _get_sampledata_dir():
+    # Workaround for tox only. This is not supported as a user option
+    sampledata_dir = os.environ.get("SUNPY_SAMPLEDIR", False)
+    if sampledata_dir:
+        sampledata_dir = Path(sampledata_dir).expanduser().resolve()
+        _is_writable_dir(sampledata_dir)
+    else:
+        # Creating the directory for sample files to be downloaded
+        sampledata_dir = Path(get_and_create_sample_dir())
+    return sampledata_dir
+
+
+@deprecated('4.1', alternative='`sunpy.data.sample.download_all`')
 def download_sample_data(overwrite=False):
     """
     Download all sample data at once. This will overwrite any existing files.
@@ -131,14 +145,7 @@ def download_sample_data(overwrite=False):
     overwrite : `bool`
         Overwrite existing sample data.
     """
-    # Workaround for tox only. This is not supported as a user option
-    sampledata_dir = os.environ.get("SUNPY_SAMPLEDIR", False)
-    if sampledata_dir:
-        sampledata_dir = Path(sampledata_dir).expanduser().resolve()
-        _is_writable_dir(sampledata_dir)
-    else:
-        # Creating the directory for sample files to be downloaded
-        sampledata_dir = Path(get_and_create_sample_dir())
+    sampledata_dir = _get_sampledata_dir()
 
     already_downloaded = []
     to_download = []
@@ -166,3 +173,31 @@ def download_sample_data(overwrite=False):
             _handle_final_errors(results)
 
     return results + already_downloaded
+
+
+def _get_sample_files(filename_list, no_download=False, force_download=False):
+    sampledata_dir = _get_sampledata_dir()
+
+    fullpath = [sampledata_dir/fn for fn in filename_list]
+
+    if no_download:
+        fullpath = [fp if fp.exists() else None for fp in fullpath]
+    else:
+        to_download = zip(filename_list, fullpath)
+        if not force_download:
+            to_download = [(fn, fp) for fn, fp in to_download if not fp.exists()]
+
+        if to_download:
+            results = _download_sample_data(_BASE_URLS[0], to_download, overwrite=force_download)
+
+            # Something went wrong
+            if results.errors:
+                for next_url in _BASE_URLS[1:]:
+                    results = _retry_sample_data(results, next_url)
+                    if not results.errors:
+                        break
+                else:
+                    _handle_final_errors(results)
+                    raise RuntimeError
+
+    return fullpath

--- a/sunpy/data/_sample.py
+++ b/sunpy/data/_sample.py
@@ -176,21 +176,47 @@ def download_sample_data(overwrite=False):
 
 
 def _get_sample_files(filename_list, no_download=False, force_download=False):
+    """
+    Returns a list of disk locations corresponding to a list of filenames for
+    sample data, downloading the sample data files as necessary.
+
+    Parameters
+    ----------
+    filename_list : `list` of `str`
+        List of filenames for sample data
+    no_download : `bool`
+        If ``True``, do not download any files, even if they are not present.
+        Default is ``False``.
+    force_download : `bool`
+        If ``True``, download all files, and overwrite any existing ones.
+        Default is ``False``.
+
+    Returns
+    -------
+    `list` of `pathlib.Path`
+        List of disk locations corresponding to the list of filenames.  An entry
+        will be ``None`` if ``no_download == True`` and the file is not present.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if any of the files cannot be downloaded from any of the mirrors.
+    """
     sampledata_dir = _get_sampledata_dir()
 
-    fullpath = [sampledata_dir/fn for fn in filename_list]
+    fullpaths = [sampledata_dir/fn for fn in filename_list]
 
     if no_download:
-        fullpath = [fp if fp.exists() else None for fp in fullpath]
+        fullpaths = [fp if fp.exists() else None for fp in fullpaths]
     else:
-        to_download = zip(filename_list, fullpath)
+        to_download = zip(filename_list, fullpaths)
         if not force_download:
             to_download = [(fn, fp) for fn, fp in to_download if not fp.exists()]
 
         if to_download:
             results = _download_sample_data(_BASE_URLS[0], to_download, overwrite=force_download)
 
-            # Something went wrong
+            # Try the other mirrors for any download errors
             if results.errors:
                 for next_url in _BASE_URLS[1:]:
                     results = _retry_sample_data(results, next_url)
@@ -200,4 +226,4 @@ def _get_sample_files(filename_list, no_download=False, force_download=False):
                     _handle_final_errors(results)
                     raise RuntimeError
 
-    return fullpath
+    return fullpaths

--- a/sunpy/data/sample.py
+++ b/sunpy/data/sample.py
@@ -9,8 +9,8 @@ Summary variables
    :widths: auto
 
    * - ``file_dict``
-     - Dictionary of all sample shortnames and, if downloaded, file locations
-       on disk
+     - Dictionary of all sample shortnames and, if downloaded, corresponding
+       file locations on disk (otherwise, ``None``)
    * - ``file_list``
      - List of disk locations for sample data files that have been downloaded
 
@@ -30,19 +30,22 @@ for _keyname, _filename in sorted(_SAMPLE_DATA.items()):
     __doc__ += f'   * - ``{_keyname}``\n     - {_filename}\n'
 
 
+# file_dict and file_list are not normal variables; see __getattr__() below
 __all__ = list(sorted(_SAMPLE_DATA.keys())) + ['download_all', 'file_dict', 'file_list']
 
 
+# See PEP 562 (https://peps.python.org/pep-0562/) for module-level __dir__()
 def __dir__():
     return __all__
 
 
+# See PEP 562 (https://peps.python.org/pep-0562/) for module-level __getattr__()
 def __getattr__(name):
     if name in _SAMPLE_DATA:
         return _get_sample_files([_SAMPLE_DATA[name]])[0]
     elif name == 'file_dict':
-        return {k: _get_sample_files([_SAMPLE_DATA[k]], no_download=True)[0]
-                for k in sorted(_SAMPLE_DATA.keys())}
+        return dict(sorted(zip(_SAMPLE_DATA.keys(),
+                               _get_sample_files(_SAMPLE_DATA.values(), no_download=True))))
     elif name == 'file_list':
         return [v for v in __getattr__('file_dict').values() if v]
     else:

--- a/sunpy/data/sample.py
+++ b/sunpy/data/sample.py
@@ -1,35 +1,62 @@
 """
-This module provides the following sample data files.  These files are
-downloaded when this module is imported for the first time.
+This module provides the following sample data files.  When a sample shortname
+is accessed, the corresponding file is downloaded if needed.  All files can be
+downloaded by calling :func:`~sunpy.data.sample.download_all`.
 
+Summary variables
+-----------------
+.. list-table::
+   :widths: auto
+
+   * - ``file_dict``
+     - Dictionary of all sample shortnames and, if downloaded, file locations
+       on disk
+   * - ``file_list``
+     - List of disk locations for sample data files that have been downloaded
+
+Sample shortnames
+-----------------
 .. list-table::
    :widths: auto
    :header-rows: 1
 
-   * - Variable name
+   * - Sample shortname
      - Name of downloaded file
 """
-import sys
-from pathlib import Path
+from ._sample import _SAMPLE_DATA, _get_sample_files, download_sample_data
 
-from ._sample import _SAMPLE_FILES, download_sample_data
+# Add a table row to the module docstring for each sample file
+for _keyname, _filename in sorted(_SAMPLE_DATA.items()):
+    __doc__ += f'   * - ``{_keyname}``\n     - {_filename}\n'
 
-files = download_sample_data()
 
-file_dict = {}
-for f in files:
-    name = Path(f).name
-    _key = _SAMPLE_FILES.get(name, None)
-    if _key:
-        setattr(sys.modules[__name__], _key, str(f))
-        file_dict.update({_key: f})
+__all__ = list(sorted(_SAMPLE_DATA.keys())) + ['download_all', 'file_dict', 'file_list']
 
-# Sort the entries in the dictionary
-file_dict = dict(sorted(file_dict.items()))
 
-file_list = file_dict.values()
+def __dir__():
+    return __all__
 
-for keyname, filename in file_dict.items():
-    __doc__ += f'   * - ``{keyname}``\n     - {Path(filename).name}\n'
 
-__all__ = list(_SAMPLE_FILES.values()) + ['file_dict', 'file_list']
+def __getattr__(name):
+    if name in _SAMPLE_DATA:
+        return _get_sample_files([_SAMPLE_DATA[name]])[0]
+    elif name == 'file_dict':
+        return {k: _get_sample_files([_SAMPLE_DATA[k]], no_download=True)[0]
+                for k in sorted(_SAMPLE_DATA.keys())}
+    elif name == 'file_list':
+        return [v for v in __getattr__('file_dict').values() if v]
+    else:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def download_all(force_download=False):
+    """
+    Download all sample data at once that has not already been downloaded.
+
+    Parameters
+    ----------
+    force_download : `bool`
+        If ``True``, files are downloaded even if they already exist.  Default is
+        ``False``.
+    """
+    _get_sample_files(_SAMPLE_DATA.values(), force_download=force_download)

--- a/sunpy/data/sample.py
+++ b/sunpy/data/sample.py
@@ -23,7 +23,12 @@ Sample shortnames
    * - Sample shortname
      - Name of downloaded file
 """
-from ._sample import _SAMPLE_DATA, _get_sample_files, download_sample_data
+# download_sample_data is deprecated and not used here,
+# but during deprecation period want to keep it in this namespace
+# for backwards compatability. noqa stops it being removed by
+# pre-commit as an unused import
+from ._sample import download_sample_data  # noqa
+from ._sample import _SAMPLE_DATA, _get_sample_files
 
 # Add a table row to the module docstring for each sample file
 for _keyname, _filename in sorted(_SAMPLE_DATA.items()):


### PR DESCRIPTION
This PR changes the way that sample data is downloaded.  Rather than downloading all the files when `sunpy.data.sample` is imported, the download is deferred until a sample file is actually requested, and then only that file is downloaded:
```python
>>> import sunpy.data.sample
>>> import sunpy.map
>>> aiamap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
Files Downloaded: 100%|████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.61file/s]
```
It is still possible to trigger the download of the entire set – e.g., to take advantage of when internet access is available by calling `sunpy.data.sample.download_all()`.

See discussion in #6244

To consider:
~- Merge `_sample.py` into `sample.py`?~ Deferred to future cleanup (e.g., when `download_sample_data()` is removed)