### PR TITLE
Implemented site configuration for sunpyrc, modified docs

### DIFF
--- a/changelog/6478.feature.rst
+++ b/changelog/6478.feature.rst
@@ -1,0 +1,1 @@
+Implemented site configuration for sunpyrc, and modified documentation for sunpy customization.

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -45,6 +45,18 @@ in a platform specific directory, which you can see the path for by running::
 
 Do not edit the default file (the first in the "FILES USED:" list above) directly as every time you install or update sunpy, this file will be overwritten.
 
+To maintain your personal customizations place a copy of the default "sunpyrc" file into the user configuration path.
+To find this path, use:
+
+.. code-block:: python
+
+    >>> from sunpy.extern.appdirs import AppDirs
+    >>> AppDirs('sunpy', 'sunpy').user_config_dir  # doctest: +SKIP
+
+You can use `sunpy.util.config.copy_default_config` to write the default config into the correct place.
+
+The user configuration path can also be set using an environment variable ``SUNPY_CONFIGDIR``.
+
 Depending on your system, it may be useful to have a site-wide configuration file.
 If it is used, it will be on the "FILES USED:" list below the default file.
 To find your system's site configuration path for ``sunpy``, use:
@@ -56,19 +68,7 @@ To find your system's site configuration path for ``sunpy``, use:
 
 In Unix, the site and user configuration paths follow the `XDG specifications <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
 
-To maintain your personal customizations place a copy of the default "sunpyrc" file into the user configuration path.
-To find this path, use:
-
-.. code-block:: python
-
-    >>> from sunpy.extern.appdirs import AppDirs
-    >>> AppDirs('sunpy', 'sunpy').user_config_dir  # doctest: +SKIP
-
-You can use `sunpy.util.config.copy_default_config` to write the default config into the correct place.
-
-Note that if your site has a site configuration file, you may want to replicate the site configuration items into your own configuration file, as your own configuration overrides the site configuration.
-
-The user configuration path can also be set using an environment variable ``SUNPY_CONFIGDIR``.
+The site configuration is applied before your personal user configuration, thus your configuration file will override the site configuration settings. For this reason, when you create or edit your personal configuration file, you may want to replicate the site configuration items into your own configuration file, or comment out the items in your configuration file that are set in the site configuration file.
 
 See below for the example config file.
 

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -47,7 +47,7 @@ Do not edit the default file (the first in the "FILES USED:" list above) directl
 
 Depending on your system, it may be useful to have a site-wide configuration file.
 If it is used, it will be on the "FILES USED:" list below the default file.
-To find your system's site configuration path for sunpy, use:
+To find your system's site configuration path for ``sunpy``, use:
 
 .. code-block:: python
 

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -43,10 +43,26 @@ in a platform specific directory, which you can see the path for by running::
     log_file_format = %(asctime)s, %(origin)s, %(levelname)s, %(message)s
   <BLANKLINE>
 
-To maintain your own customizations place a copy of the default sunpyrc file
-into the *first* path printed above.
+Do not edit the default file (the first in the  FILES USED: list above) directly as every time you install or update sunpy, this file will be overwritten.
+
+Depending on your system, it may be useful to have a site-wide configuration file. If it is used, it will be on the FILES USED: list below the default file. To find your system's site configuration
+path for sunpy, use::
+
+    from sunpy.extern.appdirs import AppDirs
+    AppDirs('sunpy', 'sunpy').site_config_dir
+
+In Unixes (including Linux) the site and user configuration paths follow the `XDG specifications <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
+
+To maintain your personal customizations place a copy of the default sunpyrc file into the user configuration path. To find this path, use::
+
+    from sunpy.extern.appdirs import AppDirs
+    AppDirs('sunpy', 'sunpy').user_config_dir
+
 You can use `sunpy.util.config.copy_default_config` to write the default config into the correct place.
-Do not edit the default file directly as every time you install or update sunpy, this file will be overwritten.
+
+Note that if your site has a site configuration file, you may want to replicate the site configuration items into your own configuration file, as your own configuration overrides the site configuration.
+
+The user configuration path can also be set using an environment variable ``SUNPY_CONFIGDIR``.
 
 See below for the example config file.
 

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -43,7 +43,7 @@ in a platform specific directory, which you can see the path for by running::
     log_file_format = %(asctime)s, %(origin)s, %(levelname)s, %(message)s
   <BLANKLINE>
 
