### PR TITLE
Fix a bug in `make_fitswcs_header()` when creating a rotation matrix from an angle when the pixels are non-square

### DIFF
--- a/changelog/6597.bugfix.rst
+++ b/changelog/6597.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the incorrect calculation in :func:`~sunpy.map.header_helper.make_fitswcs_header` of the rotation matrix from a rotation angle when the pixels are non-square.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -169,7 +169,7 @@ def _set_rotation_params(meta_wcs, rotation_angle, rotation_matrix):
         rotation_angle = 0 * u.deg
 
     if rotation_angle is not None:
-        lam = meta_wcs['cdelt1'] / meta_wcs['cdelt2']
+        lam = meta_wcs['cdelt2'] / meta_wcs['cdelt1']
         p = np.deg2rad(rotation_angle)
 
         rotation_matrix = np.array([[np.cos(p), -1 * lam * np.sin(p)],

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -66,7 +66,14 @@ def test_metakeywords():
     assert isinstance(meta, dict)
 
 
-def test_deafult_rotation(map_data, hpc_coord):
+def test_scale_conversion(map_data, hpc_coord):
+    # The header will have cunit1/2 of arcsec
+    header = make_fitswcs_header(map_data, hpc_coord, scale=[1, 2] * u.arcmin / u.pix)
+    assert header['cdelt1'] == 60
+    assert header['cdelt2'] == 120
+
+
+def test_default_rotation(map_data, hpc_coord):
     header = make_fitswcs_header(map_data, hpc_coord)
     wcs = WCS(header)
     np.testing.assert_allclose(wcs.wcs.pc, [[1, 0], [0, 1]], atol=1e-5)
@@ -77,6 +84,13 @@ def test_rotation_angle(map_data, hpc_coord):
                                  rotation_angle=90*u.deg)
     wcs = WCS(header)
     np.testing.assert_allclose(wcs.wcs.pc, [[0, -1], [1, 0]], atol=1e-5)
+
+
+def test_rotation_angle_rectangular_pixels(map_data, hpc_coord):
+    header = make_fitswcs_header(map_data, hpc_coord, scale=[2, 5] * u.arcsec / u.pix,
+                                 rotation_angle=45*u.deg)
+    wcs = WCS(header)
+    np.testing.assert_allclose(wcs.wcs.pc, np.sqrt(0.5) * np.array([[1, -2.5], [0.4, 1]]), atol=1e-5)
 
 
 def test_rotation_matrix(map_data, hpc_coord):


### PR DESCRIPTION
See issue title, closes #6349

There was no unit test to fix because there were no existing unit tests for valid input for the `scale` keyword argument...