### PR TITLE
Tutorialise installation

### DIFF
--- a/changelog/6639.doc.rst
+++ b/changelog/6639.doc.rst
@@ -1,0 +1,1 @@
+Split the installation docs into a new Installation tutorial, and an installation guide.

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -4,8 +4,6 @@
 Guides
 ******
 
-Welcome to the guides for different parts of the ``sunpy`` core package.
-
 These guides provide a set of in-depth explanations for various parts of the ``sunpy`` core package.
 They assumes you have some knowledge of what ``sunpy`` is and how it works - if you're starting fresh you might want to check out the :ref:`tutorial` first.
 

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -1,20 +1,20 @@
 .. _guide:
 
-*****
-Guide
-*****
+******
+Guides
+******
 
-Welcome to the guide for the ``sunpy`` core package.
+Welcome to guides for different parts of the ``sunpy`` core package.
 
 What is this?
 -------------
-This guide provides a set of in-depth explanations for various parts of the sunpy core package.
-It assumes you have some knowledge of what sunpy is and how it works - if you're starting fresh you might want to check out the :ref:`tutorial` first.
+These guides provide a set of in-depth explanations for various parts of the sunpy core package.
+They assumes you have some knowledge of what sunpy is and how it works - if you're starting fresh you might want to check out the :ref:`tutorial` first.
 
-How to use this guide
+How to use the guides
 ---------------------
-The guide is designed to be read in a standalone manner, without running any code at the same time.
-Although there are code snippets in various bits of the guide, these are to help explanation, and are not structured in a way that they can be run as you're reading the guide.
+The guides are designed to be read in a standalone manner, without running code at the same time.
+Although there are code snippets in various bits of the guides, these are to help explanation, and are not structured in a way that they can be run as you're reading each guide.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -4,12 +4,10 @@
 Guides
 ******
 
-Welcome to guides for different parts of the ``sunpy`` core package.
+Welcome to the guides for different parts of the ``sunpy`` core package.
 
-What is this?
--------------
-These guides provide a set of in-depth explanations for various parts of the sunpy core package.
-They assumes you have some knowledge of what sunpy is and how it works - if you're starting fresh you might want to check out the :ref:`tutorial` first.
+These guides provide a set of in-depth explanations for various parts of the ``sunpy`` core package.
+They assumes you have some knowledge of what ``sunpy`` is and how it works - if you're starting fresh you might want to check out the :ref:`tutorial` first.
 
 How to use the guides
 ---------------------

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -1,0 +1,22 @@
+.. _guide:
+
+***************
+The sunpy guide
+***************
+
+Welcome to the guide for the ``sunpy`` core package.
+
+What is this?
+-------------
+This guide provides a set of in-depth explanations for various parts of the sunpy core package.
+It assumes you have some knowledge of what sunpy is and how it works - if you're starting fresh you might want to check out the :ref:`tutorial` first.
+
+How to use this guide
+---------------------
+The guide is designed to be read in a standalone manner, without running any code at the same time.
+Although there are code snippets in various bits of the guide, these are to help explanation, and are not structured in a way that they can be run as you're reading the guide.
+
+.. toctree::
+   :maxdepth: 2
+
+   installation

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -1,8 +1,8 @@
 .. _guide:
 
-***************
-The sunpy guide
-***************
+*****
+Guide
+*****
 
 Welcome to the guide for the ``sunpy`` core package.
 

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -1,3 +1,5 @@
+.. _guide_installing:
+
 ************
 Installation
 ************

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -4,15 +4,18 @@
 Installation
 ************
 
-The SunPy project `maintains a range of packages <https://sunpy.org/project/affiliated>`__ that leverage the wider ecosystem of scientific Python packages for solar physics.
+The SunPy project `maintains a range of affiliated packages <https://sunpy.org/project/affiliated>`__ that leverage the wider ecosystem of scientific Python packages for solar physics.
+This page focuses on how to install the ``sunpy`` core package, but these instructions should apply to most of the affiliated packages as well.
 
 conda
 =====
 Full instructions for installing using conda are in :ref:`installing`.
-This is the recommended way to install sunpy, because it creates a fresh Python environment that is independent from any other Python install or packages on your system.
+This is the recommended way to install sunpy, because it creates a fresh Python environment that is independent from any other Python install or packages on your system, and allows the installation of non-python packages.
+SunPy publishes many of it's packages to the `conda-forge <https://conda-forge.org/>`__ channel.
+If you have an existing conda install, without the conda-forge channel added you can configure the conda-forge channel by following the `instructions in the conda-forge <https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge>`__ documentation.
 
-Updating a package
-------------------
+Updating a conda package
+------------------------
 You can update to the latest version of any package by running:
 
 .. code-block:: bash
