### PR TITLE
CompositeMap replacement tutorials

### DIFF
--- a/changelog/6459.feature.rst
+++ b/changelog/6459.feature.rst
@@ -1,0 +1,2 @@
+Adds three tutorials which replace `~sunpy.map.CompositeMap` functionality.
+A fourth tutorial demonstrates how to create an RGB image with three different maps.

--- a/changelog/6459.feature.rst
+++ b/changelog/6459.feature.rst
@@ -1,2 +1,2 @@
-Adds three tutorials which replace `~sunpy.map.CompositeMap` functionality.
-A fourth tutorial demonstrates how to create an RGB image with three different maps.
+Added three tutorials which replicate `~sunpy.map.CompositeMap` functionality (:ref:`sphx_glr_generated_gallery_plotting_AIA_HMI_composite.py`, :ref:`sphx_glr_generated_gallery_plotting_masked_composite_plot.py`, :ref:`sphx_glr_generated_gallery_plotting_three_map_composite.py`).
+A fourth tutorial (:ref:`sphx_glr_generated_gallery_plotting_rgb_composite.py`) demonstrates how to create an RGB image with three different maps.

--- a/examples/plotting/AIA_HMI_composite.py
+++ b/examples/plotting/AIA_HMI_composite.py
@@ -55,4 +55,5 @@ norm = matplotlib.colors.Normalize(vmin=-1000, vmax=1000)
 cbar = fig.colorbar(plt.cm.ScalarMappable(norm=norm, cmap="viridis"), ax=ax)
 cbar.ax.set_title("Gauss", fontsize=10)
 ax.set_title("AIA & HMI Composite Plot")
+
 plt.show()

--- a/examples/plotting/AIA_HMI_composite.py
+++ b/examples/plotting/AIA_HMI_composite.py
@@ -3,8 +3,10 @@
 Overlaying Two Maps
 ===================
 
-This example demonstrates how to overlay two maps to compare features.
+This example demonstrates how to draw contours of one map on top of another
+to compare features.
 """
+import matplotlib.colors
 import matplotlib.pyplot as plt
 
 import astropy.units as u
@@ -18,6 +20,7 @@ from sunpy.map import Map
 # the photosphere while AIA 171 images show the resulting magnetic fields
 # filled with hot plasma above, in the corona. We want to see what coronal
 # features overlap with regions of strong line-of-sight magnetic fields.
+
 aia_map = Map(sunpy.data.sample.AIA_171_IMAGE)
 hmi_map = Map(sunpy.data.sample.HMI_LOS_IMAGE)
 
@@ -36,15 +39,20 @@ hmi_smap = hmi_map.submap(SkyCoord(*bottom_left,
 # Let's set the contours of the HMI map from a few hundred to a thousand
 # Gauss, which is the typical field strength associated with umbral regions of
 # pores and sunspots.
+
 levels = [-1000, -500, -250, 250, 500, 1000] * u.G
 
 ##############################################################################
 # Now let's look at the result. Notice that we can see the coronal structures
 # present on the AIA image and how they correspond to the line of sight
 # magnetic field.
+
 fig = plt.figure()
 ax = fig.add_subplot(projection=aia_smap)
 aia_smap.plot(axes=ax)
-hmi_smap.draw_contours(axes=ax, levels=levels)
-plt.title("AIA & HMI Composite Plot")
+hmi_smap.draw_contours(axes=ax, levels=levels, cmap="viridis")
+norm = matplotlib.colors.Normalize(vmin=-1000, vmax=1000)
+cbar = fig.colorbar(plt.cm.ScalarMappable(norm=norm, cmap="viridis"), ax=ax)
+cbar.ax.set_title("Gauss", fontsize=10)
+ax.set_title("AIA & HMI Composite Plot")
 plt.show()

--- a/examples/plotting/AIA_HMI_composite.py
+++ b/examples/plotting/AIA_HMI_composite.py
@@ -1,0 +1,50 @@
+"""
+===================
+Overlaying Two Maps
+===================
+
+This example demonstrates how to overlay two maps to compare features.
+"""
+import matplotlib.pyplot as plt
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+import sunpy.data.sample
+from sunpy.map import Map
+
+###############################################################################
+# We start with the sample data. HMI shows the line-of-sight magnetic field at
+# the photosphere while AIA 171 images show the resulting magnetic fields
+# filled with hot plasma above, in the corona. We want to see what coronal
+# features overlap with regions of strong line-of-sight magnetic fields.
+aia_map = Map(sunpy.data.sample.AIA_171_IMAGE)
+hmi_map = Map(sunpy.data.sample.HMI_LOS_IMAGE)
+
+bottom_left = [0, 0] * u.arcsec
+top_right = [800, 800] * u.arcsec
+aia_smap = aia_map.submap(SkyCoord(*bottom_left,
+                                   frame=aia_map.coordinate_frame),
+                          top_right=SkyCoord(*top_right,
+                                             frame=aia_map.coordinate_frame))
+hmi_smap = hmi_map.submap(SkyCoord(*bottom_left,
+                                   frame=hmi_map.coordinate_frame),
+                          top_right=SkyCoord(*top_right,
+                                             frame=hmi_map.coordinate_frame))
+
+###############################################################################
+# Let's set the contours of the HMI map from a few hundred to a thousand
+# Gauss, which is the typical field strength associated with umbral regions of
+# pores and sunspots.
+levels = [-1000, -500, -250, 250, 500, 1000] * u.G
+
+##############################################################################
+# Now let's look at the result. Notice that we can see the coronal structures
+# present on the AIA image and how they correspond to the line of sight
+# magnetic field.
+fig = plt.figure()
+ax = fig.add_subplot(projection=aia_smap)
+aia_smap.plot(axes=ax)
+hmi_smap.draw_contours(axes=ax, levels=levels)
+plt.title("AIA & HMI Composite Plot")
+plt.show()

--- a/examples/plotting/masked_composite_plot.py
+++ b/examples/plotting/masked_composite_plot.py
@@ -1,12 +1,12 @@
 """
 ================================
