### PR TITLE
Fix `draw_quadrangle()` so that it accepts frames with data

### DIFF
--- a/changelog/6648.bugfix.rst
+++ b/changelog/6648.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that prevented specifying a `~astropy.coordinates.BaseCoordinateFrame` (as opposed to a `~astropy.coordinates.SkyCoord`) to :meth:`sunpy.map.GenericMap.draw_quadrangle`.

--- a/examples/differential_rotation/differentially_rotated_coordinate.py
+++ b/examples/differential_rotation/differentially_rotated_coordinate.py
@@ -34,7 +34,7 @@ point = SkyCoord(187*u.arcsec, 283*u.arcsec, frame=aiamap.coordinate_frame)
 # times.  Let's define a daily cadence for +/- five days.
 
 durations = np.concatenate([range(-5, 0), range(1, 6)]) * u.day
-diffrot_point = RotatedSunFrame(base=point, duration=durations)
+diffrot_point = SkyCoord(RotatedSunFrame(base=point, duration=durations))
 
 ##############################################################################
 # To see what this coordinate looks like in "real" helioprojective

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2262,7 +2262,7 @@ class GenericMap(NDData):
             width = Longitude(top_right.spherical.lon - bottom_left.spherical.lon)
             height = top_right.spherical.lat - bottom_left.spherical.lat
             anchor = self._get_lon_lat(bottom_left)
-            transform = axes.get_transform(bottom_left.frame.replicate_without_data())
+            transform = axes.get_transform(bottom_left.replicate_without_data())
 
         kwergs = {
             "transform": transform,

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -126,7 +126,7 @@ def test_quadrangle_aia17_width_height(aia171_test_map):
         50 * u.deg, -10 * u.deg, frame=HeliographicStonyhurst, obstime=aia171_test_map.date)
     w = 30 * u.deg
     h = 90 * u.deg
-    aia171_test_map.draw_quadrangle(bottom_left=bottom_left, width=w, height=h)
+    aia171_test_map.draw_quadrangle(bottom_left=bottom_left.frame, width=w, height=h)
 
 
 @figure_test


### PR DESCRIPTION
Users are intended to use `SkyCoord` to define coordinates.  However, users can end up with a lower-level frame with data, and for the most part, they behave very similarly.  `draw_quadrangle()` has a line that errors for input that is a frame with data, and the change to support both types of input is very easy.