### PR TITLE
Remove 4.1 changelogs

### DIFF
--- a/changelog/5951.feature.rst
+++ b/changelog/5951.feature.rst
@@ -1,1 +1,0 @@
-Updated and expanded the HTML representation for `~sunpy.timeseries.TimeSeries`.

--- a/changelog/5956.feature.rst
+++ b/changelog/5956.feature.rst
@@ -1,1 +1,0 @@
-When reading CDF files, any columns with a floating point data type now have their masked values converted to NaN.

--- a/changelog/6056.trivial.rst
+++ b/changelog/6056.trivial.rst
@@ -1,1 +1,0 @@
-Added a ``columns`` keyword to each plot method for all `sunpy.timeseries.GenericTimeSeries` sources.

--- a/changelog/6127.trivial.rst
+++ b/changelog/6127.trivial.rst
@@ -1,1 +1,0 @@
-Added a script in the ``sunpy/tools`` that will update all the Python libraries in ``sunpy/extern``.

--- a/changelog/6153.feature.rst
+++ b/changelog/6153.feature.rst
@@ -1,1 +1,0 @@
-Add support for saving `~sunpy.map.GenericMap` as JPEG 2000 files.

--- a/changelog/6159.trivial.rst
+++ b/changelog/6159.trivial.rst
@@ -1,1 +1,0 @@
-Added automatic conversion of unit strings in CDF files to astropy unit objects for the following instruments: PSP/ISOIS, SOHO/CELIAS, SOHO/COSTEP-EPHIN, and SOHO/ERNE.

--- a/changelog/6166.trivial.rst
+++ b/changelog/6166.trivial.rst
@@ -1,2 +1,0 @@
-Add an environment variable ``SUNPY_NO_BUILD_ANA_EXTENSION`` which when present
-will cause sunpy to not compile the ANA C extension when building from source.

--- a/changelog/6171.trivial.rst
+++ b/changelog/6171.trivial.rst
@@ -1,2 +1,0 @@
-``sunpy`` now uses the `Limited Python API <https://docs.python.org/3/c-api/stable.html>`__.
-Therefore, one binary distribution (wheel) per platform is now published and it is compatible with all Python versions ``sunpy`` supports.

--- a/changelog/6189.feature.rst
+++ b/changelog/6189.feature.rst
@@ -1,3 +1,0 @@
-Add a function `sunpy.map.extract_along_coord` that, for a given set of coordinates,
-finds each array index that crosses the line traced by those coordinates and returns the value of the data
-array of a given map at those array indices.

--- a/changelog/6196.doc.rst
+++ b/changelog/6196.doc.rst
@@ -1,1 +1,0 @@
-Improved annotations in the SRS active regions plotting example.

--- a/changelog/6197.doc.rst
+++ b/changelog/6197.doc.rst
@@ -1,2 +1,0 @@
-Updated gallery examples that use STEREO data to use sample data instead
-of searching for and downloading data via Fido.

--- a/changelog/6197.feature.rst
+++ b/changelog/6197.feature.rst
@@ -1,7 +1,0 @@
-Three new maps have been added to the sample data from STEREO A and STEREO B at
-195 Angstrom, and AIA at 193 Angstrom. These images are from a time when
-the three spacecraft were equally spaced around the Sun, and therefore form
-near complete instantaneous coverage of the solar surface.
-
-Users upgrading to this version will find this three files download when they
-use the sample data for the first time.

--- a/changelog/6199.bugfix.rst
+++ b/changelog/6199.bugfix.rst
@@ -1,1 +1,0 @@
-Fix a bug that prevented EUI maps with missing wavelength metadata loading.

--- a/changelog/6221.breaking.rst
+++ b/changelog/6221.breaking.rst
@@ -1,2 +1,0 @@
-Updated the sample data file, ``AIA_171_ROLL_IMAGE`` to be rice compressed instead of gzip compressed.
-This means that the data is now stored in the second HDU.

--- a/changelog/6242.feature.rst
+++ b/changelog/6242.feature.rst
@@ -1,1 +1,0 @@
-Added a SDO/AIA 1600 file of the Venus transit to the sunpy sample data.

--- a/changelog/6243.trivial.rst
+++ b/changelog/6243.trivial.rst
@@ -1,1 +1,0 @@
-Add support for upcoming parfive 2.0 release.

