### PR TITLE
LASCO_tutorials_and_masking

### DIFF
--- a/changelog/6576.feature.rst
+++ b/changelog/6576.feature.rst
@@ -1,0 +1,1 @@
+Adds two tutorials that demonstrate how to use LASCO data in overlaying maps (:ref:`sphx_glr_generated_gallery_plotting_lasco_overlay.py`) and how to create a custom mask for a LASCO C2 image (:ref:`sphx_glr_generated_gallery_map_lasco_mask.py`).

--- a/examples/map/lasco_mask.py
+++ b/examples/map/lasco_mask.py
@@ -35,10 +35,10 @@ lasco_map = Map(lasco_file)
 # :ref:`sphx_glr_generated_gallery_computer_vision_techniques_finding_masking_bright_pixels.py`
 # to express the coordinates relative to the occulter center.
 
-hpc_coords = all_coordinates_from_map(lasco_map)
-occult_coord = SkyCoord(0*u.deg, 0*u.deg, frame="helioprojective")
-pixel_radii = np.sqrt((hpc_coords.Tx-occult_coord.Tx)**2 +
-                      (hpc_coords.Ty-occult_coord.Ty)**2)
+pixel_coords = all_coordinates_from_map(lasco_map)
+solar_center = SkyCoord(0*u.deg, 0*u.deg, frame=lasco_map.coordinate_frame)
+pixel_radii = np.sqrt((pixel_coords.Tx-solar_center.Tx)**2 +
+                      (pixel_coords.Ty-solar_center.Ty)**2)
 # Note that the inner mask extends just beyond 2 solar radii to mask the
 # Fresnel diffraction caused by the occulter edge.
 mask_inner = pixel_radii < lasco_map.rsun_obs*2.4

--- a/examples/map/lasco_mask.py
+++ b/examples/map/lasco_mask.py
@@ -1,0 +1,73 @@
+"""
+=================================
+Creating a mask for LASCO C2 data
+=================================
+
+In this example, we will manually create a mask to block the occulter in an
+unprocessed LASCO C2 coronagraph image.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.ma as ma
+
+import astropy.units as u
+
+from sunpy.map import Map
+from sunpy.map.maputils import all_coordinates_from_map
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+
+###############################################################################
+# First, download some unprocessed LASCO C2 data with `~sunpy.net.Fido`.
+
+result = Fido.search(a.Time('2011/06/07 06:30', '2011/06/07 06:36'),
+                     a.Instrument.lasco,
+                     a.Detector.c2)
+lasco_file = Fido.fetch(result)
+lasco_map = Map(lasco_file)
+
+###############################################################################
+# The LASCO C2 coronagraph has a field of view extending from 2-6 solar
+# radii. So, our mask will have two parts: an inner component which masks the
+# occulter and an outer component which masks data outside the field of view.
+#
+# First, let's define the Sun center using ``CRPIXi`` and apply a shift (if
+# necessary) to the reference coordinates ``CRVALi``
+# (see `here <https://lasco-www.nrl.navy.mil/level_1/level_1_keywords.html>`_).
+
+x_occult = lasco_map.meta['crval1']/lasco_map.meta['cdelt1'] + lasco_map.meta['crpix1']
+y_occult = lasco_map.meta['crval2']/lasco_map.meta['cdelt2'] + lasco_map.meta['crpix2']
+occult_coord = lasco_map.pixel_to_world(x_occult*u.pixel, y_occult*u.pixel)
+
+###############################################################################
+# Next, we will follow a process similar to
+# :ref:`sphx_glr_generated_gallery_computer_vision_techniques_finding_masking_bright_pixels.py`
+# to express the coordinates relative to the occulter center. Then, we will
+# use `numpy.ma` functions to mask the correct regions.
+# Note that the inner mask extends just beyond 2 solar radii to mask the
+# Fresnel diffraction caused by the occulter edge.
+
+hpc_coords = all_coordinates_from_map(lasco_map)
+norm_mask = np.sqrt((hpc_coords.Tx-occult_coord.Tx)**2 +
+                    (hpc_coords.Ty-occult_coord.Ty)**2)
+mask_inner = ma.masked_less_equal(norm_mask, lasco_map.rsun_obs*2.4)
+mask_outer = ma.masked_greater_equal(norm_mask, lasco_map.rsun_obs*6)
+final_mask = mask_inner + mask_outer
+
+###############################################################################
+# To apply the final mask, create a new map using ``.mask`` to get the actual
+# masked array.
+
+masked_lasco = Map(lasco_map.data, lasco_map.meta, mask=final_mask.mask)
+
+# Before plotting the map, we need to create a new colormap to ensure we mask
+# the bad values correctly.
+occult_colormap = lasco_map.cmap.copy()
+occult_colormap.set_bad('black')
+
+plt.figure()
+masked_lasco.plot(clip_interval=(2, 98)*u.percent, cmap=occult_colormap)
+masked_lasco.draw_limb()
+plt.title("Custom mask for LASCO C2")
+
+plt.show()

--- a/examples/map/lasco_mask.py
+++ b/examples/map/lasco_mask.py
@@ -8,9 +8,9 @@ unprocessed LASCO C2 coronagraph image.
 """
 import matplotlib.pyplot as plt
 import numpy as np
