### PR TITLE
Converts some parts of documentation to OSPL style

### DIFF
--- a/docs/code_ref/coordinates/index.rst
+++ b/docs/code_ref/coordinates/index.rst
@@ -9,8 +9,7 @@ This sub-package contains:
 * Functions to obtain the locations of solar-system bodies (`sunpy.coordinates.ephemeris`)
 * Functions to calculate Sun-specific coordinate information (`sunpy.coordinates.sun`)
 
-The SunPy coordinate framework extends the
-:ref:`Astropy coordinates framework <astropy:astropy-coordinates>`.
+The SunPy coordinate framework extends the :ref:`Astropy coordinates framework <astropy:astropy-coordinates>`.
 
 .. _sunpy-coordinate-systems:
 
@@ -102,9 +101,7 @@ The easiest interface to work with coordinates is through the `~astropy.coordina
       (70., -30.)>
 
 
-It is also possible to use strings to specify the frame but in that case make sure to
-explicitly import `sunpy.coordinates` as it registers SunPy's coordinate frames with
-the Astropy coordinates framework::
+It is also possible to use strings to specify the frame but in that case make sure to explicitly import `sunpy.coordinates` as it registers SunPy's coordinate frames with the Astropy coordinates framework::
 
   >>> import astropy.units as u
   >>> from astropy.coordinates import SkyCoord
@@ -116,13 +113,9 @@ the Astropy coordinates framework::
       (-100., 500.)>
 
 
-`~astropy.coordinates.SkyCoord` and all coordinate frames
-support array coordinates. These work the same as single-value coordinates,
-but they store multiple coordinates in a single object. When you're going to
-apply the same operation to many different coordinates, this is a better choice
-than a list of `~astropy.coordinates.SkyCoord` objects, because it will be
-*much* faster than applying the operation to each
-`~astropy.coordinates.SkyCoord` in a ``for`` loop::
+`~astropy.coordinates.SkyCoord` and all coordinate frames support array coordinates.
+These work the same as single-value coordinates, but they store multiple coordinates in a single object.
+When you're going to apply the same operation to many different coordinates, this is a better choice than a list of `~astropy.coordinates.SkyCoord` objects, because it will be *much* faster than applying the operation to each `~astropy.coordinates.SkyCoord` in a ``for`` loop::
 
    >>> c = SkyCoord([-500, 400]*u.arcsec, [100, 200]*u.arcsec, frame=frames.Helioprojective)
    >>> c
@@ -136,9 +129,7 @@ than a list of `~astropy.coordinates.SkyCoord` objects, because it will be
 Accessing Coordinates
 ---------------------
 
-Individual coordinates can be accessed via attributes on the SkyCoord object,
-but the names of the components of the coordinates can depend on the the frame and the chosen
-representation (e.g., Cartesian versus spherical).
+Individual coordinates can be accessed via attributes on the SkyCoord object, but the names of the components of the coordinates can depend on the the frame and the chosen representation (e.g., Cartesian versus spherical).
 
 `~sunpy.coordinates.Helioprojective`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -178,9 +169,8 @@ Both of the heliographic frames have the components of latitude, longitude and r
    >>> c.radius
    <Distance 1. AU>
 
-Heliographic Stonyhurst, when used with Cartesian components, is known as Heliocentric
-Earth Equatorial (HEEQ).  Here's an example of how to use
-`~sunpy.coordinates.frames.HeliographicStonyhurst` for HEEQ coordinates::
+Heliographic Stonyhurst, when used with Cartesian components, is known as Heliocentric Earth Equatorial (HEEQ).
+Here's an example of how to use `~sunpy.coordinates.frames.HeliographicStonyhurst` for HEEQ coordinates::
 
   >>> c = SkyCoord(-72241.0*u.km, 361206.1*u.km, 589951.4*u.km,
   ...              representation_type='cartesian', frame=frames.HeliographicStonyhurst)
@@ -194,13 +184,9 @@ Earth Equatorial (HEEQ).  Here's an example of how to use
 Transforming Between Coordinate Frames
 ======================================
 
-Both `~astropy.coordinates.SkyCoord` and
-`~astropy.coordinates.BaseCoordinateFrame` instances have a
-`~astropy.coordinates.SkyCoord.transform_to` method. This can be used to
-transform the frame to any other frame, either implemented in SunPy or in
-Astropy (see also :ref:`astropy-coordinates-transforming`).
-An example of transforming the center of the solar disk to Carrington
-coordinates is::
+Both `~astropy.coordinates.SkyCoord` and `~astropy.coordinates.BaseCoordinateFrame` instances have a `~astropy.coordinates.SkyCoord.transform_to` method.
+This can be used to transform the frame to any other frame, either implemented in SunPy or in Astropy (see also :ref:`astropy-coordinates-transforming`).
+An example of transforming the center of the solar disk to Carrington coordinates is::
 
    >>> c = SkyCoord(0*u.arcsec, 0*u.arcsec, frame=frames.Helioprojective, obstime="2017-07-26",
    ...              observer="earth")
@@ -226,29 +212,17 @@ It is also possible to transform to any coordinate system implemented in Astropy
 Observer Location Information
 =============================
 
-The `~sunpy.coordinates.frames.Helioprojective`, `~sunpy.coordinates.frames.Heliocentric`
-and `~sunpy.coordinates.frames.HeliographicCarrington` frames are defined by the location of
-the observer. For example in `~sunpy.coordinates.frames.Helioprojective` the
-observer is at the origin of the coordinate system. This information is encoded
-in such observer-based frames as the ``observer`` attribute, which is itself an instance of the
-`~sunpy.coordinates.frames.HeliographicStonyhurst` frame.
-The ``observer`` can be a string for a solar-system body (e.g., "earth" or
-"mars"), and
-`~sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst` will be used
-with the specified ``obstime`` to fully specify the observer location.  If
-the observer location is not fully specified, or not present at all, most
-transformations cannot be performed.
-The location of the observer is automatically populated from meta data when
-coordinate frames are created using map.
+The `~sunpy.coordinates.frames.Helioprojective`, `~sunpy.coordinates.frames.Heliocentric` and `~sunpy.coordinates.frames.HeliographicCarrington` frames are defined by the location of the observer.
+For example in `~sunpy.coordinates.frames.Helioprojective` the observer is at the origin of the coordinate system.
+This information is encoded in such observer-based frames as the ``observer`` attribute, which is itself an instance of the `~sunpy.coordinates.frames.HeliographicStonyhurst` frame.
+The ``observer`` can be a string for a solar-system body (e.g., "earth" or "mars"), and `~sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst` will be used with the specified ``obstime`` to fully specify the observer location.
+If the observer location is not fully specified, or not present at all, most transformations cannot be performed.
+The location of the observer is automatically populated from meta data when coordinate frames are created using map.
 
 In the case of `~sunpy.coordinates.frames.HeliographicCarrington`, one can specify ``observer='self'`` to indicate that the coordinate itself should be used as the observer for defining the coordinate frame.
 
-It is possible to convert from a `~sunpy.coordinates.frames.Helioprojective`
-frame with one observer location to another
-`~sunpy.coordinates.frames.Helioprojective` frame with a different observer
-location, by converting through `~sunpy.coordinates.frames.HeliographicStonyhurst`, this
-does involve making an assumption of the radius of the Sun to calculate the
-position on the solar sphere. The conversion can be performed as follows::
+It is possible to convert from a `~sunpy.coordinates.frames.Helioprojective` frame with one observer location to another `~sunpy.coordinates.frames.Helioprojective` frame with a different observer location, by converting through `~sunpy.coordinates.frames.HeliographicStonyhurst`, this does involve making an assumption of the radius of the Sun to calculate the position on the solar sphere.
+The conversion can be performed as follows::
 
   # Input coordinate
   >>> hpc1 = SkyCoord(0*u.arcsec, 0*u.arcsec, observer="earth", obstime="2017-07-26", frame=frames.Helioprojective)
@@ -269,49 +243,32 @@ An example with two maps, named ``aia`` and ``stereo``::
 Design of the Coordinates Sub-Package
 =====================================
 
-This sub-package works by defining a collection of ``Frames``
-(`sunpy.coordinates.frames`), which exists on a transformation graph, where the
-transformations between the coordinate frames are then defined and registered
-with the transformation graph (`sunpy.coordinates.transformations`). It is also
-possible to transform SunPy frames to Astropy frames.
+This sub-package works by defining a collection of ``Frames`` (`sunpy.coordinates.frames`), which exists on a transformation graph, where the transformations between the coordinate frames are then defined and registered with the transformation graph (`sunpy.coordinates.transformations`).
+It is also possible to transform SunPy frames to Astropy frames.
 
-Positions within these ``Frames`` are stored as a ``Representation`` of a
-coordinate, a representation being a description of a point in a Cartesian,
-spherical or cylindrical system (see :ref:`astropy-coordinates-representations`). A frame
-that contains a representation of one or many points is said to have been
-'realized'.
+Positions within these ``Frames`` are stored as a ``Representation`` of a coordinate, a representation being a description of a point in a Cartesian, spherical or cylindrical system (see :ref:`astropy-coordinates-representations`).
+A frame that contains a representation of one or many points is said to have been 'realized'.
 
-For a more in depth look at the design and concepts of the Astropy coordinates
-system see :ref:`astropy-coordinates-overview`
+For a more in depth look at the design and concepts of the Astropy coordinates system see :ref:`astropy-coordinates-overview`
 
 
 
 Frames and SkyCoord
 -------------------
 
-The `~astropy.coordinates.SkyCoord` class is a high level wrapper around the
-`astropy.coordinates` sub-package. It provides an easier way to create and transform
-coordinates, by using string representations for frames rather than the classes
-themselves and some other usability improvements, for more information see the
-`~astropy.coordinates.SkyCoord` documentation.
+The `~astropy.coordinates.SkyCoord` class is a high level wrapper around the `astropy.coordinates` sub-package.
+It provides an easier way to create and transform coordinates, by using string representations for frames rather than the classes themselves and some other usability improvements, for more information see the `~astropy.coordinates.SkyCoord` documentation.
 
-The main advantage provided by `~astropy.coordinates.SkyCoord` is the support it
-provides for caching Frame attributes. Frame attributes are extra data specified
-with a frame, some examples in `sunpy.coordinates` are ``obstime`` or
-``observer`` for observer location. Only the frames where this data is
-meaningful have these attributes, i.e. only the Helioprojective frames have
-``observer``. However, when you transform into another frame and then back to a
-projective frame using `~astropy.coordinates.SkyCoord` it will remember the attributes previously
-provided, and repopulate the final frame with them. If you were to do
-transformations using the Frames alone this would not happen.
+The main advantage provided by `~astropy.coordinates.SkyCoord` is the support it provides for caching Frame attributes.
+Frame attributes are extra data specified with a frame, some examples in `sunpy.coordinates` are ``obstime`` or ``observer`` for observer location.
+Only the frames where this data is meaningful have these attributes, i.e., only the Helioprojective frames have ``observer``.
+However, when you transform into another frame and then back to a projective frame using `~astropy.coordinates.SkyCoord` it will remember the attributes previously provided, and repopulate the final frame with them.
+If you were to do transformations using the Frames alone this would not happen.
 
-The most important implication for this in `sunpy.coordinates` is the ``rsun``
-parameter in the projective frames. If you create a projective frame with a
-``rsun`` attribute, if you convert back to a projective frame it will be set
-correctly. It should also be noted that, if you create a Heliographic frame and
-then transform to a projective frame with an ``rsun`` attribute, it will not
-match the ``radius`` coordinate in the Heliographic frame. This is because you may
-mean to be describing a point above the defined 'surface' of the Sun.
+The most important implication for this in `sunpy.coordinates` is the ``rsun`` parameter in the projective frames.
+If you create a projective frame with a ``rsun`` attribute, if you convert back to a projective frame it will be set correctly.
+It should also be noted that, if you create a Heliographic frame and then transform to a projective frame with an ``rsun`` attribute, it will not match the ``radius`` coordinate in the Heliographic frame.
+This is because you may mean to be describing a point above the defined 'surface' of the Sun.
 
 More Detailed Information
 =========================

--- a/docs/code_ref/coordinates/wcs.rst
+++ b/docs/code_ref/coordinates/wcs.rst
@@ -3,20 +3,14 @@
 Coordinates and WCS
 *******************
 
-The `sunpy.coordinates` sub-package provides a mapping between FITS-WCS CTYPE
-convention and the coordinate frames as defined in `sunpy.coordinates`. This is
-used via the `astropy.wcs.utils.wcs_to_celestial_frame` function, with which the
-SunPy frames are registered upon being imported. This list is used by packages
-such as ``wcsaxes`` to convert from `astropy.wcs.WCS` objects to coordinate
-frames.
+The `sunpy.coordinates` sub-package provides a mapping between FITS-WCS CTYPE convention and the coordinate frames as defined in `sunpy.coordinates`.
+This is used via the `astropy.wcs.utils.wcs_to_celestial_frame` function, with which the SunPy frames are registered upon being imported.
+This list is used by packages such as ``wcsaxes`` to convert from `astropy.wcs.WCS` objects to coordinate frames.
 
-The `sunpy.map.GenericMap` class creates `astropy.wcs.WCS` objects as
-``amap.wcs``, however, it adds some extra attributes to the `~astropy.wcs.WCS`
-object to be able to fully specify the coordinate frame. It adds
-``heliographic_observer`` and ``rsun``.
+The `sunpy.map.GenericMap` class creates `astropy.wcs.WCS` objects as ``amap.wcs``, however, it adds some extra attributes to the `~astropy.wcs.WCS` object to be able to fully specify the coordinate frame.
+It adds ``heliographic_observer`` and ``rsun``.
 
-If you want to obtain a un-realized coordinate frame corresponding to a
-`~sunpy.map.GenericMap` object you can do the following::
+If you want to obtain a un-realized coordinate frame corresponding to a `~sunpy.map.GenericMap` object you can do the following::
 
   >>> import sunpy.map
   >>> from sunpy.data.sample import AIA_171_IMAGE  # doctest: +REMOTE_DATA

--- a/docs/code_ref/data.rst
+++ b/docs/code_ref/data.rst
@@ -1,8 +1,7 @@
 Data (`sunpy.data`)
 *******************
 
-``sunpy.data`` contains ways to access sample data and small test files for
-running the sunpy test suite.
+``sunpy.data`` contains ways to access sample data and small test files for running the sunpy test suite.
 
 .. automodapi:: sunpy.data
    :include-all-objects:

--- a/docs/code_ref/database.rst
+++ b/docs/code_ref/database.rst
@@ -1,9 +1,8 @@
 Database (`sunpy.database`)
 ***************************
 
-``sunpy.database`` can be used to provide a local cache of the files and
-records retrieved from various remote services. For an introduction to the
-database see :ref:`database_guide`.
+``sunpy.database`` can be used to provide a local cache of the files and records retrieved from various remote services.
+For an introduction to the database see :ref:`database_guide`.
 
 
 .. automodapi:: sunpy.database

--- a/docs/code_ref/image.rst
+++ b/docs/code_ref/image.rst
@@ -1,9 +1,8 @@
 Image processing (`sunpy.image`)
 ********************************
 
-``sunpy.image`` contains routines to process images (i.e. `numpy` arrays). The
-routines in this submodule are generally exposed through map-specific functions
-in other places.
+``sunpy.image`` contains routines to process images (i.e., `numpy` arrays).
+The routines in this submodule are generally exposed through map-specific functions in other places.
 
 .. automodapi:: sunpy.image
 

--- a/docs/code_ref/io.rst
+++ b/docs/code_ref/io.rst
@@ -26,21 +26,16 @@ Special File Readers
 asdf (Advanced Scientific Data Format)
 --------------------------------------
 
-`ASDF <https://asdf-standard.readthedocs.io/en/latest/>`__ is a modern file format
-designed to meet the needs of the astronomy community. It has deep integration
-with Python, SunPy, and Astropy, as well as implementations in other languages.
-It can be used to store known Python objects in a portable, well defined file
-format. It is primarily useful for storing complex Astropy and SunPy objects in
-a way that can be loaded back into the same form as they were saved.
-It is designed to be an archive file format, with human readable metadata and a
-simple on-disk layout.
+`ASDF <https://asdf-standard.readthedocs.io/en/latest/>`__ is a modern file format designed to meet the needs of the astronomy community.
+It has deep integration with Python, SunPy, and Astropy, as well as implementations in other languages.
+It can be used to store known Python objects in a portable, well defined file format.
+It is primarily useful for storing complex Astropy and SunPy objects in a way that can be loaded back into the same form as they were saved.
+It is designed to be an archive file format, with human readable metadata and a simple on-disk layout.
 