-Combining off-limb and disc maps
+Combining off-limb and disk maps
 ================================
 
 This example combines creating a composite plot with masking out the
 solar disk. The purpose is to introduce users to the plotting process
-required to overlay multiple Maps that have been modified with other
-**sunpy** functions. The resulting plot in this tutorial shows information
+required to overlay multiple maps that have been modified with other
+``sunpy`` functions. The resulting plot in this tutorial shows information
 on the upper photosphere, quiet corona, and magnetogram contours.
 """
 import matplotlib.pyplot as plt
@@ -57,5 +57,6 @@ scaled_map.plot(axes=ax, clip_interval=(1, 99.95)*u.percent,
                 cmap=colormap, zorder=0)
 aia_1600.plot(axes=ax, cmap=aia171_cmap, autoalign=True, zorder=1)
 hmi.draw_contours(axes=ax, levels=levels, zorder=2)
-ax.set_title("AIA 171 (off limb) + AIA 1600 (on disc) + HMI (contours)")
+ax.set_title("AIA 171 (off limb) + AIA 1600 (on disk) + HMI (contours)")
+
 plt.show()

--- a/examples/plotting/masked_composite_plot.py
+++ b/examples/plotting/masked_composite_plot.py
@@ -1,0 +1,57 @@
+"""
+================================
+Creating a Masked Composite Plot
+================================
+
+This example combines creating a composite plot with masking out the
+solar disk. The purpose is to introduce users to the plotting process
+required to overlay multiple Maps that have been modified with other
+**sunpy** functions. The resulting plot in this tutorial shows information
+on the upper photosphere, quiet corona, and magnetogram contours.
+"""
+import matplotlib.pyplot as plt
+
+import astropy.units as u
+
+import sunpy.data.sample
+from sunpy.map import Map
+from sunpy.map.maputils import all_coordinates_from_map, coordinate_is_on_solar_disk
+
+###############################################################################
+# Let's import sample data representing the three types of data we want to
+# overlay: AIA 1600 (upper photosphere), AIA 171 (quiet corona), and HMI
+# data (magnetic fields in the photosphere).
+aia_1600 = Map(sunpy.data.sample.AIA_1600_IMAGE)
+aia_171 = Map(sunpy.data.sample.AIA_171_IMAGE)
+hmi = Map(sunpy.data.sample.HMI_LOS_IMAGE)
+
+###############################################################################
+# Next, let's mask out the solar disk of the AIA 171 image since we will be
+# overlaying the AIA 1600 photosphere.
+hpc_coords = all_coordinates_from_map(aia_171)
+mask = coordinate_is_on_solar_disk(hpc_coords)
+palette = aia_171.cmap.copy()
+palette.set_bad('black')
+
+scaled_map = Map(aia_171.data, aia_171.meta, mask=mask)
+
+###############################################################################
+# Before we plot the composite image, let's define the contour levels that will
+# be applied to the HMI image. Also, grab the AIA 171 colormap to use with
+# the AIA 1600 image to better match the images.
+levels = [-1000, -500, -250, 250, 500, 1000]*u.G
+aia171_cmap = plt.get_cmap('sdoaia171')
+
+###############################################################################
+# Now, create the plot by overlaying the maps and contours. Note that
+# `clip_interval` is being defined to highlight the coronal features of the
+# scaled AIA 171 map and the AIA 1600 map is autoaligned to the AIA 171 WCS
+# Axes.
+fig = plt.figure()
+ax = fig.add_subplot(projection=scaled_map)
+scaled_map.plot(axes=ax, clip_interval=(1, 99.95)*u.percent,
+                cmap=palette, zorder=0)
+aia_1600.plot(axes=ax, cmap=aia171_cmap, autoalign=True, zorder=1)
+hmi.draw_contours(axes=ax, levels=levels, zorder=2)
+plt.title("A Masked Composite Plot")
+plt.show()

--- a/examples/plotting/masked_composite_plot.py
+++ b/examples/plotting/masked_composite_plot.py
@@ -1,6 +1,6 @@
 """
 ================================