-import numpy.ma as ma
 
 import astropy.units as u
+from astropy.coordinates import SkyCoord
 
 from sunpy.map import Map
 from sunpy.map.maputils import all_coordinates_from_map
@@ -31,43 +31,40 @@ lasco_map = Map(lasco_file)
 # radii. So, our mask will have two parts: an inner component which masks the
 # occulter and an outer component which masks data outside the field of view.
 #
-# First, let's define the Sun center using ``CRPIXi`` and apply a shift (if
-# necessary) to the reference coordinates ``CRVALi``
-# (see `here <https://lasco-www.nrl.navy.mil/level_1/level_1_keywords.html>`_).
-
-x_occult = lasco_map.meta['crval1']/lasco_map.meta['cdelt1'] + lasco_map.meta['crpix1']
-y_occult = lasco_map.meta['crval2']/lasco_map.meta['cdelt2'] + lasco_map.meta['crpix2']
-occult_coord = lasco_map.pixel_to_world(x_occult*u.pixel, y_occult*u.pixel)
-
-###############################################################################
-# Next, we will follow a process similar to
+# We will follow a process similar to
 # :ref:`sphx_glr_generated_gallery_computer_vision_techniques_finding_masking_bright_pixels.py`
-# to express the coordinates relative to the occulter center. Then, we will
-# use `numpy.ma` functions to mask the correct regions.
-# Note that the inner mask extends just beyond 2 solar radii to mask the
-# Fresnel diffraction caused by the occulter edge.
+# to express the coordinates relative to the occulter center.
 
 hpc_coords = all_coordinates_from_map(lasco_map)
-norm_mask = np.sqrt((hpc_coords.Tx-occult_coord.Tx)**2 +
-                    (hpc_coords.Ty-occult_coord.Ty)**2)
-mask_inner = ma.masked_less_equal(norm_mask, lasco_map.rsun_obs*2.4)
-mask_outer = ma.masked_greater_equal(norm_mask, lasco_map.rsun_obs*6)
+occult_coord = SkyCoord(0*u.deg, 0*u.deg, frame="helioprojective")
+pixel_radii = np.sqrt((hpc_coords.Tx-occult_coord.Tx)**2 +
+                      (hpc_coords.Ty-occult_coord.Ty)**2)
+# Note that the inner mask extends just beyond 2 solar radii to mask the
+# Fresnel diffraction caused by the occulter edge.
+mask_inner = pixel_radii < lasco_map.rsun_obs*2.4
+mask_outer = pixel_radii > lasco_map.rsun_obs*6
 final_mask = mask_inner + mask_outer
 
 ###############################################################################