-sunpy currently implements support for saving `Map <sunpy.map.GenericMap>` and
-`coordinate frame <sunpy.coordinates.frames>` objects into asdf files. As asdf
-tightly integrates into Python, saving a map to an asdf file will save the
-metadata, data and mask. In comparison, the mask is not currently saved
-to FITS. The following code shows to to save and load a sunpy Map to an asdf
-file
+sunpy currently implements support for saving `Map <sunpy.map.GenericMap>` and `coordinate frame <sunpy.coordinates.frames>` objects into asdf files.
+As asdf tightly integrates into Python, saving a map to an asdf file will save the metadata, data and mask.
+In comparison, the mask is not currently saved to FITS.
+The following code shows to to save and load a sunpy Map to an asdf file
 
 .. doctest-requires:: asdf
 
@@ -94,9 +89,7 @@ It also follows the philosophy of the way maps are saved and loaded in the FITS 
 CDF (common data format)
 ------------------------
 
-CDF files are commonly used to store timeseries data observed by instruments
-taking in-situ measurements of plasmas throughout the heliosphere.
-sunpy provides support for reading in CDF files that conform to the
-`Space Physics Guidelines for CDF <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_.
+CDF files are commonly used to store timeseries data observed by instruments taking in-situ measurements of plasmas throughout the heliosphere.
+sunpy provides support for reading in CDF files that conform to the `Space Physics Guidelines for CDF <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_.
 
 .. automodapi:: sunpy.io.cdf

--- a/docs/code_ref/map.rst
+++ b/docs/code_ref/map.rst
@@ -13,17 +13,16 @@ Maps (`sunpy.map`)
 
 Overview
 ========
-One of core classes in sunpy is a Map. A sunpy Map object is simply a
-spatially-aware data array, often an image. In order to make it easy to work
-with image data in sunpy, the Map object provides a number of methods for
-commonly performed operations.
+One of core classes in sunpy is a Map.
+A sunpy Map object is simply a spatially-aware data array, often an image.
+In order to make it easy to work with image data in sunpy, the Map object provides a number of methods for commonly performed operations.
 
-2D map objects are subclasses of `~sunpy.map.GenericMap` and these objects are
-created using the Map factory `~sunpy.map.Map`.
+2D map objects are subclasses of `~sunpy.map.GenericMap` and these objects are created using the Map factory `~sunpy.map.Map`.
 
-A number of instrument are supported by subclassing this base object. See
-:ref:`map-sources` to see a list of all of them. More complex subclasses are also
-available. See :ref:`map-classes`.
+A number of instrument are supported by subclassing this base object.
+See :ref:`map-sources` to see a list of all of them.
+More complex subclasses are also available.
+See :ref:`map-classes`.
 
 .. todo :
     1. Map factory and registration
@@ -33,22 +32,17 @@ available. See :ref:`map-classes`.
 
 Creating Map Objects
 ====================
-sunpy Map objects are constructed using the special factory
-class `~sunpy.map.Map`: ::
+sunpy Map objects are constructed using the special factory class `~sunpy.map.Map`: ::
 
     >>> x = sunpy.map.Map('file.fits')  # doctest: +SKIP
 
-The result of a call to `~sunpy.map.Map` will be either a `~sunpy.map.mapbase.GenericMap` object,
-or a subclass of `~sunpy.map.mapbase.GenericMap` which either deals with a specific type of data,
-e.g. `~sunpy.map.sources.sdo.AIAMap` or `~sunpy.map.sources.soho.LASCOMap`
-(see :ref:`map-classes` to see a list of all of them), or if no
-instrument matches, a 2D map `~sunpy.map.mapbase.GenericMap`.
+The result of a call to `~sunpy.map.Map` will be either a `~sunpy.map.mapbase.GenericMap` object, or a subclass of `~sunpy.map.mapbase.GenericMap` which either deals with a specific type of data, e.g.
+`~sunpy.map.sources.sdo.AIAMap` or `~sunpy.map.sources.soho.LASCOMap` (see :ref:`map-classes` to see a list of all of them), or if no instrument matches, a 2D map `~sunpy.map.mapbase.GenericMap`.
 
 Fixing map metadata
 -------------------
 
-If you need to fix the metadata of a fits file before it is handed to `Map`, this can be done as
-follows:
+If you need to fix the metadata of a fits file before it is handed to `Map`, this can be done as follows:
 
     >>> data, header = astropy.io.fits.read(filepath)[0] # doctest: +SKIP
     >>> header['cunit1'] = 'arcsec' # doctest: +SKIP
@@ -88,13 +82,9 @@ The header_helper sub-module contains helper functions for generating FITS-WCS h
 
 Instrument Map Classes
 ======================
-Defined in ``sunpy.map.sources`` are a set of `~sunpy.map.GenericMap` subclasses
-which convert the specific metadata and other differences in each instruments
-data to the standard `~sunpy.map.GenericMap` interface.
-These 'sources' also define things like the colormap and default
-normalisation for each instrument.
-These subclasses also provide a method, which describes to the `~sunpy.map.Map` factory
-which data and metadata pairs match its instrument.
+Defined in ``sunpy.map.sources`` are a set of `~sunpy.map.GenericMap` subclasses which convert the specific metadata and other differences in each instruments data to the standard `~sunpy.map.GenericMap` interface.
+These 'sources' also define things like the colormap and default normalisation for each instrument.
+These subclasses also provide a method, which describes to the `~sunpy.map.Map` factory which data and metadata pairs match its instrument.
 
 .. automodapi:: sunpy.map.sources
     :no-main-docstr:
@@ -104,16 +94,11 @@ which data and metadata pairs match its instrument.
 Writing a new Instrument Map Class
 ==================================
 
-Any subclass of `~sunpy.map.GenericMap` which defines a method named
-``is_datasource_for`` will automatically be registered with
-the `~sunpy.map.Map` factory. The ``is_datasource_for`` method describes the form of the
-data and metadata for which the `~sunpy.map.GenericMap` subclass is valid. For
-example it might check the value of the ``INSTRUMENT`` key in the metadata
-dictionary.
-This makes it straightforward to define your own
-`~sunpy.map.GenericMap` subclass for a new instrument or a custom data source
-like simulated data. These classes only have to be imported for this to work, as
-demonstrated by the following example.
+Any subclass of `~sunpy.map.GenericMap` which defines a method named ``is_datasource_for`` will automatically be registered with the `~sunpy.map.Map` factory.
+The ``is_datasource_for`` method describes the form of the data and metadata for which the `~sunpy.map.GenericMap` subclass is valid.
+For example it might check the value of the ``INSTRUMENT`` key in the metadata dictionary.
+This makes it straightforward to define your own `~sunpy.map.GenericMap` subclass for a new instrument or a custom data source like simulated data.
+These classes only have to be imported for this to work, as demonstrated by the following example.
 
 .. code-block:: python
 
@@ -134,11 +119,10 @@ demonstrated by the following example.
             return str(header.get('instrume', '')).startswith('FUTURESCOPE')
 
 
-This class will now be available through the `~sunpy.map.Map` factory as long as this
-class has been defined, i.e. imported into the current session.
+This class will now be available through the `~sunpy.map.Map` factory as long as this class has been defined, i.e.
+imported into the current session.
 
-If you do not want to create a method named ``is_datasource_for`` you can
-manually register your class and matching method using the following method
+If you do not want to create a method named ``is_datasource_for`` you can manually register your class and matching method using the following method
 
 .. code-block:: python
 

--- a/docs/code_ref/net.rst
+++ b/docs/code_ref/net.rst
@@ -1,11 +1,10 @@
 Remote data (`sunpy.net`)
 *************************
 
-``sunpy.net`` contains a lot of different code for accessing various solar
-physics related web services. This submodule contains many layers. Most users
-should use `~sunpy.net.Fido`, which is an interface to multiple sources
-including all the sources implemented in `~sunpy.net.dataretriever` as well as
-`~sunpy.net.vso` and `~sunpy.net.jsoc`. `~sunpy.net.Fido` can be used like so::
+``sunpy.net`` contains a lot of different code for accessing various solar physics related web services.
+This submodule contains many layers.
+Most users should use `~sunpy.net.Fido`, which is an interface to multiple sources including all the sources implemented in `~sunpy.net.dataretriever` as well as `~sunpy.net.vso` and `~sunpy.net.jsoc`.
+`~sunpy.net.Fido` can be used like so::
 
     >>> from sunpy.net import Fido, attrs as a
     >>> results = Fido.search(a.Time("2012/1/1", "2012/1/2"), a.Instrument.lyra)  # doctest: +REMOTE_DATA
@@ -85,8 +84,7 @@ Helioviewer
 Internal Classes and Functions
 ==============================
 
-These classes and functions are designed to be used to help develop new clients
-for `sunpy.net.Fido`.
+These classes and functions are designed to be used to help develop new clients for `sunpy.net.Fido`.
 
 .. automodapi:: sunpy.net.base_client
 

--- a/docs/code_ref/physics.rst
+++ b/docs/code_ref/physics.rst
@@ -1,8 +1,7 @@
 Physics (`sunpy.physics`)
 *************************
 
