### PR TITLE
Optionally preserve metadata in `reproject_to`

### DIFF
--- a/changelog/6502.feature.rst
+++ b/changelog/6502.feature.rst
@@ -1,0 +1,2 @@
+`~sunpy.map.GenericMap.reproject_to` now optionally preserves a subset of the metadata from the input map
+if ``preserve_meta=True``.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -50,7 +50,6 @@ from sunpy.util.decorators import (
     add_common_docstring,
     cached_property_based_on,
     check_arithmetic_compatibility,
-    deprecate_positional_args_since,
 )
 from sunpy.util.exceptions import warn_metadata, warn_user
 from sunpy.util.functools import seconddispatch
@@ -2731,18 +2730,12 @@ class GenericMap(NDData):
         # Reconstruct header
         target_header = MetaDict(target_wcs.to_header())
         if preserve_meta:
-            from .header_helper import _set_instrument_meta
-            target_header = _set_instrument_meta(target_header,
-                                                 self.instrument,
-                                                 self.meta.get('telescop', None),
-                                                 self.observatory,
-                                                 self.wavelength,
-                                                 self.exposure_time,
-                                                 self.unit)
+            original_header = copy.deepcopy(self.meta)
+            original_header.update(target_header)
+            target_header = original_header
 
         # Create and return a new GenericMap
-        outmap = GenericMap(output_array, target_header,
-                            plot_settings=self.plot_settings)
+        outmap = self._new_instance(output_array, target_header, plot_settings=self.plot_settings)
 
         if return_footprint:
             return outmap, footprint

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2722,15 +2722,15 @@ class GenericMap(NDData):
         # Reconstruct header
         target_header = MetaDict(target_wcs.to_header())
         if preserve_meta:
-            # TODO: pass through units once that PR is merged
-            # TODO: if we have a telescope attribute, use that property
             from header_helper import _set_instrument_meta
             target_header = _set_instrument_meta(target_header,
                                                  self.instrument,
+                                                 # TODO: if we have a telescope attribute, use that property
                                                  self.meta.get('telescop', None),
                                                  self.observatory,
                                                  self.wavelength,
-                                                 self.exposure_time)
+                                                 self.exposure_time,
+                                                 self.unit)
             outmap = self._new_instance(output_array, target_header, plot_settings=self.plot_settings)
         else:
             # Create and return a new GenericMap

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2667,6 +2667,9 @@ class GenericMap(NDData):
         return_footprint : `bool`
             If ``True``, the footprint is returned in addition to the new map.
             Defaults to ``False``.
+        preserve_meta : `bool`
+            If ``True``, a subset of the metadata from the input map is passed
+            to the reprojected map.
 
         Returns
         -------
@@ -2680,8 +2683,14 @@ class GenericMap(NDData):
 
         Notes
         -----
-        The reprojected map does not preserve any metadata beyond the WCS-associated
-        metadata.
+        By default, the reprojected map does not preserve any metadata beyond the WCS-associated
+        metadata. If ``preserve_meta=True``, the following map properties are preserved,
+
+        * `~sunpy.map.GenericMap.instrument`
+        * `~sunpy.map.GenericMap.observatory`
+        * `~sunpy.map.GenericMap.wavelength`
+        * `~sunpy.map.GenericMap.exposure_time`
+        * `~sunpy.map.GenericMap.unit`
 
         The supported `reproject` algorithms are:
 
@@ -2722,20 +2731,18 @@ class GenericMap(NDData):
         # Reconstruct header
         target_header = MetaDict(target_wcs.to_header())
         if preserve_meta:
-            from header_helper import _set_instrument_meta
+            from .header_helper import _set_instrument_meta
             target_header = _set_instrument_meta(target_header,
                                                  self.instrument,
-                                                 # TODO: if we have a telescope attribute, use that property
                                                  self.meta.get('telescop', None),
                                                  self.observatory,
                                                  self.wavelength,
                                                  self.exposure_time,
                                                  self.unit)
