### PR TITLE
Fix scraper file timerange

### DIFF
--- a/changelog/6472.feature.rst
+++ b/changelog/6472.feature.rst
@@ -1,0 +1,5 @@
+`sunpy.net.Scraper` now includes treats files as spanning a full interval equal to the smallest increment specified in the file pattern.
+For example, a pattern like ``"%Y.txt"`` that only contains a year specifier will be considered to span that full year.
+
+This means searches that fall entirely within the whole interval spanned by a pattern will return that file, where previously they did not.
+As an example, matching ``"%Y.txt"`` with ``TimeRange('2022-02-01', '2022-04-01')`` will now return ``["2022.txt"]`` where previously no files were returned.

--- a/changelog/xxxx.feature.rst
+++ b/changelog/xxxx.feature.rst
@@ -1,0 +1,5 @@
+`sunpy.net.Scraper` now includes treats files as spanning a full interval equal to the smallest increment specified.
+For example, a pattern like ``"%Y.txt"`` that only contains a year interval will be considered to span that full year.
+
+This means searches that fall entirely within the interval will return that file where previously they did not.
+For example matching ``"%Y.txt"`` with ``TimeRange('2022-02-01', '2022-04-01')`` will now return ``["2022.txt"]`` where previously no files were returned.

--- a/changelog/xxxx.feature.rst
+++ b/changelog/xxxx.feature.rst
@@ -1,5 +1,0 @@
-`sunpy.net.Scraper` now includes treats files as spanning a full interval equal to the smallest increment specified.
-For example, a pattern like ``"%Y.txt"`` that only contains a year interval will be considered to span that full year.
-
-This means searches that fall entirely within the interval will return that file where previously they did not.
-For example matching ``"%Y.txt"`` with ``TimeRange('2022-02-01', '2022-04-01')`` will now return ``["2022.txt"]`` where previously no files were returned.

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -373,8 +373,8 @@ class Scraper:
 
     def _check_timerange(self, url, timerange):
         """
-        Checks whether the time extracted from the URL
-        is valid according to the given time range.
+        Checks whether the time range represented in *url* intersects
+        with the given time range.
 
         Parameters
         ----------
@@ -386,15 +386,17 @@ class Scraper:
         Returns
         -------
         `bool`
-            `True` if URL's time overlaps the given timerange, else `False`.
+            `True` if URL's valid time range overlaps the given timerange, else `False`.
         """
         if hasattr(self, 'extractor'):
             exdict = parse(self.extractor, url).named
             tr = get_timerange_from_exdict(exdict)
-            return (tr.end >= timerange.start and tr.start <= timerange.end)
+            return tr.intersects(timerange)
         else:
             datehref = self._extractDateURL(url).to_datetime()
-            return (timerange.start.to_datetime() <= datehref <= timerange.end.to_datetime())
+            smaller_pattern = self._smallerPattern(self.pattern)
+            file_timerange = TimeRange(datehref, datehref + smaller_pattern)
+            return file_timerange.intersects(timerange)
 
     def _smallerPattern(self, directoryPattern):
         """

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -201,7 +201,10 @@ def testFilesRange_sameDirectory_months_remote():
     startdate = parse_time((2007, 8, 1))
     enddate = parse_time((2007, 9, 10))
     timerange = TimeRange(startdate, enddate)
-    assert len(s.filelist(timerange)) == 3
+    files = s.filelist(timerange)
+    assert files == ['http://www.srl.caltech.edu/STEREO/DATA/HET/Ahead/1minute/AeH07Aug.1m',
+                     'http://www.srl.caltech.edu/STEREO/DATA/HET/Ahead/1minute/AeH07Jul.1m',
+                     'http://www.srl.caltech.edu/STEREO/DATA/HET/Ahead/1minute/AeH07Sep.1m']
 
 
 @pytest.mark.remote_data
@@ -291,6 +294,7 @@ def test_get_timerange_with_extractor(exdict, start, end):
     tr = TimeRange(start, end)
     file_timerange = get_timerange_from_exdict(exdict)
     assert file_timerange == tr
+
 
 @pytest.mark.remote_data
 def test_yearly_overlap():

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -201,7 +201,7 @@ def testFilesRange_sameDirectory_months_remote():
     startdate = parse_time((2007, 8, 1))
     enddate = parse_time((2007, 9, 10))
     timerange = TimeRange(startdate, enddate)
-    assert len(s.filelist(timerange)) == 2
+    assert len(s.filelist(timerange)) == 3
 
 
 @pytest.mark.remote_data
@@ -211,8 +211,8 @@ def test_ftp():
     timerange = TimeRange('2016/5/18 15:28:00', '2016/5/20 16:30:50')
     urls = s.filelist(timerange)
     assert urls[0] == ('ftp://solar-pub.nao.ac.jp'
-                       '/pub/nsro/norh/data/tcx/2016/05/tca160519')
-    assert len(urls) == 2
+                       '/pub/nsro/norh/data/tcx/2016/05/tca160518')
+    assert len(urls) == 3
 
 
 @pytest.mark.remote_data
@@ -291,3 +291,14 @@ def test_get_timerange_with_extractor(exdict, start, end):
     tr = TimeRange(start, end)
     file_timerange = get_timerange_from_exdict(exdict)
     assert file_timerange == tr
+
+@pytest.mark.remote_data
+def test_yearly_overlap():
+    # Check that a time range that falls within the interval that a file reprsents
+    # returns a single result.
+    pattern = "https://www.ngdc.noaa.gov/stp/space-weather/solar-data/solar-features/solar-flares/x-rays/goes/xrs/goes-xrs-report_%Y.txt"
+    scraper = Scraper(pattern)
+
+    # Should return a single file for 2013
+    trange = TimeRange("2013-01-02", "2013-01-03")
+    assert len(scraper.filelist(trange)) == 1

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -306,3 +306,27 @@ def test_yearly_overlap():
     # Should return a single file for 2013
     trange = TimeRange("2013-01-02", "2013-01-03")
     assert len(scraper.filelist(trange)) == 1
+
+
+def test_check_timerange():
+    s = Scraper('%Y.fits')
+    # Valid time range for 2014.fits is the whole of 2014
+    # Test different cases to make sure check_timerange is working as expected
+
+    # Interval exactly on lower boundary
+    assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2014-01-01"))
+    # Overlaps lower boundary
+    assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2014-01-02"))
+    # Overlaps upper and lower boundary
+    assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2015-01-02"))
+    # Entirely within both boundaries
+    assert s._check_timerange('2014.fits', TimeRange("2014-06-01", "2014-07-02"))
+    # Overlaps upper boundary
+    assert s._check_timerange('2014.fits', TimeRange("2014-06-01", "2015-01-02"))
+    # Interval exactly on upper boundary
+    assert s._check_timerange('2014.fits', TimeRange("2015-01-01", "2015-01-02"))
+
+    # Interval below both boundaries
+    assert not s._check_timerange('2014.fits', TimeRange("2002-01-01", "2013-01-02"))
+    # Interval above both boundaries
+    assert not s._check_timerange('2014.fits', TimeRange("2022-01-01", "2025-01-02"))


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/5217, by making sure that the code determining the timerange a given file represents extends across the smallest interval specified in the filename.