@@ -56,3 +59,11 @@ The available options are: ``[asdf]``, ``[dask]``, ``[database]``, ``[image]``, 
     If you get a ``PermissionError`` this means that you do not have the required administrative access to install new packages to your Python installation.
     Do **not** install ``sunpy`` or other Python packages using ``sudo``.
     This error implies you have an incorrectly configured virtual environment or it is not activated.
+
+Updating a pip package
+----------------------
+You can update to the latest version of any package by running:
+
+.. code-block:: bash
+
+    $ pip install --upgrade <package_name>

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -1,0 +1,54 @@
+************
+Installation
+************
+
+The SunPy project `maintains a range of packages <https://sunpy.org/project/affiliated>`__ that leverage the wider ecosystem of scientific Python packages for solar physics.
+
+conda
+=====
+
+Updating a package
+------------------
+You can update to the latest version of any package by running:
+
+.. code-block:: bash
+
+    $ conda update <package_name>
+
+pip
+===
+This is for installing ``sunpy`` within a Python distribution, where ``pip`` has been used to install packages.
+You will want to make sure you are using a `Python virtual environment <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/>`__.
+
+Once the environment active, to acquire a full ``sunpy`` installation:
+
+.. code-block:: bash
+
+    $ pip install "sunpy[all]"
+
+.. note::
+
+    We strive to provide binary wheels for all of our packages.
+    If you are using a Python distribution or operating system that is missing a binary wheel.
+    ``pip`` will try to compile the package from source and this is likely to fail without a C compiler (e.g., ``gcc`` or ``clang``).
+    Getting the compiler either from your system package manager or XCode should address this.
+
+If you have a reason to want a more minimal installation, you can install sunpy with no optional dependencies, however this means a lot of submodules will not import:
+
+.. code-block:: bash
+
+    $ pip install "sunpy"
+
+It is possible to select which "extra" dependencies you want to install, if you know you only need certain submodules:
+
+.. code-block:: bash
+
+    $ pip install "sunpy[map,timeseries]"
+
+The available options are: ``[asdf]``, ``[dask]``, ``[database]``, ``[image]``, ``[jpeg2000]``, ``[map]``, ``[net]``, ``[timeseries]``, ``[visualization]``.
+
+.. note::
+
+    If you get a ``PermissionError`` this means that you do not have the required administrative access to install new packages to your Python installation.
+    Do **not** install ``sunpy`` or other Python packages using ``sudo``.
+    This error implies you have an incorrectly configured virtual environment or it is not activated.

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -8,6 +8,8 @@ The SunPy project `maintains a range of packages <https://sunpy.org/project/affi
 
 conda
 =====
+Full instructions for installing using conda are in :ref:`installing`.
+This is the recommended way to install sunpy, because it creates a fresh Python environment that is independent from any other Python install or packages on your system.
 
 Updating a package
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ For help installing ``sunpy`` refer to our :ref:`installation guide <installing>
 If you are a first time user or new to Python, our **tutorial** provides a walkthrough on how to use the key features of sunpy core.
 Once you've installed sunpy, start here.
 
-* :ref:`guide`
+* :ref:`tutorial`
     #. :ref:`installing`
     #. :ref:`units-sunpy`
     #. :ref:`time-in-sunpy`
@@ -36,6 +36,7 @@ Once you've installed sunpy, start here.
 Next Steps
 ==========
 
+* :ref:`guide` contains in depth guides for different parts of sunpy.
 * :doc:`Example gallery <generated/gallery/index>` contains short-form guides on accomplishing common tasks using sunpy.
 * :ref:`API reference<reference>` contains a technical description of the inputs, outputs, and behaviour of each component of sunpy core.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,6 +71,7 @@ Further Info
     intro/index
     intro/installation
     generated/gallery/index
+    guide/index
     reference/index
     whatsnew/index
     about

--- a/docs/intro/index.rst
+++ b/docs/intro/index.rst
@@ -1,4 +1,4 @@
-.. _guide:
+.. _tutorial:
 
 **********************
 The sunpy tutorial

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -41,6 +41,6 @@ If you want to install another package later, you can run ``conda install <packa
 
 Now we've got a working installation of ``sunpy``, in the next few chapters we'll look at some of the basic data structures ``sunpy`` uses for representing times, coordinates, and data with physical units.
 
-Futher reading
---------------
+Further reading
+---------------
 For more info on different ways to install ``sunpy`` (beyond the recommended way described above), see :ref:`guide_installing`.

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -4,22 +4,22 @@
 Installation
 ************
 