-            outmap = self._new_instance(output_array, target_header, plot_settings=self.plot_settings)
-        else:
-            # Create and return a new GenericMap
-            outmap = GenericMap(output_array, target_header,
-                                plot_settings=self.plot_settings)
+
+        # Create and return a new GenericMap
+        outmap = GenericMap(output_array, target_header,
+                            plot_settings=self.plot_settings)
 
         if return_footprint:
             return outmap, footprint

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2732,10 +2732,9 @@ class GenericMap(NDData):
         if preserve_meta:
             original_header = copy.deepcopy(self.meta)
             original_header.update(target_header)
-            target_header = original_header
-
-        # Create and return a new GenericMap
-        outmap = self._new_instance(output_array, target_header, plot_settings=self.plot_settings)
+            outmap = self._new_instance(output_array, original_header, plot_settings=self.plot_settings)
+        else:
+            outmap = GenericMap(output_array, target_header, plot_settings=self.plot_settings)
 
         if return_footprint:
             return outmap, footprint

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -50,6 +50,7 @@ from sunpy.util.decorators import (
     add_common_docstring,
     cached_property_based_on,
     check_arithmetic_compatibility,
+    deprecate_positional_args_since,
 )
 from sunpy.util.exceptions import warn_metadata, warn_user
 from sunpy.util.functools import seconddispatch
@@ -2647,6 +2648,7 @@ class GenericMap(NDData):
 
         return axes
 
+    @deprecate_positional_args_since("4.1")
     def reproject_to(self, target_wcs, *, algorithm='interpolation', return_footprint=False,
                      preserve_meta=False, **reproject_args):
         """

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2667,8 +2667,8 @@ class GenericMap(NDData):
             If ``True``, the footprint is returned in addition to the new map.
             Defaults to ``False``.
         preserve_meta : `bool`
-            If ``True``, a subset of the metadata from the input map is passed
-            to the reprojected map.
+            If ``True``, all of the non-WCS related metadata from the origonal
+            map will be preserved in the reprojected map.
 
         Returns
         -------
@@ -2683,13 +2683,7 @@ class GenericMap(NDData):
         Notes
         -----
         By default, the reprojected map does not preserve any metadata beyond the WCS-associated
-        metadata. If ``preserve_meta=True``, the following map properties are preserved,
-
-        * `~sunpy.map.GenericMap.instrument`
-        * `~sunpy.map.GenericMap.observatory`
-        * `~sunpy.map.GenericMap.wavelength`
-        * `~sunpy.map.GenericMap.exposure_time`
-        * `~sunpy.map.GenericMap.unit`
+        metadata. If ``preserve_meta=True``, all of the non-WCS metadata will also be preserved.
 
         The supported `reproject` algorithms are:
 

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -132,6 +132,7 @@ def test_deprecated_positional_args(aia171_test_map, hpc_header):
 
 def test_preserve_metadata(aia171_test_map, hpc_header):
     aia171_repr = aia171_test_map.reproject_to(hpc_header, preserve_meta=True)
+    aia171_test_map.reproject_to(hpc_header, preserve_meta=False)
     preserved_properties = ['instrument',
                             'observatory',
                             'wavelength',

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -128,3 +128,14 @@ def test_deprecated_positional_args(aia171_test_map, hpc_header):
 
     with pytest.warns(SunpyDeprecationWarning, match=r"Pass algorithm=interpolation, return_footprint=True as keyword args"):
         aia171_test_map.reproject_to(hpc_header, 'interpolation', True)
+
+
+def test_preserve_metadata(aia171_test_map, hpc_header):
+    aia171_repr = aia171_test_map.reproject_to(hpc_header, preserve_meta=True)
+    preserved_properties = ['instrument',
+                            'observatory',
+                            'wavelength',
+                            'exposure_time',
+                            'unit']
+    for p in preserved_properties:
+        assert getattr(aia171_repr, p) == getattr(aia171_test_map, p)


### PR DESCRIPTION
Fixes #5627 

This uses the header helper to optionally pass through a subset of the instrument keywords when using `reproject_to` and also ensures that the new map is the same subclass as the old map. As discussed in the above issue, this is not always a correct assumption so this False by default.

I'm not completely sure about the best way to do this. This should also wait on #6499 so that the unit can be easily passed through to the new instance.

## TODOs 

- [x] Incorporate changes from #6499 
- [ ] ~~Incorporate changes from #6503~~
- [x] Tests
- [x] Changelog
- [x] docstring