### PR TITLE
Fixing issues related to tox-conda

### DIFF
--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -35,6 +35,7 @@ dependencies:
   # Testing
   - hypothesis
   - pytest
+  - pytest-arraydiff
   - pytest-astropy
   - pytest-cov
   - pytest-doctestplus
@@ -44,9 +45,11 @@ dependencies:
   - pytest-timeout
   - pytest-xdist
   - tox
+  - tox-conda
 
   # Documentation
   - graphviz
+  - hvpy
   - ruamel.yaml
   - sphinx
   - sphinx-automodapi

--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -49,7 +49,6 @@ dependencies:
 
   # Documentation
   - graphviz
-  - hvpy
   - ruamel.yaml
   - sphinx
   - sphinx-automodapi
@@ -65,8 +64,12 @@ dependencies:
   # Development
   - pre-commit
 
+  # Remove once hvpy can be installed through conda
+  - pydantic
+
   # Not installable through conda
   - pip:
+    - hvpy
     - sphinx-bootstrap-theme
     - sphinx-changelog
     - sphinxext-opengraph

--- a/tox.ini
+++ b/tox.ini
@@ -122,17 +122,10 @@ commands =
 pypi_filter =
 extras =
 deps =
-conda_deps =
-#   These packages are needed to install sunpy even with --no-deps
-    extension-helpers
-    numpy
-    setuptools-scm
-conda_channels = conda-forge
+conda_env = sunpy-dev-env.yml
 install_command = pip install --no-deps --no-build-isolation {opts} {packages}
 allowlist_externals = conda
 commands_pre =
-#   Update the base environment to preserve the Python version
-    conda env update -q -f {toxinidir}/sunpy-dev-env.yml
 #   Remove pytest-rerunfailures to avoid appearing to access the internet when pytest-xdist is used
     conda remove -y -q --force pytest-rerunfailures
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -123,6 +123,10 @@ pypi_filter =
 extras =
 deps =
 conda_env = sunpy-dev-env.yml
+conda_deps =
+    pytest<7.2
+    pytest-xdist<3.0
+conda_channels = conda-forge
 install_command = pip install --no-deps --no-build-isolation {opts} {packages}
 allowlist_externals = conda
 commands_pre =


### PR DESCRIPTION
For our cron CI builds between the 25th and the 27th this past week, `pytest` went from 7.1.3 to 7.2.0 and `tox` went from 3.26.0 to 3.27.0, but also `tox-conda` went from 0.9.2 to 0.10.0.  Probably due to the new `tox-conda` release, but maybe due to something else, our `py39-conda` build is once again running Python 3.10 instead of the intended 3.9.  This PR reverts my workaround in #6494, and as predicted in that PR, the new `tox-conda` release no longer needs to be worked around.

Also, adding `pytest-arraydiff` as a direct dependency (it was already an indirect dependency through `pytest-astropy`)

Also, pinning `pytest` and `pytest-xdist` a la #6508 (see also #6505)

Also, adding `hvpy` as a dependency, via `pip` until it is available on `conda-forge`.  `hvpy` has a dependency (`pydantic`) that is not otherwise installed in the conda environment, so temporarily explicitly install `pydantic`.