--- a/changelog/6251.feature.rst
+++ b/changelog/6251.feature.rst
@@ -1,3 +1,0 @@
-Created the `sunpy.visualization.drawing` module which includes
-new :func:`~sunpy.visualization.drawing.equator` and
-:func:`~sunpy.visualization.drawing.prime_meridian` functions.

--- a/changelog/6256.bugfix.rst
+++ b/changelog/6256.bugfix.rst
@@ -1,2 +1,0 @@
-The `sunpy.net.dataretriever.sources.noaa.SRSClient` was not correctly setting the passive mode for FTP connection resulting in a permission error.
-This has been fixed.

--- a/changelog/6260.feature.rst
+++ b/changelog/6260.feature.rst
@@ -1,1 +1,0 @@
-Expose GOES quality flags in order to allow filtering corrupt values when using the `~sunpy.timeseries.sources.goes.XRSTimeSeries`.

--- a/changelog/6262.bugfix.rst
+++ b/changelog/6262.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed `~sunpy.timeseries.sources.XRSTimeSeries` inability to read leap-second files for GOES.
-It floors the leap-second timestamp to be ``59.999``, so that Python datetime does not raise an exception.

--- a/changelog/6264.feature.rst
+++ b/changelog/6264.feature.rst
@@ -1,2 +1,0 @@
-All TimeSeries plotting methods now consistently set the same
-formatter and locator for the x-axis.

--- a/changelog/6285.bugfix.rst
+++ b/changelog/6285.bugfix.rst
@@ -1,6 +1,0 @@
-Changed the default scaling for `~sunpy.map.sources.EUIMap` from a linear stretch to a asinh stretch.
-
-To revert to the previous linear stretch do the following::
-
-     from astropy.visualization import ImageNormalize, LinearStretch
-     euimap.plot_settings["norm"] = ImageNormalize(stretch=LinearStretch())

--- a/changelog/6289.trivial.rst
+++ b/changelog/6289.trivial.rst
@@ -1,3 +1,0 @@
-The primary sample-data URL will be changing from ``https://github.com/sunpy/sample-data/raw/master/sunpy/v1/`` to ``https://github.com/sunpy/data/raw/main/sunpy/v1/``.
-We expect GitHub to redirect from the old URL for sometime but will eventually expire it.
-The ``data.sunpy.org`` mirror will continue to be available.

--- a/changelog/6295.trivial.rst
+++ b/changelog/6295.trivial.rst
@@ -1,1 +1,0 @@
-Add support for downloading sample data from more than two mirror locations.

--- a/changelog/6304.feature.rst
+++ b/changelog/6304.feature.rst
@@ -1,2 +1,0 @@
-:meth:`sunpy.timeseries.GenericTimeSeries.peek` now takes a ``title`` argument
-to set the title of the plot.

--- a/changelog/6304.trivial.rst
+++ b/changelog/6304.trivial.rst
@@ -1,3 +1,0 @@
-Timeseries data sources can now set the ``_peek_title`` class attribute
-to set the default plot title produced when ``.peek()`` is called and the user
-does not provide a custom title.

--- a/changelog/6310.deprecation.rst
+++ b/changelog/6310.deprecation.rst
@@ -1,3 +1,0 @@
-Passing positional arguments to all ``timeseries`` ``peek()`` methods
-is now deprecated, and will raise an error in sunpy 5.1. Pass the arguments
-with keywords (e.g. ``title='my plot title'``) instead.

--- a/changelog/6311.bugfix.rst
+++ b/changelog/6311.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed bugs when working with a coordinate frame where the observer is specified in `~sunpy.coordinates.frames.HeliographicStonyhurst` with a Cartesian representation, which is equivalent to Heliocentric Earth Equatorial (HEEQ).
-Now, the observer will always be converted to spherical representation when the coordinate frame is created.

--- a/changelog/6318.bugfix.rst
+++ b/changelog/6318.bugfix.rst
@@ -1,3 +1,0 @@
-Fixed an error when Fido returns zero results from the VSO
-and some results from at least one other data source. This
-(now fixed) error is only present when using numpy version >= 1.23.

--- a/changelog/6327.deprecation.rst
+++ b/changelog/6327.deprecation.rst
@@ -1,3 +1,0 @@
-Using `sunpy.timeseries.GenericTimeSeries.index` is deprecated.
-Use `~sunpy.timeseries.GenericTimeSeries.time` to get an astropy Time object,
-or ``ts.to_dataframe().index`` to get the times as a pandas ``DataTimeIndex``.

