### PR TITLE
Bump min Python to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,15 @@ jobs:
           - openjpeg
       envs: |
         - linux: py311
-        - windows: py39
-        - macos: py38
-        - linux: py38-oldestdeps
+        - windows: py310
+        - macos: py39
+        - linux: py39-oldestdeps
 
   docs:
     needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
-      default_python: '3.8'
+      default_python: '3.9'
       submodules: false
       pytest: false
       toxdeps: "'tox<4' tox-pypi-filter"
@@ -79,7 +79,7 @@ jobs:
     needs: [docs]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
-      default_python: '3.8'
+      default_python: '3.9'
       submodules: false
       coverage: codecov
       toxdeps: "'tox<4' tox-pypi-filter"
@@ -110,7 +110,7 @@ jobs:
       )
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
-      default_python: '3.8'
+      default_python: '3.9'
       submodules: false
       coverage: codecov
       toxdeps: "'tox<4' tox-pypi-filter"
@@ -146,13 +146,9 @@ jobs:
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
       targets: |
-        - cp3{8,9,10}-manylinux*_x86_64
-        - cp3{8,9,10}-macosx_x86_64
-        - cp3{8,9,10}-macosx_arm64
-        # Split these out for more rapid debugging
-        - cp311-manylinux*_x86_64
-        - cp311-macosx_x86_64
-        - cp311-macosx_arm64
+        - cp3{9,10,11}-manylinux*_x86_64
+        - cp3{9,10,11}-macosx_x86_64
+        - cp3{9,10,11}-macosx_arm64
       # This can be removed when there are binaries for h5py on 3.11
       libraries: libhdf5-dev
     secrets:

--- a/changelog/6741.feature.rst
+++ b/changelog/6741.feature.rst
@@ -1,0 +1,1 @@
+The minimum required version of Python has been increase to Python 3.9.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ classifiers =
   Operating System :: OS Independent
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
@@ -35,7 +34,7 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=3.8
+python_requires = >=3.9
 packages = find:
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
According to NEP 29, Python 3.8 support drops on Apr 14, 2023. Since sunpy 5.0 release date is 2023-05-06, drop Python 3.8 support.