### PR TITLE
Update test that was marked xfail due to numpy version and trigger warning also based on numpy version

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -5,7 +5,6 @@ import re
 import copy
 import html
 import inspect
-import numbers
 import textwrap
 import itertools
 import webbrowser
@@ -1687,20 +1686,13 @@ class GenericMap(NDData):
         unpad_y = -np.min((diff[1], 0))
 
         # Pad the image array
-
-        if issubclass(self.data.dtype.type, numbers.Integral) and (missing % 1 != 0):
-            warn_user("The specified `missing` value is not an integer, but the data "
-                      "array is of integer type, so the output may be strange.")
-
         new_data = np.pad(self.data,
                           ((pad_y, pad_y), (pad_x, pad_x)),
                           mode='constant',
                           constant_values=(missing, missing))
 
         # All of the following pixel calculations use a pixel origin of 0
-
         pixel_array_center = (np.flipud(new_data.shape) - 1) / 2.0
-
         pixel_rotation_center = u.Quantity(self.reference_pixel).value + [pad_x, pad_y]
 
         if recenter:

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -5,6 +5,7 @@ import re
 import copy
 import html
 import inspect
+import numbers
 import textwrap
 import itertools
 import webbrowser
@@ -15,6 +16,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.figure import Figure
+from packaging import version
 
 try:
     from dask.array import Array as DaskArray
@@ -1685,6 +1687,11 @@ class GenericMap(NDData):
         unpad_x = -np.min((diff[0], 0))
         unpad_y = -np.min((diff[1], 0))
 
+        # Numpy 1.20+ prevents np.pad from padding with NaNs in integer arrays
+        # Before it would be cast to 0, but now it raises an error.
+        if version.parse(np.__version__) < version.parse("1.20.0") and issubclass(self.data.dtype.type, numbers.Integral) and (missing % 1 != 0):
+            warn_user("The specified `missing` value is not an integer, but the data "
+                      "array is of integer type, so the output may be strange.")
         # Pad the image array
         new_data = np.pad(self.data,
                           ((pad_y, pad_y), (pad_x, pad_x)),

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 from hypothesis import given, settings
 from matplotlib.figure import Figure
-from packaging import version
 
 import astropy.units as u
 import astropy.wcs
@@ -939,20 +938,6 @@ def test_rotate(aia171_test_map):
     aia171_test_map_crop_rot = aia171_test_map_crop.rotate(60 * u.deg)
     assert aia171_test_map_crop.data.shape[0] > aia171_test_map_crop.data.shape[1]
     assert aia171_test_map_crop_rot.data.shape[0] < aia171_test_map_crop_rot.data.shape[1]
-
-
-@pytest.mark.xfail(version.parse(np.__version__) >= version.parse("1.2.0"),
-                   reason="Numpy >= 1.20.0 doesn't allow NaN to int conversion")
-def test_rotate_with_incompatible_missing_dtype():
-    data = np.arange(0, 100).reshape(10, 10)
-    coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, obstime='2013-10-28',
-                     observer='earth', frame=sunpy.coordinates.Helioprojective)
-    header = sunpy.map.make_fitswcs_header(data, coord)
-    test_map = sunpy.map.Map(data, header)
-    with pytest.warns(SunpyUserWarning,
-                      match="The specified `missing` value is not an integer, but the data "
-                      "array is of integer type, so the output may be strange."):
-        test_map.rotate(order=3, missing=np.nan)
 
 
 def test_rotate_crpix_zero_degrees(generic_map):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from hypothesis import given, settings
 from matplotlib.figure import Figure
+from packaging import version
 
 import astropy.units as u
 import astropy.wcs
@@ -938,6 +939,32 @@ def test_rotate(aia171_test_map):
     aia171_test_map_crop_rot = aia171_test_map_crop.rotate(60 * u.deg)
     assert aia171_test_map_crop.data.shape[0] > aia171_test_map_crop.data.shape[1]
     assert aia171_test_map_crop_rot.data.shape[0] < aia171_test_map_crop_rot.data.shape[1]
+
+
+@pytest.mark.skipif(version.parse(np.__version__) >= version.parse("1.2.0"),
+                    reason="Numpy >= 1.20.0 doesn't allow NaN to int conversion")
+def test_rotate_with_incompatible_missing_dtype_warning():
+    data = np.arange(0, 100).reshape(10, 10)
+    coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, obstime='2013-10-28',
+                     observer='earth', frame=sunpy.coordinates.Helioprojective)
+    header = sunpy.map.make_fitswcs_header(data, coord)
+    test_map = sunpy.map.Map(data, header)
+    with pytest.warns(SunpyUserWarning,
+                      match="The specified `missing` value is not an integer, but the data "
+                      "array is of integer type, so the output may be strange."):
+        test_map.rotate(order=3, missing=np.nan)
+
+
+@pytest.mark.skipif(version.parse(np.__version__) <= version.parse("1.2.0"),
+                    reason="Numpy >= 1.20.0 doesn't allow NaN to int conversion")
+def test_rotate_with_incompatible_missing_dtype_error():
+    data = np.arange(0, 100).reshape(10, 10)
+    coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, obstime='2013-10-28',
+                     observer='earth', frame=sunpy.coordinates.Helioprojective)
+    header = sunpy.map.make_fitswcs_header(data, coord)
+    test_map = sunpy.map.Map(data, header)
+    with pytest.raises(ValueError, match="cannot convert float NaN to integer"):
+        test_map.rotate(order=3, missing=np.nan)
 
 
 def test_rotate_crpix_zero_degrees(generic_map):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -941,7 +941,7 @@ def test_rotate(aia171_test_map):
     assert aia171_test_map_crop_rot.data.shape[0] < aia171_test_map_crop_rot.data.shape[1]
 
 
-@pytest.mark.skipif(version.parse(np.__version__) >= version.parse("1.2.0"),
+@pytest.mark.skipif(version.parse(np.__version__) >= version.parse("1.20.0"),
                     reason="Numpy >= 1.20.0 doesn't allow NaN to int conversion")
 def test_rotate_with_incompatible_missing_dtype_warning():
     data = np.arange(0, 100).reshape(10, 10)
@@ -955,7 +955,7 @@ def test_rotate_with_incompatible_missing_dtype_warning():
         test_map.rotate(order=3, missing=np.nan)
 
 
-@pytest.mark.skipif(version.parse(np.__version__) <= version.parse("1.2.0"),
+@pytest.mark.skipif(version.parse(np.__version__) <= version.parse("1.20.0"),
                     reason="Numpy >= 1.20.0 doesn't allow NaN to int conversion")
 def test_rotate_with_incompatible_missing_dtype_error():
     data = np.arange(0, 100).reshape(10, 10)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -941,8 +941,8 @@ def test_rotate(aia171_test_map):
     assert aia171_test_map_crop_rot.data.shape[0] < aia171_test_map_crop_rot.data.shape[1]
 
 
-@pytest.mark.skipif(version.parse(np.__version__) >= version.parse("1.20.0"),
-                    reason="Numpy >= 1.20.0 doesn't allow NaN to int conversion")
+@pytest.mark.xfail(version.parse(np.__version__) >= version.parse("1.20.0"),
+                   reason="Numpy >= 1.20.0 doesn't allow NaN to int conversion")
 def test_rotate_with_incompatible_missing_dtype_warning():
     data = np.arange(0, 100).reshape(10, 10)
     coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, obstime='2013-10-28',


### PR DESCRIPTION
The test almost always fails and anyone who gets the warning will also most likely raise a error from numpy when you try to pad a nan to a int.