### PR TITLE
Ignore pandas warning coming from DRMS

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -188,6 +188,8 @@ filterwarnings =
     ignore:Starting with ImageIO v3 the behavior of this function will switch:DeprecationWarning
     # Appears in devdeps
     ignore:unable to download valid IERS file, using local IERS-B
+    # See https://github.com/sunpy/drms/issues/72
+    ignore:.*will attempt to set the values inplace instead of always setting a new array:FutureWarning
 
 [pycodestyle]
 max_line_length = 110


### PR DESCRIPTION
See https://github.com/sunpy/sunpy/issues/6439 for corresponding issue. I think it's probalby fine to ignore this until it's fixed in `drms`?