-Do not edit the default file (the first in the  FILES USED: list above) directly as every time you install or update sunpy, this file will be overwritten.
+Do not edit the default file (the first in the "FILES USED:" list above) directly as every time you install or update sunpy, this file will be overwritten.
 
 Depending on your system, it may be useful to have a site-wide configuration file. If it is used, it will be on the FILES USED: list below the default file. To find your system's site configuration
 path for sunpy, use::

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -45,8 +45,9 @@ in a platform specific directory, which you can see the path for by running::
 
 Do not edit the default file (the first in the "FILES USED:" list above) directly as every time you install or update sunpy, this file will be overwritten.
 
-Depending on your system, it may be useful to have a site-wide configuration file. If it is used, it will be on the FILES USED: list below the default file. To find your system's site configuration
-path for sunpy, use::
+Depending on your system, it may be useful to have a site-wide configuration file.
+If it is used, it will be on the "FILES USED:" list below the default file.
+To find your system's site configuration path for sunpy, use:
 
     from sunpy.extern.appdirs import AppDirs
     AppDirs('sunpy', 'sunpy').site_config_dir

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -56,10 +56,13 @@ To find your system's site configuration path for sunpy, use:
 
 In Unix, the site and user configuration paths follow the `XDG specifications <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
 
-To maintain your personal customizations place a copy of the default sunpyrc file into the user configuration path. To find this path, use::
+To maintain your personal customizations place a copy of the default "sunpyrc" file into the user configuration path.
+To find this path, use:
 
-    from sunpy.extern.appdirs import AppDirs
-    AppDirs('sunpy', 'sunpy').user_config_dir
+.. code-block:: python
+
+    >>> from sunpy.extern.appdirs import AppDirs
+    >>> AppDirs('sunpy', 'sunpy').user_config_dir
 
 You can use `sunpy.util.config.copy_default_config` to write the default config into the correct place.
 

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -52,7 +52,7 @@ To find your system's site configuration path for sunpy, use:
 .. code-block:: python
 
     >>> from sunpy.extern.appdirs import AppDirs
-    >>> AppDirs('sunpy', 'sunpy').site_config_dir
+    >>> AppDirs('sunpy', 'sunpy').site_config_dir  # doctest: +SKIP
 
 In Unix, the site and user configuration paths follow the `XDG specifications <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
 
@@ -62,7 +62,7 @@ To find this path, use:
 .. code-block:: python
 
     >>> from sunpy.extern.appdirs import AppDirs
-    >>> AppDirs('sunpy', 'sunpy').user_config_dir
+    >>> AppDirs('sunpy', 'sunpy').user_config_dir  # doctest: +SKIP
 
 You can use `sunpy.util.config.copy_default_config` to write the default config into the correct place.
 

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -54,7 +54,7 @@ To find your system's site configuration path for sunpy, use:
     >>> from sunpy.extern.appdirs import AppDirs
     >>> AppDirs('sunpy', 'sunpy').site_config_dir
 
-In Unixes (including Linux) the site and user configuration paths follow the `XDG specifications <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
+In Unix, the site and user configuration paths follow the `XDG specifications <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
 
 To maintain your personal customizations place a copy of the default sunpyrc file into the user configuration path. To find this path, use::
 

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -49,8 +49,10 @@ Depending on your system, it may be useful to have a site-wide configuration fil
 If it is used, it will be on the "FILES USED:" list below the default file.
 To find your system's site configuration path for sunpy, use:
 
-    from sunpy.extern.appdirs import AppDirs
-    AppDirs('sunpy', 'sunpy').site_config_dir
+.. code-block:: python
+
+    >>> from sunpy.extern.appdirs import AppDirs
+    >>> AppDirs('sunpy', 'sunpy').site_config_dir
 
 In Unixes (including Linux) the site and user configuration paths follow the `XDG specifications <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
 

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -68,7 +68,8 @@ To find your system's site configuration path for ``sunpy``, use:
 
 In Unix, the site and user configuration paths follow the `XDG specifications <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
 