--- a/changelog/6327.feature.rst
+++ b/changelog/6327.feature.rst
@@ -1,2 +1,0 @@
-Added the `sunpy.timeseries.GenericTimeSeries.time` property to get the times
-of a timeseries as a `~astropy.time.Time` object.

--- a/changelog/6332.deprecation.rst
+++ b/changelog/6332.deprecation.rst
@@ -1,3 +1,0 @@
-Deprecated the ``sunpy.visualization.limb`` module.
-The ``sunpy.visualization.limb.draw_limb`` function has been moved into
-`~sunpy.visualization.drawing` as :func:`~sunpy.visualization.drawing.limb`.

--- a/changelog/6332.feature.rst
+++ b/changelog/6332.feature.rst
@@ -1,1 +1,0 @@
-Added the :ref:`sphx_glr_generated_gallery_plotting_plot_equator_prime_meridian.py` example to the Example Gallery.

--- a/changelog/6332.trivial.rst
+++ b/changelog/6332.trivial.rst
@@ -1,1 +1,0 @@
-All internal code for limb drawing now uses :func:`~sunpy.visualization.drawing.limb`.

--- a/changelog/6333.bugfix.rst
+++ b/changelog/6333.bugfix.rst
@@ -1,3 +1,0 @@
-If a level 1 XRT file does not specify the heliographic longitude of the spacecraft,
-a silent assumption is made that the spacecraft is at zero Stonyhurst
-heliographic longitude (i.e., the same longitude as Earth).

--- a/changelog/6334.bugfix.rst
+++ b/changelog/6334.bugfix.rst
@@ -1,1 +1,0 @@
-The sample data retry was failing under parfive 2.0.0.

--- a/changelog/6336.doc.rst
+++ b/changelog/6336.doc.rst
@@ -1,1 +1,0 @@
-Added the current bugfix release policy to the docs.

--- a/changelog/6342.bugfix.rst
+++ b/changelog/6342.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed bug that prevented `~sunpy.coordinates.metaframes.RotatedSunFrame` instances from being pickled.

--- a/changelog/6345.doc.rst
+++ b/changelog/6345.doc.rst
@@ -1,1 +1,0 @@
-The :ref:`map_guide` and :ref:`timeseries_guide` have been reviewed and updated.

--- a/changelog/6346.doc.rst
+++ b/changelog/6346.doc.rst
@@ -1,1 +1,0 @@
-Adds a pull request check list to the Developer's Guide.

--- a/changelog/6355.trivial.rst
+++ b/changelog/6355.trivial.rst
@@ -1,1 +1,0 @@
-Add maintainer documentation on the backport bot

--- a/changelog/6376.trivial.rst
+++ b/changelog/6376.trivial.rst
@@ -1,1 +1,0 @@
-Switched to using the standard matrix-multiplication operator (available in Python 3.5+) instead of a custom function.

--- a/changelog/6379.trivial.rst
+++ b/changelog/6379.trivial.rst
@@ -1,2 +1,0 @@
-Fixed a colormap deprecation warning when importing the sunpy colormaps
-with Matplotlib 3.6.

--- a/changelog/6385.trivial.rst
+++ b/changelog/6385.trivial.rst
@@ -1,1 +1,0 @@
-Removed custom tick label rotation from Lyra, EVE, and Norh timeseries sources, and grid drawing from NOAA and RHESSI sources.

--- a/changelog/6404.deprecation.rst
+++ b/changelog/6404.deprecation.rst
@@ -1,3 +1,0 @@
-The ``sunpy.net.helioviewer`` module is deprecated and will be removed in version 5.1.
-The Helioviewer Project now maintains a replacement Python library called `hvpy <https://hvpy.readthedocs.io/en/latest/>`__.
-As such, in consultation with the Helioviewer Project, we have decided to deprecate the ``HelioviewerClient`` class.

--- a/changelog/6406.deprecation.rst
+++ b/changelog/6406.deprecation.rst
@@ -1,1 +1,0 @@
-Passing the ``algorithm``, ``return_footprint`` arguments as positional arguments is deprecated. Pass them as keyword arguments (e.g. ``..., return_footprint=True, ...``) instead.