-This is the first chapter in the sunpy tutorial, and by the end of it you should have a working installation of Python and sunpy.
+This is the first chapter in the sunpy tutorial, and by the end of it you should have a working installation of Python and ``sunpy``.
 
 Installing Python
 =================
 There are many ways to install Python, but even if you have Python installed somewhere on your computer we recommend following these instructions anyway.
 That's because we will create a new Python environment.
-As well as containing a Python installation, this environment provides an isolated place to install Python packages (like sunpy).
+As well as containing a Python installation, this environment provides an isolated place to install Python packages (like ``sunpy``) without affecting any other current Python installation.
 
 The package manager we'll be using is called ``conda``.
 To install conda, follow the `the miniforge installation instructions <https://github.com/conda-forge/miniforge#install>`__.
-This will install ``conda`` and automatically configure the default channel (a channel is a remote software repository) to be ``conda-forge``, which is where ``sunpy`` packages are available.
+This will install ``conda`` and automatically configure the default channel (a channel is a remote software repository) to be ``conda-forge``, which is where ``sunpy`` is available.
 
 Installing sunpy
 ----------------
-To install ``sunpy``, start by launching a terminal (under a UNIX-like system) or miniforge Prompt (under Windows).
-Then create a and activate new virtual environment
+To install ``sunpy``, start by launching a terminal (under a UNIX-like system) or the miniforge Prompt (under Windows).
+Then create and activate new virtual environment
 
 .. code-block:: bash
 
@@ -28,7 +28,7 @@ Then create a and activate new virtual environment
 
 In this case the environment is named 'sunpy'.
 Feel free to change this to a different environment name.
-Now we have a fresh environment we can install sunpy:
+Now we have a fresh environment we can install ``sunpy``:
 
 .. code-block:: bash
 
@@ -37,7 +37,7 @@ Now we have a fresh environment we can install sunpy:
 This will install ``sunpy`` and all of its dependencies.
 If you want to install another package later, you can run ``conda install <package_name>``.
 
-Now we've got a working installation of sunpy, in the next few chapters we'll look at some of the basic data structures sunpy uses for representing times, coordinates, and data with physical units.
+Now we've got a working installation of ``sunpy``, in the next few chapters we'll look at some of the basic data structures ``sunpy`` uses for representing times, coordinates, and data with physical units.
 
 Futher reading
 --------------

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -5,6 +5,7 @@ Installation
 ************
 
 This is the first chapter in the sunpy tutorial, and by the end of it you should have a working installation of Python and ``sunpy``.
+For more info on different ways to install ``sunpy`` beyond the recommended way below, see :ref:`guide_installing`.
 
 Installing Python
 =================
@@ -40,7 +41,3 @@ This will install ``sunpy`` and all of its dependencies.
 If you want to install another package later, you can run ``conda install <package_name>``.
 
 Now we've got a working installation of ``sunpy``, in the next few chapters we'll look at some of the basic data structures ``sunpy`` uses for representing times, coordinates, and data with physical units.
-
-Further reading
----------------
-For more info on different ways to install ``sunpy`` (beyond the recommended way described above), see :ref:`guide_installing`.

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -24,6 +24,8 @@ Then create and activate new virtual environment
 .. code-block:: bash
 
     $ conda create --name sunpy
+    $ conda config --add channels conda-forge
+    $ conda config --set channel_priority strict
     $ conda activate sunpy
 
 In this case the environment is named 'sunpy'.

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -4,86 +4,37 @@
 Installation
 ************
 
-The SunPy project `maintains a range of packages <https://sunpy.org/project/affiliated>`__ that leverage the wider ecosystem of scientific Python packages for solar physics.
+This is the first chapter in the sunpy tutorial, and by the end of it you should have a working installation of Python and sunpy.
 
 Installing Python
 =================
-These instructions will set you up with `miniforge <https://conda-forge.org/docs/user/introduction.html>`__, which makes it easy to install and manage Python packages.
+There are many ways to install Python, but even if you have Python installed somewhere on your computer we recommend following these instructions anyway.
+That's because we will create a new Python environment.
+As well as containing a Python installation, this environment provides an isolated place to install Python packages (like sunpy).
 
-To install the miniforge Python distribution follow `the miniforge installation instructions <https://github.com/conda-forge/miniforge#install>`__.
+The package manager we'll be using is called ``conda``.
+To install conda, follow the `the miniforge installation instructions <https://github.com/conda-forge/miniforge#install>`__.
+This will install ``conda`` and automatically configure the default channel (a channel is a remote software repository) to be ``conda-forge``, which is where ``sunpy`` packages are available.
 
-This makes installing ``sunpy`` and many other packages in the scientific Python ecosystem much easier and quicker.
-It also provides many pre-compiled binaries that are not available on PyPI.
+Installing sunpy
+----------------
+To install ``sunpy``, start by launching a terminal (under a UNIX-like system) or miniforge Prompt (under Windows).
+Then create a and activate new virtual environment
 