-The site configuration is applied before your personal user configuration, thus your configuration file will override the site configuration settings. For this reason, when you create or edit your personal configuration file, you may want to replicate the site configuration items into your own configuration file, or comment out the items in your configuration file that are set in the site configuration file.
+The site configuration is applied before your personal user configuration, thus your configuration file will override the site configuration settings.
+For this reason, when you create or edit your personal configuration file, you may want to replicate the site configuration items into your own configuration file, or comment out the items in your configuration file that are set in the site configuration file.
 
 See below for the example config file.
 

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -70,6 +70,13 @@ def _find_config_files():
     module_dir = Path(sunpy.__file__).parent
     config_files.append(str(module_dir / 'data' / 'sunpyrc'))
 
+    # if a site configuration file exists, add that to list of files to read
+    # so that any values set there will override ones specified in the default
+    # config file
+    config_path = Path(dirs.site_config_dir)
+    if config_path.joinpath(config_filename).exists():
+        config_files.append(str(config_path.joinpath(config_filename)))
+
     # if a user configuration file exists, add that to list of files to read
     # so that any values set there will override ones specified in the default
     # config file
@@ -166,6 +173,15 @@ def copy_default_config(overwrite=False):
 
     if not _is_writable_dir(user_config_dir):
         raise RuntimeError(f'Could not write to SunPy config directory {user_config_dir}')
+
+    config_path = Path(dirs.site_config_dir)
+    site_config_file = config_path.joinpath(config_filename)
+    if site_config_file.exists():
+        message = f"Site config file {str(site_config_file)} exists. " \
+            "You must update the User config file to take the " \
+            "site configuration into account manually. Consult your" \
+            "site manager."
+        warn_user(message)
 
     if user_config_file.exists():
         if overwrite:

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -177,11 +177,11 @@ def copy_default_config(overwrite=False):
     config_path = Path(dirs.site_config_dir)
     site_config_file = config_path.joinpath(config_filename)
     if site_config_file.exists():
-        message = (f"Site config file {str(site_config_file)} exists. " 
-            "You must update the User config file to take the " 
-            "site configuration into account manually. Consult your" 
-            "site manager."
-            )
+        message = (f"Site config file {str(site_config_file)} exists. "
+                   "You must update the User config file to take the "
+                   "site configuration into account manually. Consult your"
+                   "site manager."
+                   )
         warn_user(message)
 
     if user_config_file.exists():

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -177,10 +177,11 @@ def copy_default_config(overwrite=False):
     config_path = Path(dirs.site_config_dir)
     site_config_file = config_path.joinpath(config_filename)
     if site_config_file.exists():
-        message = f"Site config file {str(site_config_file)} exists. " \
-            "You must update the User config file to take the " \
-            "site configuration into account manually. Consult your" \
+        message = (f"Site config file {str(site_config_file)} exists. " 
+            "You must update the User config file to take the " 
+            "site configuration into account manually. Consult your" 
             "site manager."
+            )
         warn_user(message)
 
     if user_config_file.exists():

--- a/sunpy/util/tests/test_config.py
+++ b/sunpy/util/tests/test_config.py
@@ -67,7 +67,7 @@ def test_print_config_files(tmpdir, tmp_path, undo_download_dir_patch):
     assert get_and_create_sample_dir() in printed
 
 
-def test__find_config_user_site_files(tmpdir, tmp_path, undo_download_dir_patch, monkeypatch):
+def test_find_config_user_site_files(tmpdir, tmp_path, undo_download_dir_patch, monkeypatch):
 
     # Set a site config dir
     tmp_config_site_dir = tmpdir.mkdir("sunpy_test_configdir_site")


### PR DESCRIPTION
## PR Description

Adds configuration from global directories

This pull request implements [issue #6407](https://github.com/sunpy/sunpy/issues/6407), implementing configuration from global directories for sites that could benefit for example shared data path.

Documentation is also updated, fixing an error (the first FILES USED: path is always the default sunpyrc; also the user path isn't shown unless the file exists), and outlining the hierarchy default->site ->user.

A potential clash exists: user can automatically override the site configuration when copying the default configuration. Warnings added to copy_default_config and documentation.
