### PR TITLE
[doc-sprint] Add some narrative text to landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,49 +2,46 @@
 sunpy core Documentation
 ************************
 
-``sunpy`` is a community-developed, free and open-source solar
-data analysis environment for Python.
+``sunpy`` is a community-developed, free and open-source solar data analysis environment for Python.
+
 
 New Users
-*********
+==========
 
-If you are a first time user or new to Python,
-
+For help installing ``sunpy`` refer to our :ref:`installation guide <installing>`.
 ..
         * :Introduction to sunpy core [new page described in #6615]
 
-* :doc:`installation guide <intro/installation>`
+If you are a first time user or new to Python, our **tutorial** provides a walkthrough on how to use the key features of sunpy core.
+Once you've installed sunpy, start here.
 
-Our **tutorial** provides a walkthrough on how to use the key features of sunpy core, we recommend new users start here.
+.. toctree::
+    :maxdepth: 2
 
-* :doc:`Getting Started <intro/index>`
+    intro/index
 
-  #. :doc:`Data Acquisition <intro/acquiring_data/index>`
-  #. :doc:`Data Types <intro/data_types/index>`
-  #. :doc:`Plotting <intro/plotting>`
-  #. :doc:`Units <intro/units>`
-  #. :doc:`Coordinates <intro/coordinates>`
-  #. :doc:`Time <intro/time>`
+
 
 
 Next Steps
-**********
+==========
 
 * :doc:`Example gallery <generated/gallery/index>` contains short-form guides on accomplishing common tasks using sunpy.
-* :doc:`API reference<reference/index>` contains a technical description of the functionality of sunpy core's modules. It describes how they work and how to use them but assume you have a good understanding of sunpy and the scientific python ecosystem in general.
+* :ref:`API reference<reference>` contains a technical description of the inputs, outputs, and behaviour of each component of sunpy core.
 
 ..
     * [if we have how-tos?] How to guides provide detailed overview on some of the features of sunpy. These assume some level of experience using sunpy.
 ..
     * [we dont have a link to these but we do have some explanation pages] Topic guides (name?) provide
 
-Further Info
-************
 
-* Find out :doc:`what's new <whatsnew/index>` with sunpy.
-* View a list of :doc:`known issues <reference/known_issues>` or report new issues on our `GitHub issue tracker`_.
+Further Info
+============
+
+* Find out :ref:`what's new <whatsnew>` with sunpy.
+* View a list of :ref:`known issues <known_issues>` or report new issues on our `GitHub issue tracker`_.
 * Join our `chat room`_ or post to our `discourse`_ for help.
-* Read the :doc:`Developers guide <dev_guide/index>` to start contributing to the sunpy project.
+* Read the :ref:`Developers guide <dev_guide>` to start contributing to the sunpy project.
 
 
 .. _chat room: https://openastronomy.element.io/#/room/#sunpy:openastronomy.org
@@ -55,7 +52,6 @@ Further Info
     :maxdepth: 1
     :hidden:
 
-    intro/index
     generated/gallery/index
     reference/index
     whatsnew/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,18 +9,25 @@ New Users
 ==========
 
 For help installing ``sunpy`` refer to our :ref:`installation guide <installing>`.
-..
-        * :Introduction to sunpy core [new page described in #6615]
+
+
+.. todo::
+
+    if #6615 is completed link here
+    Introduction to sunpy core
 
 If you are a first time user or new to Python, our **tutorial** provides a walkthrough on how to use the key features of sunpy core.
 Once you've installed sunpy, start here.
 
-.. toctree::
-    :maxdepth: 2
-
-    intro/index
-
-
+* :ref:`guide`
+    #. :ref:`installing`
+    #. :ref:`units-sunpy`
+    #. :ref:`time-in-sunpy`
+    #. :ref:`coordinates-sunpy`
+    #. :ref:`acquiring_data`
+    #. :ref:`map_guide`
+    #. :ref:`timeseries_guide`
+    #. :ref:`plotting`
 
 
 Next Steps
@@ -29,10 +36,15 @@ Next Steps
 * :doc:`Example gallery <generated/gallery/index>` contains short-form guides on accomplishing common tasks using sunpy.
 * :ref:`API reference<reference>` contains a technical description of the inputs, outputs, and behaviour of each component of sunpy core.
 
-..
-    * [if we have how-tos?] How to guides provide detailed overview on some of the features of sunpy. These assume some level of experience using sunpy.
-..
-    * [we dont have a link to these but we do have some explanation pages] Topic guides (name?) provide
+.. todo::
+
+    When a page or subgallery containing more diataxis like how-to (longer form) guides is added then link here
+    [How to guides] provide detailed overview on some of the features of sunpy. These assume some level of experience using sunpy.
+
+.. todo::
+
+    Index explanation pages (e.g. different map rotation methods and then link here.)
+    [Topic guides] discuss key topics and concepts at a fairly high level and provide useful background information and explanation.
 
 
 Further Info
@@ -52,6 +64,8 @@ Further Info
     :maxdepth: 1
     :hidden:
 
+    intro/index
+    intro/installation
     generated/gallery/index
     reference/index
     whatsnew/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,42 +2,64 @@
 sunpy core Documentation
 ************************
 
-The sunpy core package is a community-developed, free and open-source solar
+``sunpy`` is a community-developed, free and open-source solar
 data analysis environment for Python.
 
+New Users
+*********
+
+If you are a first time user or new to Python,
+
+..
+        * :Introduction to sunpy core [new page described in #6615]
+
+* :doc:`installation guide <intro/installation>`
+
+Our **tutorial** provides a walkthrough on how to use the key features of sunpy core, we recommend new users start here.
+
+* :doc:`Getting Started <intro/index>`
+
+  #. :doc:`Data Acquisition <intro/acquiring_data/index>`
+  #. :doc:`Data Types <intro/data_types/index>`
+  #. :doc:`Plotting <intro/plotting>`
+  #. :doc:`Units <intro/units>`
+  #. :doc:`Coordinates <intro/coordinates>`
+  #. :doc:`Time <intro/time>`
+
+
+Next Steps
+**********
+
+* :doc:`Example gallery <generated/gallery/index>` contains short-form guides on accomplishing common tasks using sunpy.
+* :doc:`API reference<reference/index>` contains a technical description of the functionality of sunpy core's modules. It describes how they work and how to use them but assume you have a good understanding of sunpy and the scientific python ecosystem in general.
+
+..
+    * [if we have how-tos?] How to guides provide detailed overview on some of the features of sunpy. These assume some level of experience using sunpy.
+..
+    * [we dont have a link to these but we do have some explanation pages] Topic guides (name?) provide
+
+Further Info
+************
+
+* Find out :doc:`what's new <whatsnew/index>` with sunpy.
+* View a list of :doc:`known issues <reference/known_issues>` or report new issues on our `GitHub issue tracker`_.
+* Join our `chat room`_ or post to our `discourse`_ for help.
+* Read the :doc:`Developers guide <dev_guide/index>` to start contributing to the sunpy project.
+
+
+.. _chat room: https://openastronomy.element.io/#/room/#sunpy:openastronomy.org
+.. _GitHub issue tracker: https://github.com/sunpy/sunpy/issues
+.. _discourse: https://community.openastronomy.org/c/sunpy/5
+
 .. toctree::
-   :maxdepth: 1
-   :hidden:
+    :maxdepth: 1
+    :hidden:
 
-   intro/index
-   generated/gallery/index
-   reference/index
-   whatsnew/index
-   about
-   reference/known_issues
-   reference/stability
-   dev_guide/index
-
-.. grid:: 1 2 2 2
-    :gutter: 3
-
-    .. grid-item-card::
-        :class-card: card
-
-        Getting started
-        ^^^^^^^^^^^^^^^
-        | :ref:`installing`
-        | :ref:`guide`
-        | :doc:`generated/gallery/index`
-        | :ref:`reference`
-        | :ref:`whatsnew`
-
-    .. grid-item-card::
-        :class-card: card
-
-        Other info
-        ^^^^^^^^^^
-        | :ref:`citing_sunpy`
-        | :ref:`known_issues`
-        | :ref:`stability`
-        | :ref:`dev_guide`
+    intro/index
+    generated/gallery/index
+    reference/index
+    whatsnew/index
+    about
+    reference/known_issues
+    reference/stability
+    dev_guide/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ Further Info
 * Find out :ref:`what's new <whatsnew>` with sunpy.
 * View a list of :ref:`known issues <known_issues>` or report new issues on our `GitHub issue tracker`_.
 * Join our `chat room`_ or post to our `discourse`_ for help.
-* Read the :ref:`Developers guide <dev_guide>` to start contributing to the sunpy project.
+* Read the :ref:`Developers guide <dev_guide>` to start contributing to the SunPy project.
 
 
 .. _chat room: https://openastronomy.element.io/#/room/#sunpy:openastronomy.org


### PR DESCRIPTION
A very quick attempt  (slowed by everything having being renamed when rebasing) at solving the same problem as #6615 but in a different way. This has the same information as the current landing page but presented in a more descriptive manner.  

I envision the flashy, attention grabbing content suggested in that issue as going in a new "what is sunpy" page linked right at the start here such that the first steps section goes "what is sunpy -> installation guide -> tutorial/walkthrough"

I think having laid it out like this it highlights the need for the tutorial to be improved and reorganised.

There is some placeholder code-comments envisioning where links to future envisioned sections would go. The whole thing Very much up for feedback.