-Creating a Masked Composite Plot
+Combining off-limb and disc maps
 ================================
 
 This example combines creating a composite plot with masking out the
@@ -21,6 +21,7 @@ from sunpy.map.maputils import all_coordinates_from_map, coordinate_is_on_solar_
 # Let's import sample data representing the three types of data we want to
 # overlay: AIA 1600 (upper photosphere), AIA 171 (quiet corona), and HMI
 # data (magnetic fields in the photosphere).
+
 aia_1600 = Map(sunpy.data.sample.AIA_1600_IMAGE)
 aia_171 = Map(sunpy.data.sample.AIA_171_IMAGE)
 hmi = Map(sunpy.data.sample.HMI_LOS_IMAGE)
@@ -28,10 +29,11 @@ hmi = Map(sunpy.data.sample.HMI_LOS_IMAGE)
 ###############################################################################
 # Next, let's mask out the solar disk of the AIA 171 image since we will be
 # overlaying the AIA 1600 photosphere.
+
 hpc_coords = all_coordinates_from_map(aia_171)
 mask = coordinate_is_on_solar_disk(hpc_coords)
-palette = aia_171.cmap.copy()
-palette.set_bad('black')
+colormap = aia_171.cmap.copy()
+colormap.set_bad('black')
 
 scaled_map = Map(aia_171.data, aia_171.meta, mask=mask)
 
@@ -39,19 +41,21 @@ scaled_map = Map(aia_171.data, aia_171.meta, mask=mask)
 # Before we plot the composite image, let's define the contour levels that will
 # be applied to the HMI image. Also, grab the AIA 171 colormap to use with
 # the AIA 1600 image to better match the images.
+
 levels = [-1000, -500, -250, 250, 500, 1000]*u.G
 aia171_cmap = plt.get_cmap('sdoaia171')
 
 ###############################################################################
 # Now, create the plot by overlaying the maps and contours. Note that
-# `clip_interval` is being defined to highlight the coronal features of the
+# ``clip_interval`` is being defined to highlight the coronal features of the
 # scaled AIA 171 map and the AIA 1600 map is autoaligned to the AIA 171 WCS
 # Axes.
