### PR TITLE
rename test_data_filenames to get_test_data_filenames

### DIFF
--- a/docs/dev_guide/contents/code_standards.rst
+++ b/docs/dev_guide/contents/code_standards.rst
@@ -190,7 +190,7 @@ Data and Configuration
 ======================
 
 * We store test data in ``sunpy/data/test`` as long as it is less than about 100 kB.
-  These data should always be accessed via the :func:`sunpy.data.test.get_test_filepath` and :func:`sunpy.data.test.test_data_filenames` functions.
+  These data should always be accessed via the :func:`sunpy.data.test.get_test_filepath` and :func:`sunpy.data.test.get_test_data_filenames` functions.
 
 * We store data used for examples in the `sample-data repository <https://github.com/sunpy/sample-data>`_.
   This data should not be used for unit tests but can be within our documentation.

--- a/docs/dev_guide/contents/tests.rst
+++ b/docs/dev_guide/contents/tests.rst
@@ -263,7 +263,7 @@ Tests that use test data
 ------------------------
 
 We store test data in "sunpy/data/test" as long as it is less than about 100 kB.
-These data should always be accessed via the :func:`sunpy.data.test.get_test_filepath` and :func:`sunpy.data.test.test_data_filenames` functions.
+These data should always be accessed via the :func:`sunpy.data.test.get_test_filepath` and :func:`sunpy.data.test.get_test_data_filenames` functions.
 This way you can use them when you create a test.
 
 You can also use our sample data but this will have to be marked as an online test (see above)::

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -11,7 +11,7 @@ import astropy.config.paths
 import astropy.io.fits
 from astropy.utils import iers
 
-from sunpy.data.test import get_test_filepath, test_data_filenames, write_image_file_from_header_file
+from sunpy.data.test import get_test_data_filenames, get_test_filepath, write_image_file_from_header_file
 from sunpy.map import Map
 from sunpy.util import SunpyUserWarning
 
@@ -193,7 +193,7 @@ def eit_fits_directory(tmp_path_factory):
     # from the header data. This directory is then used to
     # test directory and glob patterns for the map factory
     eit_dir = tmp_path_factory.mktemp('EIT')
