### PR TITLE
Add codespell configuration and apply spelling changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,5 +69,10 @@ repos:
         pass_filenames: false
         always_run: true
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+
 ci:
   autofix_prs: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,6 @@ repos:
     rev: v2.2.2
     hooks:
       - id: codespell
-
+        args: ['--config setup.cfg']
 ci:
   autofix_prs: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1535,7 +1535,7 @@ Backwards Incompatible Changes
   https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html for more information. (`#2719 <https://github.com/sunpy/sunpy/pull/2719>`__)
 - The ``sunpy.cm.show_colormaps`` function now accepts the keyword 'search' instead of 'filter'. (`#2731 <https://github.com/sunpy/sunpy/pull/2731>`__)
 - The keyword arguments to all client ``.fetch`` methods have been changed to
-  support the new parfive downloader and to ensure consisteny across all Fido
+  support the new parfive downloader and to ensure consistency across all Fido
   clients. (`#2797 <https://github.com/sunpy/sunpy/pull/2797>`__)
 - The Helioviewer client has been switched to using the newer Helioviewer API.
   This has meant that we have changed some of the keywords that were passed into client's methods.
@@ -2465,7 +2465,7 @@ detection \* Automatic fits file detection improved \* extract\_waveunit
 added to io.fits for detection of common ways of storing wavelength unit
 in fits files.
 
--  A major re-work of all interal imports has resulted in a much cleaner
+-  A major re-work of all internal imports has resulted in a much cleaner
    namespace, i.e. sunpy.util.util is no longer used to import util.
 -  Some SOHO and STEREO files were not reading properly due to a
    date\_obs parameter.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,7 +71,7 @@ New Features
 - Add a basic HTML representation for `~sunpy.timeseries.TimeSeries`. (`#6032 <https://github.com/sunpy/sunpy/pull/6032>`__)
 - The minimum supported asdf version has been increased to 2.8.0 to allow future
   compatibility with the breaking changes planned for asdf 3.0.
-  In addtion to this the `asdf-astropy <https://github.com/astropy/asdf-astropy>`__
+  In addition to this the `asdf-astropy <https://github.com/astropy/asdf-astropy>`__
   package is now required to serialise and deserialise the sunpy coordinate frame
   classes to ASDF. (`#6057 <https://github.com/sunpy/sunpy/pull/6057>`__)
 - Added the option to rotate using `OpenCV <https://opencv.org>`__ when using :func:`sunpy.image.transform.affine_transform` or :meth:`sunpy.map.GenericMap.rotate` by specifying ``method='cv2'``.
@@ -96,7 +96,7 @@ Bug Fixes
   added for it in sunpy, please raise an issue at
   https://github.com/sunpy/sunpy/issues. (`#5692 <https://github.com/sunpy/sunpy/pull/5692>`__)
 - The default ``id_type`` in :func:`sunpy.coordinates.get_horizons_coord` is now
-  `None` to match the deafult ``id_type`` in astroquery 0.4.4, which will search
+  `None` to match the default ``id_type`` in astroquery 0.4.4, which will search
   major bodies first, and if no major bodies are found, then search small bodies.
   For older versions of astroquery the default ``id_type`` used by
   :func:`~sunpy.coordinates.get_horizons_coord` is still ``'majorbody'``. (`#5707 <https://github.com/sunpy/sunpy/pull/5707>`__)
@@ -136,7 +136,7 @@ Bug Fixes
 - Fixes a bug where the ``cmap`` and ``norm`` keyword arguments were ignored when calling
   `~sunpy.map.MapSequence.plot`. (`#5889 <https://github.com/sunpy/sunpy/pull/5889>`__)
 - Fix parsing of the GOES/XRS netcdf files to ignore leap seconds. (`#5915 <https://github.com/sunpy/sunpy/pull/5915>`__)
-- Fixed compatability with ``h5netcdf>0.14`` when loading GOES netcdf files. (`#5920 <https://github.com/sunpy/sunpy/pull/5920>`__)
+- Fixed compatibility with ``h5netcdf>0.14`` when loading GOES netcdf files. (`#5920 <https://github.com/sunpy/sunpy/pull/5920>`__)
 - Fixed bugs with the rebinning and per-keV calculation for Fermi/GBM summary lightcurves (`~sunpy.timeseries.sources.GBMSummaryTimeSeries`). (`#5943 <https://github.com/sunpy/sunpy/pull/5943>`__)
 - Fixed the unintentionally slow parsing of Fermi/GBM files (`~sunpy.timeseries.sources.GBMSummaryTimeSeries`). (`#5943 <https://github.com/sunpy/sunpy/pull/5943>`__)
 - Fixes a bug in `~sunpy.map.sources.SJIMap` where undefined variable was
@@ -180,14 +180,14 @@ Internal Changes
   reduces the time needed to perform a query to the VSO. (`#5681 <https://github.com/sunpy/sunpy/pull/5681>`__)
 - `sunpy.map.GenericMap.wcs` now checks that the scale property has the correct
   units whilst constructing the WCS. (`#5682 <https://github.com/sunpy/sunpy/pull/5682>`__)
-- Added `packaging <https://pypi.org/project/packaging/>`__ as a core depedency as distutils is now deprecated. (`#5713 <https://github.com/sunpy/sunpy/pull/5713>`__)
+- Added `packaging <https://pypi.org/project/packaging/>`__ as a core dependency as distutils is now deprecated. (`#5713 <https://github.com/sunpy/sunpy/pull/5713>`__)
 - `~sunpy.util.exceptions.SunpyWarning` is no longer a subclass of `~astropy.utils.exceptions.AstropyWarning`. (`#5722 <https://github.com/sunpy/sunpy/pull/5722>`__)
 - Running the tests now requires the ``pytest-xdist`` package. By
   default tests are *not* run in parallel, but can be configured to do so
   using ``pytest-xdist`` command line options. (`#5827 <https://github.com/sunpy/sunpy/pull/5827>`__)
 - Migrate the asdf infrastructure to the new style converters etc added in asdf
   2.8.0. This makes sure sunpy will be compatible with the upcoming asdf 3.0 release. (`#6057 <https://github.com/sunpy/sunpy/pull/6057>`__)
-- Declare in our dependancies that we are not compatible with asdf 3.0.0 until we
+- Declare in our dependencies that we are not compatible with asdf 3.0.0 until we
   are. (`#6077 <https://github.com/sunpy/sunpy/pull/6077>`__)
 - Improved performance of the code that parses dates in clients that use the
   `~sunpy.net.scraper.Scraper` to get available files. (`#6101 <https://github.com/sunpy/sunpy/pull/6101>`__)
@@ -246,7 +246,7 @@ Deprecations
 - Using "neighbour" as a resampling method in
   :func:`sunpy.image.resample.resample` is deprecated. Use "nearest" instead,
   which has the same effect. (`#5480 <https://github.com/sunpy/sunpy/pull/5480>`__)
-- The `sunpy.visualization.animator` subpackge has been spun out into the
+- The `sunpy.visualization.animator` subpackage has been spun out into the
   standalone `mpl-animators <https://pypi.org/project/mpl-animators>`_ package,
   with the exception of `~sunpy.visualization.animator.MapSequenceAnimator`.
   Please update your imports to replace ``sunpy.visualization.animator`` with