+
 fig = plt.figure()
 ax = fig.add_subplot(projection=scaled_map)
 scaled_map.plot(axes=ax, clip_interval=(1, 99.95)*u.percent,
-                cmap=palette, zorder=0)
+                cmap=colormap, zorder=0)
 aia_1600.plot(axes=ax, cmap=aia171_cmap, autoalign=True, zorder=1)
 hmi.draw_contours(axes=ax, levels=levels, zorder=2)
-plt.title("A Masked Composite Plot")
+ax.set_title("AIA 171 (off limb) + AIA 1600 (on disc) + HMI (contours)")
 plt.show()

--- a/examples/plotting/rgb_composite.py
+++ b/examples/plotting/rgb_composite.py
@@ -6,7 +6,7 @@ Making an RGB composite image
 This example shows the process required to create an RGB composite image
 of three AIA images at different wavelengths. To read more about the
 algorithm used in this example, see this
-`Astropy tutorial <https://docs.astropy.org/en/stable/visualization/rgb.html>`_.
+`Astropy tutorial <https://docs.astropy.org/en/stable/visualization/rgb.html>`__.
 """
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
@@ -32,6 +32,11 @@ maps = Map(sunpy.data.sample.AIA_171_IMAGE,
 # normalized so that features in each wavelength are visible in the combined
 # image. We will apply multi-scale Gaussian normalization using
 # `sunkit_image.enhance.mgn` to each map and then create the rgb composite.
+# The ``k`` parameter is a scaling factor applied to the normalized image. A
+# value of 5 produces sharper details in the transformed image. In the
+# `~astropy.visualization.make_lupton_rgb` function, ``Q`` is a softening
+# parameter which we set to 0 and ``stretch`` controls the linear stretch
+# applied to the combined image.
 
 maps_mgn = [Map(mgn(m.data, k=5), m.meta) for m in maps]
 im_rgb = make_lupton_rgb(maps_mgn[0].data,
@@ -42,7 +47,8 @@ im_rgb = make_lupton_rgb(maps_mgn[0].data,
 ###############################################################################
 # The output of the `astropy.visualization.make_lupton_rgb` algorithm is not
 # a Map, but instead an image. So, we need to create a WCS Axes using one of
-# original maps and manually set the label.
+# original maps and manually set the label. In the first step below, we grab
+# the Set1 qualitative colormap to apply to the custom legend lines.
 
 cmap = plt.cm.Set1
 custom_lines = [Line2D([0], [0], color=cmap(0), lw=4),
@@ -56,4 +62,5 @@ lon.set_axislabel('Helioprojective Longitude')
 lat.set_axislabel('Helioprojective Latitude')
 ax.legend(custom_lines, ["AIA 171", "AIA 193", "AIA 211"])
 ax.set_title("AIA RGB Composite")
+
 plt.show()

--- a/examples/plotting/rgb_composite.py
+++ b/examples/plotting/rgb_composite.py
@@ -1,0 +1,58 @@
+"""
+=============================
+Making an RGB composite image
+=============================
+
+This example shows the process required to create an RGB composite image
+of three AIA images at different wavelengths. To read more about the
+algorithm used in this example, see this
+`Astropy tutorial <https://docs.astropy.org/en/stable/visualization/rgb.html>`_.
+"""
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+from sunkit_image.enhance import mgn
+
+from astropy.visualization import make_lupton_rgb
+
+import sunpy.data.sample
+from sunpy.map import Map
+
+###############################################################################
+# We will use three AIA images from the sample data at the following
+# wavelengths: 171, 193, and 211 Angstroms. The 171 image shows the quiet
+# solar corona, 193 shows a hotter region of the corona, and 211 shows
+# active magnetic regions in the corona.
+a171 = Map(sunpy.data.sample.AIA_171_IMAGE)
+a193 = Map(sunpy.data.sample.AIA_193_IMAGE)
+a211 = Map(sunpy.data.sample.AIA_211_IMAGE)
+
+maps = Map(a171, a193, a211)
+
+###############################################################################
+# Before the images are assigned colors and combined, they need to be
+# normalized so that features in each wavelength are visible in the combined
+# image. We will apply multi-scale Gaussian normalization using
+# `sunkit_image.enhance.mgn` to each map and then create the rgb composite.
+maps_mgn = [Map(mgn(m.data, k=5), m.meta) for m in maps]
+im_rgb = make_lupton_rgb(maps_mgn[0].data,
+                         maps_mgn[1].data,
+                         maps_mgn[2].data,
+                         Q=0, stretch=1)
+
+###############################################################################
+# The output of the `astropy.visualization.make_lupton_rgb` algorithm is not
+# a Map, but instead an image. So, we need to create a WCS Axes using one of
+# original maps and manually set the label.
+cmap = plt.cm.Set1
+custom_lines = [Line2D([0], [0], color=cmap(0), lw=4),
+                Line2D([0], [0], color=cmap(2), lw=4),
+                Line2D([0], [0], color=cmap(1), lw=4)]
+fig = plt.figure()
+ax = fig.add_subplot(111, projection=a171.wcs)
+im = ax.imshow(im_rgb)
+lon, lat = ax.coords
+lon.set_axislabel('Helioprojective Longitude')
+lat.set_axislabel('Helioprojective Latitude')
+ax.legend(custom_lines, ["AIA 171", "AIA 193", "AIA 211"])
+plt.title("AIA RGB Composite")
+plt.show()

--- a/examples/plotting/rgb_composite.py
+++ b/examples/plotting/rgb_composite.py
@@ -22,17 +22,17 @@ from sunpy.map import Map
 # wavelengths: 171, 193, and 211 Angstroms. The 171 image shows the quiet
 # solar corona, 193 shows a hotter region of the corona, and 211 shows
 # active magnetic regions in the corona.
-a171 = Map(sunpy.data.sample.AIA_171_IMAGE)
-a193 = Map(sunpy.data.sample.AIA_193_IMAGE)
-a211 = Map(sunpy.data.sample.AIA_211_IMAGE)
 
-maps = Map(a171, a193, a211)
+maps = Map(sunpy.data.sample.AIA_171_IMAGE,
+           sunpy.data.sample.AIA_193_IMAGE,
+           sunpy.data.sample.AIA_211_IMAGE)
 
 ###############################################################################
 # Before the images are assigned colors and combined, they need to be
 # normalized so that features in each wavelength are visible in the combined
 # image. We will apply multi-scale Gaussian normalization using
 # `sunkit_image.enhance.mgn` to each map and then create the rgb composite.
+
 maps_mgn = [Map(mgn(m.data, k=5), m.meta) for m in maps]
 im_rgb = make_lupton_rgb(maps_mgn[0].data,
                          maps_mgn[1].data,
@@ -43,16 +43,17 @@ im_rgb = make_lupton_rgb(maps_mgn[0].data,
 # The output of the `astropy.visualization.make_lupton_rgb` algorithm is not
 # a Map, but instead an image. So, we need to create a WCS Axes using one of
 # original maps and manually set the label.
+
 cmap = plt.cm.Set1
 custom_lines = [Line2D([0], [0], color=cmap(0), lw=4),
                 Line2D([0], [0], color=cmap(2), lw=4),
                 Line2D([0], [0], color=cmap(1), lw=4)]
 fig = plt.figure()
-ax = fig.add_subplot(111, projection=a171.wcs)
+ax = fig.add_subplot(111, projection=maps[0].wcs)
 im = ax.imshow(im_rgb)
 lon, lat = ax.coords
 lon.set_axislabel('Helioprojective Longitude')
 lat.set_axislabel('Helioprojective Latitude')
 ax.legend(custom_lines, ["AIA 171", "AIA 193", "AIA 211"])
-plt.title("AIA RGB Composite")
+ax.set_title("AIA RGB Composite")
 plt.show()

--- a/examples/plotting/three_map_composite.py
+++ b/examples/plotting/three_map_composite.py
@@ -53,4 +53,5 @@ eit_smap.plot(axes=ax, zorder=0)
 rhessi.draw_contours(axes=ax, levels=levels, zorder=1)
 aia_smap.plot(axes=ax, alpha=0.6, autoalign=True, zorder=2)
 ax.set_title("Three Map Composite")
+
 plt.show()

--- a/examples/plotting/three_map_composite.py
+++ b/examples/plotting/three_map_composite.py
@@ -20,25 +20,37 @@ from sunpy.map import Map
 # shows a hot region of the solar corona, while AIA shows the cooler upper
 # region of the corona. RHESSI data is focused on a solar flare, and will be
 # plotted using contours.
+
 eit = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE)
 rhessi = sunpy.map.Map(sunpy.data.sample.RHESSI_IMAGE)
 aia = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 
 ###############################################################################
-# Next, specify the RHESSI contour levels to be plotted. When creating the
-# plot, choose which Map will be used to create the WCS Axes that the other
-# Maps will be plotted with. The EIT map is plotted first, followed by the
-# RHESSI contours, and lastly the AIA map. Transparency is changed to 50% on
-# the AIA map by specifying the parameter `alpha`, and the image data is
-# autoaligned to the EIT WCS Axes. The parameter `zorder` specifies
-# how each plot is layered (0 is plotted first and 1 is layered on top of 0,
-# and so on). Lastly, note that `draw_grid()` is called using the EIT map.
-levels = [50, 60, 70, 80, 90]*u.percent
+# Before we plot the image, let's zoom in around the solar flare so the RHESSI
+# contours are visible. Also, specify the RHESSI contour levels to be plotted.
+
+bottom_left = [200, -800] * u.arcsec
+top_right = [1000, -200] * u.arcsec
+eit_smap = eit.submap(SkyCoord(*bottom_left, frame=eit.coordinate_frame),
+                      top_right=SkyCoord(*top_right, frame=eit.coordinate_frame))
+aia_smap = aia.submap(SkyCoord(*bottom_left, frame=aia.coordinate_frame),
+                      top_right=SkyCoord(*top_right, frame=aia.coordinate_frame))
+levels = [5, 10, 20, 30, 40]*u.percent
+
+###############################################################################
+# When creating the plot, choose which Map will be used to create the WCS Axes
+# that the other Maps will be plotted with. The EIT map is plotted first,
+# followed by the RHESSI contours, and lastly the AIA map. Transparency is
+# changed to 50% on the AIA map by specifying the parameter ``alpha``, and the
+# image data is autoaligned to the EIT WCS Axes. The parameter ``zorder``
+# specifies how each plot is layered (0 is plotted first and 1 is layered on
+# top of 0, and so on). Lastly, note that ``draw_grid()`` is called using the
+# EIT map.
+
 fig = plt.figure()
-ax = fig.add_subplot(projection=eit)
-eit.plot(axes=ax, zorder=0)
+ax = fig.add_subplot(projection=eit_smap)
+eit_smap.plot(axes=ax, zorder=0)
 rhessi.draw_contours(axes=ax, levels=levels, zorder=1)
-aia.plot(axes=ax, alpha=0.5, autoalign=True, zorder=2)
-eit.draw_grid(axes=ax)
-plt.title("Three Map Composite")
+aia_smap.plot(axes=ax, alpha=0.6, autoalign=True, zorder=2)
+ax.set_title("Three Map Composite")
 plt.show()

--- a/examples/plotting/three_map_composite.py
+++ b/examples/plotting/three_map_composite.py
@@ -21,9 +21,9 @@ from sunpy.map import Map
 # region of the corona. RHESSI data is focused on a solar flare, and will be
 # plotted using contours.
 
-eit = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE)
-rhessi = sunpy.map.Map(sunpy.data.sample.RHESSI_IMAGE)
-aia = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
+eit = Map(sunpy.data.sample.EIT_195_IMAGE)
+rhessi = Map(sunpy.data.sample.RHESSI_IMAGE)
+aia = Map(sunpy.data.sample.AIA_171_IMAGE)
 
 ###############################################################################
 # Before we plot the image, let's zoom in around the solar flare so the RHESSI

--- a/examples/plotting/three_map_composite.py
+++ b/examples/plotting/three_map_composite.py
@@ -1,0 +1,44 @@
+"""
+=========================================
+Creating a Composite Plot with Three Maps
+=========================================
+
+In this example, a composite plot is created with three maps.
+It demonstrates how to specify contour levels, transparency, and
+ordering when overlaying multiple maps.
+"""
+import matplotlib.pyplot as plt
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+import sunpy.data.sample
+from sunpy.map import Map
+
+###############################################################################
+# First, we will import sample data from EIT, RHESSI, and AIA. The EIT data
+# shows a hot region of the solar corona, while AIA shows the cooler upper
+# region of the corona. RHESSI data is focused on a solar flare, and will be
+# plotted using contours.
+eit = sunpy.map.Map(sunpy.data.sample.EIT_195_IMAGE)
+rhessi = sunpy.map.Map(sunpy.data.sample.RHESSI_IMAGE)
+aia = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
+
+###############################################################################
+# Next, specify the RHESSI contour levels to be plotted. When creating the
+# plot, choose which Map will be used to create the WCS Axes that the other
+# Maps will be plotted with. The EIT map is plotted first, followed by the
+# RHESSI contours, and lastly the AIA map. Transparency is changed to 50% on
+# the AIA map by specifying the parameter `alpha`, and the image data is
+# autoaligned to the EIT WCS Axes. The parameter `zorder` specifies
+# how each plot is layered (0 is plotted first and 1 is layered on top of 0,
+# and so on). Lastly, note that `draw_grid()` is called using the EIT map.
+levels = [50, 60, 70, 80, 90]*u.percent
+fig = plt.figure()
+ax = fig.add_subplot(projection=eit)
+eit.plot(axes=ax, zorder=0)
+rhessi.draw_contours(axes=ax, levels=levels, zorder=1)
+aia.plot(axes=ax, alpha=0.5, autoalign=True, zorder=2)
+eit.draw_grid(axes=ax)
+plt.title("Three Map Composite")
+plt.show()

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,6 +105,7 @@ docs =
   sphinx-gallery>=0.9.0 # First to include the defer figures functionality
   sphinx-design
   sphinxext-opengraph
+  sunkit_image
   sunpy-sphinx-theme
 
 [options.packages.find]


### PR DESCRIPTION
The purpose of this pull request is to add several tutorials that are meant to replace the functionality of `CompositeMap`. It addresses issue #6375 and issue #5940.

Tutorial descriptions:
-	"Overlaying Two Maps" is directly adapted from the current [Creating a CompositeMap example](https://docs.sunpy.org/en/latest/generated/gallery/map/composite_map_AIA_HMI.html). It shows how to overlay HMI contours onto an AIA image.
-	"Creating a Composite Plot with Three Maps" is directly adapted from the [CompositeMap example](https://docs.sunpy.org/en/v4.0.4/guide/data_types/maps.html#composite-maps-and-overlaying-maps) in the old Map guide. It shows how to overlay EIT and AIA data along with RHESSI contours. Now, it also demonstrates how to specify transparency and ordering when plotting data. 
-	"Making an RGB composite image" is adapted from an example created by @wtbarnes in the #5940 discussion. This is not a functionality of `CompositeMap`, but I have included it here as it fits the overall composite plotting theme of this pull request. As I am not a solar physicist, please let me know if I overlooked any details or steps that should be included/mentioned in this tutorial.
-	"Creating a Masked Composite Plot" is a slightly more advanced example that demonstrates how to use a masked map as well as contours in a single composite plot. I include it here as a possible example that shows how to combine sunpy functionalities. 

If there are other `CompositeMap` functionalities that are not covered above, let me know.
![aia_hmi_composite](https://user-images.githubusercontent.com/88404225/194923584-d050b4ba-97c6-42c3-846a-e4799ba8c4b4.png)
![three_maps](https://user-images.githubusercontent.com/88404225/194923647-053354f5-f0ad-4e9e-b46b-5500a31677e4.png)
![rgb_composite](https://user-images.githubusercontent.com/88404225/194923663-8ea004e8-1ebe-4c1a-b1a4-ba846e23d214.png)
![masked_composite](https://user-images.githubusercontent.com/88404225/194923681-675ddf89-f600-4d27-bb3c-275ae2e89bd4.png)
