### PR TITLE
Added a git diff hook for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,14 @@ repos:
       - id: prohibit-string
         args: [--prohibit-string, "from warnings import warn,warnings.warn"]
         exclude: "sunpy/version.py|sunpy/util/decorators.py|sunpy/util/exceptions.py|sunpy/extern/|sunpy/util/tests/test_logger.py"
+  - repo: local
+    hooks:
+      - id: git-diff
+        name: git diff
+        entry: git diff --color --exit-code
+        language: system
+        pass_filenames: false
+        always_run: true
 
 ci:
   autofix_prs: false


### PR DESCRIPTION
When a PR fails our `pre-commit` CI check, it'd be nice to see what `pre-commit` wants to change.  When running `pre-commit` from the command line, one can specify the option `--show-diff-on-failure`.  However, for whatever reason, that's not an option on `pre-commit.ci`.  So, this PR is a way to get the same effect (see https://github.com/pre-commit/pre-commit/issues/1712#issuecomment-733113341).