@@ -362,10 +362,10 @@ Bug Fixes
   (e.g. ```u.kpix``) are now handled correctly. (`#5301 <https://github.com/sunpy/sunpy/pull/5301>`__)
 - Fractional inputs to the ``dimensions`` and ``offset`` arguments to
   :meth:`sunpy.map.GenericMap.superpixel` were previously rounded using `int`
-  in the superpixel algorithm, but not assigned integer values in the new meatadata.
-  This has now been changed so the rounding is correctly reflected in the meatadata. (`#5301 <https://github.com/sunpy/sunpy/pull/5301>`__)
+  in the superpixel algorithm, but not assigned integer values in the new metadata.
+  This has now been changed so the rounding is correctly reflected in the metadata. (`#5301 <https://github.com/sunpy/sunpy/pull/5301>`__)
 - Remove runtime use of ``astropy.tests.helper.assert_quantity_allclose`` which
-  introduces a runtime dependancy on ``pytest``. (`#5305 <https://github.com/sunpy/sunpy/pull/5305>`__)
+  introduces a runtime dependency on ``pytest``. (`#5305 <https://github.com/sunpy/sunpy/pull/5305>`__)
 - :meth:`sunpy.map.GenericMap.resample` now keeps the reference coordinate of the
   WCS projection the same as the input map, and updates the reference pixel accordingly.
   This fixes inconsistencies in the input and output world coordinate systems when a
@@ -476,7 +476,7 @@ Added/Improved Documentation
 Backwards Incompatible Changes
 ------------------------------
 
-- ``sunpy.instr`` has been depreacted and will be removed in sunpy 3.1 in favour of `sunkit_instruments`.
+- ``sunpy.instr`` has been deprecated and will be removed in sunpy 3.1 in favour of `sunkit_instruments`.
   The code that is under ``sunpy.instr`` is imported via `sunkit_instruments` to ensure backwards comparability. (`#4526 <https://github.com/sunpy/sunpy/pull/4526>`__)
 - Several `sunpy.map.GenericMap` attributes have been updated to return `None` when the relevant piece of FITS metadata is missing. These are:
 
@@ -610,10 +610,10 @@ Bug Fixes
   (e.g. ```u.kpix``) are now handled correctly. (`#5301 <https://github.com/sunpy/sunpy/pull/5301>`__)
 - Fractional inputs to the ``dimensions`` and ``offset`` arguments to
   :meth:`sunpy.map.GenericMap.superpixel` were previously rounded using `int`
-  in the superpixel algorithm, but not assigned integer values in the new meatadata.
-  This has now been changed so the rounding is correctly reflected in the meatadata. (`#5301 <https://github.com/sunpy/sunpy/pull/5301>`__)
+  in the superpixel algorithm, but not assigned integer values in the new metadata.
+  This has now been changed so the rounding is correctly reflected in the metadata. (`#5301 <https://github.com/sunpy/sunpy/pull/5301>`__)
 - Remove runtime use of ``astropy.tests.helper.assert_quantity_allclose`` which
-  introduces a runtime dependancy on ``pytest``. (`#5305 <https://github.com/sunpy/sunpy/pull/5305>`__)
+  introduces a runtime dependency on ``pytest``. (`#5305 <https://github.com/sunpy/sunpy/pull/5305>`__)
 - :meth:`sunpy.map.GenericMap.resample` now keeps the reference coordinate of the
   WCS projection the same as the input map, and updates the reference pixel accordingly.
   This fixes inconsistencies in the input and output world coordinate systems when a
@@ -739,7 +739,7 @@ Backwards Incompatible Changes
 - Results from the `~sunpy.net.dataretriever.NOAAIndicesClient` and the
   `~sunpy.net.dataretriever.NOAAPredictClient` no longer has ``Start Time`` or
   ``End Time`` in their results table as the results returned from the client are
-  not dependant upon the time parameter of a search. (`#4798 <https://github.com/sunpy/sunpy/pull/4798>`__)
+  not dependent upon the time parameter of a search. (`#4798 <https://github.com/sunpy/sunpy/pull/4798>`__)
 - The ``sunpy.net.vso.QueryResponse.search`` method has been removed as it has not
   worked since the 1.0 release of sunpy. (`#4798 <https://github.com/sunpy/sunpy/pull/4798>`__)
 - The ``sunpy.net.hek.hek.HEKColumn`` class has been removed, the ``HEKTable`` class
@@ -802,7 +802,7 @@ Deprecations
 - ``sunpy.net.hek.attrs.Time`` is deprecated; `~sunpy.net.attrs.Time` should be used instead. (`#4358 <https://github.com/sunpy/sunpy/pull/4358>`__)
 - Support for :func:`sunpy.coordinates.wcs_utils.solar_wcs_frame_mapping` to
   use the ``.heliographic_observer`` and ``.rsun`` attributes on a
-  `~astropy.wcs.WCS` is depreacted. (`#4620 <https://github.com/sunpy/sunpy/pull/4620>`__)
+  `~astropy.wcs.WCS` is deprecated. (`#4620 <https://github.com/sunpy/sunpy/pull/4620>`__)
 - The ``origin`` argument to `sunpy.map.GenericMap.pixel_to_world` and
   `sunpy.map.GenericMap.world_to_pixel` is deprecated.
 
@@ -829,7 +829,7 @@ Features
 --------
 
 
-- For :meth:`sunpy.map.GenericMap.quicklook` and :meth:`sunpy.map.MapSequence.quicklook` (also used for the HTML reprsentation shown in Jupyter notebooks), the histogram is now shaded corresponding to the colormap of the plotted image.
+- For :meth:`sunpy.map.GenericMap.quicklook` and :meth:`sunpy.map.MapSequence.quicklook` (also used for the HTML representation shown in Jupyter notebooks), the histogram is now shaded corresponding to the colormap of the plotted image.
   Clicking on the histogram will toggle an alternate version of the histogram. (`#4931 <https://github.com/sunpy/sunpy/pull/4931>`__)
 - Add an ``SRS_TABLE`` file to the sample data, and use it in the magnetogram
   plotting example. (`#4993 <https://github.com/sunpy/sunpy/pull/4993>`__)
@@ -890,7 +890,7 @@ Features
 - Add support for GOES XRS netcdf files to be read as a `sunpy.timeseries.sources.XRSTimeSeries`. (`#4592 <https://github.com/sunpy/sunpy/pull/4592>`__)
 - Add `~sunpy.net.jsoc.attrs.Cutout` attr for requesting cutouts
   from JSOC via `~sunpy.net.jsoc.JSOCClient` and ``Fido``. (`#4595 <https://github.com/sunpy/sunpy/pull/4595>`__)
-- sunpy now sets auxillary parameters on `sunpy.map.GenericMap.wcs` using the
+- sunpy now sets auxiliary parameters on `sunpy.map.GenericMap.wcs` using the
   `astropy.wcs.Wcsprm.aux` attribute. This stores observer information, along with
   the reference solar radius if present. (`#4620 <https://github.com/sunpy/sunpy/pull/4620>`__)
 - The `~sunpy.coordinates.frames.HeliographicCarrington` frame now accepts the specification of ``observer='self'`` to indicate that the coordinate itself is also the observer for the coordinate frame.
@@ -999,7 +999,7 @@ Bug Fixes
   This 2D->3D upgrade is performed internally when transforming a 2D `~sunpy.coordinates.frames.Helioprojective` coordinate to any other coordinate frame. (`#4724 <https://github.com/sunpy/sunpy/pull/4724>`__)
 - All columns from a :meth:`sunpy.net.vso.vso.VSOClient.search` will now be shown. (`#4788 <https://github.com/sunpy/sunpy/pull/4788>`__)
 - The search results object returned from ``Fido.search``
-  (`~sunpy.net.fido_factory.UnifiedResponse`) now correcly counts all results in
+  (`~sunpy.net.fido_factory.UnifiedResponse`) now correctly counts all results in
   it's `~sunpy.net.fido_factory.UnifiedResponse.file_num` property. Note that
   because some ``Fido`` clients now return metadata only results, this is really
   the number of records and does not always correspond to the number of files
@@ -1223,7 +1223,7 @@ Bug Fixes
 - Fixes a bug in fido_factory to allow  path="./" in fido.fetch(). (`#4058 <https://github.com/sunpy/sunpy/pull/4058>`__)
 - Prevented ``sunpy.io.fits.header_to_fits`` modifying the passed header in-place. (`#4067 <https://github.com/sunpy/sunpy/pull/4067>`__)
 - Strip out any unknown unicode from the HEK response to prevent it failing to load some results. (`#4088 <https://github.com/sunpy/sunpy/pull/4088>`__)
-- Fixed a bug in :func:`~sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst` that resulted in a error when requesting an array of locations in conjuction with enabling the light-travel-time correction. (`#4112 <https://github.com/sunpy/sunpy/pull/4112>`__)
+- Fixed a bug in :func:`~sunpy.coordinates.ephemeris.get_body_heliographic_stonyhurst` that resulted in a error when requesting an array of locations in conjunction with enabling the light-travel-time correction. (`#4112 <https://github.com/sunpy/sunpy/pull/4112>`__)
 - `sunpy.map.GenericMap.top_right_coord` and `~sunpy.map.GenericMap.center`
   have had their definitions clarified, and both have had off-by-one indexing
   errors fixed. (`#4121 <https://github.com/sunpy/sunpy/pull/4121>`__)
@@ -1281,7 +1281,7 @@ Improved Documentation
 - Mini-galleries are now easier to create in the documentation thanks to a custom Sphinx directive (``minigallery``).
   The page :ref:`sunpy-coordinates-rotatedsunframe` has an example of a mini-gallery at the bottom. (`#4124 <https://github.com/sunpy/sunpy/pull/4124>`__)
 - Added `sunpy.visualization.colormaps.color_tables` to the docs. (`#4182 <https://github.com/sunpy/sunpy/pull/4182>`__)
-- Made minor improvments to the map histogramming example. (`#4205 <https://github.com/sunpy/sunpy/pull/4205>`__)
+- Made minor improvements to the map histogramming example. (`#4205 <https://github.com/sunpy/sunpy/pull/4205>`__)
 - Add a warning to `sunpy.io` docs to recommend not using it for FITS (`#4208 <https://github.com/sunpy/sunpy/pull/4208>`__)
 
 
@@ -1364,7 +1364,7 @@ Features
 - Added the coordinate frames `~sunpy.coordinates.frames.HeliocentricEarthEcliptic` (HEE), `~sunpy.coordinates.frames.GeocentricSolarEcliptic` (GSE), `~sunpy.coordinates.frames.HeliocentricInertial` (HCI), and `~sunpy.coordinates.frames.GeocentricEarthEquatorial` (GEI). (`#3212 <https://github.com/sunpy/sunpy/pull/3212>`__)
 - Added SunPy Map support for GOES SUVI images. (`#3269 <https://github.com/sunpy/sunpy/pull/3269>`__)
 - - Support APE14 for ``ImageAnimatorWCS`` in SunPy's visualization module (`#3275 <https://github.com/sunpy/sunpy/pull/3275>`__)
-- Add ability to disable progressbars when dowloading files using `sunpy.net.helioviewer` and edited docstrings to mention this feature. (`#3280 <https://github.com/sunpy/sunpy/pull/3280>`__)
+- Add ability to disable progressbars when downloading files using `sunpy.net.helioviewer` and edited docstrings to mention this feature. (`#3280 <https://github.com/sunpy/sunpy/pull/3280>`__)
 - Adds support for searching and downloading SUVI data. (`#3301 <https://github.com/sunpy/sunpy/pull/3301>`__)
 - Log all VSO XML requests and responses to the SunPy logger at the ``DEBUG``
   level. (`#3330 <https://github.com/sunpy/sunpy/pull/3330>`__)
@@ -1415,7 +1415,7 @@ Bug Fixes
   ensure that the default reference pixel is indexed from 1. (`#3184 <https://github.com/sunpy/sunpy/pull/3184>`__)
 - Fixed the missing transformation between two `~sunpy.coordinates.HeliographicCarrington` frames with different observation times. (`#3186 <https://github.com/sunpy/sunpy/pull/3186>`__)
 - `sunpy.map.sources.AIAMap` and `sunpy.map.sources.HMIMap` will no longer assume
-  the existance of certain header keys. (`#3217 <https://github.com/sunpy/sunpy/pull/3217>`__)
+  the existence of certain header keys. (`#3217 <https://github.com/sunpy/sunpy/pull/3217>`__)
 - :func:`sunpy.map.header_helper.make_fitswcs_header` now supports specifying the map projection
   rather than defaulting to ``TAN``. (`#3218 <https://github.com/sunpy/sunpy/pull/3218>`__)
 - Fix the behaviour of
@@ -1455,7 +1455,7 @@ Bug Fixes
   tarball (`#3423 <https://github.com/sunpy/sunpy/pull/3423>`__)
 - Fixed a bug where clipping behavior had been enabled by default in the plotting normalizers for ``Map`` objects.  Clipping needs to be disabled to make use of the over/under/masked colors in the colormap. (`#3427 <https://github.com/sunpy/sunpy/pull/3427>`__)
 - Fix a bug with observer based frames that prevented a coordinate with an array of obstimes being transformed to other frames. (`#3455 <https://github.com/sunpy/sunpy/pull/3455>`__)
-- `sunpy.map.GenericMap` will no longer raise a warning if the posisition of the
+- `sunpy.map.GenericMap` will no longer raise a warning if the position of the
   observer is not known for frames that don't need an observer, i.e. heliographic
   frames. (`#3462 <https://github.com/sunpy/sunpy/pull/3462>`__)
 - Apply `os.path.expanduser` to `sunpy.map.map_factory.MapFactory` input
@@ -1657,8 +1657,8 @@ Bug Fixes
 - ``sunpy.instr.fermi.met_to_utc`` now returns the correct utc time which takes into account the leap seconds that have passed. (`#2679 <https://github.com/sunpy/sunpy/pull/2679>`__)
 - Support passing Python file objects to ``sunpy.io.fits.write``. (`#2688 <https://github.com/sunpy/sunpy/pull/2688>`__)
 - Added DRMS to setup.py so sunpy[all] installs it as a dependency. (`#2693 <https://github.com/sunpy/sunpy/pull/2693>`__)
-- Fix eve 0cs timeseries seperator regex to support Python 3.7 (`#2697 <https://github.com/sunpy/sunpy/pull/2697>`__)
-- Fix the bug which crashes `~sunpy.map.sources.LASCOMap` for when 'date-obs' is reformatted agian from a self applied function. (`#2700 <https://github.com/sunpy/sunpy/pull/2700>`__)
+- Fix eve 0cs timeseries separator regex to support Python 3.7 (`#2697 <https://github.com/sunpy/sunpy/pull/2697>`__)
+- Fix the bug which crashes `~sunpy.map.sources.LASCOMap` for when 'date-obs' is reformatted again from a self applied function. (`#2700 <https://github.com/sunpy/sunpy/pull/2700>`__)
 - Change all instances of quantity_allclose to `astropy.units.allclose` this prevents pytest being needed to import `sunpy.coordinates` on Astropy 3 (`#2701 <https://github.com/sunpy/sunpy/pull/2701>`__)
 - Fix RHESSI obssum file downloading to include the final day in the time range. (`#2714 <https://github.com/sunpy/sunpy/pull/2714>`__)
 - Raise an error when transforming between HPC and HCC frames if the observer is not the same. (`#2725 <https://github.com/sunpy/sunpy/pull/2725>`__)
@@ -1712,7 +1712,7 @@ Improved Documentation
 - Added gallery example showing how to access the SunPy colormaps (`#2865 <https://github.com/sunpy/sunpy/pull/2865>`__)
 - Added gallery example showing how to access the SunPy solar physics constants. (`#2882 <https://github.com/sunpy/sunpy/pull/2882>`__)
 - Major clean up of the developer documentation. (`#2951 <https://github.com/sunpy/sunpy/pull/2951>`__)
-- Overhaul of the install intructions for the guide section of our documentation. (`#3147 <https://github.com/sunpy/sunpy/pull/3147>`__)
+- Overhaul of the install instructions for the guide section of our documentation. (`#3147 <https://github.com/sunpy/sunpy/pull/3147>`__)
 
 
 Trivial/Internal Changes
@@ -1731,7 +1731,7 @@ Trivial/Internal Changes
   the generated images and expected images. (`#2660 <https://github.com/sunpy/sunpy/pull/2660>`__)
 - Change to using pytest-cov for coverage report generation to enable support for parallel builds (`#2667 <https://github.com/sunpy/sunpy/pull/2667>`__)
 - Use of `textwrap` to keep source code indented when multiline texts is used (`#2671 <https://github.com/sunpy/sunpy/pull/2671>`__)
-- Fix mispelling of private attribute ``_default_heliographic_latitude`` in map. (`#2730 <https://github.com/sunpy/sunpy/pull/2730>`__)
+- Fix misspelling of private attribute ``_default_heliographic_latitude`` in map. (`#2730 <https://github.com/sunpy/sunpy/pull/2730>`__)
 - Miscellaneous fixes to developer docs about building sunpy's documentation. (`#2825 <https://github.com/sunpy/sunpy/pull/2825>`__)
 - Changed ``sunpy.instr.aia.aiaprep`` to update BITPIX keyword to reflect the float64 dtype. (`#2831 <https://github.com/sunpy/sunpy/pull/2831>`__)
 - Remove warning from ``GenericMap.submap`` when using pixel ``Quantities`` as input. (`#2833 <https://github.com/sunpy/sunpy/pull/2833>`__)
@@ -1780,7 +1780,7 @@ Bug Fixes
 - Updated docstring with pointer to access EVE data for other levels [#2402]
 - Fix broken links and redirections in documentation [#2403]
 - Fixes Documentation changes due to NumPy 1.14 [#2404]
-- Added docstrings to functions in dowload.py [#2415]
+- Added docstrings to functions in download.py [#2415]
 - Clean up database doc [#2414]
 - rhessi.py now uses sunpy.io instead of astropy.io [#2416]
 - Remove Gamma usage in Map [#2424]
@@ -2023,7 +2023,7 @@ Bug fixes
 0.7.5
 =====
 
--  Fix test faliure (mapbase) with 1.7.4
+-  Fix test failure (mapbase) with 1.7.4
 -  Restrict supported Astropy version to 1.0<astropy<1.3
 -  Add Figure test env to SunPy repo.
 
@@ -2323,7 +2323,7 @@ Bug fixes
 
 -  MAJOR FIX: map.rotate() now works correctly for all submaps and off
    center rotations.
--  HELIO URL updated, querys should now work as expected.
+-  HELIO URL updated, queries should now work as expected.
 -  All tabs removed from the code base.
 -  All tests now use tempfile rather than creating files in the current
    directory.
@@ -2358,8 +2358,8 @@ Bug fixes
 -  Cleaned up the sunpy namespace, removed .units, /ssw and .sphinx.
    Also moved .coords .physics.transforms.
 -  Added contains functionality to TimeRange module
--  Added t-'now' to parse\_time to privide utcnow datetime.
--  Fixed time dependant functions (.sun) to default to t-'now'
+-  Added t-'now' to parse\_time to provide utcnow datetime.
+-  Fixed time dependent functions (.sun) to default to t-'now'
 -  Fixed solar\_semidiameter\_angular\_size
 -  Improved line quality and performances issues with map.draw\_grid()
 -  Remove deprecated make\_map command.
@@ -2377,7 +2377,7 @@ Bug fixes
 -  Change of source for GOES data.
 -  Fix EIT test data and sunpy FITS saving
 -  Some documentation fixes
--  fix file paths to use os.path.join for platform independance.
+-  fix file paths to use os.path.join for platform independence.
 
 0.4.0
 =====
@@ -2399,7 +2399,7 @@ Bug fixes
 -  The Glymur library is now used to read JPEG2000 files.
 -  GOESLightCurve now supports all satellites.
 -  Add support for VSO queries through proxies.
--  Fix apparent Right Ascension calulations.
+-  Fix apparent Right Ascension calculations.
 -  LightCurve meta data member now an OrderedDict Instance
 
 0.3.2
@@ -2412,7 +2412,7 @@ Bug fixes
 -  Update to new EVE data URL
 -  Update LogicalLightcurve example in docs
 -  Improved InteractiveVSOClient documentation
--  GOESLightCurve now fails politely if no data is avalible.
+-  GOESLightCurve now fails politely if no data is available.
 
 Known Bugs:
 
@@ -2434,14 +2434,14 @@ Known Bugs:
 -  Parse\_time now looks through nested lists/tuples
 -  Draw\_limb and draw\_grid are now implemented on MapCube and
    CompositeMap
--  Caculations for differential roation added
+-  Calculations for differential rotation added
 -  mapcube.plot() now runs a mpl animation with optional controls
 -  A basic Region of Interest framework now exists under sunpy.roi
 -  STEREO COR colour maps have been ported from solarsoft.
 -  sunpy.time.timerange has a split() method that divides up a time
    range into n equal parts.
 -  Added download progress bar
--  pyfits is depricated in favor of Astropy
+-  pyfits is deprecated in favor of Astropy
 
 spectra:
 
@@ -2455,11 +2455,11 @@ new factory class \* sunpy.map.Map is now sunpy.map.GenericMap \*
 mymap.header is now mymap.meta \* attributes of the map class are now
 read only, changes have to be made through map.meta \* new MapMeta class
 to replace MapHeader, MapMeta is not returned by sunpy.io \* The
-groundwork for GenericMap inherting from astropy.NDData has been done,
+groundwork for GenericMap inheriting from astropy.NDData has been done,
 there is now a NDDataStandin class to provide basic functionality.
 
 io: \* top level file\_tools improved to be more flexible and support
-multiple HDUs \* all functions in sunpy.io now assume mutliple HDUs,
+multiple HDUs \* all functions in sunpy.io now assume multiple HDUs,
 even JP2 ones. \* there is now a way to override the automatic filetype
 detection \* Automatic fits file detection improved \* extract\_waveunit
 added to io.fits for detection of common ways of storing wavelength unit

--- a/changelog/6434.removal.rst
+++ b/changelog/6434.removal.rst
@@ -1,3 +1,3 @@
-Most of the `sunpy.visualization.animator` subpackge has been removed, with the exception of `~sunpy.visualization.animator.MapSequenceAnimator`
+Most of the `sunpy.visualization.animator` subpackage has been removed, with the exception of `~sunpy.visualization.animator.MapSequenceAnimator`
 It has been moved into the standalone `mpl-animators <https://pypi.org/project/mpl-animators>`_ package
 Please update your imports to replace ``sunpy.visualization.animator`` with ``mpl_animators``.

--- a/changelog/6574.trivial.rst
+++ b/changelog/6574.trivial.rst
@@ -1,0 +1,3 @@
+Added a pre-commit hook for `codespell
+<https://github.com/codespell-project/codespell>`__, and applied
+spelling fixes throughout the package.

--- a/docs/code_ref/coordinates/carrington.rst
+++ b/docs/code_ref/coordinates/carrington.rst
@@ -82,7 +82,7 @@ Compared to |AA| and older methods of calculation
 |AA| publishes the apparent sub-Earth Carrington longitude (|L0|), and these values include the stellar-aberration correction.
 Consequently, SunPy values will be consistently ~0.006 degrees (~20 arcseconds) greater than |AA| values, although these discrepancies are not always apparent at the printed precision (0.01 degrees).
 
-Since |AA| specifically tuned the IAU parameters to minimize the discrepancies with older methods of calulation under their prescription that includes the stellar-aberration correction, SunPy values will also be ~20 arcseconds greater than values calculated using older methods.
+Since |AA| specifically tuned the IAU parameters to minimize the discrepancies with older methods of calculation under their prescription that includes the stellar-aberration correction, SunPy values will also be ~20 arcseconds greater than values calculated using older methods.
 Be aware that older methods of calculation may not have accounted for the variable light travel time between the Sun and the Earth, which can cause additional discrepancies of up to ~5 arcseconds.
 
 |AA| does not appear to account for the difference in light travel time between the sub-Earth point on the Sun's surface and the center of the Sun (~2.3 lightseconds), which results in a fixed discrepancy of ~1.4 arcseconds in |L0|.

--- a/docs/dev_guide/contents/code_standards.rst
+++ b/docs/dev_guide/contents/code_standards.rst
@@ -74,7 +74,7 @@ The decision is up to the developer, but if these might be useful for other pack
 Formatting
 ==========
 
-We enforce a minimum level of code style with our continuous intergration (the name is ``sunpy.sunpy (python_codestyle [linux]``).
+We enforce a minimum level of code style with our continuous integration (the name is ``sunpy.sunpy (python_codestyle [linux]``).
 This runs a tool called `pre-commit <https://pre-commit.com/>`__.
 
 The settings and tools we use for the pre-commit can be found in the file :file:`.pre-commit-config.yaml` at the root of the sunpy git repository.

--- a/docs/dev_guide/contents/conda_for_dependencies.rst
+++ b/docs/dev_guide/contents/conda_for_dependencies.rst
@@ -42,7 +42,7 @@ Editable Installation of ``sunpy``
 ==================================
 
 If you plan to modify the code of ``sunpy`` itself, you will want to perform an "editable install" of your local repository, via ``pip``, so that Python will link to your local repository.
-Normally it is discouraged to have an environment that mixes package installations via ``conda`` with package installations via ``pip`` because it can lead to enviroment states that confuse the ``conda`` solver.
+Normally it is discouraged to have an environment that mixes package installations via ``conda`` with package installations via ``pip`` because it can lead to environment states that confuse the ``conda`` solver.
 That is the reason why our instructions for new developers recommends that dependencies be installed exclusively via ``pip``.
 However, some of the dependencies in the complete set are difficult or even impossible to install via ``pip`` alone, yet are straightforward to install via ``conda``.
 

--- a/docs/dev_guide/contents/extending_fido.rst
+++ b/docs/dev_guide/contents/extending_fido.rst
@@ -7,7 +7,7 @@ Extending Fido with New Sources of Data
 Sunpy's data search and retrieval tool (``Fido``) is designed to be extensible, so that new sources of data or metadata can be supported, either inside or outside the sunpy core package.
 There are two ways of defining a new client, depending on the complexity of the web service.
 A "scraper" client inherits from `~sunpy.net.dataretriever.client.GenericClient` which provides helper methods for downloading from a list of URLs.
-If the service you want to add has easily accesible HTTP or FTP URLs that have a well defined folder and filename structure, this is probably the best approach.
+If the service you want to add has easily accessible HTTP or FTP URLs that have a well defined folder and filename structure, this is probably the best approach.
 If the service you want to add requires making requests to an API with parameters for the search and getting a list of results in return, then you probably want to write a "full" client.
 
 Before writing a new client, ensure you are familiar with how searches are specified by the `sunpy.net.attr` system, including combining them with logical operations.
@@ -75,7 +75,7 @@ A good example of the use of these two methods is the `sunpy.net.dataretriever.s
 
 It may also be possible that the ``baseurl`` property needs to be customised based on attrs other than Time.
 Since `~sunpy.net.scraper.Scraper` doesn't currently support generating directories that have non-time variables, the :meth:`~sunpy.net.dataretriever.client.GenericClient.search` needs to be customised.
-The search method should in this case, generate a ``baseurl`` dependant on the values of these attrs, and then call ``super().search`` or `~sunpy.net.scraper.Scraper` for each ``baseurl`` generated.
+The search method should in this case, generate a ``baseurl`` dependent on the values of these attrs, and then call ``super().search`` or `~sunpy.net.scraper.Scraper` for each ``baseurl`` generated.
 For an example of a complex modification of the ``search()`` method see the implementation of `.SUVIClient.search`.
 
 Customizing the Downloader
@@ -105,7 +105,7 @@ Suppose any file of a data archive can be described by this URL ``https://some-d
 ``baseurl`` becomes ``r'https://some-domain.com/%Y/%m/%d/satname_(\d){2}_(\d){1}_(\d){12}_(\d){2}\.fits'``.
 
 Note all variables in the filename are converted to regex that will match any possible value for it.
-A character enclosed within ``()`` followed by a number enclosed within ``{}`` is used to match the specified number of occurences of that special sequence.
+A character enclosed within ``()`` followed by a number enclosed within ``{}`` is used to match the specified number of occurrences of that special sequence.
 For example, ``%y%m%d%H%M%S`` is a twelve digit variable (with 2 digits for each item) and thus represented by ``r'(\d){12}'``.
 Note that ``\`` is used to escape the special character ``.``.
 
@@ -169,7 +169,7 @@ it would be passed to the client as
 So you can process each element of the OR in turn without having to consult any other part of the query.
 
 If the query the user provided contains an OR statement you get passed an instance of `~sunpy.net.attr.AttrOr` and each sub-element of that `~sunpy.net.attr.AttrOr` will be `~sunpy.net.attr.AttrAnd` (or a single other attr class).
-If the user query dosen't contain an OR you get a single `~.Attr` instance or an `~.AttrAnd`.
+If the user query doesn't contain an OR you get a single `~.Attr` instance or an `~.AttrAnd`.
 
 For example you could get any of the following queries (using ``&`` for AND and ``|`` for OR):
 
@@ -194,7 +194,7 @@ A class is provided to facilitate this conversion, `~sunpy.net.attr.AttrWalker`.
 The `~sunpy.net.attr.AttrWalker` class consists of three main components:
 
 * **Creators**: The `~sunpy.net.attr.AttrWalker.create` method is one of two generic functions for which a different function is called for each Attr type.
-  The intended use for creators is to return a new object dependant on different attrs.
+  The intended use for creators is to return a new object dependent on different attrs.
   It is commonly used to dispatch on `~sunpy.net.attr.AttrAnd` and `~sunpy.net.attr.AttrOr`.
 
 * **Appliers**: The `~sunpy.net.attr.AttrWalker.apply` method is the same as `~sunpy.net.attr.AttrWalker.create` in that it is a generic function.

--- a/docs/dev_guide/contents/newcomers.rst
+++ b/docs/dev_guide/contents/newcomers.rst
@@ -70,7 +70,7 @@ Generally the more people that can look over a pull request the better it will t
 Code
 ----
 
-If you would prefer to code instead, the best way to start is to work on an exisiting and known `issues`_.
+If you would prefer to code instead, the best way to start is to work on an existing and known `issues`_.
 We have several repositories you can investigate.
 The main one is the sunpy repository with where all the known `issues`_ with sunpy are detailed.
 Each issue should have a series of labels that provide information about the nature of the issue.
@@ -146,7 +146,7 @@ Next we will want to setup the conda environment and we will need to add the `co
     $ conda activate sunpy-dev
 
 This will create a new conda environment called "sunpy-dev" and install the latest version of pip from the conda-forge channel.
-The next step is get a developement version of sunpy.
+The next step is get a development version of sunpy.
 This will require that `git`_ be installed.
 If you have a `GitHub`_ account, we suggest that you `fork`_ the `sunpy repository`_ (the fork button is to the top right) and **use that url for the clone step**.
 This will make submitting changes easier in the long term for you:
@@ -194,7 +194,7 @@ Now that you have written some code to address an issue.
 You will need to check two things:
 
 1. The changes you have made are correct, i.e., it fixes a bug or the feature works.
-   This requires you to run the code either manually or by writting/running a test function.
+   This requires you to run the code either manually or by writing/running a test function.
    `pytest`_ is the framework we use for this.
 
 2. The changes you have made follow the correct coding style.

--- a/docs/dev_guide/contents/tests.rst
+++ b/docs/dev_guide/contents/tests.rst
@@ -223,7 +223,7 @@ The result is::
     test.py:5: AssertionError
     =========================== 1 failed in 0.07 seconds ===========================
 
-Sometimes the output from the test suite will have ``xfail`` meaning a test has passed although it has been marked as ``@pytest.mark.xfail``), or ``skipped`` meaing a test that has been skipped due to not meeting some condition (online and figure tests are the most common).
+Sometimes the output from the test suite will have ``xfail`` meaning a test has passed although it has been marked as ``@pytest.mark.xfail``), or ``skipped`` meaning a test that has been skipped due to not meeting some condition (online and figure tests are the most common).
 
 You need to use the option ``-rs`` for skipped tests and ``-rx`` for xfailed tests, respectively.
 Or use ``-rxs`` for detailed information on both skipped and xfailed tests.

--- a/docs/guide/acquiring_data/database.rst
+++ b/docs/guide/acquiring_data/database.rst
@@ -538,7 +538,7 @@ year:
 Attributes for entries in the database can be manually edited. The
 :meth:`Database.edit` method receives the database entry to be edited and any
 number of keyword arguments to describe which values to change and how. For
-example, to change the time entires that are ``None`` to the start of the
+example, to change the time entries that are ``None`` to the start of the
 observation time (because it's possible, not because it is accurate!):
 
     >>> for database_entry in database:

--- a/docs/guide/data_types/timeseries.rst
+++ b/docs/guide/data_types/timeseries.rst
@@ -54,7 +54,7 @@ The `~sunpy.timeseries.TimeSeries` factory has the ability to create a list of T
     >>> my_ts_list = ts.TimeSeries('/goesdirectory/', source='XRS')   # doctest: +SKIP
     >>> my_ts_list = ts.TimeSeries(glob, source='XRS')   # doctest: +SKIP
 
-When manually specifing the source this functionality will only work with files from the same single source, generating a source specific child of the `~sunpy.timeseries.GenericTimeSeries` class such as the `~sunpy.timeseries.sources.goes.XRSTimeSeries` above.
+When manually specifying the source this functionality will only work with files from the same single source, generating a source specific child of the `~sunpy.timeseries.GenericTimeSeries` class such as the `~sunpy.timeseries.sources.goes.XRSTimeSeries` above.
 
 Instead of creating a list of one TimeSeries object per file, you can create a single time series from multiple files using the keyword argument ``concatenate=True``:
 

--- a/docs/guide/units.rst
+++ b/docs/guide/units.rst
@@ -8,7 +8,7 @@ sunpy makes use of the `astropy.units` for this task.
 
 Quantity objects
 ================
-All functions in sunpy that accept or return numbers associated with physcial quantities accept and return `~astropy.units.Quantity` objects.
+All functions in sunpy that accept or return numbers associated with physical quantities accept and return `~astropy.units.Quantity` objects.
 These objects represent a number (or an array of numbers) and a unit.
 This means sunpy is always explicit about the units associated with a value.
 Quantities and units are powerful tools for keeping track of variables with a physical meaning and make it straightforward to convert the same physical quantity into different units.

--- a/docs/whatsnew/0.9.rst
+++ b/docs/whatsnew/0.9.rst
@@ -36,7 +36,7 @@ By the numbers:
 * 19 new contributors
 
 There have been numerous improvements to large parts of SunPy, notably in the content of SunPy's documentation, and the continuous integration testing of SunPy.
-In addition, SunPy co-ordinate system functionality has been improved, and the transformation between SunPy specific co-ordinate systems and those implemented by Astropy is now tested.
+In addition, SunPy coordinate system functionality has been improved, and the transformation between SunPy specific coordinate systems and those implemented by Astropy is now tested.
 The `sunpy.map.CompositeMap` object has received numerous bugfixes, improving its functionality.
 Bugfixes for various animation functionality have also been implemented.
 

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -228,7 +228,7 @@ Messages can have one of several levels, in increasing order of importance:
 * DEBUG: Detailed information, typically of interest only when diagnosing problems.
 * INFO: A message conveying information about the current task, and confirming that things are working as expected.
 * WARNING: An indication that something unexpected happened, and that user action may be required.
-* ERROR: An indication that a more serious issue has occured, where something failed but the task is continuing.
+* ERROR: An indication that a more serious issue has occurred, where something failed but the task is continuing.
 * CRITICAL: A serious error, indicating that the program itself may be unable to continue running.
 
 By default, all messages except for DEBUG messages are displayed. Messages can also be sent to a file and time stamped.
@@ -383,7 +383,7 @@ Config File Location Moved
 
 If you have customised your :ref:`customizing-with-sunpyrc-files` you will need to move it to the new config file location.
 Your old file should be in ``~/.sunpy/sunpyrc`` file and the new location, which is now platform specific, can be found by running `sunpy.print_config`.
-We recommand that your take a look at the new file as available configuration options have increased.
+We recommend that your take a look at the new file as available configuration options have increased.
 
 .. _whatsnew-1.0-renamed-removed:
 

--- a/docs/whatsnew/2.1.rst
+++ b/docs/whatsnew/2.1.rst
@@ -199,7 +199,7 @@ Performance improvements
 ========================
 Several functions in `sunpy.map` have been significantly sped up with improved algorithms.
 
-In addition, `sunpy.map.GenericMap.wcs` is now cached when the map metadata remains unchanged, significantly improving performance in applications which make mutiple requests for the map WCS (e.g. plotting), and reducing the number of repeated warnings thrown when metadata is missing.
+In addition, `sunpy.map.GenericMap.wcs` is now cached when the map metadata remains unchanged, significantly improving performance in applications which make multiple requests for the map WCS (e.g. plotting), and reducing the number of repeated warnings thrown when metadata is missing.
 
 .. _whatsnew-2.1-python:
 

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -103,7 +103,7 @@ To avoid a warning pass all arguments with keywords (e.g. ``plot(title='my plot 
 
 Updated data downloader dependency
 ==================================
-The pacakge that handles downloading data from remote sources, ``parfive``, has had a recent major release to version 2.0.
+The package that handles downloading data from remote sources, ``parfive``, has had a recent major release to version 2.0.
 This new version comes with major usability improvements: removal of incomplete files and major error reporting upgrades.
 
 sunpy users are encouraged to upgrade ``parfive`` to benefit from these improvements.

--- a/examples/example_template/example_template.py
+++ b/examples/example_template/example_template.py
@@ -23,7 +23,7 @@ import numpy as np
 # continues to start with a **comment hash and space** (respecting code style)
 # is text that has to be rendered in
 # html format. Keep in mind to always keep your comments always together by
-# comment hashes. That means to break a paragraph you still need to commend
+# comment hashes. That means to break a paragraph you still need to comment
 # that line break.
 #
 # In this example the next block of code produces some plotable data. Code is

--- a/examples/map/compare_rotation_results.py
+++ b/examples/map/compare_rotation_results.py
@@ -33,7 +33,7 @@ cv2_map = hmi_map.rotate(method='opencv')
 
 ###############################################################################
 # Now for a visual comparison, the raw differences, that should highlight the differences.
-# Note that only two comparisions are shown.  Note the scale here is ± 10.
+# Note that only two comparisons are shown.  Note the scale here is ± 10.
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 6))
 
@@ -59,7 +59,7 @@ cv2_map = aia_map.rotate(30*u.deg, method='opencv')
 
 ###############################################################################
 # Now for a visual comparison, the raw differences, that should highlight the differences.
-# Note that only two comparisions are shown. Note the scale here is ± 75.
+# Note that only two comparisons are shown. Note the scale here is ± 75.
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 6))
 

--- a/examples/map_transformations/upside_down_hmi.py
+++ b/examples/map_transformations/upside_down_hmi.py
@@ -4,7 +4,7 @@ Rotating HMI maps so they're not 'upside-down'
 ==============================================
 
 This example shows how to rotate a HMI magnetogram, so when you plot it
-it appears with solar North puting up, and pointing up.
+it appears with solar North pointing up.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/plotting/xy_lims.py
+++ b/examples/plotting/xy_lims.py
@@ -37,7 +37,7 @@ xlims_world = [500, 1100]*u.arcsec
 ylims_world = [-800, 0]*u.arcsec
 
 ###############################################################################
-# We can then covert these into a SkyCoord which can be passed to :func:`~sunpy.map.GenericMap.world_to_pixel` to
+# We can then convert these into a SkyCoord which can be passed to :func:`~sunpy.map.GenericMap.world_to_pixel` to
 # determine which pixel coordinates these represent on the Map.
 
 world_coords = SkyCoord(Tx=xlims_world, Ty=ylims_world, frame=aia_map.coordinate_frame)

--- a/examples/time_series/goes_xrs_example.py
+++ b/examples/time_series/goes_xrs_example.py
@@ -78,7 +78,7 @@ df = df[(df["xrsa_quality"] == 0) & (df["xrsb_quality"] == 0)]
 goes_15 = ts.TimeSeries(df, goes_15.meta, goes_15.units)
 
 ###############################################################
-# We can also pull out the individual GOES chanels and plot. The 0.5-4 angstrom
+# We can also pull out the individual GOES channels and plot. The 0.5-4 angstrom
 # channel is known as the "xrsa" channel and the 1-8 angstrom channel is known
 # as the "xrsb" channel.
 

--- a/examples/time_series/power_spectra_example.py
+++ b/examples/time_series/power_spectra_example.py
@@ -23,7 +23,7 @@ ts = sunpy.timeseries.TimeSeries(RHESSI_TIMESERIES)
 ###############################################################################
 # We now use SciPy's `~scipy.signal.periodogram` to estimate the
 # power spectra of the first column of the Timeseries. The first column contains
-# X-Ray emmisions in the range of 3-6 keV. An alternative version is Astropy's
+# X-Ray emissions in the range of 3-6 keV. An alternative version is Astropy's
 # `~astropy.timeseries.LombScargle` periodogram.
 
 x_ray = ts.columns[0]

--- a/examples/time_series/timeseries_peak_finding.py
+++ b/examples/time_series/timeseries_peak_finding.py
@@ -52,7 +52,7 @@ def findpeaks(series, DELTA):
         Lists consisting of pos, val pairs for both local minima points and
         local maxima points.
     """
-    # Set inital values
+    # Set initial values
     mn, mx = np.Inf, -np.Inf
     minpeaks = []
     maxpeaks = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -265,7 +265,7 @@ exclude_lines =
   pragma: py{ignore_python_version}
 
 [codespell]
-skip = *.png,*cache*,*egg*,.git,.idea,.tox,_build,*.fits,*.fts,*extern,*.header,data,*.xsh,*.json
+skip = *.png,*cache*,*egg*,.git,.idea,.tox,_build,*.fits,*.fts,*extern*,*.header,data,*.xsh,*.json
 ignore-words-list =
     alog,
     nd,

--- a/setup.cfg
+++ b/setup.cfg
@@ -265,7 +265,7 @@ exclude_lines =
   pragma: py{ignore_python_version}
 
 [codespell]
-skip = *.png,*cache*,*egg*,.git,.idea,.tox,_build,*.fits,*.fts,*extern,data,*.xsh
+skip = *.png,*cache*,*egg*,.git,.idea,.tox,_build,*.fits,*.fts,*extern,*.header,data,*.xsh,*.json
 ignore-words-list =
     alog,
     nd,

--- a/setup.cfg
+++ b/setup.cfg
@@ -263,3 +263,14 @@ exclude_lines =
   def main\(.*\):
   # Ignore branches that don't pertain to this version of Python
   pragma: py{ignore_python_version}
+
+[codespell]
+skip = *.png,*cache*,*egg*,.git,.idea,.tox,_build,*.fits,*.fts,*extern,data,*.xsh
+ignore-words-list =
+    alog,
+    nd,
+    nin,
+    observ,
+    ot,
+    te,
+    upto

--- a/setup.cfg
+++ b/setup.cfg
@@ -265,7 +265,7 @@ exclude_lines =
   pragma: py{ignore_python_version}
 
 [codespell]
-skip = *.png,*cache*,*egg*,.git,.idea,.tox,_build,*.fits,*.fts,*extern*,*.header,data,*.xsh,*.json
+skip = *.asdf,*.fits,*.fts,*.header,*.json,*.xsh,*cache*,*egg*,*extern*,.git,.idea,.tox,_build,*truncated
 ignore-words-list =
     alog,
     nd,

--- a/sunpy/coordinates/offset_frame.py
+++ b/sunpy/coordinates/offset_frame.py
@@ -12,7 +12,7 @@ class NorthOffsetFrame:
     The original coordinate frame and the direction of the new north pole are specified by the
     ``north`` keyword.
 
-    This class should be used when specifying a new north pole is natural.  In constrast, for
+    This class should be used when specifying a new north pole is natural.  In contrast, for
     shifting the origin in the projected sky (e.g., where helioprojective X and Y coordinates are
     zero), use `~astropy.coordinates.SkyOffsetFrame` instead.
 

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -360,7 +360,7 @@ def true_declination(t='now', equinox_of_date=True):
         result = np.arcsin(np.sin(lat) * np.cos(obl) + np.cos(lat) * np.sin(obl) * np.sin(lon))
     else:
         # J2000.0 epoch
-        # Calculate Earth's true geometric declination relative to the Sun and multipy by -1.
+        # Calculate Earth's true geometric declination relative to the Sun and multiply by -1.
         # This approach is used because Astropy's GCRS includes aberration.
         earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU, frame='gcrs', obstime=parse_time(t))
         result = -earth.hcrs.dec

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -43,7 +43,7 @@ from sunpy.time import parse_time
 def test_hcc_to_hgs():
     '''
     Check that a coordinate pointing to the observer in Heliocentric
-    coordinates maps to the lattitude/longitude of the observer in
+    coordinates maps to the latitude/longitude of the observer in
     HeliographicStonyhurst coordinates.
     '''
     lat = 10 * u.deg

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -15,8 +15,8 @@ from sunpy.coordinates.utils import (
 from sunpy.sun import constants
 
 # Test the great arc code against calculable quantities
-# The inner angle is the same between each pair of co-ordinates.  You can
-# calculate these co-ordinates using the inner angle formulae as listed here:
+# The inner angle is the same between each pair of coordinates.  You can
+# calculate these coordinates using the inner angle formulae as listed here:
 # https://en.wikipedia.org/wiki/Great-circle_distance
 
 

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -72,7 +72,7 @@ def test_wcs_frame_mapping_observer_hgc_self():
 
 def test_wcs_aux():
     """
-    Make sure auxillary information round trips properly from coordinate frames
+    Make sure auxiliary information round trips properly from coordinate frames
     to WCS and back.
     """
     data = np.ones([6, 6], dtype=np.float64)

--- a/sunpy/coordinates/transformations.py
+++ b/sunpy/coordinates/transformations.py
@@ -243,19 +243,19 @@ def _transformation_debug(description):
             debug_output = log.getEffectiveLevel() <= logging.DEBUG
 
             if debug_output:
-                # Indention for transformation layer
-                indention = u"\u2502   " * _layer_level
+                # Indentation for transformation layer
+                indentation = u"\u2502   " * _layer_level
 
-                # For the input arguments, add indention to any lines after the first line
-                from_str = str(args[0]).replace("\n", f"\n       {indention}\u2502       ")
-                to_str = str(args[1]).replace("\n", f"\n       {indention}\u2502       ")
+                # For the input arguments, add indentation to any lines after the first line
+                from_str = str(args[0]).replace("\n", f"\n       {indentation}\u2502       ")
+                to_str = str(args[1]).replace("\n", f"\n       {indentation}\u2502       ")
 
                 # Log the description and the input arguments
-                log.debug(f"{indention}{description}")
-                log.debug(f"{indention}\u251c\u2500From: {from_str}")
-                log.debug(f"{indention}\u251c\u2500To  : {to_str}")
+                log.debug(f"{indentation}{description}")
+                log.debug(f"{indentation}\u251c\u2500From: {from_str}")
+                log.debug(f"{indentation}\u251c\u2500To  : {to_str}")
 
-                # Increment the layer level to increase the indention for nested transformations
+                # Increment the layer level to increase the indentation for nested transformations
                 _layer_level += 1
 
             result = func(*args, **kwargs)
@@ -265,10 +265,10 @@ def _transformation_debug(description):
                 _layer_level -= 1
 
                 # For the output, add intention to any lines after the first line
-                out_str = str(result).replace("\n", f"\n       {indention}        ")
+                out_str = str(result).replace("\n", f"\n       {indentation}        ")
 
                 # Log the output
-                log.debug(f"{indention}\u2514\u2500Out : {out_str}")
+                log.debug(f"{indentation}\u2514\u2500Out : {out_str}")
 
             return result
         return wrapped_func

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -47,16 +47,16 @@ class GreatArc:
     -------
     inner_angles : `~astropy.units.Quantity`
         Angles of the points along the great arc from the start to end
-        co-ordinate.
+        coordinate.
 
     distances : `~astropy.units.Quantity`
         Distances of the points along the great arc from the start to end
-        co-ordinate.  The units are defined as those returned after transforming
-        the co-ordinate system of the start co-ordinate into its Cartesian
+        coordinate.  The units are defined as those returned after transforming
+        the coordinate system of the start coordinate into its Cartesian
         equivalent.
 
     coordinates : `~astropy.coordinates.SkyCoord`
-        Co-ordinates along the great arc in the co-ordinate frame of the
+        Coordinates along the great arc in the coordinate frame of the
         start point.
 
     References
@@ -88,7 +88,7 @@ class GreatArc:
         # Observer
         self.observer = start.observer
 
-        # Co-ordinate frame of the starting point
+        # Coordinate frame of the starting point
         self.start_frame = start.frame
 
         # Observation time
@@ -175,7 +175,7 @@ class GreatArc:
     def inner_angles(self, points=None):
         """
         Calculates the inner angles for the parameterized points along the arc
-        and returns the value in radians, from the start co-ordinate to the
+        and returns the value in radians, from the start coordinate to the
         end.
 
         Parameters
@@ -193,7 +193,7 @@ class GreatArc:
         -------
         inner_angles : `~astropy.units.Quantity`
             Angles of the points along the great arc from the start to
-            end co-ordinate.
+            end coordinate.
 
         """
         these_points = self._points_handler(points)
@@ -201,8 +201,8 @@ class GreatArc:
 
     def distances(self, points=None):
         """
-        Calculates the distance from the start co-ordinate to the end
-        co-ordinate on the sphere for all the parameterized points.
+        Calculates the distance from the start coordinate to the end
+        coordinate on the sphere for all the parameterized points.
 
         Parameters
         ----------
@@ -219,16 +219,16 @@ class GreatArc:
         -------
         distances : `~astropy.units`
             Distances of the points along the great arc from the start to end
-            co-ordinate.  The units are defined as those returned after
-            transforming the co-ordinate system of the start co-ordinate into
+            coordinate.  The units are defined as those returned after
+            transforming the coordinate system of the start coordinate into
             its Cartesian equivalent.
         """
         return self.radius * self.inner_angles(points=points).value
 
     def coordinates(self, points=None):
         """
-        Calculates the co-ordinates on the sphere from the start to the end
-        co-ordinate for all the parameterized points.  Co-ordinates are
+        Calculates the coordinates on the sphere from the start to the end
+        coordinate for all the parameterized points.  Coordinates are
         returned in the frame of the start coordinate.
 
         Parameters
@@ -245,7 +245,7 @@ class GreatArc:
         Returns
         -------
         arc : `~astropy.coordinates.SkyCoord`
-            Co-ordinates along the great arc in the co-ordinate frame of the
+            Coordinates along the great arc in the coordinate frame of the
             start point.
 
         """

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -37,7 +37,7 @@ except ImportError:
             A shape ``(6, )`` array representing ``OBSGEO-[XYZ], OBSGEO-[BLH]`` as
             returned by ``WCS.wcs.obsgeo``.
         obstime : time-like
-            The time assiociated with the coordinate, will be passed to
+            The time associated with the coordinate, will be passed to
             `~.builtin_frames.ITRS` as the obstime keyword.
 
         Returns
@@ -100,11 +100,11 @@ def solar_wcs_frame_mapping(wcs):
 
     dateobs = wcs.wcs.dateobs or None
 
-    # Get observer coordinate from the WCS auxillary information
+    # Get observer coordinate from the WCS auxiliary information
     required_attrs = {HeliographicStonyhurst: ['hgln_obs', 'hglt_obs', 'dsun_obs'],
                       HeliographicCarrington: ['crln_obs', 'hglt_obs', 'dsun_obs']}
 
-    # Get rsun from the WCS auxillary information
+    # Get rsun from the WCS auxiliary information
     rsun = wcs.wcs.aux.rsun_ref
     if rsun is not None:
         rsun *= u.m

--- a/sunpy/data/data_manager/storage.py
+++ b/sunpy/data/data_manager/storage.py
@@ -22,7 +22,7 @@ class StorageProviderBase(metaclass=ABCMeta):
     @abstractmethod
     def find_by_key(self, key, value):
         """
-        Returns the file details if value coresponding to the key
+        Returns the file details if value corresponding to the key
         found in storage. Returns `None` if hash not found.
 
         Parameters
@@ -137,7 +137,7 @@ class SqliteStorage(StorageProviderBase):
         Parameters
         ----------
         commit : `bool`
-            Whether to commit after succesful execution of db command.
+            Whether to commit after successful execution of db command.
         """
         conn = sqlite3.connect(str(self._db_path))
         self._create_table(conn)

--- a/sunpy/data/data_manager/tests/test_manager.py
+++ b/sunpy/data/data_manager/tests/test_manager.py
@@ -212,7 +212,7 @@ def test_namespacing_with_manager_override_file(module_patched_manager, download
     # Request the original file again
     data_function_from_fake_module()
 
-    # File dosn't get redownloaded, instead it is retrieved using the file hash
+    # File doesn't get redownloaded, instead it is retrieved using the file hash
     assert downloader.times_called == 2
 
     # new_file entry in manager._file_cache is replaced with the original test_file

--- a/sunpy/data/sample.py
+++ b/sunpy/data/sample.py
@@ -25,7 +25,7 @@ Sample shortnames
 """
 # download_sample_data is deprecated and not used here,
 # but during deprecation period want to keep it in this namespace
-# for backwards compatability. noqa stops it being removed by
+# for backwards compatibility. noqa stops it being removed by
 # pre-commit as an unused import
 from ._sample import download_sample_data  # noqa
 from ._sample import _SAMPLE_DATA, _get_sample_files

--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -411,7 +411,7 @@ class DatabaseEntry(DatabaseEntryType, Base):
         if self.wavemin is None and other.wavemin is None:
             wavemins_equal = True
         elif not all([self.wavemin, other.wavemin]):
-            # This means one is None and the other isnt
+            # This means one is None and the other isn't
             wavemins_equal = False
         else:
             wavemins_equal = np.allclose([self.wavemin], [other.wavemin], equal_nan=True)
@@ -419,7 +419,7 @@ class DatabaseEntry(DatabaseEntryType, Base):
         if self.wavemax is None and other.wavemax is None:
             wavemaxs_equal = True
         elif not all([self.wavemax, other.wavemax]):
-            # This means one is None and the other isnt
+            # This means one is None and the other isn't
             wavemaxs_equal = False
         else:
             wavemaxs_equal = np.allclose([self.wavemax], [other.wavemax], equal_nan=True)

--- a/sunpy/image/resample.py
+++ b/sunpy/image/resample.py
@@ -16,7 +16,7 @@ def resample(orig, dimensions, method='linear', center=False, minusone=False):
     Currently only supports maintaining the same number of dimensions.
     To use 1-D arrays, first promote them to shape (x,1).
 
-    Uses the same parameters and creates the same co-ordinate lookup points
+    Uses the same parameters and creates the same coordinate lookup points
     as IDL's ``congrid`` routine (which apparently originally came from a
     VAX/VMS routine of the same name.)
 

--- a/sunpy/image/transform.py
+++ b/sunpy/image/transform.py
@@ -34,7 +34,7 @@ def affine_transform(image, rmatrix, order=3, scale=1.0, image_center=None,
         Linear transformation rotation matrix.
     order : `int` 0-5, optional
         Interpolation order to be used, defaults to 3.  The precise meaning depends
-        on the rotation method specifed by ``method``.
+        on the rotation method specified by ``method``.
     scale : `float`
         A scale factor for the image with the default being no scaling.
     image_center : tuple, optional

--- a/sunpy/io/_fits.py
+++ b/sunpy/io/_fits.py
@@ -4,7 +4,7 @@ This module provides a FITS file reader.
 .. warning::
 
    ``sunpy.io.fits`` is deprecated, and will be removed in sunpy 4.1. This is
-   because it was designed for interal use only. We instead recommend users
+   because it was designed for internal use only. We instead recommend users
    use the `astropy.io.fits` module, which provides more generic functionality
    to read FITS files.
 

--- a/sunpy/io/special/srs.py
+++ b/sunpy/io/special/srs.py
@@ -38,7 +38,7 @@ def read_srs(filepath):
 
 def make_table(header, section_lines):
     """
-    From the seperated section lines and the header, clean up the data and
+    From the separated section lines and the header, clean up the data and
     convert to a `~astropy.table.QTable`.
     """
     meta_data = get_meta_data(header)

--- a/sunpy/map/compositemap.py
+++ b/sunpy/map/compositemap.py
@@ -390,7 +390,7 @@ class CompositeMap:
         `~matplotlib.axes.Axes.pcolormesh`, and contours are plotted using
         `~matplotlib.axes.Axes.contour`.
         The Matplotlib arguments accepted by the plotting method are passed to it.
-        (For compatability reasons, we enforce a more restrictive set of
+        (For compatibility reasons, we enforce a more restrictive set of
         accepted `~matplotlib.axes.Axes.pcolormesh` arguments.)
         If any Matplotlib arguments are not used by any plotting method,
         a ``TypeError`` will be raised.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -227,7 +227,7 @@ def _get_wcs_meta(coordinate, projection_code):
             * ctype1, ctype2
             * cunit1, cunit2
             * date_obs
-            * observer auxillary information, if set on `coordinate`
+            * observer auxiliary information, if set on `coordinate`
     """
 
     coord_meta = {}

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -68,7 +68,7 @@ _META_FIX_URL = 'https://docs.sunpy.org/en/stable/code_ref/map.html#fixing-map-m
 _meta_doc = """
 The map metadata.
 
-This is used to intepret the map data. It may
+This is used to interpret the map data. It may
 have been modified from the original metadata by sunpy. See the
 `~sunpy.util.MetaDict.added_items`, `~sunpy.util.MetaDict.removed_items`
 and `~sunpy.util.MetaDict.modified_items` properties of MetaDict
@@ -596,7 +596,7 @@ class GenericMap(NDData):
         w2.wcs.crpix = u.Quantity(self.reference_pixel) + 1 * u.pix
         # Make these a quantity array to prevent the numpy setting element of
         # array with sequence error.
-        # Explicityly call ``.to()`` to check that scale is in the correct units
+        # Explicitly call ``.to()`` to check that scale is in the correct units
         w2.wcs.cdelt = u.Quantity([self.scale[0].to(self.spatial_units[0] / u.pix),
                                    self.scale[1].to(self.spatial_units[1] / u.pix)])
         w2.wcs.crval = u.Quantity([self._reference_longitude, self._reference_latitude])
@@ -835,7 +835,7 @@ class GenericMap(NDData):
         Average time of the image acquisition.
 
         Taken from the DATE-AVG FITS keyword if present, otherwise halfway
-        between `date_start` and `date_end` if both peices of metadata are
+        between `date_start` and `date_end` if both pieces of metadata are
         present.
         """
         avg = self._get_date('date-avg')
@@ -1291,7 +1291,7 @@ class GenericMap(NDData):
         Matrix describing the transformation needed to align the reference
         pixel with the coordinate axes.
 
-        The order or precendence of FITS keywords which this is taken from is:
+        The order or precedence of FITS keywords which this is taken from is:
         - PC\*_\*
         - CD\*_\*
         - CROTA\*
@@ -1497,7 +1497,7 @@ class GenericMap(NDData):
         """
         Resample to new dimension sizes.
 
-        Uses the same parameters and creates the same co-ordinate lookup points
+        Uses the same parameters and creates the same coordinate lookup points
         as IDL''s congrid routine, which apparently originally came from a
         VAX/VMS routine of the same name.
 

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -101,7 +101,7 @@ class MapSequence:
             warn_user(f"Rendering the summary for a MapSequence of {nmaps} Maps "
                       "may take a while.")
 
-        # Assemble the individual HTML repr from each Map, all hidden initally
+        # Assemble the individual HTML repr from each Map, all hidden initially
         repr_list = [f"<div style='display: none' index={i}>{m._repr_html_()}</div>"
                      for i, m in enumerate(self.maps)]
 

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -401,7 +401,7 @@ def contains_coordinate(smap, coordinates):
     bool
         `True` if ``coordinates`` falls within the bounds of ``smap``.
         This includes the edges of the map. If multiple coordinates are input,
-        returns a boolean arrary.
+        returns a boolean array.
     """
     # Dimensions of smap
     ys, xs = smap.wcs.array_shape

--- a/sunpy/map/sources/hinode.py
+++ b/sunpy/map/sources/hinode.py
@@ -142,7 +142,7 @@ class SOTMap(GenericMap):
         super().__init__(data, header, **kwargs)
         self._nickname = self.detector
 
-        # TODO (add other options, Now all threated as intensity. This follows
+        # TODO (add other options, Now all treated as intensity. This follows
         # Hinode SDC archive) StokesQUV -> grey, Velocity -> EIS, Width -> EIS,
         # Mag Field Azi -> IDL 5 (STD gamma II)
         # 'WB' -> red

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -53,7 +53,7 @@ class EITMap(GenericMap):
     @property
     def waveunit(self):
         """
-        If WAVEUNIT FITS keyword isn't present, deafults to Angstrom.
+        If WAVEUNIT FITS keyword isn't present, defaults to Angstrom.
         """
         unit = self.meta.get("waveunit", "Angstrom") or "Angstrom"
         return u.Unit(unit)
@@ -91,7 +91,7 @@ class LASCOMap(GenericMap):
     1.1 to 32 solar radii.
 
     The C1 images rom 1.1 to 3 solar radii. The C2 telescope images the corona
-    from 2 to 6 solar radii, overlaping the outer field-of-view of C1 from 2 to
+    from 2 to 6 solar radii, overlapping the outer field-of-view of C1 from 2 to
     3 solar radii. The C3 telescope extends the field-of-view to 32 solar radii.
 
     SOHO was launched on 2 December 2 1995 into a sun-synchronous orbit.
@@ -131,7 +131,7 @@ class LASCOMap(GenericMap):
     @property
     def date(self):
         date = self.meta.get('date-obs', self.meta.get('date_obs'))
-        # Incase someone fixes the header
+        # In case someone fixes the header
         if 'T' in date:
             return parse_time(date)
 
@@ -188,7 +188,7 @@ class MDIMap(GenericMap):
     @property
     def _date_obs(self):
         if 'T' in self.meta['date-obs']:
-            # Helioviewer MDI files have the full date in DATE_OBS, but we stil
+            # Helioviewer MDI files have the full date in DATE_OBS, but we still
             # want to let normal FITS files use DATE-OBS
             return parse_time(self.meta['date-obs'])
         else:

--- a/sunpy/map/sources/tests/test_suvi_source.py
+++ b/sunpy/map/sources/tests/test_suvi_source.py
@@ -44,8 +44,8 @@ def test_norm_clip(suvi):
 
 
 # SUVI provides observer coordinate information in an OBSGEO system, so this test
-# needs remote data to access the latest IERS table to do a coordiante transformation from
-# OBSGEO to heliographic Stonyhurst coordiantes.
+# needs remote data to access the latest IERS table to do a coordinate transformation from
+# OBSGEO to heliographic Stonyhurst coordinates.
 @pytest.mark.remote_data
 def test_wcs(suvi):
     # Smoke test that WCS is valid and can transform from pixels to world coordinates

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -179,7 +179,7 @@ def test_errors(tmpdir):
         # Check a random unsupported type (int) fails
         sunpy.map.Map(78)
 
-    # If one file failed to load, make sure it's raised as an expection.
+    # If one file failed to load, make sure it's raised as an exception.
     p = tmpdir.mkdir("sub").join("hello.fits")
     p.write("content")
     files = [AIA_171_IMAGE, p.strpath]

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -77,7 +77,7 @@ def test_wcs(aia171_test_map):
 def test_wcs_cache(aia171_test_map):
     wcs1 = aia171_test_map.wcs
     wcs2 = aia171_test_map.wcs
-    # Check that without any changes to the header, retreiving the wcs twice
+    # Check that without any changes to the header, retrieving the wcs twice
     # returns the same object instead of recomputing the wcs
     assert wcs1 is wcs2
 

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -138,7 +138,7 @@ def test_all_meta(mapsequence_all_the_same):
 
 def test_repr(mapsequence_all_the_same, mapsequence_different_maps):
     """
-    Tests that overidden __repr__ functionality works as expected. Test
+    Tests that overridden __repr__ functionality works as expected. Test
     for mapsequence of same maps as well that of different maps.
     """
     # Test the case of MapSequence having same maps

--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -124,7 +124,7 @@ class Wavelength(Range):
             if wavemin.unit.is_equivalent(unit):
                 break
         else:
-            raise u.UnitsError(f"This unit is not convertable to any of {supported_units}")
+            raise u.UnitsError(f"This unit is not convertible to any of {supported_units}")
 
         wavemin, wavemax = sorted([wavemin.to(unit), wavemax.to(unit)])
         self.unit = unit

--- a/sunpy/net/base_client.py
+++ b/sunpy/net/base_client.py
@@ -412,7 +412,7 @@ class BaseClient(ABC):
             if name not in attrs.__all__:
                 attrs.__all__.append(name)
 
-        # Register client attrs after it has regsitered its own attrs
+        # Register client attrs after it has registered its own attrs
         from sunpy.net import attr
         values = cls.register_values()
         # If the client has no support, we won't try to register attrs

--- a/sunpy/net/cdaweb/cdaweb.py
+++ b/sunpy/net/cdaweb/cdaweb.py
@@ -67,7 +67,7 @@ class CDAWEBClient(BaseClient):
     See Also
     --------
     sunpy.net.cdaweb.get_datasets : Find dataset IDs for a given observatory
-    sunpy.net.cdaweb.get_observatory_groups : Get all observatories avaiable from CDAWeb
+    sunpy.net.cdaweb.get_observatory_groups : Get all observatories available from CDAWeb
     """
     @property
     def info_url(self):

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -51,7 +51,7 @@ class NOAAIndicesClient(GenericClient):
                 rowdict[key] = rowdict[key][0]
         rowdict['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json'
         rowdict['Instrument'] = 'NOAA-Indices'
-        # These results are not dependant on time, but we allow time as a
+        # These results are not dependent on time, but we allow time as a
         # parameter for easy searching, so remove time from the results table
         # injected by GenericClient.
         rowdict.pop('Start Time', None)
@@ -112,7 +112,7 @@ class NOAAPredictClient(GenericClient):
                 rowdict[key] = rowdict[key][0]
         rowdict['url'] = 'https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json'
         rowdict['Instrument'] = 'NOAA-Predict'
-        # These results are not dependant on time, but we allow time as a
+        # These results are not dependent on time, but we allow time as a
         # parameter for easy searching, so remove time from the results table
         # injected by GenericClient.
         rowdict.pop('Start Time', None)

--- a/sunpy/net/dataretriever/sources/tests/test_norh.py
+++ b/sunpy/net/dataretriever/sources/tests/test_norh.py
@@ -108,7 +108,7 @@ def test_query(time, wave):
     if qr1:
         # There are no observations everyday
         #  so the results found have to be equal or later than the queried time
-        #  (looking at the date because it may search for miliseconds, but only date is available)
+        #  (looking at the date because it may search for milliseconds, but only date is available)
         assert qr1[0]['Start Time'].strftime('%Y-%m-%d') >= time.start.strftime('%Y-%m-%d')
         #  and the end time equal or smaller.
         # hypothesis can give same start-end, but the query will give you from start to end (so +1)

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -243,7 +243,7 @@ def test_path_read_only(tmp_path):
     results = Fido.search(
         a.Time("2012/1/1", "2012/1/5"), a.Instrument.lyra)
 
-    # chmod dosen't seem to work correctly on the windows CI
+    # chmod doesn't seem to work correctly on the windows CI
     os.chmod(tmp_path, S_IREAD | S_IRGRP | S_IROTH)
     # Check to see if it's actually read only before running the test
     if not os.access(tmp_path, os.W_OK):

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -298,7 +298,7 @@ def test_get_timerange_with_extractor(exdict, start, end):
 
 @pytest.mark.remote_data
 def test_yearly_overlap():
-    # Check that a time range that falls within the interval that a file reprsents
+    # Check that a time range that falls within the interval that a file represents
     # returns a single result.
     pattern = "https://www.ngdc.noaa.gov/stp/space-weather/solar-data/solar-features/solar-flares/x-rays/goes/xrs/goes-xrs-report_%Y.txt"
     scraper = Scraper(pattern)

--- a/sunpy/net/vso/tests/test_attrs.py
+++ b/sunpy/net/vso/tests/test_attrs.py
@@ -133,7 +133,7 @@ def test_wave_toangstrom():
 
     with pytest.raises(u.UnitsError) as excinfo:
         core_attrs.Wavelength(10 * u.g, 23 * u.g)
-    assert ('This unit is not convertable to any of [Unit("Angstrom"), Unit("kHz"), '
+    assert ('This unit is not convertible to any of [Unit("Angstrom"), Unit("kHz"), '
             'Unit("keV")]' in str(excinfo.value))
 
 

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -290,22 +290,22 @@ def solar_rotate_coordinate(coordinate, observer=None, time=None, **diff_rot_kwa
     # Ignore some invalid NaN comparisons within astropy
     # (fixed in astropy 4.0.1 https://github.com/astropy/astropy/pull/9843)
     with np.errstate(invalid='ignore'):
-        # Compute Stonyhurst Heliographic co-ordinates - returns (longitude,
+        # Compute Stonyhurst Heliographic coordinates - returns (longitude,
         # latitude). Points off the limb are returned as nan.
         heliographic_coordinate = coordinate.transform_to(HeliographicStonyhurst)
 
         # Compute the differential rotation
         drot = diff_rot(interval, heliographic_coordinate.lat.to(u.degree), **diff_rot_kwargs)
 
-        # Rotate the input co-ordinate as seen by the original observer
+        # Rotate the input coordinate as seen by the original observer
         heliographic_rotated = SkyCoord(heliographic_coordinate.lon + drot,
                                         heliographic_coordinate.lat,
                                         heliographic_coordinate.radius,
                                         obstime=coordinate.obstime,
                                         frame=HeliographicStonyhurst)
 
-        # Calculate where the rotated co-ordinate appears as seen by new observer
-        # for the co-ordinate system of the input co-ordinate.  The translational
+        # Calculate where the rotated coordinate appears as seen by new observer
+        # for the coordinate system of the input coordinate.  The translational
         # motion of the Sun will be ignored for the transformation.
         frame_newobs = coordinate.frame.replicate_without_data(observer=new_observer,
                                                                obstime=new_observer.obstime)
@@ -483,7 +483,7 @@ def _warp_sun_coordinates(xy, smap, new_observer, **diff_rot_kwargs):
             # Re-project the pixels which are on disk back to location of the original observer
             coordinates_at_map_observer = rotated_coord.transform_to(smap.coordinate_frame)
 
-        # Go back to pixel co-ordinates
+        # Go back to pixel coordinates
         x2, y2 = smap.world_to_pixel(coordinates_at_map_observer)
 
     # Re-stack the data to make it correct output form

--- a/sunpy/sun/_constants.py
+++ b/sunpy/sun/_constants.py
@@ -1,5 +1,5 @@
 """
-This module provies a non-comprehensive collection of solar physical constants.
+This module provides a non-comprehensive collection of solar physical constants.
 """
 # TODO: Need better sources for some constants as well as error values.
 import astropy.constants.astropyconst20 as astrocon

--- a/sunpy/tests/tests/test_mocks.py
+++ b/sunpy/tests/tests/test_mocks.py
@@ -173,7 +173,7 @@ def test_read_and_write_MockOpenTextFile():
     assert rd_wr.readable() is True
     assert rd_wr.writable() is True
 
-    # Initailly empty
+    # Initially empty
     assert rd_wr.read() == ''
 
     data = '0123456789'

--- a/sunpy/tests/tests/test_self_test.py
+++ b/sunpy/tests/tests/test_self_test.py
@@ -56,6 +56,6 @@ def test_main_figure_only(monkeypatch):
 
 
 def test_warnings():
-    # Ensure that our warning trickery dosen't stop pytest.warns working
+    # Ensure that our warning trickery doesn't stop pytest.warns working
     with pytest.warns(SunpyDeprecationWarning):
         warn_deprecated("Hello")

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -1,5 +1,5 @@
 """
-This module provies a collection of time handing functions.
+This module provides a collection of time handing functions.
 """
 import re
 import textwrap

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -238,7 +238,7 @@ def convert_time_str(time_string, **kwargs):
         except ValueError:
             pass
 
-    # when no format matches, call default fucntion
+    # when no format matches, call default function
     return convert_time.dispatch(object)(time_string, **kwargs)
 
 

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -1,5 +1,5 @@
 """
-This module provies a object that can handle a time range.
+This module provides an object that can handle a time range.
 """
 from datetime import timedelta
 

--- a/sunpy/timeseries/metadata.py
+++ b/sunpy/timeseries/metadata.py
@@ -1,5 +1,5 @@
 """
-This module provies metadata support for `~sunpy.timeseries.TimeSeries`.
+This module provides metadata support for `~sunpy.timeseries.TimeSeries`.
 """
 import copy
 import itertools

--- a/sunpy/timeseries/metadata.py
+++ b/sunpy/timeseries/metadata.py
@@ -398,7 +398,7 @@ class TimeSeriesMetaData:
 
         # Now update each matching entries
         for i in indices:
-            # Seperate keys for new and current pairs
+            # Separate keys for new and current pairs
             old_keys = set(dictionary.keys())
             old_keys.intersection_update(set(self.metadata[i][2].keys()))
             new_keys = set(dictionary.keys())

--- a/sunpy/timeseries/sources/__init__.py
+++ b/sunpy/timeseries/sources/__init__.py
@@ -1,5 +1,5 @@
 """
-This module provies a collection of datasource-specific
+This module provides a collection of datasource-specific
 `~sunpy.timeseries.TimeSeries` classes.
 
 Each mission should have its own file with one or more classes defined.

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -32,7 +32,7 @@ class ESPTimeSeries(GenericTimeSeries):
     by 4 photodiodes) provides the soft X-ray measurements from 0.1-7nm.
 
     The ESP level 1 fits files are fully calibrated. The TimeSeries object created from
-    an ESP fits file will conatain 4 columns namely:
+    an ESP fits file will contain 4 columns namely:
 
         * 'QD' - sum of 4 quad diodes, this is the soft X-ray measurements 0.1-7nm
         * 'CH_18' - EUV irradiance 18nm
@@ -189,7 +189,7 @@ class EVESpWxTimeSeries(GenericTimeSeries):
     * `SDO Mission Homepage <https://sdo.gsfc.nasa.gov/>`__
     * `EVE Homepage <http://lasp.colorado.edu/home/eve/>`__
     * `Level 0CS Definition <http://lasp.colorado.edu/home/eve/data/>`__
-    * `EVE Data Acess <http://lasp.colorado.edu/home/eve/data/data-access/>`__
+    * `EVE Data Access <http://lasp.colorado.edu/home/eve/data/data-access/>`__
     * `Instrument Paper <https://doi.org/10.1007/s11207-009-9487-6>`__
     """
     # Class attribute used to specify the source class of the TimeSeries.

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -122,7 +122,7 @@ class XRSTimeSeries(GenericTimeSeries):
         pattern_1m = ("sci_xrsf-l2-avg1m_g{SatelliteNumber:02d}_d{year:4d}{month:2d}{day:2d}_{}.nc")
         pattern_telescop = ("GOES {SatelliteNumber:02d}")
         # The ordering of where we get the metadata from is important.
-        # We alway want to check ID first as that will most likely have the correct information.
+        # We always want to check ID first as that will most likely have the correct information.
         # The other fields are fallback and sometimes have data in them that is "useless".
         id = (
             self.meta.metas[0].get("id", "").strip()

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -1,5 +1,5 @@
 """
-This module provies GOES XRS `~sunpy.timeseries.TimeSeries` source.
+This module provides GOES XRS `~sunpy.timeseries.TimeSeries` source.
 """
 from pathlib import Path
 from collections import OrderedDict

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -1,5 +1,5 @@
 """
-This module provies Proba-2 `~sunpy.timeseries.TimeSeries` source.
+This module provides Proba-2 `~sunpy.timeseries.TimeSeries` source.
 """
 import sys
 from collections import OrderedDict

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -1,5 +1,5 @@
 """
-This module provies NOAA Solar Cycle `~sunpy.timeseries.TimeSeries` source.
+This module provides NOAA Solar Cycle `~sunpy.timeseries.TimeSeries` source.
 """
 from pathlib import Path
 from collections import OrderedDict

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -1,5 +1,5 @@
 """
-This module provies a Nobeyama Radioheliograph `~sunpy.timeseries.TimeSeries`
+This module provides a Nobeyama Radioheliograph `~sunpy.timeseries.TimeSeries`
 source.
 """
 from collections import OrderedDict

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -1,5 +1,5 @@
 """
-This module provies a RHESSI `~sunpy.timeseries.TimeSeries` source.
+This module provides a RHESSI `~sunpy.timeseries.TimeSeries` source.
 """
 import itertools
 from collections import OrderedDict

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -139,7 +139,7 @@ def test_read_cdf_empty_variable():
     ts = sunpy.timeseries.TimeSeries(filename)
     assert ts.quantity('nH').unit == u.cm**-3
 
-    # Reset again to check that registring units via. astropy works too
+    # Reset again to check that registering units via. astropy works too
     sunpy_cdf._known_units = {}
     u.add_enabled_units([u.def_unit('#/cm^3', represents=u.cm**-3)])
     ts = sunpy.timeseries.TimeSeries(filename)
@@ -157,7 +157,7 @@ def test_read_empty_cdf(caplog):
 
 
 def test_meta_from_fits_header():
-    # Generate the data and the corrisponding dates
+    # Generate the data and the corresponding dates
     base = parse_time(datetime.datetime.today())
     times = base - TimeDelta(np.arange(24*60)*u.minute)
     intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
@@ -183,7 +183,7 @@ def test_meta_from_fits_header():
 
 
 def test_generic_construction_basic():
-    # Generate the data and the corrisponding dates
+    # Generate the data and the corresponding dates
     base = parse_time(datetime.datetime.today())
     times = base - TimeDelta(np.arange(24 * 60)*u.minute)
     intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
@@ -207,7 +207,7 @@ def test_generic_construction_basic():
 
 
 def test_generic_construction_basic_omitted_details():
-    # Generate the data and the corrisponding dates
+    # Generate the data and the corresponding dates
     base = parse_time(datetime.datetime.today())
     times = base - TimeDelta(np.arange(24 * 60)*u.minute)
     intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
@@ -233,7 +233,7 @@ def test_generic_construction_basic_omitted_details():
 
 
 def test_generic_construction_basic_different_meta_types():
-    # Generate the data and the corrisponding dates
+    # Generate the data and the corresponding dates
     base = parse_time(datetime.datetime.today())
     times = base - TimeDelta(np.arange(24 * 60)*u.minute)
     intensity = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
@@ -258,7 +258,7 @@ def test_generic_construction_basic_different_meta_types():
 
 
 def test_generic_construction_ts_list():
-    # Generate the data and the corrisponding dates
+    # Generate the data and the corresponding dates
     base = parse_time(datetime.datetime.today())
     times = base - TimeDelta(np.arange(24 * 60)*u.minute)
     intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
@@ -289,7 +289,7 @@ def test_generic_construction_ts_list():
 
 
 def test_generic_construction_concatenation():
-    # Generate the data and the corrisponding dates
+    # Generate the data and the corresponding dates
     base = parse_time(datetime.datetime.today())
     times = base - TimeDelta(np.arange(24 * 60)*u.minute)
     intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (24*60))))
@@ -308,7 +308,7 @@ def test_generic_construction_concatenation():
     ts_2 = sunpy.timeseries.TimeSeries(data2, meta2, units2)
     ts_concat_1 = ts_1.concatenate(ts_2)
 
-    # Concatinate during construction
+    # Concatenate during construction
     ts_concat_2 = sunpy.timeseries.TimeSeries(
         data, meta, units, data2, meta2, units2, concatenate=True)
     assert isinstance(ts_concat_2, sunpy.timeseries.timeseriesbase.GenericTimeSeries)

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -357,7 +357,7 @@ def test_concatenation_different_data_ts_error(eve_test_ts, fermi_gbm_test_ts):
 
 def test_generic_construction_concatenation():
     nrows = 10
-    # Generate the data and the corrisponding dates
+    # Generate the data and the corresponding dates
     base = parse_time(datetime.datetime.today())
     times = base - TimeDelta(np.arange(nrows)*u.minute)
     intensity1 = np.sin(np.arange(0, 12 * np.pi, ((12 * np.pi) / (nrows))))
@@ -400,7 +400,7 @@ def test_add_column_from_quantity(eve_test_ts, column_quantity):
     new_ts = eve_test_ts.add_column('quantity_added', column_quantity)
     # Test the column similar to the original quantity?
     assert_quantity_allclose(new_ts.quantity('quantity_added'), column_quantity)
-    # Test the full list of columns are pressent
+    # Test the full list of columns are present
     assert set(new_ts.to_dataframe().columns) == set(
         eve_test_ts.to_dataframe().columns) | {'quantity_added'}
 
@@ -418,7 +418,7 @@ def test_remove_column(eve_test_ts):
     # Check data updated correctly
     assert len(removed.columns) == removed.to_dataframe().shape[1]
 
-    # Check that removing a non-existant column errors
+    # Check that removing a non-existent column errors
     with pytest.raises(ValueError):
         eve_test_ts.remove_column('random column name')
 
@@ -430,7 +430,7 @@ def test_add_column_from_array(eve_test_ts, column_quantity):
     assert_quantity_allclose(
         new_ts.quantity('array_added'), column_quantity)
 
-    # Test the full list of columns are pressent
+    # Test the full list of columns are present
     assert set(new_ts.to_dataframe().columns) == set(
         eve_test_ts.to_dataframe().columns) | {'array_added'}
 
@@ -489,7 +489,7 @@ def test_equality(generic_ts, table_ts):
 
 
 def test_equality_different_ts_types(generic_ts, eve_test_ts):
-    # this should fail as they're not the smae type and can't match
+    # this should fail as they're not the same type and can't match
     assert not (generic_ts == eve_test_ts)
 
 

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -1,5 +1,5 @@
 """
-This module provies the `~sunpy.timeseries.TimeSeriesFactory` class.
+This module provides the `~sunpy.timeseries.TimeSeriesFactory` class.
 """
 import os
 import copy

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -351,7 +351,7 @@ class GenericTimeSeries:
                 )
                 plt.title(self.columns[i] + " [click for other channels]")
                 plt.xlabel(self.units[self.columns[i]])
-                plt.ylabel("# of occurences")
+                plt.ylabel("# of occurrences")
                 hlist.append(_figure_to_base64(fig))
                 plt.close(fig)
 
@@ -857,7 +857,7 @@ class GenericTimeSeries:
         # Truncate the metadata
         self.meta._truncate(self.time_range)
 
-        # Remove non-existant columns
+        # Remove non-existent columns
         redundant_cols = list(set(self.meta.columns) - set(self.columns))
         self.meta._remove_columns(redundant_cols)
 

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -1,5 +1,5 @@
 """
-This module provies `sunpy.timeseries.GenericTimeSeries` which all other
+This module provides `sunpy.timeseries.GenericTimeSeries` which all other
 `sunpy.timeseries.TimeSeries` classes inherit from.
 """
 import copy

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -365,7 +365,7 @@ def cached_property_based_on(attr_name):
             cache = instance.__dict__
             prop_key = prop.__name__
 
-            # Check if our caching method has changed ouptut
+            # Check if our caching method has changed output
             new_attr_val = getattr(instance, attr_name)
             old_attr_val = cache.get(attr_name, _NOT_FOUND)
             if (old_attr_val is _NOT_FOUND or

--- a/sunpy/util/sphinx/generate.py
+++ b/sunpy/util/sphinx/generate.py
@@ -36,7 +36,7 @@ class Generate(Directive):
 
         old_stdout, sys.stdout = sys.stdout, StringIO()
         try:
-            # Exceute the Python code and capture its output
+            # Execute the Python code and capture its output
             exec('\n'.join(self.content))
             text = sys.stdout.getvalue()
 

--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -394,7 +394,7 @@ def test_popitem_with_keycomments(atomic_weights_keycomments, empty_keycomments)
 def test_update_with_distinct_keys(seas_metadict, sea_locations, atomic_weights):
     """
     Update the MetaDict 'world_seas', with another MetaDict, 'chem_elems' which
-    has a completley different set of keys.
+    has a completely different set of keys.
 
     This should result in adding 'chem_elems' onto 'world_seas'.
     Original insertion order of 'world_seas' should be preserved.

--- a/sunpy/util/tests/test_xml.py
+++ b/sunpy/util/tests/test_xml.py
@@ -293,7 +293,7 @@ def test_with_multiple_children_in_list():
     assert len(actual['Config']['Children']) == 2
 
     # As the child dictionaries are in lists we cannot be certain what order
-    # they are in. Test individualy.
+    # they are in. Test individually.
 
     expected_children = expected['Config']['Children']
     actual_children = actual['Config']['Children']

--- a/sunpy/util/util.py
+++ b/sunpy/util/util.py
@@ -148,7 +148,7 @@ def dict_keys_same(list_of_dicts):
     Parameters
     ----------
     list_of_dicts : `list` of `dict`
-          A list containing each dictonary to parse.
+          A list containing each dictionary to parse.
 
     Returns
     ------


### PR DESCRIPTION
[Codespell](https://github.com/codespell-project/codespell) is a spellcheck tool specifically intended for source code.  Instead of looking for words not found in a dictionary, it looks for words that match common misspellings.  Consequently, codespell leads to very few false positives, but will miss some misspelled words that are not contained in its dictionaries for misspellings.  Overall, it's a great tool that we've been using over in PlasamPy and I highly recommend it!  

This PR adds a configuration for codespell in `setup.cfg` which specifies which files to ignore and which false positives to allow.  It also applies the spelling changes found by codespell.  I'll comment on a few of these which I'm not sure about.  I'm planning to add a pre-commit hook for codespell.