### PR TITLE
Python 3.11 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,13 +145,11 @@ jobs:
       test_extras: 'dev'
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
-      # This can be removed when there are binaries for h5py on 3.11
-      libraries: 'libhdf5-dev'
       targets: |
         - cp3{8,9,10}-manylinux*_x86_64
         - cp3{8,9,10}-macosx_x86_64
         - cp3{8,9,10}-macosx_arm64
-        # Split these out as building h5py is slower, can be reintegrated when binaries for h5py exist
+        # Split these out for more rapid debugging
         - cp311-manylinux*_x86_64
         - cp311-macosx_x86_64
         - cp311-macosx_arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,14 @@ jobs:
       libraries: |
         apt:
           - libopenjp2-7
+          # This can be removed when there are binaries for h5py on 3.11
+          - libhdf5-dev
         brew:
           - openjpeg
       envs: |
-        - macos: py38
+        - linux: py311
         - windows: py39
+        - macos: py38
         - linux: py38-oldestdeps
 
   docs:
@@ -115,9 +118,11 @@ jobs:
       libraries: |
         apt:
           - libopenjp2-7
+          # This can be removed when there are binaries for h5py on 3.11
+          - libhdf5-dev
       envs: |
         - linux: base_deps
-        - linux: py39-devdeps
+        - linux: py311-devdeps
         - linux: py39-conda
           libraries: ''
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,10 +145,16 @@ jobs:
       test_extras: 'dev'
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
+      # This can be removed when there are binaries for h5py on 3.11
+      libraries: 'libhdf5-dev'
       targets: |
-        - cp3{8,9,10,11}-manylinux*_x86_64
-        - cp3{8,9,10,11}-macosx_x86_64
-        - cp3{8,9,10,11}-macosx_arm64
+        - cp3{8,9,10}-manylinux*_x86_64
+        - cp3{8,9,10}-macosx_x86_64
+        - cp3{8,9,10}-macosx_arm64
+        # Split these out as building h5py is slower, can be reintegrated when binaries for h5py exist
+        - cp311-manylinux*_x86_64
+        - cp311-macosx_x86_64
+        - cp311-macosx_arm64
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,9 @@ jobs:
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
       targets: |
-        - cp3{8,9,10}-manylinux*_x86_64
-        - cp3{8,9,10}-macosx_x86_64
-        - cp3{8,9,10}-macosx_arm64
+        - cp3{8,9,10,11}-manylinux*_x86_64
+        - cp3{8,9,10,11}-macosx_x86_64
+        - cp3{8,9,10,11}-macosx_arm64
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
 

--- a/changelog/6512.bugfix.rst
+++ b/changelog/6512.bugfix.rst
@@ -1,0 +1,4 @@
+Add support for Python 3.11.
+
+The deprecated `cgi.parse_header` is now available as
+`sunpy.util.net.parse_header`.

--- a/docs/dev_guide/contents/extending_fido.rst
+++ b/docs/dev_guide/contents/extending_fido.rst
@@ -426,7 +426,7 @@ This function will be called by `parfive` with the ``resp`` and ``url`` argument
         if resp:
             cdheader = resp.headers.get("Content-Disposition", None)
             if cdheader:
-            _, params = cgi.parse_header(cdheader)
+            _, params = sunpy.util.net.parse_header(cdheader)
             name = params.get('filename', "")
 
         return path.format(file=name, **row.response_block_map)
@@ -466,7 +466,7 @@ An example client class may look something like
 
 .. code-block:: python
 
-    import cgi
+    import sunpy.util.net
 
     import sunpy.net.atrrs as a
     from sunpy.net.attr import AttrWalker, AttrAnd, AttrOr, DataAttr
@@ -522,7 +522,7 @@ An example client class may look something like
             if resp:
                 cdheader = resp.headers.get("Content-Disposition", None)
                 if cdheader:
-                _, params = cgi.parse_header(cdheader)
+                _, params = sunpy.util.net.parse_header(cdheader)
                 name = params.get('filename', "")
 
             return path.format(file=name, **row.response_block_map)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ requires = [
          ]
 build-backend = 'setuptools.build_meta'
 
+# Until we have h5py binaries we can't test wheels on Python 3.11
+[tool.cibuildwheel]
+test-skip = "cp311-*"
+
 [ tool.gilesbot ]
   [ tool.gilesbot.circleci_artifacts ]
     enabled = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -194,6 +194,8 @@ filterwarnings =
     ignore:unable to download valid IERS file, using local IERS-B
     # See https://github.com/sunpy/drms/issues/72
     ignore:.*will attempt to set the values inplace instead of always setting a new array:FutureWarning
