### PR TITLE
Optionally set detector in header helper

### DIFF
--- a/changelog/6558.feature.rst
+++ b/changelog/6558.feature.rst
@@ -1,0 +1,2 @@
+`~sunpy.map.make_fitswcs_header` now includes the keyword argument ``detector`` for setting the
+``DETECTOR`` FITS keyword in the resulting header.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -36,6 +36,7 @@ def make_fitswcs_header(data, coordinate,
                         instrument=None,
                         telescope=None,
                         observatory=None,
+                        detector=None,
                         wavelength: u.angstrom = None,
                         exposure: u.s = None,
                         projection_code="TAN",
@@ -76,6 +77,8 @@ def make_fitswcs_header(data, coordinate,
         Name of the telescope of the observation.
     observatory : `~str`, optional
         Name of the observatory of the observation.
+    detector : `str`, optional
+        Name of the detector of the observation.
     wavelength : `~astropy.units.Quantity`, optional
         Wavelength of the observation as an astropy quanitity, e.g. 171*u.angstrom.
         From this keyword, the meta keywords ``wavelnth`` and ``waveunit`` will be populated.
@@ -127,7 +130,7 @@ def make_fitswcs_header(data, coordinate,
 
     meta_wcs = _get_wcs_meta(coordinate, projection_code)
 
-    meta_wcs = _set_instrument_meta(meta_wcs, instrument, telescope, observatory, wavelength, exposure, unit)
+    meta_wcs = _set_instrument_meta(meta_wcs, instrument, telescope, observatory, detector, wavelength, exposure, unit)
     meta_wcs = _set_transform_params(meta_wcs, coordinate, reference_pixel, scale, shape)
     meta_wcs = _set_rotation_params(meta_wcs, rotation_angle, rotation_matrix)
 
@@ -274,7 +277,7 @@ def get_observer_meta(observer, rsun: (u.Mm, None) = None):
     return coord_meta
 
 
-def _set_instrument_meta(meta_wcs, instrument, telescope, observatory, wavelength, exposure, unit):
+def _set_instrument_meta(meta_wcs, instrument, telescope, observatory, detector, wavelength, exposure, unit):
     """
     Function to correctly name keywords from keyword arguments
     """
@@ -284,6 +287,8 @@ def _set_instrument_meta(meta_wcs, instrument, telescope, observatory, wavelengt
         meta_wcs['telescop'] = str(telescope)
     if observatory is not None:
         meta_wcs['obsrvtry'] = str(observatory)
+    if detector is not None:
+        meta_wcs['detector'] = str(detector)
     if wavelength is not None:
         meta_wcs['wavelnth'] = wavelength.to_value()
         meta_wcs['waveunit'] = wavelength.unit.to_string("fits")

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -168,6 +168,7 @@ def test_instrument_keyword(map_data, hpc_coord):
         'instrument': 'test name',
         'observatory': 'test observatory',
         'telescope': 'test telescope',
+        'detector': 'test detector',
         'wavelength': 171 * u.Angstrom,
         'exposure': 2 * u.s,
         'unit': u.Unit('ct s-1'),
@@ -176,6 +177,7 @@ def test_instrument_keyword(map_data, hpc_coord):
     assert header['instrume'] == instrument_kwargs['instrument']
     assert header['obsrvtry'] == instrument_kwargs['observatory']
     assert header['telescop'] == instrument_kwargs['telescope']
+    assert header['detector'] == instrument_kwargs['detector']
     assert header['wavelnth'] == instrument_kwargs['wavelength'].to_value()
     assert header['waveunit'] == instrument_kwargs['wavelength'].unit.to_string("fits")
     assert header['exptime'] == instrument_kwargs['exposure'].to_value('s')


### PR DESCRIPTION
Optionally set the `DETECTOR` key using the header helper. In `GenericMap`, we derive the `.detector` property from this key so it make sense to be able to set it using the header helper.