### PR TITLE
Exclude the CITATION.rst symbolic link from EOF checking by pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
       - id: check-added-large-files
         args: ['--enforce-all','--maxkb=1054']
       - id: end-of-file-fixer
-        exclude: ".*(.fits|.fts|.fit|.header|.txt|tca.*)$"
+        exclude: ".*(.fits|.fts|.fit|.header|.txt|tca.*)$|^CITATION.rst$"
       - id: mixed-line-ending
         exclude: ".*(.fits|.fts|.fit|.header|.txt|tca.*)$"
   - repo: https://github.com/devanshshukla99/pre-commit-hook-prohibit-string


### PR DESCRIPTION
Windows gets confused by the symbolic link