-# To apply the final mask, create a new map using ``.mask`` to get the actual
-# masked array.
+# To apply the final mask, we must create a new map.
 
-masked_lasco = Map(lasco_map.data, lasco_map.meta, mask=final_mask.mask)
+masked_lasco = Map(lasco_map.data, lasco_map.meta, mask=final_mask)
 
 # Before plotting the map, we need to create a new colormap to ensure we mask
 # the bad values correctly.
 occult_colormap = lasco_map.cmap.copy()
 occult_colormap.set_bad('black')
 
-plt.figure()
-masked_lasco.plot(clip_interval=(2, 98)*u.percent, cmap=occult_colormap)
+fig = plt.figure()
+ax1 = fig.add_subplot(1, 2, 1, projection=lasco_map)
+ax2 = fig.add_subplot(1, 2, 2, projection=masked_lasco)
+
+lasco_map.plot(clip_interval=(2, 98)*u.percent, cmap=occult_colormap, axes=ax1)
+lasco_map.draw_limb()
+ax1.set_title("Level 1 LASCO C2")
+
+masked_lasco.plot(clip_interval=(2, 98)*u.percent, cmap=occult_colormap, axes=ax2)
 masked_lasco.draw_limb()
-plt.title("Custom mask for LASCO C2")
+ax2.set_title("Masked LASCO C2")
 
 plt.show()

--- a/examples/plotting/lasco_overlay.py
+++ b/examples/plotting/lasco_overlay.py
@@ -5,8 +5,6 @@ Overlay an AIA image on a LASCO C2 coronagraph
 
 This example shows the steps needed to overlay the disc and off-limb
 components of an AIA image within the masked occulter of a LASCO C2 image.
