### PR TITLE
Add `telescope` property to `GenericMap`

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -970,6 +970,15 @@ class GenericMap(NDData):
                              self.meta.get('telescop', "")).replace("_", " ")
 
     @property
+    def telescope(self):
+        """
+        Telescope name
+
+        This is taken from the 'TELESCOP' FITS keyword.
+        """
+        return self.meta.get('telescop', "").replace("_", " ")
+
+    @property
     def processing_level(self):
         """
         Returns the FITS processing level if present.


### PR DESCRIPTION
This adds a `telescope` property to `GenericMap` by exposing the `'TELESCOP'` fits keyword as a string. Currently, we only expose the `'TELESCOP'` through the `observoatory` property and only if the `'OBSRVTRY'` key is missing,

https://github.com/sunpy/sunpy/blob/0980fd6d4d3d846e87536faefb7e1ce69d721625/sunpy/map/mapbase.py#L962-L970

While working on #6502, it seems strange to me that we don't expose this key directly, yet we have a place for it in the header helper.

I'm going to leave this in draft for now, but if people are not opposed to this, this PR still needs

- [ ] Tests (on GenericMap? on the sources?)
- [ ] Changelog