### PR TITLE
Avoid casting to quantity in arithmetic dunder methods

### DIFF
--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1494,9 +1494,9 @@ def test_map_arithmetic_neg(aia171_test_map):
 
 @pytest.mark.parametrize('value,warn_context', [
     ('map', pytest.warns(RuntimeWarning)),
-    ('foobar', contextlib.nullcontext()),
-    (None, contextlib.nullcontext()),
-    (['foo', 'bar'], contextlib.nullcontext()),
+    ('foobar', pytest.warns(RuntimeWarning)),
+    (None, pytest.warns(RuntimeWarning)),
+    (['foo', 'bar'], pytest.warns(RuntimeWarning)),
 ])
 def test_map_arithmetic_operations_raise_exceptions(aia171_test_map, value, warn_context):
     value = aia171_test_map if value == 'map' else value


### PR DESCRIPTION
This is an attempt to avoid using `Quantity` to check for arithmetic compatibility such that arithmetic operations preserve the "laziness" of Dask arrays when a Map is backed by a Dask array. 
For more context, see sunpy/ndcube#541.
I'm not really convinced this is worth doing as this has gotten really messy because of the need to manually check for compatibility between inputs to these operators and the Map.
I'm almost inclined to wait on `Quantity` to support these types of arrays and to just fall back on that again.

In the case of addition,
* Operations with Quantity are supported 
* Operations with non-Quantity are supported (with the assumption that the units of the input are compatible with those of the map)

In the case of multiplication,
* Operations with Quantity and non-Quantity are supported
* If map has no unit and input has no unit, can multiply
* If map has unit but input has no unit, can multiply
* If both have units, can multiply
* If map does not have unit but input does, cannot multiply

## TODOs

If I proceed down this route, still need to do a few things

- [ ] Add test for dask array
- [ ] Add unitless tests, especially for multiplication
- [ ] Changelog

