### PR TITLE
Fix NOAA ind plotting on devdeps

### DIFF
--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -102,8 +102,6 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         to_plot = self.to_dataframe()[to_plot]
         to_plot.plot(ax=axes, **kwargs)
 
-        axes.set_xlim(min(to_plot.dropna(how='all').index),
-                      max(to_plot.dropna(how='all').index))
         axes.set_ylim(0)
         axes.set_ylabel(ylabel)
         axes.legend()


### PR DESCRIPTION
I have no idea why this is failing - the only difference in packages between passing and failing tests on circleCI that could have caused the failure was different commits for Matplotlib dev version. I had a look at Matplotlib commits and couldn't find anything obvious that would casue the failure.

I can't reproduce outside tox, so this is my best guess at a fix...