-
-It also demonstrates the usage of ``hypy`` to download data from the Helioviewer Project.
 """
 from datetime import datetime
 
@@ -20,6 +18,7 @@ from astropy.coordinates import SkyCoord
 import sunpy.data.sample
 from sunpy.coordinates import Helioprojective
 from sunpy.map import Map
+from sunpy.util.config import get_and_create_download_dir
 
 ###############################################################################
 # First, we will acquire a calibrated LASCO C2 image from Helioviewer and
@@ -27,13 +26,20 @@ from sunpy.map import Map
 
 lasco_jp2_file = hvpy.save_file(hvpy.getJP2Image(datetime(2011, 6, 7, 6, 34),
                                                  DataSource.LASCO_C2.value),
-                                filename="lasco.jp2", overwrite=True)
+                                filename=get_and_create_download_dir() + "/LASCO_C2.jp2", overwrite=True)
 lasco_map = Map(lasco_jp2_file)
 aia_map = Map(sunpy.data.sample.AIA_171_IMAGE)
 
 ###############################################################################
-# In order to plot off-limb features of the AIA image, we need to reproject AIA
-# using `~sunpy.coordinates.Helioprojective.assume_spherical_screen`.
+# In order to plot off-limb features of the AIA image.
+#
+# Note that off-disk AIA data are not retained by default because an
+# additional assumption is required to define the location of the AIA
+# emission in 3D space. We can use
+# :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` to
+# retain the off-disk AIA data. See
+# :ref:`sphx_glr_generated_gallery_map_transformations_reprojection_spherical_screen.py`
+# for more reference.
 
 projected_coord = SkyCoord(0*u.arcsec, 0*u.arcsec,
                            obstime=lasco_map.observer_coordinate.obstime,
@@ -45,6 +51,8 @@ projected_header = sunpy.map.make_fitswcs_header(aia_map.data.shape,
                                                  scale=u.Quantity(aia_map.scale),
                                                  instrument=aia_map.instrument,
                                                  wavelength=aia_map.wavelength)
+# We use `assume_spherical_screen` to ensure that the off limb AIA pixels are reprojected
+# otherwise it will only be the on disk pixels that are reprojected.
 with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate):
     aia_reprojected = aia_map.reproject_to(projected_header)
 

--- a/examples/plotting/lasco_overlay.py
+++ b/examples/plotting/lasco_overlay.py
@@ -1,0 +1,61 @@
+"""
+==============================================
+Overlay an AIA image on a LASCO C2 coronagraph
+==============================================
+
+This example shows the steps needed to overlay the disc and off-limb
+components of an AIA image within the masked occulter of a LASCO C2 image.
+
+It also demonstrates the usage of ``hypy`` to download data from the Helioviewer Project.
+"""
+from datetime import datetime
+
+import hvpy
+import matplotlib.pyplot as plt
+from hvpy.datasource import DataSource
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+import sunpy.data.sample
+from sunpy.coordinates import Helioprojective
+from sunpy.map import Map
+
+###############################################################################
+# First, we will acquire a calibrated LASCO C2 image from Helioviewer and
+# create a map. hvpy uses the standard datetime instead of astropy.time.
+
+lasco_jp2_file = hvpy.save_file(hvpy.getJP2Image(datetime(2011, 6, 7, 6, 34),
+                                                 DataSource.LASCO_C2.value),
+                                filename="lasco.jp2", overwrite=True)
+lasco_map = Map(lasco_jp2_file)
+aia_map = Map(sunpy.data.sample.AIA_171_IMAGE)
+
+###############################################################################
+# In order to plot off-limb features of the AIA image, we need to reproject AIA
+# using `~sunpy.coordinates.Helioprojective.assume_spherical_screen`.
+
+projected_coord = SkyCoord(0*u.arcsec, 0*u.arcsec,
+                           obstime=lasco_map.observer_coordinate.obstime,
+                           frame='helioprojective',
+                           observer=lasco_map.observer_coordinate,
+                           rsun=aia_map.coordinate_frame.rsun)
+projected_header = sunpy.map.make_fitswcs_header(aia_map.data.shape,
+                                                 projected_coord,
+                                                 scale=u.Quantity(aia_map.scale),
+                                                 instrument=aia_map.instrument,
+                                                 wavelength=aia_map.wavelength)
+with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate):
+    aia_reprojected = aia_map.reproject_to(projected_header)
+
+###############################################################################
+# Finally, we plot the images by layering the AIA image on top of the LASCO C2
+# image.
+
+fig = plt.figure()
+ax = fig.add_subplot(projection=lasco_map)
+lasco_map.plot(axes=ax)
+aia_reprojected.plot(axes=ax, clip_interval=(1, 99.9)*u.percent, autoalign=True)
+ax.set_title("AIA and LASCO C2 Overlay")
+
+plt.show()


### PR DESCRIPTION
This pull request fixes #6420 and fixes #3098. The tutorial lasco_overlay.py demonstrates the process required to overlay an AIA image onto a processed LASCO C2 image. It doubles as an example to show the usage of hvpy, since the Helioviewer Client is deprecated (#6404). 

The tutorial lasco_mask.py is partly based upon a script by @AlthKouloumvakos (in #3098) that shows how to create a custom mask for an unprocessed LASCO C2 image that is downloaded using Fido. Overall, this tutorial combines elements from the current two masking tutorials and could help serve as a guide for creating custom masks.

I have also added the process from the lasco_mask tutorial as a property in the LASCO subclass. This allows a user to generate a LACSO mask (e.g., using `mask = lasco.mask_occulter`) which they can then apply to their `Map`. The bounds I have set for the LASCO C2 mask is based on the [specified field of view](https://lasco-www.nrl.navy.mil/content/handbook/images/tab3-1.gif), as well as in comparison to LASCO C2 data in HelioViewer. C3 data uses the mask recommended in [LASCO calibration directory](https://hesperia.gsfc.nasa.gov/ssw/soho/lasco/idl/data/calib/) (this way the occulter pylon is also masked). I have not found many examples of LASCO C1 data, so I have not added a mask for this detector (but I would be happy to add one).
