### PR TITLE
pin pytest for tests until we fix the tests and upstream changes

### DIFF
--- a/.test_package_pins.txt
+++ b/.test_package_pins.txt
@@ -1,1 +1,2 @@
-
+pytest<7.2
+pytest-xdist<3.0


### PR DESCRIPTION
We need to wait for pytest-arraydiff to be patched and https://github.com/sunpy/sunpy/pull/6507 merged in.

But since we we need the tests back, this will do for now.

Also there is a warning message for pytest-xdist 3

```
INTERNALERROR>     warnings.warn(warning, stacklevel=stacklevel)
INTERNALERROR> DeprecationWarning: The --rsyncdir command line argument and rsyncdirs config variable are deprecated.
INTERNALERROR> The rsync feature will be removed in pytest-xdist 4.0.
```

I am unclear where that comes from and pasting that little of the log is useless. 