### PR TITLE
Fix sunkit_instrument links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -476,8 +476,8 @@ Added/Improved Documentation
 Backwards Incompatible Changes
 ------------------------------
 
-- ``sunpy.instr`` has been depreacted and will be removed in sunpy 3.1 in favour of `sunkit_instruments`.
-  The code that is under ``sunpy.instr`` is imported via `sunkit_instruments` to ensure backwards comparability. (`#4526 <https://github.com/sunpy/sunpy/pull/4526>`__)
+- ``sunpy.instr`` has been depreacted and will be removed in sunpy 3.1 in favour of :external+sunkit_instruments:ref:`index <sunkit_instruments>`.
+  The code that is under ``sunpy.instr`` is imported via :external+sunkit_instruments:ref:`index <sunkit_instruments>` to ensure backwards comparability. (`#4526 <https://github.com/sunpy/sunpy/pull/4526>`__)
 - Several `sunpy.map.GenericMap` attributes have been updated to return `None` when the relevant piece of FITS metadata is missing. These are:
 
   - `~sunpy.map.GenericMap.exposure_time`, previously defaulted to zero seconds.


### PR DESCRIPTION
It's not particularly pretty, but this should fix the doc links to `sunkit_instruments`. I think these were broken by https://github.com/sunpy/sunkit-instruments/pull/79.