### PR TITLE
Raise error if downloader for cache fails

### DIFF
--- a/changelog/6711.bugfix.rst
+++ b/changelog/6711.bugfix.rst
@@ -1,0 +1,2 @@
+The ``data_manager`` was not raising failed downloads correctly and would continue as if the file existed locally.
+Now it will raise any errors from ``parfive``.

--- a/sunpy/data/data_manager/downloader.py
+++ b/sunpy/data/data_manager/downloader.py
@@ -48,6 +48,8 @@ class ParfiveDownloader(DownloaderBase):
         directory = path.parent
         downloader.enqueue_file(url, directory, filename)
         try:
-            downloader.download()
+            output = downloader.download()
         except Exception as e:
             raise DownloaderError from e
+        if output.errors:
+            raise DownloaderError(output.errors[0].exception)

--- a/sunpy/data/data_manager/tests/test_downloader.py
+++ b/sunpy/data/data_manager/tests/test_downloader.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+
+import pytest
+from parfive import Results
+from parfive.results import Error
+
+from sunpy.data.data_manager.downloader import DownloaderError, ParfiveDownloader
+
+
+def test_ParfiveDownloader_errors():
+    """
+    Test that ParfiveDownloader raises an error when the download fails.
+    """
+    downloader = ParfiveDownloader()
+    results = Results()
+    results.errors.append(Error("", "FAKE_URL", ValueError("TEST_ERROR")))
+    with patch('parfive.Downloader.download') as download:
+        download.return_value = results
+        with pytest.raises(DownloaderError, match='TEST_ERROR'):
+            downloader.download('https://www.fakewebsite.com', 'test_file')

--- a/sunpy/data/data_manager/tests/test_downloader.py
+++ b/sunpy/data/data_manager/tests/test_downloader.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
+import parfive
 import pytest
+from packaging.version import Version
 from parfive import Results
-from parfive.results import Error
 
 from sunpy.data.data_manager.downloader import DownloaderError, ParfiveDownloader
 
@@ -11,8 +12,15 @@ def test_ParfiveDownloader_errors():
     """
     Test that ParfiveDownloader raises an error when the download fails.
     """
+
     downloader = ParfiveDownloader()
     results = Results()
+
+    # TODO: Remove this when we support parfive 2.0.
+    if Version(parfive.__version__) >= Version("2.0.0"):
+        from parfive.results import Error
+    else:
+        Error = results._error
     results.errors.append(Error("", "FAKE_URL", ValueError("TEST_ERROR")))
     with patch('parfive.Downloader.download') as download:
         download.return_value = results


### PR DESCRIPTION
Noticed in aiapy, if the cache/data manager fails to download a file.

It does not raise the error that happened, and continues as if the file is there. Then errors when it goes to open the file. 

I think this code was before parfive returned the errors and used to raise exceptions. 