### PR TITLE
Include the actual CITATION.rst rather than a symlink to it

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,1 +1,1 @@
-.. include:: ../CITATION.rst
+.. include:: ../sunpy/CITATION.rst


### PR DESCRIPTION
The symbolic link doesn't work on Windows, but we can simply include the actual file instead of using the symlink.