-Installing a package
---------------------
-To install ``sunpy``, launch a terminal (under a UNIX-like system) or miniforge Prompt (under Windows).
+.. code-block:: bash
 
-It is considered good practice to create a new virtual environment for each project you work on.
-`Here are some instructions on setting up a conda virtual environment. <https://towardsdatascience.com/getting-started-with-python-environments-using-conda-32e9f2779307>`__
+    $ conda create --name sunpy
+    $ conda activate sunpy
 
-You will want to activate your virtual environment then run:
+In this case the environment is named 'sunpy'.
+Feel free to change this to a different environment name.
+Now we have a fresh environment we can install sunpy:
 
 .. code-block:: bash
 
     $ conda install sunpy
 
 This will install ``sunpy`` and all of its dependencies.
+If you want to install another package later, you can run ``conda install <package_name>``.
 
-You can replace ``sunpy`` in the above install command with other packages such as``sunkit-instruments`` to install them.
-For a list of some other Python packages for solar physics, `see the SunPy Affiliated Packages list <https://sunpy.org/project/affiliated>`__.
-
-.. warning::
-
-    Please do not mix ``pip`` and ``conda`` to install packages within your environments.
-    There are no guarantees that this will work and it is likely to cause problems.
-
-Updating a package
-------------------
-You can update to the latest version of any package by running:
-
-.. code-block:: bash
-
-    $ conda update <package_name>
-
-Installing without conda
-========================
-This is for installing ``sunpy`` within a Python distribution, where ``pip`` has been used to install packages.
-You will want to make sure you are using a `Python virtual environment <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/>`__.
-
-Once the environment active, to acquire a full ``sunpy`` installation:
-
-.. code-block:: bash
-
-    $ pip install "sunpy[all]"
-
-.. note::
-
-    For fast and consistent installs, we strive to provide pure Python wheels for all of our packages.
-    The core ``sunpy`` package also provides *compiled* wheels for CPython on Linux (x86-64) and macOS (x86-64 and ARM64), containing an optional C extension (``sunpy.io.ana``).
-    On these platforms ``pip`` will install the compiled wheel by default, while on other platforms it will install the pure Python wheel without ``sunpy.io.ana``.
-    If you require this extension on other platforms, install with ``pip install --no-binary sunpy "sunpy[all]"`` and ``pip`` will try to compile the package from source.
-    Installing from source requires a C compiler (e.g., ``gcc`` or ``clang``), which can typically be installed from your system package manager, if not already installed.
-    This extension is not compatible with Windows.
-
-If you have a reason to want a more minimal installation, you can install sunpy with no optional dependencies, however this means a lot of submodules will not import:
-
-.. code-block:: bash
-
-    $ pip install "sunpy"
-
-It is possible to select which "extra" dependencies you want to install, if you know you only need certain submodules:
-
-.. code-block:: bash
-
-    $ pip install "sunpy[map,timeseries]"
-
-The available options are: ``[asdf]``, ``[dask]``, ``[database]``, ``[image]``, ``[jpeg2000]``, ``[map]``, ``[net]``, ``[timeseries]``, ``[visualization]``.
-
-.. note::
-
-    If you get a ``PermissionError`` this means that you do not have the required administrative access to install new packages to your Python installation.
-    Do **not** install ``sunpy`` or other Python packages using ``sudo``.
-    This error implies you have an incorrectly configured virtual environment or it is not activated.
-
-If you want to develop ``sunpy`` we would strongly recommend reading the `Newcomers' Guide <https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html>`__.
+Now we've got a working installation of sunpy, in the next few chapters we'll look at some of the basic data structures sunpy uses for representing times, coordinates, and data with physical units.

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -38,3 +38,7 @@ This will install ``sunpy`` and all of its dependencies.
 If you want to install another package later, you can run ``conda install <package_name>``.
 
 Now we've got a working installation of sunpy, in the next few chapters we'll look at some of the basic data structures sunpy uses for representing times, coordinates, and data with physical units.
+
+Futher reading
+--------------
+For more info on different ways to install ``sunpy`` (beyond the recommended way described above), see :ref:`guide_installing`.


### PR DESCRIPTION
This converts the "Installation" section of the tutorial to a tutorial style. This means providing a set of instructions and code that is copy/pasted one at a time, and having a linear narrative with the single goal of getting a working sunpy installation.

I am aware that a lot of info at the end has been cut - for the tutorial I think this is right, as it provides one way to install and reduces bloat. Perhaps we want to move this content to an explanation-style page instead?