--- a/changelog/6410.bugfix.rst
+++ b/changelog/6410.bugfix.rst
@@ -1,1 +1,0 @@
-Fix a bug in loading `.XRSTimeSeries` due to unsupported quality flag column names.

--- a/changelog/6415.feature.rst
+++ b/changelog/6415.feature.rst
@@ -1,1 +1,0 @@
-Added a new function :func:`sunpy.map.header_helper.make_heliographic_header` to help with generating FITS-WCS headers in Carrington or Stonyhurst coordinate systems that span the entire solar surface.

--- a/changelog/6423.bugfix.rst
+++ b/changelog/6423.bugfix.rst
@@ -1,1 +1,0 @@
-Adds units (dimensionless units) to the quality columns in `.XRSTimeSeries`.

--- a/changelog/6426.deprecation.rst
+++ b/changelog/6426.deprecation.rst
@@ -1,2 +1,0 @@
-:func:`sunpy.data.download_sample_data` is now deprecated.
-Use :func:`sunpy.data.sample.download_all` instead.

--- a/changelog/6426.feature.rst
+++ b/changelog/6426.feature.rst
@@ -1,2 +1,0 @@
-Sample data files provided through `sunpy.data.sample` are now downloaded individually on demand rather than being all downloaded upon import of that module.
-To download all sample data files, call :func:`sunpy.data.sample.download_all`.

--- a/changelog/6430.doc.rst
+++ b/changelog/6430.doc.rst
@@ -1,1 +1,0 @@
-Improved the plotting guide.

--- a/changelog/6432.removal.rst
+++ b/changelog/6432.removal.rst
@@ -1,2 +1,0 @@
-The ``sunpy.io.fits`` sub-module has been removed, as it was designed for internal use.
-Use the `astropy.io.fits` module instead for more generic functionality to read FITS files.

--- a/changelog/6433.removal.rst
+++ b/changelog/6433.removal.rst
@@ -1,1 +1,0 @@
-The ``sunpy.physics.solar_rotation`` sub-module has been removed, having been moved to `sunkit_image.coalignment`.

--- a/changelog/6434.removal.rst
+++ b/changelog/6434.removal.rst
@@ -1,3 +1,0 @@
-Most of the `sunpy.visualization.animator` subpackage has been removed, with the exception of `~sunpy.visualization.animator.MapSequenceAnimator`
-It has been moved into the standalone `mpl-animators <https://pypi.org/project/mpl-animators>`_ package
-Please update your imports to replace ``sunpy.visualization.animator`` with ``mpl_animators``.

--- a/changelog/6436.bugfix.1.rst
+++ b/changelog/6436.bugfix.1.rst
@@ -1,4 +1,0 @@
-Refactored `~sunpy.map.sources.SXTMap` to use ITRS observer coordinate information
-in header rather than incorrect HGS keywords.
-The `~sunpy.map.sources.SXTMap` also now uses the default ``dsun`` property as this
-information can be derived from the (now corrected) observer coordinate.

--- a/changelog/6436.bugfix.2.rst
+++ b/changelog/6436.bugfix.2.rst
@@ -1,4 +1,0 @@
-In `sunpy.map.GenericMap.coordinate_system` and `sunpy.map.GenericMap.date`, the default values
-will now be used if the expected key(s) used to derive those properties are empty.
-Previously, empty values of these keys were not treated as missing and thus the default values
-were not correctly filled in.

--- a/changelog/6436.trivial.rst
+++ b/changelog/6436.trivial.rst
@@ -1,1 +1,0 @@
-Added tests and test data for `~sunpy.map.sources.SXTMap`

--- a/changelog/6437.removal.rst
+++ b/changelog/6437.removal.rst
@@ -1,2 +1,0 @@
-Remove ``GenericMap.shift`` method and the ``GenericMap.shifted_value``.
-Use `~sunpy.map.GenericMap.shift_reference_coord` instead.

--- a/changelog/6438.removal.rst
+++ b/changelog/6438.removal.rst
@@ -1,1 +1,0 @@
-``sunpy.util.scraper`` has been removed. Use `sunpy.net.scraper` instead.

--- a/changelog/6440.removal.rst
+++ b/changelog/6440.removal.rst
@@ -1,1 +1,0 @@
-``sunpy.image.coalignment`` has been removed. Use `sunkit_image.coalignment` instead, which contains all the same functionality.