-    eit_header_files = [f for f in test_data_filenames()
+    eit_header_files = [f for f in get_test_data_filenames()
                         if f.parents[0].relative_to(f.parents[1]).name == 'EIT_header'
                         and f.suffix == '.header']
     for f in eit_header_files:
@@ -207,7 +207,7 @@ def waveunit_fits_directory(tmp_path_factory):
     # from the header data. This directory is then used to
     # test directory patterns for database
     waveunit_dir = tmp_path_factory.mktemp('waveunit')
-    header_files = [f for f in test_data_filenames()
+    header_files = [f for f in get_test_data_filenames()
                     if f.parents[0].relative_to(f.parents[1]).name == 'waveunit']
     for f in header_files:
         _ = write_image_file_from_header_file(f, waveunit_dir)

--- a/sunpy/data/test/__init__.py
+++ b/sunpy/data/test/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     'rootdir',
     'file_list',
     'get_test_filepath',
-    'test_data_filenames',
+    'get_test_data_filenames',
     'get_dummy_map_from_header',
     'write_header_file_from_image_file',
 ]
@@ -53,7 +53,7 @@ def get_test_filepath(filename, **kwargs):
     return get_pkg_data_filename(filename, package="sunpy.data.test", **kwargs)
 
 
-def test_data_filenames():
+def get_test_data_filenames():
     """
     Return a list of all test files in ``data/test`` directory.
 
@@ -64,16 +64,16 @@ def test_data_filenames():
     `list`
         The name of all test files in ``data/test`` directory.
     """
-    test_data_filenames_list = []
+    get_test_data_filenames_list = []
     excludes = ['*.pyc', '*'+os.path.sep+'__*__', '*.py']
     excludes = r'|'.join([fnmatch.translate(x) for x in excludes]) or r'$.'
 
     for root, _, files in os.walk(rootdir):
         files = [Path(root) / f for f in files]
         files = [f for f in files if not re.match(excludes, str(f))]
-        test_data_filenames_list.extend(files)
+        get_test_data_filenames_list.extend(files)
 
-    return test_data_filenames_list
+    return get_test_data_filenames_list
 
 
 def write_image_file_from_header_file(header_file, fits_directory):

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -7,7 +7,7 @@ import pytest
 
 import astropy.io.fits as fits
 
-from sunpy.data.test import get_test_filepath, test_data_filenames
+from sunpy.data.test import get_test_data_filenames, get_test_filepath
 from sunpy.data.test.waveunit import MEDN_IMAGE, MQ_IMAGE, NA_IMAGE, SVSM_IMAGE
 from sunpy.io import _fits
 from sunpy.util import MetaDict, SunpyMetadataWarning
@@ -139,7 +139,7 @@ def test_fitsheader():
     """Test that all test data can be converted back to a FITS header."""
     extensions = ('.fts', '.fits')
     for ext in extensions:
-        test_files = [f for f in test_data_filenames() if f.suffix == ext]
+        test_files = [f for f in get_test_data_filenames() if f.suffix == ext]
         for ffile in test_files:
             fits_file = fits.open(ffile)
             fits_file.verify("fix")

--- a/sunpy/map/sources/tests/test_eit_source.py
+++ b/sunpy/map/sources/tests/test_eit_source.py
@@ -5,10 +5,10 @@ import pytest
 
 import astropy.units as u
 
-from sunpy.data.test import get_dummy_map_from_header, test_data_filenames
+from sunpy.data.test import get_dummy_map_from_header, get_test_data_filenames
 from sunpy.map.sources.soho import EITMap
 
-header_list = [f for f in test_data_filenames() if 'efz' in f.name and '.header' in f.name]
+header_list = [f for f in get_test_data_filenames() if 'efz' in f.name and '.header' in f.name]
 
 __author__ = "Pritish C. (VaticanCameos)"
 

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -10,11 +10,11 @@ from astropy.wcs import WCS
 
 import sunpy
 import sunpy.map
-from sunpy.data.test import get_dummy_map_from_header, get_test_filepath, rootdir, test_data_filenames
+from sunpy.data.test import get_dummy_map_from_header, get_test_data_filenames, get_test_filepath, rootdir
 from sunpy.tests.helpers import skip_glymur
 from sunpy.util.exceptions import NoMapsInFileError, SunpyMetadataWarning, SunpyUserWarning
 
-a_list_of_many = [f for f in test_data_filenames() if 'efz' in f.name]
+a_list_of_many = [f for f in get_test_data_filenames() if 'efz' in f.name]
 
 AIA_171_IMAGE = get_test_filepath('aia_171_level1.fits')
 RHESSI_IMAGE = get_test_filepath('hsi_image_20101016_191218.fits')

--- a/sunpy/tests/tests/test_sunpy_data_filenames.py
+++ b/sunpy/tests/tests/test_sunpy_data_filenames.py
@@ -12,10 +12,10 @@ def mockreturn(path):
     return paths
 
 
-def test_test_data_filenames(monkeypatch):
+def test_get_test_data_filenames(monkeypatch):
     monkeypatch.setattr(os, 'walk', mockreturn)
     monkeypatch.setattr(os.path, 'isfile', mockreturn)
-    output = sunpy.data.test.test_data_filenames()
+    output = sunpy.data.test.get_test_data_filenames()
     assert isinstance(output, list)
     # Only the test file and not the py/pyc files should be in the return.
     assert output == [Path('test') / 'data' / 'test_file']

--- a/sunpy/timeseries/tests/conftest.py
+++ b/sunpy/timeseries/tests/conftest.py
@@ -12,7 +12,7 @@ from astropy.time import TimeDelta
 
 import sunpy
 import sunpy.timeseries
-from sunpy.data.test import get_test_filepath, test_data_filenames
+from sunpy.data.test import get_test_data_filenames, get_test_filepath
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.metadata import MetaDict
@@ -30,7 +30,7 @@ rhessi_filepath = get_test_filepath('hsi_obssumm_20120601_018_truncated.fits.gz'
 noaa_ind_json_filepath = get_test_filepath('observed-solar-cycle-indices-truncated.json')
 noaa_pre_json_filepath = get_test_filepath('predicted-solar-cycle-truncated.json')
 goes_filepath = get_test_filepath('go1520120601.fits.gz')
-a_list_of_many = [f for f in test_data_filenames() if f.parents[0].relative_to(f.parents[1]).name == 'eve']
+a_list_of_many = [f for f in get_test_data_filenames() if f.parents[0].relative_to(f.parents[1]).name == 'eve']
 
 
 @pytest.fixture

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -16,7 +16,7 @@ from astropy.time import TimeDelta
 import sunpy.io
 import sunpy.net.attrs as a
 import sunpy.timeseries
-from sunpy.data.test import get_test_filepath, rootdir, test_data_filenames
+from sunpy.data.test import get_test_data_filenames, get_test_filepath, rootdir
 from sunpy.net import Fido
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
@@ -24,7 +24,7 @@ from sunpy.util.datatype_factory_base import NoMatchError
 from sunpy.util.metadata import MetaDict
 
 eve_filepath = get_test_filepath('EVE_L0CS_DIODES_1m_truncated.txt')
-eve_many_filepath = [f for f in test_data_filenames()
+eve_many_filepath = [f for f in get_test_data_filenames()
                      if f.parents[0].relative_to(f.parents[1]).name == 'eve']
 goes_filepath = get_test_filepath('go1520110607.fits')
 psp_filepath = get_test_filepath('psp_fld_l2_mag_rtn_1min_20200104_v02.cdf')


### PR DESCRIPTION
xref https://github.com/sunpy/sunpy/issues/6505 

Pytest 7.2 now raises a warning if a function it considers a test is returning anything. 

This happens due to `test_data_filenames` and the fact that pytest looks for `test*` functions.

We could exclude it or just in this case, rename it.
I don't consider this a public API change, this function is only used to get the sunpy test data. Other packages should not be using this. 