### PR TITLE
Port sdist cibuildwheel fix from 4.1 to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,10 @@ jobs:
         - cp311-manylinux*_x86_64
         - cp311-macosx_x86_64
         - cp311-macosx_arm64
+      libraries: |
+        apt:
+          # This can be removed when there are binaries for h5py on 3.11
+          - libhdf5-dev
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,8 @@ jobs:
         - cp311-manylinux*_x86_64
         - cp311-macosx_x86_64
         - cp311-macosx_arm64
-      libraries: |
-        apt:
-          # This can be removed when there are binaries for h5py on 3.11
-          - libhdf5-dev
+      # This can be removed when there are binaries for h5py on 3.11
+      libraries: libhdf5-dev
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
 


### PR DESCRIPTION
This cherry-picks the two commits I manually pushed to 4.1 to fix the sdist build on cibuildwheel.