### PR TITLE
Fixed the determination of scale and rotation matrix from the CDij matrix

### DIFF
--- a/changelog/6573.bugfix.1.rst
+++ b/changelog/6573.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fixed a bug with the `sunpy.map.GenericMap.rotation_matrix` property for maps using the CDij matrix formulism where the rotation matrix would be calculated incorrectly for non-square pixels.

--- a/changelog/6573.bugfix.2.rst
+++ b/changelog/6573.bugfix.2.rst
@@ -1,0 +1,1 @@
+Fixd a bug with the `sunpy.map.GenericMap.scale` property for maps containing only the CDij matrix where the scale was not being determined from the CDij matrix.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1273,10 +1273,22 @@ class GenericMap(NDData):
         """
         Image scale along the x and y axes in units/pixel
         (i.e. cdelt1, cdelt2).
+
+        If the CDij matrix is defined but no CDELTi values are explicitly defined,
+        effective CDELTi values are constructed from the CDij matrix.  The effective
+        CDELTi values are chosen so that each row of the PCij matrix has unity norm.
+        This choice is optimal if the PCij matrix is a pure rotation matrix, but may not
+        be as optimal if the PCij matrix includes any skew.
         """
-        # TODO: Fix this if only CDi_j matrix is provided
-        return SpatialPair(self.meta.get('cdelt1', 1.) * self.spatial_units[0] / u.pixel,
-                           self.meta.get('cdelt2', 1.) * self.spatial_units[1] / u.pixel)
+        if 'cd1_1' in self.meta and 'cdelt1' not in self.meta and 'cdelt2' not in self.meta:
+            cdelt1 = np.sqrt(self.meta['cd1_1']**2 + self.meta['cd1_2']**2)
+            cdelt2 = np.sqrt(self.meta['cd2_1']**2 + self.meta['cd2_2']**2)
+        else:
+            cdelt1 = self.meta.get('cdelt1', 1.)
+            cdelt2 = self.meta.get('cdelt2', 1.)
+
+        return SpatialPair(cdelt1 * self.spatial_units[0] / u.pixel,
+                           cdelt2 * self.spatial_units[1] / u.pixel)
 
     @property
     def spatial_units(self):
@@ -1314,7 +1326,8 @@ class GenericMap(NDData):
 
             cdelt = u.Quantity(self.scale).value
 
-            return cd / cdelt
+            # Divide each row by each CDELT
+            return cd / np.expand_dims(cdelt, axis=1)
         else:
             return self._rotation_matrix_from_crota()
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -334,12 +334,12 @@ def test_rotation_matrix_cd_cdelt():
         'CRVAL2': 0,
         'CRPIX1': 5,
         'CRPIX2': 5,
-        'CDELT1': 10,
-        'CDELT2': 9,
-        'CD1_1': 0,
-        'CD1_2': -9,
-        'CD2_1': 10,
-        'CD2_2': 0,
+        'CDELT1': 2,
+        'CDELT2': 3,
+        'CD1_1': 1,
+        'CD1_2': -2,
+        'CD2_1': 3,
+        'CD2_2': 6,
         'NAXIS1': 6,
         'NAXIS2': 6,
         'CUNIT1': 'arcsec',
@@ -348,7 +348,7 @@ def test_rotation_matrix_cd_cdelt():
         'CTYPE2': 'HPLT-TAN',
     }
     cd_map = sunpy.map.Map((data, header))
-    np.testing.assert_allclose(cd_map.rotation_matrix, np.array([[0., -1.], [1., 0]]))
+    np.testing.assert_allclose(cd_map.rotation_matrix, np.array([[0.5, -1.], [1., 2.]]))
 
 
 def test_rotation_matrix_cd_cdelt_square():
@@ -1527,3 +1527,26 @@ def test_parse_fits_units():
 
     out_unit = GenericMap._parse_fits_unit("G")
     assert out_unit == u.G
+
+
+def test_only_cd():
+    data = np.ones([6, 6], dtype=np.float64)
+    header = {
+        'CRVAL1': 0,
+        'CRVAL2': 0,
+        'CRPIX1': 5,
+        'CRPIX2': 5,
+        'CD1_1': 3,
+        'CD1_2': -4,
+        'CD2_1': 5,
+        'CD2_2': 12,
+        'NAXIS1': 6,
+        'NAXIS2': 6,
+        'CUNIT1': 'arcsec',
+        'CUNIT2': 'arcsec',
+        'CTYPE1': 'HPLN-TAN',
+        'CTYPE2': 'HPLT-TAN',
+    }
+    cd_map = sunpy.map.Map((data, header))
+    np.testing.assert_allclose(u.Quantity(cd_map.scale).value, np.array([5, 13]))
+    np.testing.assert_allclose(cd_map.rotation_matrix, np.array([[3/5, -4/5], [5/13, 12/13]]))


### PR DESCRIPTION
- Fixes a bug with the `.rotation_matrix` property where the PCij matrix was not determined correctly from the CDij matrix in the case of non-square pixels.
- Fixes the `.scale` property to return reasonable values when a map has a CDij matrix and no CDELTi values.  The returned pixel scales are the values that are needed so that each row of the inferred PCij matrix has unity norm.