### PR TITLE
Whack-a-mole with failing tests

### DIFF
--- a/docs/intro/acquiring_data/helioviewer.rst
+++ b/docs/intro/acquiring_data/helioviewer.rst
@@ -26,7 +26,7 @@ It also supports tab-complete, to find the data source you want.
 
    >>> import hvpy
    >>> hvpy.getDataSources()  # doctest: +REMOTE_DATA
-   {'SDO': {'HMI': {'continuum': {'sourceId': 18,
+   {...'SDO': {...'HMI': {'continuum': {'sourceId': 18,
    ...
 
 ``HelioviewerClient().get_closest_image`` is replaced by :func:`hvpy.getClosestImage`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,8 @@ docs =
   sphinxext-opengraph
   sunkit_image
   sunpy-sphinx-theme
+  # Not a direct dependency, but we need to pin this until sphinx-changelog is updated (see #6668)
+  towncrier<22.12.0
 
 [options.packages.find]
 exclude = sunpy._dev

--- a/sunpy/database/tests/test_tables.py
+++ b/sunpy/database/tests/test_tables.py
@@ -189,11 +189,11 @@ def test_entries_from_fido_search_result(fido_search_result):
         observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=17634850.470588233, wavemax=17634850.470588233,
         instrument='NORH')
-    # 1 entry from rhessi
+    # 2 entries from rhessi
+    assert entries[66].fileid.endswith("/metadata/catalog/hsi_obssumm_20120101_032.fits")
     assert entries[66] == DatabaseEntry(
         source="RHESSI", provider='NASA', physobs='summary_lightcurve',
-        fileid=("https://hesperia.gsfc.nasa.gov/"
-                "hessidata/metadata/catalog/hsi_obssumm_20120101_032.fits"),
+        fileid=entries[66].fileid,
         observation_time_start=datetime(2012, 1, 1, 0, 0),
         observation_time_end=datetime(2012, 1, 1, 23, 59, 59, 999000),
         wavemin=np.nan, wavemax=np.nan,

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -148,7 +148,7 @@ class RHESSIClient(GenericClient):
         --------
         >>> from sunpy.net.dataretriever.sources.rhessi import RHESSIClient
         >>> RHESSIClient().get_observing_summary_filename(('2011/04/04', '2011/04/04'))   # doctest: +REMOTE_DATA
-        ['https://.../hessidata/metadata/catalog/hsi_obssumm_20110404_058.fits']
+        ['...://.../hessidata/metadata/catalog/hsi_obssumm_20110404_058.fits']
         """
         dt = TimeRange(time_range)
         # remove time from dates

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -63,16 +63,14 @@ class Scraper:
 
     Examples
     --------
-    >>> # Downloading data from SolarMonitor.org
     >>> from sunpy.net import Scraper
-    >>> solmon_pattern = ('http://solarmonitor.org/data/'
-    ...                   '%Y/%m/%d/fits/{instrument}/'
-    ...                   '{instrument}_{wave:05d}_fd_%Y%m%d_%H%M%S.fts.gz')
-    >>> solmon = Scraper(solmon_pattern, instrument = 'swap', wave = 174)
-    >>> print(solmon.pattern)
-    http://solarmonitor.org/data/%Y/%m/%d/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz
-    >>> print(solmon.now)  # doctest: +SKIP
-    http://solarmonitor.org/data/2017/11/20/fits/swap/swap_00174_fd_20171120_193933.fts.gz
+    >>> pattern = ('http://proba2.oma.be/{instrument}/data/bsd/%Y/%m/%d/'
+    ...            '{instrument}_lv1_%Y%m%d_%H%M%S.fits')
+    >>> swap = Scraper(pattern, instrument='swap')
+    >>> print(swap.pattern)
+    http://proba2.oma.be/swap/data/bsd/%Y/%m/%d/swap_lv1_%Y%m%d_%H%M%S.fits
+    >>> print(swap.now)  # doctest: +SKIP
+    http://proba2.oma.be/swap/data/bsd/2022/12/21/swap_lv1_20221221_112433.fits
 
     Notes
     -----
@@ -260,17 +258,15 @@ class Scraper:
         Examples
         --------
         >>> from sunpy.net import Scraper
-        >>> solmon_pattern = ('http://solarmonitor.org/data/'
-        ...                   '%Y/%m/%d/fits/{instrument}/'
-        ...                   '{instrument}_{wave:05d}_fd_%Y%m%d_%H%M%S.fts.gz')
-        >>> solmon = Scraper(solmon_pattern, instrument = 'swap', wave = 174)
+        >>> pattern = ('http://proba2.oma.be/{instrument}/data/bsd/%Y/%m/%d/'
+        ...            '{instrument}_lv1_%Y%m%d_%H%M%S.fits')
+        >>> swap = Scraper(pattern, instrument='swap')
         >>> from sunpy.time import TimeRange
-        >>> timerange = TimeRange('2015-01-01','2015-01-01T16:00:00')
-        >>> print(solmon.filelist(timerange))  # doctest: +REMOTE_DATA
-        ['http://solarmonitor.org/data/2015/01/01/fits/swap/swap_00174_fd_20150101_025423.fts.gz',
-         'http://solarmonitor.org/data/2015/01/01/fits/swap/swap_00174_fd_20150101_061145.fts.gz',
-         'http://solarmonitor.org/data/2015/01/01/fits/swap/swap_00174_fd_20150101_093037.fts.gz',
-         'http://solarmonitor.org/data/2015/01/01/fits/swap/swap_00174_fd_20150101_124927.fts.gz']
+        >>> timerange = TimeRange('2015-01-01T00:08:00','2015-01-01T00:12:00')
+        >>> print(swap.filelist(timerange))  # doctest: +REMOTE_DATA
+        ['http://proba2.oma.be/swap/data/bsd/2015/01/01/swap_lv1_20150101_000857.fits',
+         'http://proba2.oma.be/swap/data/bsd/2015/01/01/swap_lv1_20150101_001027.fits',
+         'http://proba2.oma.be/swap/data/bsd/2015/01/01/swap_lv1_20150101_001157.fits']
 
         Notes
         -----

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -179,16 +179,15 @@ def testFilesRange_sameDirectory_local():
 
 @pytest.mark.remote_data
 def testFilesRange_sameDirectory_remote():
-    pattern = ('http://solarmonitor.org/data/%Y/%m/%d/'
-               'fits/{instrument}/'
-               '{instrument}_00174_fd_%Y%m%d_%H%M%S.fts.gz')
+    pattern = ('http://proba2.oma.be/{instrument}/data/bsd/%Y/%m/%d/'
+               '{instrument}_lv1_%Y%m%d_%H%M%S.fits')
     s = Scraper(pattern, instrument='swap')
     startdate = parse_time((2014, 5, 14, 0, 0))
-    enddate = parse_time((2014, 5, 14, 6, 30))
+    enddate = parse_time((2014, 5, 14, 0, 5))
     timerange = TimeRange(startdate, enddate)
     assert len(s.filelist(timerange)) == 2
-    startdate = parse_time((2014, 5, 14, 21, 0))
-    enddate = parse_time((2014, 5, 14, 23, 30))
+    startdate = parse_time((2014, 5, 14, 0, 6))
+    enddate = parse_time((2014, 5, 14, 0, 7))
     timerange = TimeRange(startdate, enddate)
     assert len(s.filelist(timerange)) == 0
 


### PR DESCRIPTION
- Pins `towncrier` to <22.12.0 so that the docs build will not error (see #6668)
- Fixed two tests that assumed a particular mirror for RHESSI data (hesperia)
- Fixed a doctest that was not robust to a change in the hvpy data sources
- Fixed tests that scraped a non-official data repository (trying to get SWAP images from SolarMonitor.org, which now 403s)

Closes #6636