### PR TITLE
Fixes issues with `parse_time()` and the handling of excess zeros in the microsecond field

### DIFF
--- a/changelog/6581.bugfix.rst
+++ b/changelog/6581.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where :func:`~sunpy.time.parse_time` would always disregard the remainder of a time string starting with the final period if it was followed by only zeros, which could affect the parsing of the time string.

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -27,12 +27,19 @@ def test_parse_time_24_2():
     assert dt.scale == 'utc'
 
 
-def test_parse_time_trailing_zeros():
-    # see issue #289 at https://github.com/sunpy/sunpy/issues/289
-    dt = parse_time('2010-10-10T00:00:00.00000000')
-    assert dt == Time('2010-10-10')
+def test_parse_time_microseconds_excess_trailing_zeros():
+    dt = parse_time('2010-Oct-10 00:00:00.1234560')
+    assert dt == Time('2010-10-10 00:00:00.123456')
     assert dt.format == 'isot'
     assert dt.scale == 'utc'
+
+    # Excess digits beyond 6 digits should error if they are not zeros
+    with pytest.raises(ValueError):
+        dt = parse_time('2010-Oct-10 00:00:00.1234567')
+
+    # An ending run of zeros should still error if they are not a microsecond field
+    with pytest.raises(ValueError):
+        dt = parse_time('10-Oct-2010.0000000')
 
 
 def test_parse_time_tuple():

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -49,12 +49,14 @@ TIME_FORMAT_LIST = [
     "%Y-%m-%d %H:%M:%S.%f",  # Example 2007-05-04 21:08:12.999999
     "%Y-%m-%d %H:%M:%S",  # Example 2007-05-04 21:08:12
     "%Y-%m-%d %H:%M",  # Example 2007-05-04 21:08
+    "%Y-%b-%d %H:%M:%S.%f",  # Example 2007-May-04 21:08:12.999999
     "%Y-%b-%d %H:%M:%S",  # Example 2007-May-04 21:08:12
     "%Y-%b-%d %H:%M",  # Example 2007-May-04 21:08
     "%Y-%b-%d",  # Example 2007-May-04
     "%Y-%m-%d",  # Example 2007-05-04
     "%Y/%m/%d",  # Example 2007/05/04
     "%d-%b-%Y",  # Example 04-May-2007
+    "%d-%b-%Y %H:%M:%S",  # Example 04-May-2007 21:08:12
     "%d-%b-%Y %H:%M:%S.%f",  # Example 04-May-2007 21:08:12.999999
     "%Y%m%d_%H%M%S",  # Example 20070504_210812
     "%Y:%j:%H:%M:%S",  # Example 2012:124:21:08:12


### PR DESCRIPTION
- Fixed overly blunt handling of excess trailing zeros beyond the six digits allowed for the microsecond field (see #445).  Previously, any string input would be stripped of the final period and trailing zeros, even if it was not a microsecond field.  Now, the handling is properly targeted.
- Two time formats were missing for parity with other time formats with respect to with/without microseconds.

Closes #6586 