### PR TITLE
Cleanup overriding `.date` property on EUIMap

### DIFF
--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -8,7 +8,6 @@ from astropy.visualization import AsinhStretch, ImageNormalize
 from sunpy.coordinates import HeliocentricInertial
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
-from sunpy.time import parse_time
 
 __all__ = ['EUIMap']
 
@@ -53,9 +52,8 @@ class EUIMap(GenericMap):
 
     @property
     def date(self):
-        t = self.meta.get('date-avg')
-        timesys = self.meta.get('timesys')
-        return parse_time(t, scale=timesys.lower())
+        # Prioritize date-average over date-obs
+        return self.date_average or super().date
 
     @property
     def waveunit(self):


### PR DESCRIPTION
We override `.date` on `EUIMap` so that `.date` always return 'DATE-AVG' rather than 'DATE-OBS' (see #5462). This just cleans up that logic to rely on our more recently added date properties (see #5449). There should be no change in behavior here.