### PR TITLE
Switch tox-conda to use a conda environment file

### DIFF
--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -1,0 +1,67 @@
+channels:
+  - conda-forge
+
+dependencies:
+  # Required
+  - asdf
+  - asdf-astropy
+  - astropy
+  - beautifulsoup4
+  - cdflib
+  - drms
+  - glymur
+  - h5netcdf
+  - matplotlib-base
+  - mpl_animators
+  - numpy
+  - pandas
+  - parfive
+  - python
+  - python-dateutil
+  - python_abi
+  - reproject
+  - scikit-image
+  - scipy
+  - setuptools
+  - sqlalchemy
+  - tqdm
+  - zeep
+
+  # Optional
+  - astroquery
+  - jplephem
+  - opencv
+
+  # Testing
+  - hypothesis
+  - pytest
+  - pytest-astropy
+  - pytest-cov
+  - pytest-doctestplus
+  - pytest-mock
+  - pytest-mpl
+  - pytest-xdist
+  - tox
+
+  # Documentation
+  - ruamel.yaml
+  - sphinx
+  - sphinx-automodapi
+  - sphinx-gallery
+  - sphinx-design
+  - towncrier
+
+  # Installation
+  - extension-helpers
+  - pip
+  - setuptools-scm
+
+  # Development
+  - pre-commit
+ 
+  # Not installable through conda
+  - pip:
+    - sphinx-bootstrap-theme
+    - sphinx-changelog
+    - sphinxext-opengraph
+    - sunpy-sphinx-theme

--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -58,7 +58,7 @@ dependencies:
 
   # Development
   - pre-commit
- 
+
   # Not installable through conda
   - pip:
     - sphinx-bootstrap-theme

--- a/tox.ini
+++ b/tox.ini
@@ -124,6 +124,7 @@ extras =
 deps =
 conda_env = sunpy-dev-env.yml
 install_command = pip install --no-deps --no-build-isolation {opts} {packages}
+allowlist_externals = conda
 commands =
     conda list
     {env:PYTEST_COMMAND} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,7 @@ extras =
 deps =
 conda_env = sunpy-dev-env.yml
 install_command = pip install --no-deps --no-build-isolation {opts} {packages}
-allowlist_externals = conda
+whitelist_externals = conda
 commands =
     conda list
     {env:PYTEST_COMMAND} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ isolated_build = true
 
 [testenv]
 pypi_filter = file://.test_package_pins.txt
-whitelist_externals=
+allowlist_externals=
     /bin/bash
     /usr/bin/bash
 # Run the tests in a temporary directory to make sure that we don't import sunpy from the source tree
@@ -124,7 +124,7 @@ extras =
 deps =
 conda_env = sunpy-dev-env.yml
 install_command = pip install --no-deps --no-build-isolation {opts} {packages}
-whitelist_externals = conda
+allowlist_externals = conda
 commands =
     conda list
     {env:PYTEST_COMMAND} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -122,47 +122,8 @@ commands =
 pypi_filter =
 extras =
 deps =
-conda_deps =
-    asdf
-    asdf-astropy
-    astropy
-    beautifulsoup4
-    cdflib
-    conda
-    dask
-    drms
-    extension-helpers
-    glymur
-    h5netcdf
-    hypothesis
-    jinja2
-    jplephem
-    libopenblas>=0.3.12
-    lxml
-    matplotlib
-    mpl_animators
-    numpy
-    opencv
-    openjpeg
-    pandas
-    parfive
-    pillow
-    py-opencv
-    pytest
-    pytest-astropy
-    pytest-cov
-    pytest-mock
-    pytest-mpl
-    pytest-xdist
-    reproject
-    scikit-image
-    scipy
-    sphinx
-    sqlalchemy
-    towncrier
-    zeep
-conda_channels = conda-forge
-install_command = pip install --no-deps {opts} {packages}
+conda_env = sunpy-dev-env.yml
+install_command = pip install --no-deps --no-build-isolation {opts} {packages}
 commands =
     conda list
     {env:PYTEST_COMMAND} {posargs}


### PR DESCRIPTION
This PR itself is (currently) only an internal change, but the longer-term objective is to provide an (advanced) installation guide for a developer that wants to have an editable install of `sunpy` (and other specific packages) within an environment where all of the other packages are managed by `conda` (see #6445).