-``sunpy.physics`` contains routines to calculate various physical parameters
-and models for the Sun.
+``sunpy.physics`` contains routines to calculate various physical parameters and models for the Sun.
 
 .. automodapi:: sunpy.physics
 

--- a/docs/code_ref/time.rst
+++ b/docs/code_ref/time.rst
@@ -1,9 +1,7 @@
 Time (`sunpy.time`)
 *******************
 
-``sunpy.time`` contains helpers for converting strings to `astropy.time.Time`
-objects and handling common operations on these objects. As well as this a
-`~sunpy.time.TimeRange` object is provided for representing a period of time
-and performing operations on that range.
+``sunpy.time`` contains helpers for converting strings to `astropy.time.Time` objects and handling common operations on these objects.
+As well as this a `~sunpy.time.TimeRange` object is provided for representing a period of time and performing operations on that range.
 
 .. automodapi:: sunpy.time

--- a/docs/dev_guide/contents/conda_for_dependencies.rst
+++ b/docs/dev_guide/contents/conda_for_dependencies.rst
@@ -70,7 +70,8 @@ Once the ``conda`` installation of ``sunpy`` is removed, the ``pip`` installatio
 
 .. note::
 
-    For those who use ``mamba`` instead of ``conda``, most ``conda`` commands can be translated by simply substituting "mamba" for "conda".  However, ``mamba remove`` does not support the ``--force`` option, so you do in fact have to call ``conda remove``.
+    For those who use ``mamba`` instead of ``conda``, most ``conda`` commands can be translated by simply substituting "mamba" for "conda".
+    However, ``mamba remove`` does not support the ``--force`` option, so you do in fact have to call ``conda remove``.
 
 As a tip, you can follow a similar procedure to incorporate editable installations of other packages (e.g., ``astropy``) in a ``conda`` environment.
 You first install the package via ``conda`` to ensure its dependencies are present, then you remove the package alone without disturbing the dependencies, and finally you perform the editable install of the package from the base directory of your local repository:

--- a/docs/dev_guide/contents/documentation.rst
+++ b/docs/dev_guide/contents/documentation.rst
@@ -134,7 +134,7 @@ You can open the "index.html" file to browse the final product.
 The gallery examples are located under "docs/_build/html/generated/gallery".
 Sphinx builds documentation iteratively, only adding things that have changed.
 
-If you want to build the documentation without executing the gallery examples, i.e. to reduce build times while working on other sections of the documentation you can run::
+If you want to build the documentation without executing the gallery examples, i.e., to reduce build times while working on other sections of the documentation you can run::
 
     tox -e build_docs
 
@@ -216,8 +216,7 @@ To avoid, use double-underscores instead of single ones after the URL.
 
 **ERROR: Malformed table. Column span alignment problem at line offset n**
 
-Make sure there is a space before and after each colon in your class and
-function docs (e.g. attribute : type, instead of attribute: type).
+Make sure there is a space before and after each colon in your class and function docs (e.g. attribute : type, instead of attribute: type).
 Also, for some sections (e.g. Attributes) numpydoc seems to complain when a description spans more than one line, particularly if it is the first attribute listed.
 
 **WARNING: Block quote ends without a blank line; unexpected unindent.**

--- a/docs/dev_guide/contents/example_gallery.rst
+++ b/docs/dev_guide/contents/example_gallery.rst
@@ -35,7 +35,8 @@ Contribution Guidelines
 
 * When creating a plot, particularly of a map, the example should follow these rules of thumb to minimize verbosity and maintain consistency with the other gallery examples:
 
-  * Do not use `~sunpy.map.GenericMap.peek` in examples. Instead, use `~sunpy.map.GenericMap.plot`.
+  * Do not use `~sunpy.map.GenericMap.peek` in examples.
+    Instead, use `~sunpy.map.GenericMap.plot`.
 
   * Always create a figure instance using ``plt.figure()`` prior to creating a plot.
 
@@ -43,6 +44,7 @@ Contribution Guidelines
 
   * If an axes instance is created, it should be explicitly passed as a keyword argument wherever possible (e.g. in `~sunpy.map.GenericMap.plot` or `~sunpy.map.GenericMap.draw_grid`).
 
-  * After each figure is created, call ``plt.show()``. While not explicitly needed for the gallery to render, this ensures that, when run as a script, the gallery will display each figure sequentially.
+  * After each figure is created, call ``plt.show()``.
+    While not explicitly needed for the gallery to render, this ensures that, when run as a script, the gallery will display each figure sequentially.
 
   * If you need to use ``astropy.visualization.{quantity_support, time_support}``, import these functions at the top of the example, and call them directly before the first plot that needs them.

--- a/docs/dev_guide/contents/extending_fido.rst
+++ b/docs/dev_guide/contents/extending_fido.rst
@@ -375,7 +375,7 @@ The parameters for such a method should be::
 The parameters here are:
 
 * ``query_results`` which is an instance of `~.QueryResponseTable` or `~sunpy.net.base_client.QueryResponseRow`, these are the results the user wants to download.
-* ``path=`` This is the path that the user wants the file to be downloaded to, this can be a template string (i.e. expects to have ``.format()`` called on it).
+* ``path=`` This is the path that the user wants the file to be downloaded to, this can be a template string (i.e., expects to have ``.format()`` called on it).
 * ``downloader=`` This is a `parfive.Downloader` object which should be mutated by the ``fetch()`` method.
 * ``**kwargs`` It is very important that ``fetch()`` methods accept extra keyword arguments that they don't use, as the user might be passing them to other clients via ``Fido``.
 

--- a/docs/dev_guide/contents/logger.rst
+++ b/docs/dev_guide/contents/logger.rst
@@ -7,13 +7,12 @@ Logging, Warnings, and Exceptions
 Overview
 ========
 
-sunpy makes use of a logging system to deal with messages (see :ref:`logger`). This provides the users and
-developers the ability to decide which messages to show, to capture them, and to optionally also send
-them to a file. The logger will log all messages issued directly to it but also warnings issued
-through `warnings.warn` as well as exceptions.
+sunpy makes use of a logging system to deal with messages (see :ref:`logger`).
+This provides the users and developers the ability to decide which messages to show, to capture them, and to optionally also send them to a file.
+The logger will log all messages issued directly to it but also warnings issued through `warnings.warn` as well as exceptions.
 
-The logger is configured as soon as sunpy is imported. You can access it
-by importing it explicitly::
+The logger is configured as soon as sunpy is imported.
+You can access it by importing it explicitly::
 
     from sunpy import log
 
