### PR TITLE
Fix the incorrect Python version for tox-conda test build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -122,10 +122,17 @@ commands =
 pypi_filter =
 extras =
 deps =
-conda_env = sunpy-dev-env.yml
+conda_deps =
+#   These packages are needed to install sunpy even with --no-deps
+    extension-helpers
+    numpy
+    setuptools-scm
+conda_channels = conda-forge
 install_command = pip install --no-deps --no-build-isolation {opts} {packages}
 allowlist_externals = conda
 commands_pre =
+#   Update the base environment to preserve the Python version
+    conda env update -q -f {toxinidir}/sunpy-dev-env.yml
 #   Remove pytest-rerunfailures to avoid appearing to access the internet when pytest-xdist is used
     conda remove -y -q --force pytest-rerunfailures
 commands =


### PR DESCRIPTION
It turns out that when tox-conda creates a fresh environment from a YAML file (see #6479 and #6491), and that YAML file does not explicitly specify the Python version, the latest Python version is used (i.e., 3.10 currently).  For example, `py39-conda` tox build ends up having Python 3.10 instead of the intended 3.9.

Let's see if this PR works.