+    # Zeep relies on deprecated cgi in Python 3.11
+    ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:zeep.utils
 
 [pycodestyle]
 max_line_length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
   Topic :: Scientific/Engineering :: Physics
 
 [options]

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -3,7 +3,6 @@ This module provides a wrapper around the VSO API.
 """
 
 import os
-import cgi
 import copy
 import json
 import socket
@@ -24,7 +23,7 @@ from sunpy.net.base_client import BaseClient, QueryResponseRow
 from sunpy.net.vso import attrs
 from sunpy.net.vso.attrs import _walker as walker
 from sunpy.util.exceptions import warn_user
-from sunpy.util.net import slugify
+from sunpy.util.net import parse_header, slugify
 from sunpy.util.parfive_helpers import Downloader, Results
 from .. import _attrs as core_attrs
 from .exceptions import (
@@ -272,7 +271,7 @@ class VSOClient(BaseClient):
         if resp:
             cdheader = resp.headers.get("Content-Disposition", None)
             if cdheader:
-                _, params = cgi.parse_header(cdheader)
+                _, params = parse_header(cdheader)
                 name = params.get('filename', "")
                 # Work around https://github.com/sunpy/sunpy/issues/3372
                 if name.count('"') >= 2:

--- a/sunpy/util/metadata.py
+++ b/sunpy/util/metadata.py
@@ -169,8 +169,11 @@ class MetaDict(OrderedDict):
         """
         return OrderedDict.__setitem__(self, key.lower(), value)
 
-    # Note: `OrderedDict.popitem()` does not need to be overridden to prune
-    # keycomments because it calls `__delitem__` internally.
+    def popitem(self, last):
+        key, value = super().popitem(last)
+        self._prune_keycomments()
+        return key, value
+
     def __delitem__(self, key):
         """
         Override ``del dict[key]`` key deletion.

--- a/sunpy/util/net.py
+++ b/sunpy/util/net.py
@@ -12,7 +12,7 @@ from urllib.request import urlopen
 
 from sunpy.util import replacement_filename
 
-__all__ = ['slugify', 'get_content_disposition', 'get_filename', 'get_system_filename',
+__all__ = ['parse_header', 'slugify', 'get_content_disposition', 'get_filename', 'get_system_filename',
            'download_file', 'download_fileobj']
 
 # Characters not allowed in slugified version.
@@ -198,3 +198,40 @@ def download_file(url, directory, default="file", overwrite=False):
     finally:
         opn.close()
     return path
+
+# These two functions were in the stdlib cgi module which was deprecated in Python 3.11
+# They are copied here under the terms of the PSF Licence 2.0
+
+
+def _parseparam(s):
+    while s[:1] == ';':
+        s = s[1:]
+        end = s.find(';')
+        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+            end = s.find(';', end + 1)
+        if end < 0:
+            end = len(s)
+        f = s[:end]
+        yield f.strip()
+        s = s[end:]
+
+
+def parse_header(line):
+    """Parse a Content-type like header.
+
+    Return the main content-type and a dictionary of options.
+
+    """
+    parts = _parseparam(';' + line)
+    key = parts.__next__()
+    pdict = {}
+    for p in parts:
+        i = p.find('=')
+        if i >= 0:
+            name = p[:i].strip().lower()
+            value = p[i+1:].strip()
+            if len(value) >= 2 and value[0] == value[-1] == '"':
+                value = value[1:-1]
+                value = value.replace('\\\\', '\\').replace('\\"', '"')
+            pdict[name] = value
+    return key, pdict

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}{,-oldestdeps,-devdeps,-online,-figure,-hypothesis,-conda}
+    py{38,39,310,311}{,-oldestdeps,-devdeps,-online,-figure,-hypothesis,-conda}
     build_docs{,-gallery}
     codestyle
     base_deps
@@ -39,6 +39,7 @@ deps =
     devdeps: git+https://github.com/asdf-format/asdf
     devdeps: git+https://github.com/sunpy/mpl-animators
     devdeps: git+https://github.com/Cadair/parfive
+    devdeps: git+https://github.com/astropy/reproject
     # Oldest deps we pin against
     oldestdeps: astropy<4.3.0
     oldestdeps: numpy<1.18.0


### PR DESCRIPTION
Fixes #6070 

This pull request adds support for Python 3.11. Currently I am only testing 3.11 with devdeps, because there isn't a reproject release which supports 3.11 but also probably other packages as well.

The main changes in this pull request are:

* Vendor in `cgi.parse_header` and use it in vso and our docs.
* Vendor in `xdrlib.Unpacker`
* Fix `sunpy.util.metadata.MetaDict.popitem` after the 3.11 implementation moved away from using `__del__`.

There are no h5py wheels for 3.11 yet, which is a little problem here, but they are close: https://github.com/h5py/h5py/pull/2165