### PR TITLE
Use `XPOSURE` key in `exposure_time` property

### DIFF
--- a/changelog/6557.feature.rst
+++ b/changelog/6557.feature.rst
@@ -1,2 +1,2 @@
 `~sunpy.map.GenericMap.exposure_time` now looks for the exposure time in the ``XPOSURE`` key first
-and then the ``EXP_TIME`` key.
+and then the ``EXPTIME`` key.

--- a/changelog/6557.feature.rst
+++ b/changelog/6557.feature.rst
@@ -1,0 +1,2 @@
+`~sunpy.map.GenericMap.exposure_time` now looks for the exposure time in the ``XPOSURE`` key first
+and then the ``EXP_TIME`` key.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -914,7 +914,7 @@ class GenericMap(NDData):
         This is taken from the 'XPOSURE' keyword or the 'EXPTIME' FITS keyword,
         in that order.
         """
-        exptime = self.meta.get('xposure', self.meta.get('exptime', None))
+        exptime = self.meta.get('xposure') or self.meta.get('exptime')
         if exptime:
             return exptime * self.timeunit
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -911,10 +911,12 @@ class GenericMap(NDData):
         """
         Exposure time of the image.
 
-        This is taken from the 'EXPTIME' FITS keyword.
+        This is taken from the 'XPOSURE' keyword or the 'EXPTIME' FITS keyword,
+        in that order.
         """
-        if 'exptime' in self.meta:
-            return self.meta['exptime'] * self.timeunit
+        exptime = self.meta.get('xposure', self.meta.get('exptime', None))
+        if exptime:
+            return exptime * self.timeunit
 
     @property
     def instrument(self):

--- a/sunpy/map/sources/psp.py
+++ b/sunpy/map/sources/psp.py
@@ -28,10 +28,6 @@ class WISPRMap(GenericMap):
         return int(lvl[1])
 
     @property
-    def exposure_time(self):
-        return self.meta.get('xposure', 0.0) * self.timeunit
-
-    @property
     def name(self):
         return 'WISPR ' + super().name
 

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -48,10 +48,6 @@ class EUIMap(GenericMap):
             return int(self.meta.get('level')[1:])
 
     @property
-    def exposure_time(self):
-        return self.meta.get('xposure', 0.0) * self.timeunit
-
-    @property
     def date(self):
         t = self.meta.get('date-avg')
         timesys = self.meta.get('timesys')

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -210,6 +210,19 @@ def test_timeunit(generic_map):
     assert generic_map.timeunit == u.Unit('h')
 
 
+def test_exposure_time(generic_map):
+    exptime = 2 * u.s
+    generic_map.meta['exptime'] = exptime.to_value('s')
+    assert generic_map.exposure_time == exptime
+    exptime = 3 * u.s
+    # XPOSURE should take priority over EXPTIME
+    generic_map.meta['xposure'] = exptime.to_value('s')
+    assert generic_map.exposure_time == exptime
+    del generic_map.meta['exptime']
+    del generic_map.meta['xposure']
+    assert generic_map.exposure_time is None
+
+
 def test_dsun(generic_map):
     assert_quantity_allclose(generic_map.dsun, sun.earth_distance(generic_map.date))
 


### PR DESCRIPTION
Fixes #6513 

When creating the `exposure_time` property on a map, this look first for the FITS 4 compliant keyword `XPOSURE` and then for the FITS 3 keyword `EXP_TIME`. After some discussion at the most recent community meeting, it was decided that we should continue to support both keys by default (i.e. not make them source-specific as both are part of the FITS standard.
