### PR TITLE
Add hook for updating `sunpy.net.hek.attrs`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,12 @@ repos:
         exclude: "sunpy/version.py|sunpy/util/decorators.py|sunpy/util/exceptions.py|sunpy/extern/|sunpy/util/tests/test_logger.py"
   - repo: local
     hooks:
+      - id: generate-sunpy-net-hek-attrs
+        name: generate sunpy.net.hek.attrs
+        entry: python tools/hek_mkcls.py
+        language: system
+        pass_filenames: false
+        files: (^tools/(hek_mkcls|hektemplate)\.py$)|(^sunpy/net/hek/attrs\.py$)
       - id: git-diff
         name: git diff
         entry: git diff --color --exit-code


### PR DESCRIPTION
Will run `tools/hek_mkcls.py` only when any of the following occur:
- `tools/hek_mkcls.py` is modified
- `tools/hektemplate.py` is modified
- autogenerated `sunpy/net/hek/attrs.py` is modified in error

I have tested this and it works as I would expect. It needs a basic `python` interpreted to be on the path. Hopefully this is the case on pre-commit.ci.

Closes #6556 