### PR TITLE
Ignore a deprecation warning in NumPy 1.24 that is triggered by scikit-image

### DIFF
--- a/examples/plotting/three_map_composite.py
+++ b/examples/plotting/three_map_composite.py
@@ -29,7 +29,7 @@ aia = Map(sunpy.data.sample.AIA_171_IMAGE)
 ###############################################################################
 # Before we plot the image, let's reproject the off-disk AIA coordinates onto
 # a spherical screen at the same distance as the EIT map, so they can be
-# overlayed. Next, zoom in around the solar flare so the RHESSI contours are
+# overlaid. Next, zoom in around the solar flare so the RHESSI contours are
 # visible. Also, specify the RHESSI contour levels to be plotted.
 
 with Helioprojective.assume_spherical_screen(eit.observer_coordinate):

--- a/setup.cfg
+++ b/setup.cfg
@@ -197,6 +197,8 @@ filterwarnings =
     ignore:.*will attempt to set the values inplace instead of always setting a new array:FutureWarning
     # Zeep relies on deprecated cgi in Python 3.11
     ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:zeep.utils
+    # Deprecation warning added in NumPy 1.24, triggered by scikit-image
+    ignore:`np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24):DeprecationWarning
 
 [pycodestyle]
 max_line_length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -198,7 +198,7 @@ filterwarnings =
     # Zeep relies on deprecated cgi in Python 3.11
     ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:zeep.utils
     # Deprecation warning added in NumPy 1.24, triggered by scikit-image
-    ignore:`np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24):DeprecationWarning
+    ignore:.*np.bool8.*is a deprecated alias.*:DeprecationWarning
 
 [pycodestyle]
 max_line_length = 110

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ deps =
     figure-!devdeps: astropy==5.1.0
     figure-!devdeps: matplotlib==3.5.2
     figure-!devdeps: mpl-animators==1.0.0
+    figure-!devdeps: numpy<1.24
 extras =
     all
     tests


### PR DESCRIPTION
See title.  The deprecation warning is:
```
DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
```