### PR TITLE
Reverse file detection logic fall to to extension

### DIFF
--- a/changelog/6736.feature.rst
+++ b/changelog/6736.feature.rst
@@ -1,1 +1,1 @@
-:func:`sunpy.io.filetools.read` will now try to detect the filetype based on the content and then fallback to using the file extension.
+:func:`sunpy.io.read_file` will now try to detect the filetype based on the content and then fallback to using the file extension.

--- a/changelog/6736.feature.rst
+++ b/changelog/6736.feature.rst
@@ -1,0 +1,1 @@
+:func:`sunpy.io.filetools.read` will now try to detect the filetype based on the content and then fallback to using the file extension.

--- a/sunpy/io/_file_tools.py
+++ b/sunpy/io/_file_tools.py
@@ -81,14 +81,21 @@ def read_file(filepath, filetype=None, **kwargs):
     if filetype is not None:
         return _readers[filetype].read(filepath, **kwargs)
 
-    # Go through the known extensions
-    for extension, readername in _known_extensions.items():
-        if filepath.endswith(extension) or filetype in extension:
-            return _readers[readername].read(filepath, **kwargs)
-
     # If filetype is not apparent from the extension, attempt to detect it
-    readername = _detect_filetype(filepath)
-    return _readers[readername].read(filepath, **kwargs)
+    try:
+        readername = _detect_filetype(filepath)
+    except UnrecognizedFileTypeError:
+        readername = None
+
+    # Go through the known extensions
+    for extension, name in _known_extensions.items():
+        if filepath.endswith(extension) or filetype in extension:
+            readername = name
+
+    if readername is not None:
+        return _readers[readername].read(filepath, **kwargs)
+
+    raise UnrecognizedFileTypeError("The requested filetype is not currently supported by sunpy.")
 
 
 def read_file_header(filepath, filetype=None, **kwargs):
@@ -116,14 +123,21 @@ def read_file_header(filepath, filetype=None, **kwargs):
     if filetype is not None:
         return _readers[filetype].get_header(filepath, **kwargs)
 
-    # Go through the known extensions
-    for extension, readername in _known_extensions.items():
-        if filepath.endswith(extension) or filetype in extension:
-            return _readers[readername].get_header(filepath, **kwargs)
-
     # If filetype is not apparent from the extension, attempt to detect it
-    readername = _detect_filetype(filepath)
-    return _readers[readername].get_header(filepath, **kwargs)
+    try:
+        readername = _detect_filetype(filepath)
+    except UnrecognizedFileTypeError:
+        readername = None
+
+    # Go through the known extensions
+    for extension, name in _known_extensions.items():
+        if filepath.endswith(extension) or filetype in extension:
+            readername = name
+
+    if readername is not None:
+        return _readers[readername].get_header(filepath, **kwargs)
+
+    raise UnrecognizedFileTypeError("The requested filetype is not currently supported by sunpy.")
 
 
 def write_file(fname, data, header, filetype='auto', **kwargs):
@@ -180,8 +194,7 @@ def _detect_filetype(filepath):
         return detect_filetype(filepath)
 
     # Raise an error if an unsupported filetype is encountered
-    raise UnrecognizedFileTypeError("The requested filetype is not currently "
-                                    "supported by SunPy.")
+    raise UnrecognizedFileTypeError("The requested filetype is not currently supported by sunpy.")
 
 
 def detect_filetype(filepath):
@@ -245,8 +258,7 @@ def detect_filetype(filepath):
         return 'cdf'
 
     # Raise an error if an unsupported filetype is encountered
-    raise UnrecognizedFileTypeError("The requested filetype is not currently "
-                                    "supported by SunPy.")
+    raise UnrecognizedFileTypeError("The requested filetype is not currently supported by sunpy.")
 
 
 class UnrecognizedFileTypeError(OSError):

--- a/sunpy/io/_file_tools.py
+++ b/sunpy/io/_file_tools.py
@@ -51,6 +51,22 @@ _readers = Readers({
 })
 
 
+def _read(filepath, function_name, filetype=None, **kwargs):
+    filepath = str(filepath)
+    if filetype is not None:
+        return getattr(_readers[filetype], function_name)(filepath, **kwargs)
+    try:
+        readername = _detect_filetype(filepath)
+    except UnrecognizedFileTypeError:
+        readername = None
+    for extension, name in _known_extensions.items():
+        if filepath.endswith(extension) or filetype in extension:
+            readername = name
+    if readername is not None:
+        return getattr(_readers[readername], function_name)(filepath, **kwargs)
+    raise UnrecognizedFileTypeError("The requested filetype is not currently supported by sunpy.")
+
+
 def read_file(filepath, filetype=None, **kwargs):
     """
     Automatically determine the filetype and read the file.
@@ -73,19 +89,7 @@ def read_file(filepath, filetype=None, **kwargs):
     pairs : `list`
         A list of (data, header) tuples.
     """
