### PR TITLE
Update conda env with sphinx-copybutton

### DIFF
--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -52,6 +52,7 @@ dependencies:
   - ruamel.yaml
   - sphinx
   - sphinx-automodapi
+  - sphinx-copybutton
   - sphinx-gallery
   - sphinx-design
   - towncrier

--- a/sunpy/map/sources/tests/test_mdi_source.py
+++ b/sunpy/map/sources/tests/test_mdi_source.py
@@ -64,7 +64,6 @@ def test_unit(mdi):
     assert mdi.unit == u.dimensionless_unscaled
 
 
-@pytest.mark.filterwarnings("error")
 def test_synoptic_source(mdi_synoptic):
     assert isinstance(mdi_synoptic, MDISynopticMap)
     # Check that the WCS is valid


### PR DESCRIPTION
I missed that `sphinx-copybutton` was recently added as a dependency