--- a/changelog/6444.doc.rst
+++ b/changelog/6444.doc.rst
@@ -1,1 +1,0 @@
-Slight improvements to the downloading data with Fido part of the guide.

--- a/changelog/6447.bugfix.rst
+++ b/changelog/6447.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a bug where the observer coordinate was incorrectly determined for `~sunpy.map.sources.KCorMap`.

--- a/changelog/6447.trivial.rst
+++ b/changelog/6447.trivial.rst
@@ -1,1 +1,0 @@
-Fixed a bug where the private attribute ``_default_observer_coordinate`` for `~sunpy.map.GenericMap` was being used even when there was sufficient observer metadata in the header.

--- a/changelog/6449.bugfix.rst
+++ b/changelog/6449.bugfix.rst
@@ -1,2 +1,0 @@
-Trying to download an empty search response from the JSOC now results in an empty results object.
-Previously the results object contained the path to the sunpy download directory.

--- a/changelog/6450.bugfix.rst
+++ b/changelog/6450.bugfix.rst
@@ -1,2 +1,0 @@
-Removed an error when searching CDAWEB using `sunpy.net.Fido` and no results are returned.
-An empty response table is now returned.

--- a/changelog/6451.bugfix.rst
+++ b/changelog/6451.bugfix.rst
@@ -1,1 +1,0 @@
-Fix a bug to parse the GOES "observatory" number in `~.XRSTimeSeries` for GOES 13, 14, 15 and for the 1 minute GOES-R data.

--- a/changelog/6454.feature.rst
+++ b/changelog/6454.feature.rst
@@ -1,1 +1,0 @@
-`~.XRSTimeSeries` is now able to parse the primary detector information from the GOES-R XRS data if available.

--- a/changelog/6460.trivial.rst
+++ b/changelog/6460.trivial.rst
@@ -1,1 +1,0 @@
-Tidy the GOES XRSTimesSeries tests and add two new XRS files to test.

--- a/changelog/6462.doc.rst
+++ b/changelog/6462.doc.rst
@@ -1,1 +1,0 @@
-Split the units and coordinate guides on to separate pages, and made minor improvements to them.

--- a/changelog/6472.feature.rst
+++ b/changelog/6472.feature.rst
@@ -1,5 +1,0 @@
-`sunpy.net.Scraper` now includes treats files as spanning a full interval equal to the smallest increment specified in the file pattern.
-For example, a pattern like ``"%Y.txt"`` that only contains a year specifier will be considered to span that full year.
-
-This means searches that fall entirely within the whole interval spanned by a pattern will return that file, where previously they did not.
-As an example, matching ``"%Y.txt"`` with ``TimeRange('2022-02-01', '2022-04-01')`` will now return ``["2022.txt"]`` where previously no files were returned.

--- a/changelog/6478.feature.rst
+++ b/changelog/6478.feature.rst
@@ -1,1 +1,0 @@
-Implemented site configuration for sunpyrc, and modified documentation for sunpy customization.

--- a/changelog/6480.bugfix.1.rst
+++ b/changelog/6480.bugfix.1.rst
@@ -1,6 +1,0 @@
-Changed the default scaling for `~sunpy.map.sources.XRTMap` from a linear stretch to `~astropy.visualization.LogStretch`.
-
-To revert to the previous linear stretch do the following::
-
-     from astropy.visualization import ImageNormalize, LinearStretch
-     xrtmap.plot_settings["norm"] = ImageNormalize(stretch=LinearStretch())

--- a/changelog/6480.bugfix.rst
+++ b/changelog/6480.bugfix.rst
@@ -1,1 +1,0 @@
-Fix the ``detector`` property of `~sunpy.map.sources.SOTMap` to return "SOT".

--- a/changelog/6486.bugfix.rst
+++ b/changelog/6486.bugfix.rst
@@ -1,2 +1,0 @@
-The right-hand y-axis of the GOES-XRS timeseries plots with labelled flare classes
-now automatically scales with the left-hand y-axis.

--- a/changelog/6498.deprecation.rst
+++ b/changelog/6498.deprecation.rst
@@ -1,3 +1,0 @@
-The sunpy.database module is no longer actively maintained and has a number of outstanding issues.
-It is anticiapted that sunpy.database will be formally deprecated in sunpy 5.0 and removed in sunpy 6.0.
-If you are using sunpy.database and would like to see a replacement, please join the discussion thread at https://community.openastronomy.org/t/deprecating-sunpy-database/495.

