### PR TITLE
Added graphviz to the conda environment file

### DIFF
--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -40,10 +40,13 @@ dependencies:
   - pytest-doctestplus
   - pytest-mock
   - pytest-mpl
+  - pytest-rerunfailures
+  - pytest-timeout
   - pytest-xdist
   - tox
 
   # Documentation
+  - graphviz
   - ruamel.yaml
   - sphinx
   - sphinx-automodapi

--- a/tox.ini
+++ b/tox.ini
@@ -125,6 +125,9 @@ deps =
 conda_env = sunpy-dev-env.yml
 install_command = pip install --no-deps --no-build-isolation {opts} {packages}
 allowlist_externals = conda
+commands_pre =
+#   Remove pytest-rerunfailures to avoid appearing to access the internet when pytest-xdist is used
+    conda remove -y -q --force pytest-rerunfailures
 commands =
     conda list
     {env:PYTEST_COMMAND} {posargs}


### PR DESCRIPTION
Oops, left out `graphviz` in #6479.  `graphviz` is in fact one of the primary reasons that we'd want to utilize `conda`.  I also added two `pytest` extensions that are used by the test commands in our `tox` builds.