@@ -34,27 +33,24 @@ Messages can be issued directly to it with the following levels and in the follo
     log.critical("A serious error, indicating that the program itself may be unable to
                   continue running. A real error may soon by issued and the task will fail.")
 
-The difference between logging a warning/error/critical compared to issuing a Python warning or raising
-an exception are subtle but important.
+The difference between logging a warning/error/critical compared to issuing a Python warning or raising an exception are subtle but important.
 
-Use Python `warnings.warn` in library code if the issue is avoidable and the user code should be
-modified to eliminate the warning.
+Use Python `warnings.warn` in library code if the issue is avoidable and the user code should be modified to eliminate the warning.
 
-Use ``log.warning()`` if there is likely nothing the user can do about the situation, but the event
-should still be noted. An example of this might be if the input data are all zeros. This may be unavoidable or
-even by design but you may want to let the user know.
+Use ``log.warning()`` if there is likely nothing the user can do about the situation, but the event should still be noted.
+An example of this might be if the input data are all zeros.
+This may be unavoidable or even by design but you may want to let the user know.
 
 True exceptions (not ``log.error()``) should be raised only when there is no way for the function to proceed.
 
-Regardless of the type (log message or warning or exception) messages should be one or two complete sentences
-that fully describe the issue and end with a period.
+Regardless of the type (log message or warning or exception) messages should be one or two complete sentences that fully describe the issue and end with a period.
 
 Issuing Warnings
 ================
 
-sunpy warnings are provided by the `sunpy.util` module. The primary warning which
-should be used is `sunpy.util.exceptions.SunpyUserWarning`. For deprecation use `sunpy.util.exceptions.SunpyDeprecationWarning` or
-`sunpy.util.exceptions.SunpyPendingDeprecationWarning`.
+sunpy warnings are provided by the `sunpy.util` module.
+The primary warning which should be used is `sunpy.util.exceptions.SunpyUserWarning`.
+For deprecation use `sunpy.util.exceptions.SunpyDeprecationWarning` or `sunpy.util.exceptions.SunpyPendingDeprecationWarning`.
 
 These three warning types have corresponding functions to raise them::
 
@@ -73,8 +69,8 @@ See the section above for a discussion about the distinction between ``log.warn(
 Raising Exceptions
 ==================
 
-Raising errors causes the program to halt. Likely the primary error that a sunpy developer will
-want to use is
+Raising errors causes the program to halt.
+Likely the primary error that a sunpy developer will want to use is
 
 * ValueError: should be raised if the input is not what was expected and could not be used. Functions should not return anything (like None) in that case or issue a warning.
 

--- a/docs/dev_guide/contents/newcomers.rst
+++ b/docs/dev_guide/contents/newcomers.rst
@@ -90,7 +90,7 @@ If you are unsure where to start we suggest the `Good First Issue label`_.
 These are issues that have been deemed a good way to be eased into sunpy and are achievable with little understanding of the sunpy codebase.
 Please be aware that this does not mean the issue is "easy", just that you do not need to be aware of the underlying structure of sunpy.
 
-We also tag issues for specific events such as  `Hacktoberfest`_ under the `Hacktoberfest label`_.
+We also tag issues for specific events such as `Hacktoberfest`_ under the `Hacktoberfest label`_.
 The scope of the issues should be appropriate for that specific event.
 We do particpate in several other events but right now we do not have dedicated labels.
 So please use the above labels for starting issues!
@@ -153,7 +153,8 @@ This will make submitting changes easier in the long term for you:
 
 .. warning::
 
-    Do not clone the sunpy repository into ``$HOME/sunpy``. Depending on the operating system this location is used to store downloaded data files.
+    Do not clone the sunpy repository into ``$HOME/sunpy``.
+    Depending on the operating system this location is used to store downloaded data files.
     This will cause conflicts later on, so the last argument (``sunpy-git``) on the ``git clone`` line will become the local folder name of the cloned repository.
     Otherwise you are free to clone to any other location.
 

--- a/docs/dev_guide/contents/units_quantities.rst
+++ b/docs/dev_guide/contents/units_quantities.rst
@@ -8,14 +8,13 @@ Use of quantities and units
 
 Much code perform calculations using physical quantities.
 SunPy uses astropy's `quantities and units <https://docs.astropy.org/en/stable/units/index.html>`_ implementation to store, express and convert physical quantities.
-New classes and functions should adhere to the SunPy project's `quantity and unit usage guidelines
-<https://github.com/sunpy/sunpy-SEP/blob/master/SEP-0003.md>`_.
+New classes and functions should adhere to the SunPy project's `quantity and unit usage guidelines <https://github.com/sunpy/sunpy-SEP/blob/master/SEP-0003.md>`_.
 
 This document sets out SunPy's reasons and requirements for the usage of quantities and units.
 Briefly, SunPy's `policy <https://github.com/sunpy/sunpy-SEP/blob/master/SEP-0003.md>`_ is that *all user-facing function/object arguments which accept physical quantities as input **MUST** accept astropy quantities, and **ONLY** astropy quantities*.
 
-Developers should consult the `Astropy Quantities and Units page <https://docs.astropy.org/en/stable/units/index.html>`_ for the latest updates on using quantities and units.  The `astropy tutorial on quantities and units <https://www.astropy.org/astropy-tutorials/Quantities.html>`_ also provides useful examples on their
-capabilities.
+Developers should consult the `Astropy Quantities and Units page <https://docs.astropy.org/en/stable/units/index.html>`_ for the latest updates on using quantities and units.
+The `astropy tutorial on quantities and units <https://www.astropy.org/astropy-tutorials/Quantities.html>`_ also provides useful examples on their capabilities.
 
 Astropy provides the decorator `~astropy.units.quantity_input` that checks the units of the input arguments to a function against the expected units of the argument.
 We recommend using this decorator to perform function argument unit checks.

--- a/docs/guide/acquiring_data/database.rst
+++ b/docs/guide/acquiring_data/database.rst
@@ -11,49 +11,37 @@ Using the database package
 **************************
 .. currentmodule:: sunpy.database
 
-The database package offers the possibility to save retrieved data (e.g.
-via the :mod:`sunpy.net` package) onto a local or remote database. The
-database may be a single file located on a local hard drive (if a SQLite
-database is used) or a local or remote database server (see the SQLAlchemy
-documentation for a `list of supported databases
-<https://docs.sqlalchemy.org/en/latest/dialects/index.html>`_)
-This makes it possible to fetch required data from the local database
-instead of downloading it again from a remote server.
+The database package offers the possibility to save retrieved data (e.g. via the :mod:`sunpy.net` package) onto a local or remote database.
+The database may be a single file located on a local hard drive (if a SQLite database is used) or a local or remote database server (see the SQLAlchemy documentation for a `list of supported databases <https://docs.sqlalchemy.org/en/latest/dialects/index.html>`_).
+This makes it possible to fetch required data from the local database instead of downloading it again from a remote server.
 
 The package :mod:`sunpy.database` was developed as part of Google Summer of Code (GSOC) 2013.
 
 1. Connecting and initializing the database
 *******************************************
-To start a connection to an existing or a new database, create
-a :class:`Database` object:
+To start a connection to an existing or a new database, create a :class:`Database` object:
 
     >>> from sunpy.database import Database
     >>> database = Database('sqlite:///sunpydata.sqlite')
 
-The database object in our example above connects to a new SQLite database with
-the file name "sunpydata.sqlite" in the current directory.
+The database object in our example above connects to a new SQLite database with the file name "sunpydata.sqlite" in the current directory.
 
-The first parameter of :class:`Database` receives one mandatory argument:
-a URL which describes how to connect to the database. The supported
-format of this URL is described by the documentation of
-:func:`sqlalchemy.create_engine`.
+The first parameter of :class:`Database` receives one mandatory argument: a URL which describes how to connect to the database.
+The supported format of this URL is described by the documentation of :func:`sqlalchemy.create_engine`.
 
-Note that a connection is only established when it's really needed,
-i.e. if some query is sent to the database to read from it. Transactions
-can also be committed explicitly using the :meth:`Database.commit` method.
+Note that a connection is only established when it's really needed, i.e., if some query is sent to the database to read from it.
+Transactions can also be committed explicitly using the :meth:`Database.commit` method.
 
 .. warning::
 
-    If you are using :class:`Database` objects in an interactive Python
-    session you must not forget to call the :meth:`Database.commit` method
-    on them explicitly before quitting the Python session! Otherwise, all
-    changes on the altered databases are lost!
+    If you are using :class:`Database` objects in an interactive Python session you must not forget to call the :meth:`Database.commit` method on them explicitly before quitting the Python session!
+    Otherwise, all changes on the altered databases are lost!
 
 .. note::
 
-    You can set the default database url in the sunpy config file under the
-    'database' section. See :ref:`customizing-sunpy` for information on the
-    config file. A database section might look like this::
+    You can set the default database url in the sunpy config file under the 'database' section.
+    See :ref:`customizing-sunpy` for information on the config file.
+    A database section might look like this::
 
         [database]
         url = sqlite:////home/user/sunpy/my_database.sqlite
@@ -61,8 +49,7 @@ can also be committed explicitly using the :meth:`Database.commit` method.
 
 2. Adding new entries
 *********************
-Each entry in a database is an instance of the class
-:class:`tables.DatabaseEntry` with the following attributes:
+Each entry in a database is an instance of the class :class:`tables.DatabaseEntry` with the following attributes:
 
 ====================== ===================================================
       Attribute                            Description
@@ -106,67 +93,44 @@ tags                   A list of :class:`tables.Tag` instances.
 
 * The ``id`` attribute is automatically set if an entry is added to a database.
 
-* The attributes ``source``, ``provider``, ``physobs``, ``fileid``,
-  ``observation_time_start``, ``observation_time_end``, ``instrument``,  ``size``,
-  ``wavemin``, and ``wavemax`` are set by methods which use the VSO interface. In
-  particular, these are :meth:`Database.add_from_vso_query_result`,
-  and possibly :meth:`Database.fetch`.
+* The attributes ``source``, ``provider``, ``physobs``, ``fileid``, ``observation_time_start``, ``observation_time_end``, ``instrument``, ``size``, ``wavemin``, and ``wavemax`` are set by methods which use the VSO interface.
+  In particular, these are :meth:`Database.add_from_vso_query_result`, and possibly :meth:`Database.fetch`.
 
-* The attributes ``path`` and ``download_time`` are set by the method
-  ``Database.download`` and also possibly by :meth:`Database.fetch`.
+* The attributes ``path`` and ``download_time`` are set by the method ``Database.download`` and also possibly by :meth:`Database.fetch`.
 
 * ``starred`` is set or changed via :meth:`Database.star` or :meth:`Database.unstar`.
 
 * ``tags`` is set via :meth:`Database.tag` or :meth:`Database.remove_tag`.
 
-* The attribute ``fits_header_entries`` is set by the methods
-  ``Database.download``, :meth:`Database.add_from_dir`, and
-  :meth:`Database.add_from_file`.
+* The attribute ``fits_header_entries`` is set by the methods ``Database.download``, :meth:`Database.add_from_dir`, and :meth:`Database.add_from_file`.
 
 2.1 Adding entries from one FITS file
 =====================================
-The method :meth:`Database.add_from_file` receives one positional argument
-(either a string or a file-like object) which is used to add at least one
-new entry from the given FITS file to the database. Why "at least one" and
-not "exactly one"? The reason is that each database entry does not
-represent one file, but one FITS header from a file. That means if you pass
-a file which has 5 FITS headers in it, 5 entries will be added to the
-database. The file in the following example
-(``sunpy.data.sample.AIA_171_IMAGE``) has only one FITS header, so just one
-entry is added to the database.
+The method :meth:`Database.add_from_file` receives one positional argument (either a string or a file-like object) which is used to add at least one new entry from the given FITS file to the database.
+Why "at least one" and not "exactly one"?
+The reason is that each database entry does not represent one file, but one FITS header from a file.
+That means if you pass a file which has 5 FITS headers in it, 5 entries will be added to the database.
+The file in the following example (``sunpy.data.sample.AIA_171_IMAGE``) has only one FITS header, so just one entry is added to the database.
 
 .. note::
 
-  If you are working with Hinode/SOT files you may notice that for
-  each file you get two entries, one which refers to the observation and
-  another that contains some (useless) telemetry data.
+  If you are working with Hinode/SOT files you may notice that for each file you get two entries, one which refers to the observation and another that contains some (useless) telemetry data.
 
-:meth:`Database.add_from_file` saves the value of ``path`` by either simply
-passing on the value of the received argument (if it was a string)
-or by reading the value of ``file.name`` where ``file`` is the passed argument.
+:meth:`Database.add_from_file` saves the value of ``path`` by either simply passing on the value of the received argument (if it was a string) or by reading the value of ``file.name`` where ``file`` is the passed argument.
 If the path cannot be determined, it stays as ``None`` (the default value).
 
-``wavemin`` and ``wavemax`` are only set if the wavelength unit
-of the FITS file can be found out or if the ``default_waveunit`` attribute of
-the database object is set. These values are then
-used to convert from the used units to nanometers. The rationale behind
-this behaviour is that it makes querying for wavelengths more flexible.
+``wavemin`` and ``wavemax`` are only set if the wavelength unit of the FITS file can be found out or if the ``default_waveunit`` attribute of the database object is set.
+These values are then used to convert from the used units to nanometers.
+The rationale behind this behaviour is that it makes querying for wavelengths more flexible.
 
-``instrument`` is set by looking up the
-FITS header key *INSTRUME*. ``observation_time_start`` is set
-by searching for the FITS header key *DATE-OBS* or *DATE_OBS*.
-Analogously, ``observation_time_end`` is set by searching for *DATE-END* or
-*DATE_END*. Finally, the whole FITS header is stored in the attribute
-``fits_header_entries`` as a list of :class:`tables.FitsHeaderEntry`
-instances, and FITS comments are stored in the attribute
-``fits_key_comments`` which is a list of :class:`tables.FitsKeyComment`
-instances.
+``instrument`` is set by looking up the FITS header key *INSTRUME*.
+``observation_time_start`` is set by searching for the FITS header key *DATE-OBS* or *DATE_OBS*.
+Analogously, ``observation_time_end`` is set by searching for *DATE-END* or *DATE_END*.
+Finally, the whole FITS header is stored in the attribute ``fits_header_entries`` as a list of :class:`tables.FitsHeaderEntry` instances, and FITS comments are stored in the attribute ``fits_key_comments`` which is a list of :class:`tables.FitsKeyComment` instances.
 
-Using the function `len` on a :class:`Database` object returns the
-number of saved database entries. To get the first entry of the database,
-``database[0]`` is used (the ID number of the entries does not matter,
-``database[0]`` always returns the oldest saved entry of the database). If
-the database is empty, this expression raises an :exc:`IndexError`.
+Using the function `len` on a :class:`Database` object returns the number of saved database entries.
+To get the first entry of the database, ``database[0]`` is used (the ID number of the entries does not matter, ``database[0]`` always returns the oldest saved entry of the database).
+If the database is empty, this expression raises an :exc:`IndexError`.
 In section 3, more advanced formats of the slicing syntax are introduced.
 
     >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
@@ -228,14 +192,10 @@ In section 3, more advanced formats of the slicing syntax are introduced.
 
 2.2 Adding entries from a directory of FITS files
 =================================================
-Adding all FITS files from a directory works by calling the method
-:meth:`Database.add_from_dir` and passing the desired directory to it. By
-setting the keyword argument ``ignore_already_added`` to ``True``, no
-exception is raised if it is attempted to add an already existing entry
+Adding all FITS files from a directory works by calling the method :meth:`Database.add_from_dir` and passing the desired directory to it.
+By setting the keyword argument ``ignore_already_added`` to ``True``, no exception is raised if it is attempted to add an already existing entry
 
-In the following example case, setting this parameter is required because the
-file ``sunpy.data.sample.AIA_171_IMAGE`` was already added, which is located
-in the directory ``sampledata_dir``
+In the following example case, setting this parameter is required because the file ``sunpy.data.sample.AIA_171_IMAGE`` was already added, which is located in the directory ``sampledata_dir``
 
     >>> from sunpy import config  # doctest: +REMOTE_DATA
     >>> sampledata_dir = config.get("downloads", "sample_dir")  # doctest: +REMOTE_DATA
@@ -250,12 +210,9 @@ in the directory ``sampledata_dir``
 
 2.3.1 Adding entries from a VSO query result
 --------------------------------------------
-The number of database entries that will be added from a VSO query result
-is equal to the value of ``len(qr)`` in the following code snippet. Note that
-:meth:`Database.add_from_vso_query_result` does not download any files,
-though. If you want to add new entries using the VSO and also want to
-download files at the same time, take a look at the following two
-sections.
+The number of database entries that will be added from a VSO query result is equal to the value of ``len(qr)`` in the following code snippet.
+Note that :meth:`Database.add_from_vso_query_result` does not download any files, though.
+If you want to add new entries using the VSO and also want to download files at the same time, take a look at the following two sections.
 
     >>> from sunpy.net import vso, attrs as a
     >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
@@ -287,15 +244,11 @@ After initialising the VSO client:
 2.3.2 "Clever" Fetching
 -----------------------
 
-The method :meth:`Database.fetch` checks if the given query has already been
-used once to add entries to the database. Otherwise, the query is used to
-download and add new data. The :meth:`Database.fetch` method also accepts an
-optional keyword argument ``path`` which is passed as-is to
-:meth:`sunpy.net.vso.VSOClient.fetch` and determines the value of the ``path``
-attribute of each entry.
+The method :meth:`Database.fetch` checks if the given query has already been used once to add entries to the database.
+Otherwise, the query is used to download and add new data.
+The :meth:`Database.fetch` method also accepts an optional keyword argument ``path`` which is passed as-is to :meth:`sunpy.net.vso.VSOClient.fetch` and determines the value of the ``path`` attribute of each entry.
 
-Note that the number of entries that will be added depends on the total number
-of FITS headers, **not** the number of records in the query.
+Note that the number of entries that will be added depends on the total number of FITS headers, **not** the number of records in the query.
 
 .. testsetup:: *
    >>> qr1 = [MockQR(f"2012080500000{t}", 'AIA', w) for t,w in zip([1, 1, 2, 2], [9.4, 9.4, 33.5, 33.5])]
@@ -304,8 +257,7 @@ of FITS headers, **not** the number of records in the query.
    >>> add_data = lambda x: database.add_from_vso_query_result(x) if x else None
    >>> database.fetch = Mock(side_effect=map(add_data, produce_results))
 
-In the next code snippet new data is downloaded as this query
-has not been downloaded before.
+In the next code snippet new data is downloaded as this query has not been downloaded before.
 
     >>> entries = database.fetch(
     ...     a.Time('2012-08-05', '2012-08-05 00:00:05'),
@@ -313,8 +265,7 @@ has not been downloaded before.
     >>> len(database)  # doctest: +REMOTE_DATA
     67
 
-Any more identical fetch calls don't add any new entries to the database
-because they have already been downloaded.
+Any more identical fetch calls don't add any new entries to the database because they have already been downloaded.
 
     >>> entries = database.fetch(
     ...     a.Time('2012-08-05', '2012-08-05 00:00:05'),
@@ -322,8 +273,7 @@ because they have already been downloaded.
     >>> len(database)  # doctest: +REMOTE_DATA
     67
 
-However, this different fetch call downloads new files because there is a
-new date range whose files have not been downloaded yet.
+However, this different fetch call downloads new files because there is a new date range whose files have not been downloaded yet.
 
     >>> entries = database.fetch(
     ...     a.Time('2013-08-05', '2013-08-05 00:00:05'),
@@ -331,10 +281,9 @@ new date range whose files have not been downloaded yet.
     >>> len(database)  # doctest: +REMOTE_DATA
     71
 
-The caching also ensures that when queries have some results in
-common, files for the common results will not be downloaded again. In the
-following example, the query is new, but all of it's files have already been
-downloaded. This means no new files are downloaded.
+The caching also ensures that when queries have some results in common, files for the common results will not be downloaded again.
+In the following example, the query is new, but all of it's files have already been downloaded.
+This means no new files are downloaded.
 
     >>> entries = database.fetch(
     ...     a.Time('2012-08-05 00:00:00', '2012-08-05 00:00:01'),
@@ -344,9 +293,8 @@ downloaded. This means no new files are downloaded.
 
 2.4 Adding entries manually
 ===========================
-Although usually not required, it is also possible to add database entries
-by specifying the parameters manually. To do so pass the
-values as keyword arguments to :class:`tables.DatabaseEntry` as follows:
+Although usually not required, it is also possible to add database entries by specifying the parameters manually.
+To do so pass the values as keyword arguments to :class:`tables.DatabaseEntry` as follows:
 
     >>> from sunpy.database.tables import DatabaseEntry
     >>> entry = DatabaseEntry(instrument='EIT', wavemin=25.0)
@@ -359,25 +307,18 @@ values as keyword arguments to :class:`tables.DatabaseEntry` as follows:
     >>> len(database) # doctest: +REMOTE_DATA
     72
 
-Note that the ``in`` operator only works as expected after the
-:meth:`Database.commit` method has been called!
+Note that the ``in`` operator only works as expected after the :meth:`Database.commit` method has been called!
 
 3. Displaying entries in a table
 ********************************
-In the previous code snippets 71 entries have been added,
-all of them saving a lot of data. To display the database in a table format
-there is a helper function. :func:`tables.display_entries` takes two
-arguments: the first one is an iterator of :class:`tables.DatabaseEntry`
-instances. Remember that an instance of :class:`Database` yields instances
-of :class:`tables.DatabaseEntry` instances, so you can simply pass a
-database object. The second argument is an iterable of the resulting
-columns in the table to be displayed. Each string in this iterable is used
-to access the entry's attribute values. In the following example, the
-values of ``entry.id``, ``entry.observation_time_start``,
-``entry.observation_time_end``, ``entry.instrument``, ``entry.wavemin``,
-and ``entry.wavemax`` are displayed (where ``entry`` stands for the
-respective database entry). Note that *N/A* is displayed if the value
-cannot be found or is not set.
+In the previous code snippets 71 entries have been added, all of them saving a lot of data.
+To display the database in a table format there is a helper function.
+:func:`tables.display_entries` takes two arguments: the first one is an iterator of :class:`tables.DatabaseEntry` instances.
+Remember that an instance of :class:`Database` yields instances of :class:`tables.DatabaseEntry` instances, so you can simply pass a database object.
+The second argument is an iterable of the resulting columns in the table to be displayed.
+Each string in this iterable is used to access the entry's attribute values.
+In the following example, the values of ``entry.id``, ``entry.observation_time_start``, ``entry.observation_time_end``, ``entry.instrument``, ``entry.wavemin``, and ``entry.wavemax`` are displayed (where ``entry`` stands for the respective database entry).
+Note that *N/A* is displayed if the value cannot be found or is not set.
 
     >>> from sunpy.database.tables import display_entries
     >>> print(display_entries(database,
@@ -409,12 +350,8 @@ cannot be found or is not set.
      72                    N/A ...               25.0                N/A
     Length = 72 rows
 
-The index operator can be used to access certain single database entries like
-``database[5]``  to get the 5th entry or  ``database[-2]``
-to get the second-latest entry. It is also possible to
-use more advanced slicing syntax;
-see https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
-for more information.
+The index operator can be used to access certain single database entries like ``database[5]`` to get the 5th entry or ``database[-2]`` to get the second-latest entry.
+It is also possible to use more advanced slicing syntax; see https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html for more information.
 
     >>> print(display_entries(database[9::10],
     ...                       ['id', 'observation_time_start', 'observation_time_end',
@@ -431,14 +368,11 @@ for more information.
 
 4. Removing entries
 *******************
-`Database.remove()` can be used to remove database entries from the sunpy
-database. It takes a ``tables.DatabaseEntry`` object as argument.
+`Database.remove()` can be used to remove database entries from the sunpy database.
+It takes a ``tables.DatabaseEntry`` object as argument.
 
-For example, imagine we want to only have database entries which have an
-observation time saved. To remove all the entries where the value of both
-``observation_time_start`` and ``observation_time_end`` is ``None``,
-simply iterate over the database and the :meth:`Database.remove`
-method to remove those where there is no time set:
+For example, imagine we want to only have database entries which have an observation time saved.
+To remove all the entries where the value of both ``observation_time_start`` and ``observation_time_end`` is ``None``, simply iterate over the database and the :meth:`Database.remove` method to remove those where there is no time set:
 
     >>> for database_entry in database:
     ...     if database_entry.observation_time_start is None and database_entry.observation_time_end is None:
@@ -480,9 +414,8 @@ method to remove those where there is no time set:
 
 5.1 Starring and unstarring entries
 ===================================
-The database package supports marking certain entries as "starred" using the
-:meth:`Database.star` method. For example, to star
-all values that have a wavelength of 20nm or higher:
+The database package supports marking certain entries as "starred" using the :meth:`Database.star` method.
+For example, to star all values that have a wavelength of 20nm or higher:
 
     >>> for database_entry in database:
     ...     if database_entry.wavemin and database_entry.wavemin > 20:
@@ -504,16 +437,13 @@ all values that have a wavelength of 20nm or higher:
      70    2013-08-05 00:00:02 ...              33.5              33.5
      71    2013-08-05 00:00:02 ...              33.5              33.5
 
-To remove the star from these entries, the :meth:`Database.unstar` method
-works the same way.
+To remove the star from these entries, the :meth:`Database.unstar` method works the same way.
 
 5.2 Setting and removing tags
 =============================
-To add some more information by assigning tags to entries, the database package
-also supports *tags*. The ``tags`` property of a database object holds all tags
-that are saved in the database. For example, to assign the tag *spring* to all
-entries that have been observed in March, April, or May on any day in any
-year:
+To add some more information by assigning tags to entries, the database package also supports *tags*.
+The ``tags`` property of a database object holds all tags that are saved in the database.
+For example, to assign the tag *spring* to all entries that have been observed in March, April, or May on any day in any year:
 
     >>> for database_entry in database:
     ...     if database_entry.observation_time_start.month in [3,4,5]:
@@ -535,11 +465,9 @@ year:
 
 5.3 Manually changing attributes
 ================================
-Attributes for entries in the database can be manually edited. The
-:meth:`Database.edit` method receives the database entry to be edited and any
-number of keyword arguments to describe which values to change and how. For
-example, to change the time entires that are ``None`` to the start of the
-observation time (because it's possible, not because it is accurate!):
+Attributes for entries in the database can be manually edited.
+The :meth:`Database.edit` method receives the database entry to be edited and any number of keyword arguments to describe which values to change and how.
+For example, to change the time entires that are ``None`` to the start of the observation time (because it's possible, not because it is accurate!):
 
     >>> for database_entry in database:
     ...     if database_entry.observation_time_end is None:
@@ -575,29 +503,21 @@ observation time (because it's possible, not because it is accurate!):
      71    2013-08-05 00:00:02 ...               33.5               33.5
     Length = 39 rows
 
-It is possible to use
-``database_entry.observation_time_end = database_entry.observation_time_start``",
-but it has one major disadvantage: this operation cannot be undone.
+It is possible to use ``database_entry.observation_time_end = database_entry.observation_time_start``", but it has one major disadvantage: this operation cannot be undone.
 See section 6 to see how undoing and redoing works.
 
 6. Undoing and redoing operations
 *********************************
-A very handy feature of the database package is that every operation that
-changes the database in some way can be reverted. The Database class has
-the methods :meth:`Database.undo` and :meth:`Database.redo` to undo
-and redo the last n commands, respectively.
+A very handy feature of the database package is that every operation that changes the database in some way can be reverted.
+The Database class has the methods :meth:`Database.undo` and :meth:`Database.redo` to undo and redo the last n commands, respectively.
 
 .. warning::
 
-    The undo and redo history are only saved in-memory! That means in
-    particular, that if you work on a Database object in an interactive
-    Python session and quit this session, the undo and redo history are
-    lost.
+    The undo and redo history are only saved in-memory!
+    That means in particular, that if you work on a Database object in an interactive Python session and quit this session, the undo and redo history are lost.
 
-In the following snippet, the operations from the sections 5.3, 5.2, and
-5.1 are undone. Note the following changes: there are no longer any tags
-anymore saved in the database, there is no entry which is starred and
-the entries with no end of observation time are back.
+In the following snippet, the operations from the sections 5.3, 5.2, and 5.1 are undone.
+Note the following changes: there are no longer any tags anymore saved in the database, there is no entry which is starred and the entries with no end of observation time are back.
 
     >>> database.undo(4)  # undo the edits from 5.3 (4 records have been affected)   # doctest:  +REMOTE_DATA
     >>> print(display_entries(
@@ -630,12 +550,10 @@ the entries with no end of observation time are back.
      71    2013-08-05 00:00:02  2013-08-05 00:00:03 ...    N/A     Yes
     Length = 39 rows
 
-The :meth:`~Database.redo` method reverts the last n operations that have been
-undone. If not that many operations can be redone (i.e. any number greater than
-14 in this example), an exception is raised. The redo call
-reverts the original state: the tags have appeared again and all entries with a
-wavelength >20nm are starred again, and there are no entries with no
-stored end of observation time.
+The :meth:`~Database.redo` method reverts the last n operations that have been undone.
+If not that many operations can be redone (i.e.
+any number greater than 14 in this example), an exception is raised.
+The redo call reverts the original state: the tags have appeared again and all entries with a wavelength >20nm are starred again, and there are no entries with no stored end of observation time.
 
     >>> database.redo(1)  # redo all undone operations   # doctest:  +REMOTE_DATA
     >>> print(display_entries(
@@ -670,25 +588,19 @@ stored end of observation time.
 
 7. Querying the database
 ************************
-The API for querying databases is similar to querying the VSO using the
-method :meth:`sunpy.net.vso.VSOClient.search`. The :meth:`Database.search`
-method accepts any number of ORed query attributes (using \|) and
-combines them using AND. It returns a list of matched database entries.
-The special thing about querying databases is that all attributes support
-the unary operator ``~`` to negate specific attributes. Example: the query
-``Instrument.eit`` returns all entries that have *not* been observed
-with the EIT.
+The API for querying databases is similar to querying the VSO using the method :meth:`sunpy.net.vso.VSOClient.search`.
+The :meth:`Database.search` method accepts any number of ORed query attributes (using \|) and combines them using AND.
+It returns a list of matched database entries.
+The special thing about querying databases is that all attributes support the unary operator ``~`` to negate specific attributes.
+Example: the query ``Instrument.eit`` returns all entries that have *not* been observed with the EIT.
 
 7.1 Using VSO attributes
 ========================
-Using the attributes from :mod:`sunpy.net.attrs` is quite intuitive:
-the simple attributes and the Time attribute work exactly as you expect.
+Using the attributes from :mod:`sunpy.net.attrs` is quite intuitive: the simple attributes and the Time attribute work exactly as you expect.
 
 .. note::
 
-  The ``near`` parameter of :class:`sunpy.net.attrs.Time` is ignored, because
-  it's behaviour is not documented and it is different depending on the
-  server which is requested.
+  The ``near`` parameter of :class:`sunpy.net.attrs.Time` is ignored, because it's behaviour is not documented and it is different depending on the server which is requested.
 
 The following query returns the data that was added in section 2.3.2:
 
@@ -703,15 +615,13 @@ The following query returns the data that was added in section 2.3.2:
      66    2012-08-05 00:00:02  2012-08-05 00:00:03        AIA    33.5    33.5
      67    2012-08-05 00:00:02  2012-08-05 00:00:03        AIA    33.5    33.5
 
-.. NOTE the following code does not actually work. There seems to be a bug
-    in sunpy.util.unit_conversion.to_angstrom (this is called by the
-    __init__ of the Wave attribute)
+..NOTE the following code does not actually work.
+   There seems to be a bug in sunpy.util.unit_conversion.to_angstrom (this is called by the __init__ of the Wave attribute)
 
-When using the :class:`sunpy.net.attrs.Wavelength` attribute, you have to
-specify a unit using `astropy.units.Quantity`. If not an error is
-raised. This also means that there is no default unit that is
-used by the class. To know how you can specify a detail using astropy
-check `astropy.units`.
+When using the :class:`sunpy.net.attrs.Wavelength` attribute, you have to specify a unit using `astropy.units.Quantity`.
+If not an error is raised.
+This also means that there is no default unit that is used by the class.
+To know how you can specify a detail using astropy check `astropy.units`.
 
     >>> import astropy.units as u
     >>> print(display_entries(
@@ -737,8 +647,7 @@ check `astropy.units`.
 7.2 Database-specific attributes
 ================================
 There are 5 additional query attributes supported by the database package.
-They can be imported from the submodule :mod:`sunpy.database.attrs` and are in
-particular:
+They can be imported from the submodule :mod:`sunpy.database.attrs` and are in particular:
 
 - Starred
 - Tag
@@ -746,9 +655,7 @@ particular:
 - DownloadTime
 - FitsHeaderEntry
 
-The following query searches for all entries that have the tag 'spring' or
-(inclusive or!) are starred and have not the FITS header key 'WAVEUNIT'
-with the value 'Angstrom':
+The following query searches for all entries that have the tag 'spring' or (inclusive or!) are starred and have not the FITS header key 'WAVEUNIT' with the value 'Angstrom':
 
     >>> import sunpy.database.attrs as dbattrs
     >>> print(display_entries(
@@ -774,18 +681,13 @@ with the value 'Angstrom':
 
 8. Caching
 **********
-All entries that are saved in the database are also saved in a cache
-in-memory. The type of the cache is determined at the initialization of
-the database object and cannot be changed after that. The default type is
-:class:`caching.LRUCache` (least-recently used) and the other one which is
-supported is :class:`caching.LFUCache` (least-frequently used). By
-default the cache size is ``float('inf')``, i.e. infinite. To set the
-cache size after the database object has been initialized, use the method
-:meth:`Database.set_cache_size`. If the new size is smaller than the
-current number of database entries, entries are removed according to the
-cache type until the number of entries is equal to the given cache size.
-The following call to :meth:`Database.set_cache_size` sets the cache size
-to 10 and therefore removes the 5 entries that been used least recently.
+All entries that are saved in the database are also saved in a cache in-memory.
+The type of the cache is determined at the initialization of the database object and cannot be changed after that.
+The default type is :class:`caching.LRUCache` (least-recently used) and the other one which is supported is :class:`caching.LFUCache` (least-frequently used).
+By default the cache size is ``float('inf')``, i.e., infinite.
+To set the cache size after the database object has been initialized, use the method :meth:`Database.set_cache_size`.
+If the new size is smaller than the current number of database entries, entries are removed according to the cache type until the number of entries is equal to the given cache size.
+The following call to :meth:`Database.set_cache_size` sets the cache size to 10 and therefore removes the 5 entries that been used least recently.
 
     >>> database.set_cache_size(10)
     >>> print(display_entries(

--- a/docs/guide/acquiring_data/fido.rst
+++ b/docs/guide/acquiring_data/fido.rst
@@ -279,7 +279,7 @@ So in this case the first result would be ``results[0, 0]`` rather than ``result
 
 As we have seen above the `~sunpy.net.fido_factory.UnifiedResponse` object contains many response tables which make up the search results.
 Each of the responses are `~sunpy.net.base_client.QueryResponseTable` objects, which are `astropy.table` objects meaning that you can interact with them and filter them like any other tabular data.
-This can be used to interact with results which are metadata only, i.e. searches from the HEK, or it can be used to reduce the number of files downloaded by `Fido.fetch <sunpy.net.fido_factory.UnifiedDownloaderFactory.fetch>`.
+This can be used to interact with results which are metadata only, i.e., searches from the HEK, or it can be used to reduce the number of files downloaded by `Fido.fetch <sunpy.net.fido_factory.UnifiedDownloaderFactory.fetch>`.
 
 For example if we did a query for some AIA and HMI data::
 
@@ -511,7 +511,7 @@ You can see the list of options that can be specified in path for all the files 
 
 Retrying Downloads
 ^^^^^^^^^^^^^^^^^^
-If any files failed to download, the progress bar will show an incomplete number of files (i.e. 100/150) and the `parfive.Results` object will contain a list of the URLs that failed to transfer and the error associated with them.
+If any files failed to download, the progress bar will show an incomplete number of files (i.e., 100/150) and the `parfive.Results` object will contain a list of the URLs that failed to transfer and the error associated with them.
 This can be accessed with the ``.errors`` attribute or by printing the `~parfive.Results` object::
 
     >>> print(downloaded_files.errors)  # doctest: +SKIP

--- a/docs/guide/acquiring_data/hek.rst
+++ b/docs/guide/acquiring_data/hek.rst
@@ -2,8 +2,7 @@
 Searching the Heliophysics Event Knowledgebase
 **********************************************
 
-The Heliophysics Event Knowledgebase (HEK) is a repository of feature
-and event information about the Sun.
+The Heliophysics Event Knowledgebase (HEK) is a repository of feature and event information about the Sun.
 Entries are generated both by automated algorithms and human observers.
 sunpy accesses this information through the `~sunpy.net.hek` module, which was developed through support from the European Space Agency Summer of Code in Space (ESA-SOCIS) 2011.
 
@@ -122,7 +121,7 @@ You'll see that one of the attributes is a flare object::
     FL = <sunpy.net.hek.attrs.FL object>
 
 We can replace a.hek.EventType('FL') with a.hek.FL - they do the same thing, setting the query to look for flare events.
-Both methods of setting the event type are provided as a convenience
+Both methods of setting the event type are provided as a convenience.
 
 Let's look further at the FRM attribute::
 

--- a/docs/guide/acquiring_data/jsoc.rst
+++ b/docs/guide/acquiring_data/jsoc.rst
@@ -661,7 +661,7 @@ Only then, can we download them. The download request can be staged like this::
 
 The function `~sunpy.net.jsoc.JSOCClient.request_data` stages the request.
 It returns a `drms.client.ExportRequest` object, which has many attributes.
-The most important ones are ``id`` and ``status``. Only when the status is 0, we can move to the third step, i.e. downloading the data.
+The most important ones are ``id`` and ``status``. Only when the status is 0, we can move to the third step, i.e., downloading the data.
 
 If you are making more than 1 query at a time, it will return a list of `~drms.client.ExportRequest` objects.
 Hence, access the list elements accordingly. You can get the id and status of the request (if it is not a list) by::

--- a/docs/guide/acquiring_data/sample-data.rst
+++ b/docs/guide/acquiring_data/sample-data.rst
@@ -4,14 +4,11 @@
 Downloading Sample Data
 ***********************
 
-sunpy provides a number of sample data files which are referenced in the
-documentation and examples. These files are available to download onto your
-local machine so that you can try out the code in the documentation. To
-download the sample data simply run the following command::
+sunpy provides a number of sample data files which are referenced in the documentation and examples.
+These files are available to download onto your local machine so that you can try out the code in the documentation.
+To download the sample data simply run the following command::
 
     import sunpy.data.sample
 
-This will download the data to your sample-data directory which can be
-customized by editing the sunpyrc file (see :doc:`../customization`).
-After running this you can then import the sample data files shortcuts which
-are used below.
+This will download the data to your sample-data directory which can be customized by editing the sunpyrc file (see :doc:`../customization`).
+After running this you can then import the sample data files shortcuts which are used below.

--- a/docs/guide/customization.rst
+++ b/docs/guide/customization.rst
@@ -9,10 +9,9 @@ Customizing sunpy
 The :file:`sunpyrc` file
 ========================
 
-The sunpy core package uses a :file:`sunpyrc` configuration file to customize
-certain properties. You can control a number of key features of sunpy such as
-where your data will download to. sunpy looks for the ``sunpyrc`` file
-in a platform specific directory, which you can see the path for by running::
+The sunpy core package uses a :file:`sunpyrc` configuration file to customize certain properties.
+You can control a number of key features of sunpy such as where your data will download to.
+sunpy looks for the ``sunpyrc`` file in a platform specific directory, which you can see the path for by running::
 
   >>> import sunpy
   >>> sunpy.print_config()  # doctest: +SKIP
@@ -78,10 +77,9 @@ See below for the example config file.
 Dynamic settings
 ===================
 
-You can also dynamically change the default settings in a python script or
-interactively from the python shell. All of the settings are stored in a
-Python ConfigParser instance called ``sunpy.config``, which is global to
-the sunpy package. Settings can be modified directly, for example::
+You can also dynamically change the default settings in a python script or interactively from the python shell.
+All of the settings are stored in a Python ConfigParser instance called ``sunpy.config``, which is global to the sunpy package.
+Settings can be modified directly, for example::
 
     import sunpy
     sunpy.config.set('downloads', 'download_dir', '/home/user/Downloads')

--- a/docs/guide/data_types/index.rst
+++ b/docs/guide/data_types/index.rst
@@ -2,8 +2,7 @@
 Data Types in sunpy
 *******************
 
-In this section of the guide we introduce the parts of sunpy used to load and
-represent solar data.
+In this section of the guide we introduce the parts of sunpy used to load and represent solar data.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -471,9 +471,7 @@ You can easily get an overview of the metadata, this will show you a basic repre
 The data within a `~sunpy.timeseries.TimeSeriesMetaData` object is stored as a list of tuples, each tuple representing the metadata from a source file or time series.
 The tuple will contain a `~sunpy.time.TimeRange` telling us which rows the metadata applies to, a list of column name strings for which the metadata applies to and finally a `~sunpy.util.metadata.MetaDict` object for storing the key/value pairs of the metadata itself.
 Each time a TimeSeries is concatenated to the original a new set of rows and/or columns will be added to the `~pandas.DataFrame` and a new entry will be added into the metadata.
-Note that entries are ordered chronologically based on
-`~sunpy.time.timerange.TimeRange.start` and generally it's expected that no two
-TimeSeries will overlap on both columns and time range.
+Note that entries are ordered chronologically based on `~sunpy.time.timerange.TimeRange.start` and generally it's expected that no two TimeSeries will overlap on both columns and time range.
 For example, it is not good practice for alternate row values in a single column to be relevant to different metadata entries as this would make it impossible to uniquely identify the metadata relevant to each cell.
 
 If you want the string that's printed then you can use the `~sunpy.timeseries.TimeSeriesMetaData.to_string` method.

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -4,9 +4,9 @@
 User's Guide
 ************
 
-Welcome to the user guide for the sunpy core package. sunpy is a community-
-developed, free and open-source solar data analysis environment. It is meant to
-provide the core functionality and tools to analyze solar data with Python.
+Welcome to the user guide for the sunpy core package.
+sunpy is a community-developed, free and open-source solar data analysis environment.
+It is meant to provide the core functionality and tools to analyze solar data with Python.
 This guide provides a walkthrough of the major features in sunpy.
 For more details checkout the :ref:`reference`.
 

--- a/docs/guide/logger.rst
+++ b/docs/guide/logger.rst
@@ -8,22 +8,17 @@ Overview
 ========
 
 The sunpy logging system is an adapted version of `~astropy.logger.AstropyLogger`.
-Its purpose is to provide users the ability to decide which log and warning messages to show,
-to capture them, and to send them to a file.
+Its purpose is to provide users the ability to decide which log and warning messages to show, to capture them, and to send them to a file.
 
-All messages provided by sunpy use this logging facility which is based
-on the Python `logging` module rather than print statements.
+All messages provided by sunpy use this logging facility which is based on the Python `logging` module rather than print statements.
 
 Messages can have one of several levels, in increasing order of importance:
 
-* DEBUG: Detailed information, typically of interest only when diagnosing
-  problems.
+* DEBUG: Detailed information, typically of interest only when diagnosing problems.
 
-* INFO: A message conveying information about the current task, and
-  confirming that things are working as expected
+* INFO: A message conveying information about the current task, and confirming that things are working as expected
 
-* WARNING: An indication that something unexpected happened, and that user
-  action may be required.
+* WARNING: An indication that something unexpected happened, and that user action may be required.
 
 * ERROR: indicates a more serious issue where something failed but the task is continuing
 
@@ -33,13 +28,10 @@ By default, all messages except for DEBUG messages are displayed.
 
 Configuring the logging system
 ==============================
-The default configuration for the logger is determined by the default sunpy
-configuration file. To make permanent changes to the logger configuration
-see the ``[logger]`` section of the Sunpy configuration
-file (:doc:`sunpyrc </guide/customization>`).
+The default configuration for the logger is determined by the default sunpy configuration file.
+To make permanent changes to the logger configuration see the ``[logger]`` section of the Sunpy configuration file (:doc:`sunpyrc </guide/customization>`).
 
-If you'd like to control the logger configuration for your current session
-first import the logger::
+If you'd like to control the logger configuration for your current session first import the logger::
 
     >>> from sunpy import log
 
@@ -52,23 +44,21 @@ The threshold level for messages can be set with::
 
     >>> log.setLevel('DEBUG')  #doctest: +SKIP
 
-This will display DEBUG and all messages with that level and above. If you'd like to see the fewest
-relevant messages you'd set the logging level to WARNING or above.
+This will display DEBUG and all messages with that level and above.
+If you'd like to see the fewest relevant messages you'd set the logging level to WARNING or above.
 
-For other options such as whether to log to a file or what level of messages the log file should
-contain, see the the Sunpy configuration file (:doc:`sunpyrc </guide/customization>`).
+For other options such as whether to log to a file or what level of messages the log file should contain, see the the Sunpy configuration file (:doc:`sunpyrc </guide/customization>`).
 
 Context managers
 ================
-If you'd like to
-capture messages as they are generated you can do that with a context manager::
+If you'd like to capture messages as they are generated you can do that with a context manager::
 
     >>> from sunpy import log
     >>> with log.log_to_list() as log_list:  #doctest: +SKIP
     ...    # your code here  # doctest: +SKIP
 
-Once your code is executed, ``log_list`` will be a Python list containing all of the Sunpy
-messages during execution. This does not divert the messages from going to a file or to the screen.
+Once your code is executed, ``log_list`` will be a Python list containing all of the Sunpy messages during execution.
+This does not divert the messages from going to a file or to the screen.
 It is also possible to send the messages to a custom file with::
 
     >>> from sunpy import log

--- a/docs/guide/plotting.rst
+++ b/docs/guide/plotting.rst
@@ -107,14 +107,9 @@ plot()
 For more advanced plotting the base sunpy objects also provide a `~sunpy.map.mapbase.GenericMap.plot` command.
 This command is similar to the pyplot `~matplotlib.pyplot.imshow` command in that it will create a figure and axes object for you if you haven't already.
 
-When you create a plot with `~sunpy.map.GenericMap.peek` or
-`~sunpy.map.GenericMap.plot`, sunpy will use `astropy.visualization.wcsaxes` to
-represent coordinates on the image accurately, for more information see
-:ref:`wcsaxes-plotting`.
+When you create a plot with `~sunpy.map.GenericMap.peek` or `~sunpy.map.GenericMap.plot`, sunpy will use `astropy.visualization.wcsaxes` to represent coordinates on the image accurately, for more information see :ref:`wcsaxes-plotting`.
 
-Using `~sunpy.map.GenericMap.plot` it is possible to customise the look of the
-plot by combining sunpy and matplotlib commands, for example you can over plot
-contours on the Map:
+Using `~sunpy.map.GenericMap.plot` it is possible to customise the look of the plot by combining sunpy and matplotlib commands, for example you can over plot contours on the Map:
 
 .. plot::
     :include-source:
@@ -136,9 +131,7 @@ contours on the Map:
     plt.show()
 
 
-In this example, the `~matplotlib.figure.Figure` and
-`~astropy.visualization.wcsaxes.WCSAxes` instances are created explicitly, and
-then used to modify the plot:
+In this example, the `~matplotlib.figure.Figure` and `~astropy.visualization.wcsaxes.WCSAxes` instances are created explicitly, and then used to modify the plot:
 
 .. plot::
     :include-source:
@@ -182,22 +175,15 @@ Please see this example :ref:`sphx_glr_generated_gallery_map_plot_frameless_imag
 Maps with coordinate systems
 ----------------------------
 
-By default :ref:`map` uses the `astropy.visualization.wcsaxes` module to improve
-the representation of world coordinates, and calling
-`~sunpy.map.GenericMap.plot` or `~sunpy.map.GenericMap.peek()` will use wcsaxes
-for plotting. Unless a standard `matplotlib.axes.Axes` object is explicitly
-created.
+By default :ref:`map` uses the `astropy.visualization.wcsaxes` module to improve the representation of world coordinates, and calling `~sunpy.map.GenericMap.plot` or `~sunpy.map.GenericMap.peek()` will use wcsaxes for plotting.
+Unless a standard `matplotlib.axes.Axes` object is explicitly created.
 
-To explicitly create a `~astropy.visualization.wcsaxes.WCSAxes` instance do the
-following ::
+To explicitly create a `~astropy.visualization.wcsaxes.WCSAxes` instance do the following ::
 
     >>> fig = plt.figure()   # doctest: +SKIP
     >>> ax = plt.subplot(projection=smap)   # doctest: +SKIP
 
-when plotting on an `~astropy.visualization.wcsaxes.WCSAxes` axes, it will by
-default plot in pixel coordinates, you can override this behavior and plot in
-'world' coordinates by getting the transformation from the axes with
-``ax.get_transform('world')``.
+when plotting on an `~astropy.visualization.wcsaxes.WCSAxes` axes, it will by default plot in pixel coordinates, you can override this behavior and plot in 'world' coordinates by getting the transformation from the axes with ``ax.get_transform('world')``.
 
 .. note::
 
@@ -209,8 +195,7 @@ default plot in pixel coordinates, you can override this behavior and plot in
     >>> ax.plot((100*u.arcsec).to_value(u.deg), (500*u.arcsec).to_value(u.deg),
     ...         transform=ax.get_transform('world'))   # doctest: +SKIP
 
-Finally, here is a more complex example using sunpy maps, wcsaxes and Astropy
-units to plot a AIA image and a zoomed in view of an active region.
+Finally, here is a more complex example using sunpy maps, wcsaxes and Astropy units to plot a AIA image and a zoomed in view of an active region.
 
 .. plot::
     :include-source:

--- a/docs/guide/ssw.rst
+++ b/docs/guide/ssw.rst
@@ -2,10 +2,10 @@
 SSWIDL/sunpy Cheat Sheet
 ************************
 
-`SolarSoft (SSWIDL) <https://sohowww.nascom.nasa.gov/solarsoft/>`_ is a
-popular IDL software library for solar data analysis, and in fact, many parts
-of sunpy are inspired by data structures and functions in SSWIDL. Though IDL and Python are very different it sometimes helps to consider how to translate
-simple tasks between the two languages. The primary packages which provide much of the functionality for scientific data analysis in Python are NumPy and SciPy. In the following we assume that those packages are available to you and that you are imported Numpy is imported as np with the following import statement::
+`SolarSoft (SSWIDL) <https://sohowww.nascom.nasa.gov/solarsoft/>`_ is a popular IDL software library for solar data analysis, and in fact, many parts of sunpy are inspired by data structures and functions in SSWIDL.
+Though IDL and Python are very different it sometimes helps to consider how to translate simple tasks between the two languages.
+The primary packages which provide much of the functionality for scientific data analysis in Python are NumPy and SciPy.
+In the following we assume that those packages are available to you and that you are imported Numpy is imported as np with the following import statement::
 
     import numpy as np
     import scipy as sp

--- a/docs/guide/time.rst
+++ b/docs/guide/time.rst
@@ -4,27 +4,25 @@
 Time in sunpy
 *************
 
-Working with times and time ranges is a standard task in solar data analysis and as such
-sunpy strives to provide convenient and easy methods to do the simple stuff. Python
-already provides an object for a time or date through `datetime.datetime`.
-However, `datetime.datetime` does not provide support for common time formats used in
-solar physics nor leap seconds. To alleviate this, we use `astropy.time.Time` internally
-which allows us to provide a superior user experience.
+Working with times and time ranges is a standard task in solar data analysis and as such sunpy strives to provide convenient and easy methods to do the simple stuff.
+Python already provides an object for a time or date through `datetime.datetime`.
+However, `datetime.datetime` does not provide support for common time formats used in solar physics nor leap seconds.
+To alleviate this, we use `astropy.time.Time` internally which allows us to provide a superior user experience.
 
 .. _parse-time:
 
 1. Parsing Times
 ================
 
-Solar data is associated with a number of different time formats. sunpy provides a simple
-parsing function which can deal with most every format that a user may encounter. Called
-`sunpy.time.parse_time()`, this function can take a variety of inputs.
+Solar data is associated with a number of different time formats.
+sunpy provides a simple parsing function which can deal with most every format that a user may encounter.
+Called `sunpy.time.parse_time()`, this function can take a variety of inputs.
 
 Strings
 -------
 
-The most commonly used are strings and we support a selection of formats
-which are matched using regrex. We currently support the following style of string formats::
+The most commonly used are strings and we support a selection of formats which are matched using regrex.
+We currently support the following style of string formats::
 
     "2007-05-04T21:08:12.999999"
     "2007/05/04T21:08:12.999999"
@@ -109,10 +107,10 @@ For example::
 `astropy.time.Time` API comparison
 ----------------------------------
 
-`sunpy.time.parse_time` is a wrapper around `astropy.time.Time`. The API is
-nearly identical as `~astropy.time.Time` but supports more time input formats.
-You can specify the format, scale, precision, location and other arguments just
-as you would do with `~astropy.time.Time`. An example::
+`sunpy.time.parse_time` is a wrapper around `astropy.time.Time`.
+The API is nearly identical as `~astropy.time.Time` but supports more time input formats.
+You can specify the format, scale, precision, location and other arguments just as you would do with `~astropy.time.Time`.
+An example::
 
     >>> times = ['1999-01-01T00:00:00.123456789', '2010-01-01T00:00:00']
     >>> parse_time(times, format='isot', scale='tai')
@@ -123,10 +121,10 @@ Please be aware that all sunpy functions which require time as an input sanitize
 2. Time Ranges
 ==============
 
-A very standard task in data analysis is to have to deal with pairs of times or time
-ranges. This occurs very often with plotting or when searching for data. To deal with
-time ranges sunpy provides the `sunpy.time.TimeRange` object. A TimeRange object can be created
-very easily by providing it with two time strings, a start time and an end time: ::
+A very standard task in data analysis is to have to deal with pairs of times or time ranges.
+This occurs very often with plotting or when searching for data.
+To deal with time ranges sunpy provides the `sunpy.time.TimeRange` object.
+A TimeRange object can be created very easily by providing it with two time strings, a start time and an end time: ::
 
     >>> from sunpy.time import TimeRange
     >>> time_range = TimeRange('2010/03/04 00:10', '2010/03/04 00:20')
@@ -137,9 +135,7 @@ You can also pass the start and end times as a tuple: ::
 
 This object makes use of parse_time() so it can accept a wide variety of time formats.
 A time range object can also be created by providing a start time and a duration.
-The duration must be provided as a `~astropy.time.TimeDelta` or
-time-equivalent `astropy.units.Quantity` or `datetime.timedelta` object
-example: ::
+The duration must be provided as a `~astropy.time.TimeDelta` or time-equivalent `astropy.units.Quantity` or `datetime.timedelta` object example: ::
 
     >>> import astropy.units as u
     >>> time_range = TimeRange('2010/03/04 00:10', 400 * u.second)
@@ -155,9 +151,8 @@ or: ::
     >>> from datetime import timedelta
     >>> time_range = TimeRange('2010/03/04 00:10', timedelta(0, 400))
 
-The time range objects provides a number of useful functions. For example, you can easily
-get the time at the center of your interval or the length of your interval in minutes
-or days or seconds: ::
+The time range objects provides a number of useful functions.
+For example, you can easily get the time at the center of your interval or the length of your interval in minutes or days or seconds: ::
 
     >>> time_range.center
     <Time object: scale='utc' format='isot' value=2010-03-04T00:13:20.000>
@@ -168,10 +163,10 @@ or days or seconds: ::
     >>> time_range.seconds
     <Quantity 400. s>
 
-It also makes it easy to create new time ranges. The functions next() and previous()
-do an inplace update to the object by either adding or subtracting the same time interval
-. This could be useful if you need to step through a number of time ranges. For example,
-if you needed time ranges that spanned 30 minutes over a period of 4 hours you could do: ::
+It also makes it easy to create new time ranges.
+The functions next() and previous() do an inplace update to the object by either adding or subtracting the same time interval.
+This could be useful if you need to step through a number of time ranges.
+For example, if you needed time ranges that spanned 30 minutes over a period of 4 hours you could do: ::
 
     >>> for a in range(8):
     ...     print(time_range.next())  # doctest: +IGNORE_OUTPUT
@@ -240,8 +235,7 @@ if you needed time ranges that spanned 30 minutes over a period of 4 hours you c
                400.0 seconds
     <BLANKLINE>
 
-A time range can also be easily split into sub-intervals of equal length, for example to
-split a TimeRange object into two new TimeRange objects: ::
+A time range can also be easily split into sub-intervals of equal length, for example to split a TimeRange object into two new TimeRange objects: ::
 
     time_range.split(2)
 

--- a/docs/guide/tour.rst
+++ b/docs/guide/tour.rst
@@ -1,11 +1,9 @@
 A brief tour of sunpy
 *********************
 
-This brief tutorial will walk you through some of the functionality offered by
-the sunpy core package. Start by reading this tutorial and trying out some of
-the examples demonstrated. Once you've completed the tutorial check out the
-rest of the :doc:`User Guide </guide/index>` for a more thorough look at the
-functionality available.
+This brief tutorial will walk you through some of the functionality offered by the sunpy core package.
+Start by reading this tutorial and trying out some of the examples demonstrated.
+Once you've completed the tutorial check out the rest of the :doc:`User Guide </guide/index>` for a more thorough look at the functionality available.
 
 Sample Data
 ===========
@@ -14,19 +12,17 @@ This downloading will happen automatically when using the module `sunpy.data.sam
 
 Maps
 ====
-Maps are the primary data type in sunpy. They are spatially aware data arrays.
-There are maps for a 2D image, a time series of 2D images or temporally aligned
-2D images.
+Maps are the primary data type in sunpy.
+They are spatially aware data arrays.
+There are maps for a 2D image, a time series of 2D images or temporally aligned 2D images.
 
 **Creating a Map**
 
-sunpy supports many different data products from various sources 'out of the
-box'. We shall use SDO's AIA instrument as an example in this tutorial. The
-general way to create a Map from one of the supported data products is with the
-`~sunpy.map.Map` function from the `sunpy.map` submodule.
-`~sunpy.map.Map` takes either a filename, a list of
-filenames or a data array and header. We can test
-`~sunpy.map.Map` with:
+sunpy supports many different data products from various sources 'out of the box'.
+We shall use SDO's AIA instrument as an example in this tutorial.
+The general way to create a Map from one of the supported data products is with the `~sunpy.map.Map` function from the `sunpy.map` submodule.
+`~sunpy.map.Map` takes either a filename, a list of filenames or a data array and header.
+We can test `~sunpy.map.Map` with:
 
 
 .. plot::
@@ -39,18 +35,15 @@ filenames or a data array and header. We can test
     aia.peek()
 
 This returns a map named ``aia`` which can be manipulated with standard sunpy map commands.
-For more information about maps checkout the :doc:`map guide <data_types/maps>`
-and the :ref:`map`.
+For more information about maps checkout the :doc:`map guide <data_types/maps>` and the :ref:`map`.
 
 TimeSeries
 ==========
 
-sunpy handles time series data, fundamental to the study of any real world
-phenomenon, by creating a TimeSeries object. A timeseries consists of two parts;
-times and measurements taken at those times. The data can either be in your
-current Python session, alternatively within a local or remote file.
-In the code block that follows, data is taken from a file containing samples
-from a file containing samples from the GOES satellite's X-ray Sensors (XRS).
+sunpy handles time series data, fundamental to the study of any real world phenomenon, by creating a TimeSeries object.
+A timeseries consists of two parts; times and measurements taken at those times.
+The data can either be in your current Python session, alternatively within a local or remote file.
+In the code block that follows, data is taken from a file containing samples from a file containing samples from the GOES satellite's X-ray Sensors (XRS).
 
 
 .. plot::
@@ -63,28 +56,21 @@ from a file containing samples from the GOES satellite's X-ray Sensors (XRS).
     my_timeseries = ts.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES, source='XRS')
     my_timeseries.peek()
 
-We've created this timeseries object by passing TimeSeries a string which
-represents the name of a GOES lightcurve file. The
-`.peek() <sunpy.timeseries.GenericTimeSeries.peek>` method plots the timeseries
-data and displays the plot with some default settings. You can also use
-`my_timeseries.plot() <sunpy.timeseries.GenericTimeSeries.plot>` if you want more
-control over the style of the output plot.
+We've created this timeseries object by passing TimeSeries a string which represents the name of a GOES lightcurve file.
+The `.peek() <sunpy.timeseries.GenericTimeSeries.peek>` method plots the timeseries data and displays the plot with some default settings.
+You can also use `my_timeseries.plot() <sunpy.timeseries.GenericTimeSeries.plot>` if you want more control over the style of the output plot.
 
-For more information about TimeSeries, check out the
-:doc:`timeseries guide <data_types/timeseries>` and the
-and the :ref:`timeseries_code_ref`.
+For more information about TimeSeries, check out the :doc:`timeseries guide <data_types/timeseries>` and the and the :ref:`timeseries_code_ref`.
 
 Plotting
 ========
 
-sunpy uses a matplotlib-like interface to its plotting so more complex plots can
-be built by combining sunpy with matplotlib. If you're not familiar with
-plotting in matplotlib, you should `learn the basics <https://matplotlib.org/users/tutorials.html>`__
-before continuing with this guide.
+sunpy uses a matplotlib-like interface to its plotting so more complex plots can be built by combining sunpy with matplotlib.
+If you're not familiar with plotting in matplotlib, you should `learn the basics <https://matplotlib.org/users/tutorials.html>`__ before continuing with this guide.
 
-Let's begin by creating a simple plot of an AIA image. To make things easy,
-sunpy includes several example files which are used throughout the docs. These
-files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE``.
+Let's begin by creating a simple plot of an AIA image.
+To make things easy, sunpy includes several example files which are used throughout the docs.
+These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE``.
 
 Try typing the below example into your interactive Python shell.
 
@@ -97,18 +83,14 @@ Try typing the below example into your interactive Python shell.
     aia = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
     aia.peek()
 
-If everything has been configured properly you should see an AIA image with
-the default AIA 17.1 colormap, a colorbar on the right-hand side and a title and some
-labels.
+If everything has been configured properly you should see an AIA image with the default AIA 17.1 colormap, a colorbar on the right-hand side and a title and some labels.
 
-There is lot going on here, but we will walk you through the example. Briefly,
-the first line is importing sunpy, and the second importing the sample data
-files. On the third line we create a sunpy Map object which is a spatially-aware
-image. On the last line we then plot the `~sunpy.map.Map` object, using the built in 'quick plot'
-function `~sunpy.map.GenericMap.peek`.
+There is lot going on here, but we will walk you through the example.
+Briefly, the first line is importing sunpy, and the second importing the sample data files.
+On the third line we create a sunpy Map object which is a spatially-aware image.
+On the last line we then plot the `~sunpy.map.Map` object, using the built in 'quick plot' function `~sunpy.map.GenericMap.peek`.
 
-sunpy uses a matplotlib-like interface to it's plotting so more complex
-plots can be built by combining sunpy with matplotlib.
+sunpy uses a matplotlib-like interface to it's plotting so more complex plots can be built by combining sunpy with matplotlib.
 
 .. plot::
     :include-source:
@@ -134,8 +116,8 @@ For more information check out :ref:`plotting`.
 Solar Physical Constants
 ========================
 
-sunpy contains a convenient list of solar-related physical constants. Here is
-a short bit of code to get you started: ::
+sunpy contains a convenient list of solar-related physical constants.
+Here is a short bit of code to get you started: ::
 
     >>> from sunpy.sun import constants as con
 
@@ -155,9 +137,9 @@ a short bit of code to get you started: ::
       Unit  = m
       Reference = IAU 2015 Resolution B 3
 
-Not all constants have a shortcut assigned to them (as above). The rest of the constants
-are stored in a dictionary. The following code grabs the dictionary and gets all of the
-keys.::
+Not all constants have a shortcut assigned to them (as above).
+The rest of the constants are stored in a dictionary.
+The following code grabs the dictionary and gets all of the keys.::
 
     >>> solar_constants = con.constants
     >>> solar_constants.keys()
@@ -174,23 +156,20 @@ keys.::
                'mean synodic period', 'alpha_0',
                'delta_0'])
 
-You can also use the function `sunpy.sun.constants.print_all()` to print out a table of all of the values
-available. These constants are provided as a convenience so that everyone is using the same
-(accepted) values. For more information check out :ref:`sun_code_ref`.
+You can also use the function `sunpy.sun.constants.print_all()` to print out a table of all of the values available.
+These constants are provided as a convenience so that everyone is using the same (accepted) values.
+For more information check out :ref:`sun_code_ref`.
 
 Quantities and Units
 ====================
 
-Many capabilities in sunpy make use of physical quantities that are specified
-with units. sunpy uses `~astropy.units` to implement this functionality.
-Quantities and units are powerful tools for keeping track of variables with
-physical meaning and make it straightforward to convert the same physical
-quantity into different units. To learn more about the capabilities of
-quantities and units, consult :ref:`units-sunpy` or
-`the astropy tutorial <http://learn.astropy.org/Quantities.html>`__.
+Many capabilities in sunpy make use of physical quantities that are specified with units.
+sunpy uses `~astropy.units` to implement this functionality.
+Quantities and units are powerful tools for keeping track of variables with physical meaning and make it straightforward to convert the same physical quantity into different units.
+To learn more about the capabilities of quantities and units, consult :ref:`units-sunpy` or `the astropy tutorial <http://learn.astropy.org/Quantities.html>`__.
 
-To demonstrate this, let's look at the solar radius constant. This is a physical quantity
-that can be expressed in length units ::
+To demonstrate this, let's look at the solar radius constant.
+This is a physical quantity that can be expressed in length units ::
 
     >>> from sunpy.sun import constants as con
     >>> con.radius
@@ -207,8 +186,7 @@ or equivalently::
     >>> con.radius.to(u.km)
     <Quantity 695700. km>
 
-If, as is sometimes the case, you need just the raw value or the unit from a quantity, you can access these individually
-with the ``value`` and ```unit`` attributes, respectively::
+If, as is sometimes the case, you need just the raw value or the unit from a quantity, you can access these individually with the ``value`` and ```unit`` attributes, respectively::
 
     >>> r = con.radius.to(u.km)
     >>> r.value
@@ -226,11 +204,10 @@ The following code implements this::
     >>> def circle_area(radius):
     ...     return np.pi * radius ** 2
 
-The first line imports numpy, and the second line imports astropy's units
-module. The function then calculates the area based on a given radius. When
-it does this, it tracks the units of the input and propagates them through
-the calculation. Therefore, if we define the radius in meters, the area will
-be in meters squared::
+The first line imports numpy, and the second line imports astropy's units module.
+The function then calculates the area based on a given radius.
+When it does this, it tracks the units of the input and propagates them through the calculation.
+Therefore, if we define the radius in meters, the area will be in meters squared::
 
     >>> circle_area(4 * u.m)
     <Quantity 50.26548246 m2>
@@ -242,8 +219,7 @@ This also works with different units, for example ::
     <Quantity 50.26548246 ft2>
 
 As demonstrated above, we can convert between different systems of measurement.
-For example, if you want the area of a circle in square feet, but were given
-the radius in meters, then you can convert it before passing it into the function::
+For example, if you want the area of a circle in square feet, but were given the radius in meters, then you can convert it before passing it into the function::
 
     >>> circle_area((4 * u.m).to(imperial.foot))
     <Quantity 541.05315022 ft2>
@@ -254,16 +230,15 @@ or you can convert the output::
     <Quantity 541.05315022 ft2>
 
 
-This is an extremely brief summary of the powerful capbilities of Astropy units.  To find out more, see
-the `the astropy tutorial <http://learn.astropy.org/Quantities.html>`__ and
-`documentation <https://docs.astropy.org/en/stable/units/index.html>`__
+This is an extremely brief summary of the powerful capbilities of Astropy units.
+To find out more, see the `the astropy tutorial <http://learn.astropy.org/Quantities.html>`__ and `documentation <https://docs.astropy.org/en/stable/units/index.html>`__
 
 
 Working with Times
 ==================
 
-sunpy also contains a number of convenience functions for working with dates
-and times. Here is a short example: ::
+sunpy also contains a number of convenience functions for working with dates and times.
+Here is a short example: ::
 
     >>> import sunpy.time
 
@@ -289,11 +264,9 @@ For more information about working with time in sunpy checkout the :doc:`time gu
 Obtaining Data
 ==============
 
-sunpy supports searching for and fetching data from a variety of sources,
-including the `VSO <https://virtualsolar.org/>`__ and the
-`JSOC <http://jsoc.stanford.edu/>`__. The majority of sunpy's clients can be
-queried using the `sunpy.net.Fido` interface. An example of searching the VSO using this
-is below::
+sunpy supports searching for and fetching data from a variety of sources, including the `VSO <https://virtualsolar.org/>`__ and the `JSOC <http://jsoc.stanford.edu/>`__.
+The majority of sunpy's clients can be queried using the `sunpy.net.Fido` interface.
+An example of searching the VSO using this is below::
 
   >>> from sunpy.net import Fido, attrs as a
 
@@ -310,9 +283,7 @@ For more information and examples of downloading data with sunpy see :ref:`acqui
 Database Package
 ================
 
-The database package can be used to keep a local record of all files downloaded
-from the VSO, this means that two searches of the VSO which overlap will not
-re-download data.
+The database package can be used to keep a local record of all files downloaded from the VSO, this means that two searches of the VSO which overlap will not re-download data.
 
 A simple example of this is shown below::
 


### PR DESCRIPTION
Most of the documentation follows already this style (as suggested in #2849).
This completes (I think!) the effort in a semi-automated way (with emacs power).

What it's required now is a mechanism to check that this is kept as such.

Changes on the Changelog files have not been included as these files should not change in the future.