-    filepath = str(filepath)
-    if filetype is not None:
-        return _readers[filetype].read(filepath, **kwargs)
-    try:
-        readername = _detect_filetype(filepath)
-    except UnrecognizedFileTypeError:
-        readername = None
-    for extension, name in _known_extensions.items():
-        if filepath.endswith(extension) or filetype in extension:
-            readername = name
-    if readername is not None:
-        return _readers[readername].read(filepath, **kwargs)
-    raise UnrecognizedFileTypeError("The requested filetype is not currently supported by sunpy.")
+    return _read(filepath, 'read', filetype, **kwargs)
 
 
 def read_file_header(filepath, filetype=None, **kwargs):
@@ -109,18 +113,7 @@ def read_file_header(filepath, filetype=None, **kwargs):
     headers : `list`
         A list of headers.
     """
-    if filetype is not None:
-        return _readers[filetype].get_header(filepath, **kwargs)
-    try:
-        readername = _detect_filetype(filepath)
-    except UnrecognizedFileTypeError:
-        readername = None
-    for extension, name in _known_extensions.items():
-        if filepath.endswith(extension) or filetype in extension:
-            readername = name
-    if readername is not None:
-        return _readers[readername].get_header(filepath, **kwargs)
-    raise UnrecognizedFileTypeError("The requested filetype is not currently supported by sunpy.")
+    return _read(filepath, 'get_header', filetype, **kwargs)
 
 
 def write_file(fname, data, header, filetype='auto', **kwargs):

--- a/sunpy/io/_file_tools.py
+++ b/sunpy/io/_file_tools.py
@@ -56,7 +56,9 @@ def _read(filepath, function_name, filetype=None, **kwargs):
     if filetype is not None:
         return getattr(_readers[filetype], function_name)(filepath, **kwargs)
     try:
-        readername = _detect_filetype(filepath)
+        readername = detect_filetype(filepath)
+        if readername not in _readers.keys():
+            readername = None
     except UnrecognizedFileTypeError:
         readername = None
     for extension, name in _known_extensions.items():
@@ -147,26 +149,6 @@ def write_file(fname, data, header, filetype='auto', **kwargs):
     raise ValueError(f"The filetype provided ({filetype}) is not supported")
 
 
-def _detect_filetype(filepath):
-    """
-    Attempts to determine the type of data contained in a file and returns
-    the filetype if the available readers exist within sunpy.io
-
-    Parameters
-    ----------
-    filepath : `str`
-        Where the file is.
-
-    Returns
-    -------
-    filetype : `str`
-        The type of file.
-    """
-    if detect_filetype(filepath) in _readers.keys():
-        return detect_filetype(filepath)
-    raise UnrecognizedFileTypeError("The requested filetype is not currently supported by sunpy.")
-
-
 def detect_filetype(filepath):
     """
     Attempts to determine the type of file a given filepath is.