--- a/changelog/6499.feature.1.rst
+++ b/changelog/6499.feature.1.rst
@@ -1,3 +1,0 @@
-:func:`~sunpy.map.header_helper.make_fitswcs_header` now includes the keyword argument ``unit`` for setting the
-``BUNIT`` FITS keyword in the resulting header.
-This will take precedence over any unit information attached to ``data``.

--- a/changelog/6499.feature.2.rst
+++ b/changelog/6499.feature.2.rst
@@ -1,2 +1,0 @@
-If the ``data`` argument to :func:`~sunpy.map.header_helper.make_fitswcs_header` is an `~astropy.units.Quantity`,
-the associated unit will be used to set the ``BUNIT`` FITS keyword in the resulting header.

--- a/changelog/6512.bugfix.rst
+++ b/changelog/6512.bugfix.rst
@@ -1,4 +1,0 @@
-Add support for Python 3.11.
-
-The deprecated `cgi.parse_header` is now available as
-`sunpy.util.net.parse_header`.

--- a/changelog/6524.doc.rst
+++ b/changelog/6524.doc.rst
@@ -1,2 +1,0 @@
-Added a how-to guide (:ref:`conda_for_dependencies`) for using ``conda`` to set up an environment with the complete set of dependencies to use all optional features, build the documentation, and/or run the full test suite.
-The guide also describes how best to have an editable installation of ``sunpy`` in this environment.

--- a/changelog/6533.removal.rst
+++ b/changelog/6533.removal.rst
@@ -1,1 +1,0 @@
-:meth:`sunpy.map.GenericMap.draw_limb` can no longer be used to draw the limb on a non-WCS Axes plot.

--- a/changelog/6537.removal.rst
+++ b/changelog/6537.removal.rst
@@ -1,2 +1,0 @@
-:meth:`sunpy.image.resample` no longer accepts "neighbour" as an interpolation method.
-Use "nearest" instead.

--- a/changelog/6538.removal.rst
+++ b/changelog/6538.removal.rst
@@ -1,1 +1,0 @@
-:meth:`sunpy.image.transform.affine_transform` and :func:`sunpy.map.GenericMap.rotate` no longer accepts the ``use_scipy`` keyword.

--- a/changelog/6546.feature.rst
+++ b/changelog/6546.feature.rst
@@ -1,1 +1,0 @@
-Added a 304 sample data file called ``AIA_304_IMAGE``.

--- a/changelog/6571.bugfix.rst
+++ b/changelog/6571.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed the metadata handling of :meth:`~sunpy.map.GenericMap.resample` and :meth:`~sunpy.map.GenericMap.superpixel` so that the CDELTi values are scaled and the PCi_j matrix (if used) is modified in the correct manner for asymmetric scaling.
-The previous approach of having the PCi_j matrix store all of the scaling resulted in non-intuitive behaviors when accessing the `~sunpy.map.GenericMap.scale` and `~sunpy.map.GenericMap.rotation_matrix` properties, and when de-rotating a map via :meth:`~sunpy.map.GenericMap.rotate`.

--- a/changelog/6573.bugfix.1.rst
+++ b/changelog/6573.bugfix.1.rst
@@ -1,1 +1,0 @@
-Fixed a bug with the `sunpy.map.GenericMap.rotation_matrix` property for maps using the CDij matrix formulism where the rotation matrix would be calculated incorrectly for non-square pixels.

--- a/changelog/6573.bugfix.2.rst
+++ b/changelog/6573.bugfix.2.rst
@@ -1,1 +1,0 @@
-Fixd a bug with the `sunpy.map.GenericMap.scale` property for maps containing only the CDij matrix where the scale was not being determined from the CDij matrix.

--- a/changelog/6574.trivial.rst
+++ b/changelog/6574.trivial.rst
@@ -1,3 +1,0 @@
-Added a pre-commit hook for `codespell
-<https://github.com/codespell-project/codespell>`__, and applied
-spelling fixes throughout the package.

--- a/changelog/6581.bugfix.rst
+++ b/changelog/6581.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a bug where :func:`~sunpy.time.parse_time` would always disregard the remainder of a time string starting with the final period if it was followed by only zeros, which could affect the parsing of the time string.


### PR DESCRIPTION
Don't know what I managed to do with https://github.com/sunpy/sunpy/pull/6592, but here's a replacement with README.md not deleted.