@@ -181,6 +163,9 @@ def detect_filetype(filepath):
     filetype : `str`
         The type of file.
     """
+    if "http" in filepath or "ftp" in filepath:
+        return None
+
     with open(filepath, 'rb') as fp:
         line1 = fp.readline()
         line2 = fp.readline()

--- a/sunpy/io/tests/test_filetools.py
+++ b/sunpy/io/tests/test_filetools.py
@@ -11,12 +11,13 @@ from sunpy.tests.helpers import skip_ana, skip_glymur
 
 TEST_RHESSI_IMAGE = get_test_filepath('hsi_image_20101016_191218.fits')
 TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
-
 # Some of the tests images contain an invalid BLANK keyword;
 pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in header")
 
 
 def test_read_file_network_fits(mocker):
+    # Aim is to verify that we can read a files from a URL
+    # But it is mocked to prevent network access
     url = "https://hesperia.gsfc.nasa.gov/rhessi_extras/imagecube_fits/2015/12/20/20151220_2228_2248/hsi_imagecube_clean_20151220_2228_13tx3e.fits"
     mock = mocker.patch("astropy.io.fits.file.download_file", return_value=TEST_AIA_IMAGE)
     data = sunpy.io.read_file(url)
@@ -29,6 +30,7 @@ def test_read_file_network_fits(mocker):
 
 
 def test_read_file_fits():
+    # Aim is to verify that we can read a FITS file
     aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)
     assert isinstance(aiapair, list)
     assert len(aiapair) == 1
@@ -38,30 +40,31 @@ def test_read_file_fits():
 
 
 def test_read_file_fits_multple_hdu():
+    # Aim is to verify that we can read a FITS file with multiple HDUs
     pairs = sunpy.io.read_file(TEST_RHESSI_IMAGE)
     assert isinstance(pairs, list)
     assert len(pairs) == 4
-    assert all([len(p) == 2 for p in pairs])
-    assert all([isinstance(p[0], np.ndarray) for p in pairs])
-    assert all([isinstance(p[1],
-                           sunpy.io.header.FileHeader) for p in pairs])
+    assert all(len(p) == 2 for p in pairs)
+    assert all(isinstance(p[0], np.ndarray) for p in pairs)
+    assert all(isinstance(p[1], sunpy.io.header.FileHeader) for p in pairs)
 
 
-def test_read_file_fits_gzip():
-    gzip_fits_files = ["gzip_test.fts.gz", "gzip_test.fits.gz", "gzip_test.fit.gz", "gzip_fits_test.file"]
-    for filename in gzip_fits_files:
-        pair = sunpy.io.read_file(get_test_filepath(filename))
-        assert isinstance(pair, list)
-        assert len(pair) == 1
-        assert len(pair[0]) == 2
-        assert isinstance(pair[0][0], np.ndarray)
-        assert isinstance(pair[0][1], sunpy.io.header.FileHeader)
-        assert np.all(pair[0][0] == np.tile(np.arange(32), (32, 1)).transpose())
+@pytest.mark.parametrize('fname', ["gzip_test.fts.gz", "gzip_test.fits.gz", "gzip_test.fit.gz", "gzip_fits_test.file"])
+def test_read_file_fits_gzip(fname):
+    # Aim is to verify that we from a gzipped FITS file
+    # that has a range of different file extensions
+    pair = sunpy.io.read_file(get_test_filepath(fname))
+    assert isinstance(pair, list)
+    assert len(pair) == 1
+    assert len(pair[0]) == 2
+    assert isinstance(pair[0][0], np.ndarray)
+    assert isinstance(pair[0][1], sunpy.io.header.FileHeader)
+    assert np.all(pair[0][0] == np.tile(np.arange(32), (32, 1)).transpose())
 
 
 @skip_glymur
 def test_read_file_jp2():
-    # Test read jp2
+    # Aim is to verify that we can read a JP2 file
     pair = sunpy.io.read_file(get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2"))
     assert isinstance(pair, list)
     assert len(pair) == 1
@@ -72,7 +75,7 @@ def test_read_file_jp2():
 
 @skip_glymur
 def test_read_file_header_jp2():
-    # Test jp2
+    # Aim is to verify that we can read a header from a JP2 file
     hlist = sunpy.io.read_file_header(get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2"))
     assert isinstance(hlist, list)
     assert len(hlist) == 1
@@ -80,6 +83,7 @@ def test_read_file_header_jp2():
 
 
 def test_read_file_header_fits():
+    # Aim is to verify that we can read a header from a FITS file
     hlist = sunpy.io.read_file_header(TEST_AIA_IMAGE)
     assert isinstance(hlist, list)
     assert len(hlist) == 1
@@ -88,6 +92,7 @@ def test_read_file_header_fits():
 
 @skip_ana
 def test_read_file_ana():
+    # Aim is to verify that we can read a ANA file
     ana_data = sunpy.io.read_file(get_test_filepath("test_ana.fz"))
     assert isinstance(ana_data, list)
     assert len(ana_data) == 1
@@ -97,7 +102,8 @@ def test_read_file_ana():
 
 
 @skip_ana
-def test_read_file__header_ana():
+def test_read_file_header_ana():
+    # Aim is to verify that we can read a header from a ANA file
     ana_data = sunpy.io.read_file_header(get_test_filepath("test_ana.fz"))
     assert isinstance(ana_data, list)
     assert len(ana_data) == 1
@@ -106,22 +112,21 @@ def test_read_file__header_ana():
 
 @skip_ana
 def test_write_file_ana():
+    # Aim is to verify that we can write a ANA file and read back correctly
     ana = sunpy.io.read_file(get_test_filepath("test_ana.fz"))[0]
     sunpy.io.write_file("ana_test_write.fz", ana[0], str(ana[1]))
     assert os.path.exists("ana_test_write.fz")
     outpair = sunpy.io.read_file(get_test_filepath("test_ana.fz"))
     assert np.all(np.equal(outpair[0][1], ana[1]))
     assert outpair[0][1] == ana[1]
-    os.remove("ana_test_write.fz")
 
 
-@pytest.mark.parametrize('fname', ['aia_171_image.fits',
-                                   pathlib.Path('aia_171_image.fits')])
+@pytest.mark.parametrize('fname', ['aia_171_image.fits', pathlib.Path('aia_171_image.fits')])
 def test_write_file_fits(fname, tmpdir):
+    # Aim is to verify that we can write a FITS file and read it back correctly
     aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
     filepath = tmpdir / fname
-    sunpy.io.write_file(filepath, aiapair[0], aiapair[1],
-                        overwrite=True)
+    sunpy.io.write_file(filepath, aiapair[0], aiapair[1])
     assert filepath.exists()
     outpair = sunpy.io.read_file(filepath)[0]
     assert np.all(np.equal(outpair[0], aiapair[0]))
@@ -129,6 +134,7 @@ def test_write_file_fits(fname, tmpdir):
 
 
 def test_write_file_fits_bytes(tmpdir):
+    # Aim is to verify that we can write a FITS file via a file-like object and read it back correctly
     aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
     filepath = tmpdir / "aia_171_image_bytes.fits"
     with open(filepath, "wb") as fileo:
@@ -137,4 +143,14 @@ def test_write_file_fits_bytes(tmpdir):
     outpair = sunpy.io.read_file(filepath)[0]
     assert np.all(np.equal(outpair[0], aiapair[0]))
     assert outpair[1] == aiapair[1]
-    os.remove("aia_171_image_bytes.fits")
+
+def test_missing_file_extension(tmpdir):
+    # Aim is read a FITS file without an extension
+    aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
+    filepath = tmpdir / "test"
+    with open(filepath, 'wb') as fileo:
+        sunpy.io.write_file(fileo, aiapair[0], aiapair[1], filetype='fits')
+    assert filepath.exists()
+    outpair = sunpy.io.read_file(filepath)[0]
+    assert np.all(np.equal(outpair[0], aiapair[0]))
+    assert outpair[1] == aiapair[1]

--- a/sunpy/io/tests/test_filetools.py
+++ b/sunpy/io/tests/test_filetools.py
@@ -48,7 +48,6 @@ def test_read_file_fits_multple_hdu():
 
 
 def test_read_file_fits_gzip():
-    # Test read gzipped fits file
     gzip_fits_files = ["gzip_test.fts.gz", "gzip_test.fits.gz", "gzip_test.fit.gz", "gzip_fits_test.file"]
     for filename in gzip_fits_files:
         pair = sunpy.io.read_file(get_test_filepath(filename))

--- a/sunpy/io/tests/test_filetools.py
+++ b/sunpy/io/tests/test_filetools.py
@@ -117,23 +117,24 @@ def test_write_file_ana():
 
 @pytest.mark.parametrize('fname', ['aia_171_image.fits',
                                    pathlib.Path('aia_171_image.fits')])
-def test_write_file_fits(fname):
+def test_write_file_fits(fname, tmpdir):
     aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
-    sunpy.io.write_file(fname, aiapair[0], aiapair[1],
+    filepath = tmpdir / fname
+    sunpy.io.write_file(filepath, aiapair[0], aiapair[1],
                         overwrite=True)
-    assert os.path.exists("aia_171_image.fits")
-    outpair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
+    assert filepath.exists()
+    outpair = sunpy.io.read_file(filepath)[0]
     assert np.all(np.equal(outpair[0], aiapair[0]))
     assert outpair[1] == aiapair[1]
-    os.remove("aia_171_image.fits")
 
 
-def test_write_file_fits_bytes():
+def test_write_file_fits_bytes(tmpdir):
     aiapair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
-    with open("aia_171_image_bytes.fits", 'wb') as fileo:
+    filepath = tmpdir / "aia_171_image_bytes.fits"
+    with open(filepath, "wb") as fileo:
         sunpy.io.write_file(fileo, aiapair[0], aiapair[1], filetype='fits')
-    assert os.path.exists("aia_171_image_bytes.fits")
-    outpair = sunpy.io.read_file(TEST_AIA_IMAGE)[0]
+    assert filepath.exists()
+    outpair = sunpy.io.read_file(filepath)[0]
     assert np.all(np.equal(outpair[0], aiapair[0]))
     assert outpair[1] == aiapair[1]
     os.remove("aia_171_image_bytes.fits")


### PR DESCRIPTION
## PR Description

This PR reverses the file detection logic so first try to detect the filetype based on the content and then fallback to using extension. I could envisage some performance issues compared the current implementation but this should probably be more robust.

This partially addresses #6655 
