### PR TITLE
Deprecate `meta_keywords()`

### DIFF
--- a/changelog/6743.deprecation.rst
+++ b/changelog/6743.deprecation.rst
@@ -1,1 +1,2 @@
-Using `~sunpy.map.header_helper.meta_keywords()` is deprecated.
+Using `~sunpy.map.header_helper.meta_keywords` is deprecated.
+Please see :ref:`Meta Keywords Table` for the list of metadata keywords used by `~sunpy.map.Map`.

--- a/changelog/6743.deprecation.rst
+++ b/changelog/6743.deprecation.rst
@@ -1,0 +1,2 @@
+Using `~sunpy.map.header_helper.meta_keywords()` is deprecated.
+Use `~sunpy.map.header_helper.META_KEYWORDS` as a `MappingProxyType` dictionary of the meta keywords.

--- a/changelog/6743.deprecation.rst
+++ b/changelog/6743.deprecation.rst
@@ -1,2 +1,1 @@
 Using `~sunpy.map.header_helper.meta_keywords()` is deprecated.
-Use `~sunpy.map.header_helper.META_KEYWORDS` as a `MappingProxyType` dictionary of the meta keywords.

--- a/docs/intro/maps.rst
+++ b/docs/intro/maps.rst
@@ -507,8 +507,7 @@ This includes a :func:`~sunpy.map.header_helper.meta_keywords` function that wil
 The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 All the metadata keywords that a Map will parse along with their description are listed in the :ref:`Meta Keywords Table` at the end of this page.
 
-
-``sunpy`` provides a helper, :func:`~sunpy.map.header_helper.make_fitswcs_header`, to assist in creating a header that contains the correct metadata.
+``sunpy`` provides :func:`~sunpy.map.header_helper.make_fitswcs_header`, to assist in creating a FITS header that contains the correct metadata.
 This will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
 This function returns a `sunpy.util.MetaDict`.
@@ -654,7 +653,6 @@ From these header MetaDict's that are generated, we can now create a custom map:
 .. code-block:: python
 
     >>> my_map = sunpy.map.Map(data, header)
-
 
 .. _Meta Keywords Table:
 

--- a/docs/intro/maps.rst
+++ b/docs/intro/maps.rst
@@ -493,45 +493,45 @@ See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a bri
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
 All the metadata keywords that a Map will parse along with their description are listed below:
 
-`cunit1`: Units of the coordinate increments along naxis1 e.g. arcsec \**required
-`cunit2`: Units of the coordinate increments along naxis2 e.g. arcsec \**required
-`crval1`: Coordinate value at reference point on naxis1 \**required
-`crval2`: Coordinate value at reference point on naxis2 \**required
-`cdelt1`: Spatial scale of pixels for naxis1, i.e. coordinate increment at reference point
-`cdelt2`: Spatial scale of pixels for naxis2, i.e. coordinate increment at reference point
-`crpix1`: Pixel coordinate at reference point naxis1
-`crpix2`: Pixel coordinate at reference point naxis2
-`ctype1`: Coordinate type projection along naxis1 of data e.g. HPLT-TAN
-`ctype2`: Coordinate type projection along naxis2 of data e.g. HPLN-TAN
-`hgln_obs`: Heliographic longitude of observation
-`hglt_obs`: Heliographic latitude of observation
-`dsun_obs`: distance to Sun from observation in metres
-`rsun_obs`: radius of Sun in meters from observation
-`dateobs`: date of observation e.g. 2013-10-28 00:00
-`date_obs`: date of observation e.g. 2013-10-28 00:00
-`rsun_ref`: reference radius of Sun in meters
-`solar_r`: radius of Sun in meters from observation
-`radius`: radius of Sun in meters from observation
-`crln_obs`: Carrington longitude of observation
-`crlt_obs`: Heliographic latitude of observation
-`solar_b0`: Solar B0 angle
-`detector`: name of detector e.g. AIA
-`exptime`: exposure time of observation, in seconds e.g 2
-`instrume`: name of instrument
-`wavelnth`: wavelength of observation
-`waveunit`: unit for which observation is taken e.g. angstom
-`obsrvtry`: name of observatory of observation
-`telescop`: name of telescope of observation
-`lvl_num`: FITS processing level
-`crota2`: Rotation of the horizontal and vertical axes in degrees
-`PC1_1`: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-`PC1_2`: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-`PC2_1`: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-`PC2_2`: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-`CD1_1`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-`CD1_2`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-`CD2_1`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-`CD2_2`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+cunit1: Units of the coordinate increments along naxis1 e.g. arcsec (required)
+cunit2: Units of the coordinate increments along naxis2 e.g. arcsec (required)
+crval1: Coordinate value at reference point on naxis1 (required)
+crval2: Coordinate value at reference point on naxis2 (required)
+cdelt1: Spatial scale of pixels for naxis1, i.e. coordinate increment at reference point
+cdelt2: Spatial scale of pixels for naxis2, i.e. coordinate increment at reference point
+crpix1: Pixel coordinate at reference point naxis1
+crpix2: Pixel coordinate at reference point naxis2
+ctype1: Coordinate type projection along naxis1 of data e.g. HPLT-TAN
+ctype2: Coordinate type projection along naxis2 of data e.g. HPLN-TAN
+hgln_obs: Heliographic longitude of observation
+hglt_obs: Heliographic latitude of observation
+dsun_obs: distance to Sun from observation in metres
+rsun_obs: radius of Sun in meters from observation
+dateobs: date of observation e.g. 2013-10-28 00:00
+date_obs: date of observation e.g. 2013-10-28 00:00
+rsun_ref: reference radius of Sun in meters
+solar_r: radius of Sun in meters from observation
+radius: radius of Sun in meters from observation
+crln_obs: Carrington longitude of observation
+crlt_obs: Heliographic latitude of observation
+solar_b0: Solar B0 angle
+detector: name of detector e.g. AIA
+exptime: exposure time of observation, in seconds e.g 2
+instrume: name of instrument
+wavelnth: wavelength of observation
+waveunit: unit for which observation is taken e.g. angstom
+obsrvtry: name of observatory of observation
+telescop: name of telescope of observation
+lvl_num: FITS processing level
+crota2: Rotation of the horizontal and vertical axes in degrees
+PC1_1: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+PC1_2: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+PC2_1: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+PC2_2: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+CD1_1: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+CD1_2: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+CD2_1: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+CD2_2: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
 
 ``sunpy`` provides a helper, :func:`~sunpy.map.header_helper.make_fitswcs_header`, to assist in creating a header that contains the correct metadata.
 This will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.

--- a/docs/intro/maps.rst
+++ b/docs/intro/maps.rst
@@ -491,20 +491,51 @@ The meta information informs `sunpy.map.Map` of the correct coordinate informati
 See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a brief demonstration of generating a Map from a data array.
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
-**sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
-This includes a :func:`~sunpy.map.header_helper.meta_keywords` function that will return a `dict` of the meta keywords used when creating a Map.
+All the meta keywords used when creating a Map along with their description are listed below.
 
-.. code-block:: python
-
-    >>> from sunpy.map.header_helper import meta_keywords
-
-    >>> meta_keywords() # doctest: +SKIP
-    {'cunit1': 'Units of the coordinate increments along naxis1 e.g. arcsec **required',
-     'cunit2': 'Units of the coordinate increments along naxis2 e.g. arcsec **required',
-     'crval1': 'Coordinate value at reference point on naxis1 **required'
+`cunit1`: Units of the coordinate increments along naxis1 e.g. arcsec \**required
+`cunit2`: Units of the coordinate increments along naxis2 e.g. arcsec \**required
+`crval1`: Coordinate value at reference point on naxis1 \**required
+`crval2`: Coordinate value at reference point on naxis2 \**required
+`cdelt1`: Spatial scale of pixels for naxis1, i.e. coordinate increment at reference point
+`cdelt2`: Spatial scale of pixels for naxis2, i.e. coordinate increment at reference point
+`crpix1`: Pixel coordinate at reference point naxis1
+`crpix2`: Pixel coordinate at reference point naxis2
+`ctype1`: Coordinate type projection along naxis1 of data e.g. HPLT-TAN
+`ctype2`: Coordinate type projection along naxis2 of data e.g. HPLN-TAN
+`hgln_obs`: Heliographic longitude of observation
+`hglt_obs`: Heliographic latitude of observation
+`dsun_obs`: distance to Sun from observation in metres
+`rsun_obs`: radius of Sun in meters from observation
+`dateobs`: date of observation e.g. 2013-10-28 00:00
+`date_obs`: date of observation e.g. 2013-10-28 00:00
+`rsun_ref`: reference radius of Sun in meters
+`solar_r`: radius of Sun in meters from observation
+`radius`: radius of Sun in meters from observation
+`crln_obs`: Carrington longitude of observation
+`crlt_obs`: Heliographic latitude of observation
+`solar_b0`: Solar B0 angle
+`detector`: name of detector e.g. AIA
+`exptime`: exposure time of observation, in seconds e.g 2
+`instrume`: name of instrument
+`wavelnth`: wavelength of observation
+`waveunit`: unit for which observation is taken e.g. angstom
+`obsrvtry`: name of observatory of observation
+`telescop`: name of telescope of observation
+`lvl_num`: FITS processing level
+`crota2`: Rotation of the horizontal and vertical axes in degrees
+`PC1_1`: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+`PC1_2`: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+`PC2_1`: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+`PC2_2`: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+`CD1_1`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+`CD1_2`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+`CD2_1`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+`CD2_2`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
      ...
 
-The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
+**sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
+This includes a utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` that will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
 This function returns a `sunpy.util.MetaDict`.
 The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.

--- a/docs/intro/maps.rst
+++ b/docs/intro/maps.rst
@@ -491,69 +491,22 @@ The meta information informs `sunpy.map.Map` of the correct coordinate informati
 See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a brief demonstration of generating a Map from a data array.
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
-All the metadata keywords that a Map will parse along with their description are listed below:
+**sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
+This includes a :func:`~sunpy.map.header_helper.meta_keywords` function that will return a `dict` of the meta keywords used when creating a Map.
 
-.. list-table:: Frozen Delights!
-   :widths: 15 10 30
-   :header-rows: 1
+.. code-block:: python
 
-   * - Treat
-     - Quantity
-     - Description
-   * - Albatross
-     - 2.99
-     - On a stick!
-   * - Crunchy Frog
-     - 1.49
-     - If we took the bones out, it wouldn't be
-       crunchy, now would it?
-   * - Gannet Ripple
-     - 1.99
-     - On a stick!
-     -
-==========  =====================================================================================================
-Keyword     Description
-==========  =====================================================================================================
-cunit1      Units of the coordinate increments along naxis1 e.g. arcsec (required)
-cunit2      Units of the coordinate increments along naxis2 e.g. arcsec (required)
-crval1      Coordinate value at reference point on naxis1 (required)
-crval2      Coordinate value at reference point on naxis2 (required)
-cdelt1      Spatial scale of pixels for naxis1, i.e. coordinate increment at reference point
-cdelt2      Spatial scale of pixels for naxis2, i.e. coordinate increment at reference point
-crpix1      Pixel coordinate at reference point naxis1
-crpix2      Pixel coordinate at reference point naxis2
-ctype1      Coordinate type projection along naxis1 of data e.g. HPLT-TAN
-ctype2      Coordinate type projection along naxis2 of data e.g. HPLN-TAN
-hgln_obs    Heliographic longitude of observation
-hglt_obs    Heliographic latitude of observation
-dsun_obs    distance to Sun from observation in metres
-rsun_obs    radius of Sun in meters from observation
-dateobs     date of observation e.g. 2013-10-28 00:00
-date_obs    date of observation e.g. 2013-10-28 00:00
-rsun_ref    reference radius of Sun in meters
-solar_r     radius of Sun in meters from observation
-radius      radius of Sun in meters from observation
-crln_obs    Carrington longitude of observation
-crlt_obs    Heliographic latitude of observation
-solar_b0    Solar B0 angle
-detector    name of detector e.g. AIA
-exptime     exposure time of observation, in seconds e.g 2
-instrume    name of instrument
-wavelnth    wavelength of observation
-waveunit    unit for which observation is taken e.g. angstom
-obsrvtry    name of observatory of observation
-telescop    name of telescope of observation
-lvl_num     FITS processing level
-crota2      Rotation of the horizontal and vertical axes in degrees
-PC1_1       Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-PC1_2       Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-PC2_1       Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-PC2_2       Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-CD1_1       Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-CD1_2       Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-CD2_1       Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-CD2_2       Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-==========  =====================================================================================================
+    >>> from sunpy.map.header_helper import meta_keywords
+
+    >>> meta_keywords() # doctest: +SKIP
+    {'cunit1': 'Units of the coordinate increments along naxis1 e.g. arcsec **required',
+     'cunit2': 'Units of the coordinate increments along naxis2 e.g. arcsec **required',
+     'crval1': 'Coordinate value at reference point on naxis1 **required'
+     ...
+
+The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
+All the metadata keywords that a Map will parse along with their description are listed in the :ref:`Meta Keywords Table` at the end of this page.
+
 
 ``sunpy`` provides a helper, :func:`~sunpy.map.header_helper.make_fitswcs_header`, to assist in creating a header that contains the correct metadata.
 This will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
@@ -701,3 +654,91 @@ From these header MetaDict's that are generated, we can now create a custom map:
 .. code-block:: python
 
     >>> my_map = sunpy.map.Map(data, header)
+
+
+.. _Meta Keywords Table:
+
+.. list-table:: Meta Keywords
+   :widths: 7 30
+   :header-rows: 1
+
+   * - Keyword
+     - Description
+   * - cunit1
+     - Units of the coordinate increments along naxis1 e.g. arcsec (required)
+   * - cunit2
+     - Units of the coordinate increments along naxis2 e.g. arcsec (required)
+   * - crval1
+     - Coordinate value at reference point on naxis1 (required)
+   * - crval2
+     - Coordinate value at reference point on naxis2 (required)
+   * - cdelt1
+     - Spatial scale of pixels for naxis1, i.e. coordinate increment at reference point
+   * - cdelt2
+     - Spatial scale of pixels for naxis2, i.e. coordinate increment at reference point
+   * - crpix1
+     - Pixel coordinate at reference point naxis1
+   * - crpix2
+     - Pixel coordinate at reference point naxis2
+   * - ctype1
+     - Coordinate type projection along naxis1 of data e.g. HPLT-TAN
+   * - ctype2
+     - Coordinate type projection along naxis2 of data e.g. HPLN-TAN
+   * - hgln_obs
+     - Heliographic longitude of observation
+   * - hglt_obs
+     - Heliographic latitude of observation
+   * - dsun_obs
+     - distance to Sun from observation in metres
+   * - rsun_obs
+     - radius of Sun in meters from observation
+   * - dateobs
+     - date of observation e.g. 2013-10-28 00:00
+   * - date_obs
+     - date of observation e.g. 2013-10-28 00:00
+   * - rsun_ref
+     - reference radius of Sun in meters
+   * - solar_r
+     - radius of Sun in meters from observation
+   * - radius
+     - radius of Sun in meters from observation
+   * - crln_obs
+     - Carrington longitude of observation
+   * - crlt_obs
+     - Heliographic latitude of observation
+   * - solar_b0
+     - Solar B0 angle
+   * - detector
+     - name of detector e.g. AIA
+   * - exptime
+     - exposure time of observation, in seconds e.g 2
+   * - instrume
+     - name of instrument
+   * - wavelnth
+     - wavelength of observation
+   * - waveunit
+     - unit for which observation is taken e.g. angstom
+   * - obsrvtry
+     - name of observatory of observation
+   * - telescop
+     - name of telescope of observation
+   * - lvl_num
+     - FITS processing level
+   * - crota2
+     - Rotation of the horizontal and vertical axes in degrees
+   * - PC1_1
+     - Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+   * - PC1_2
+     - Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+   * - PC2_1
+     - Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+   * - PC2_2
+     - Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+   * - CD1_1
+     - Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+   * - CD1_2
+     - Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+   * - CD2_1
+     - Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+   * - CD2_2
+     - Matrix element CDi_j describing the rotation required to align solar North with the top of the image.

--- a/docs/intro/maps.rst
+++ b/docs/intro/maps.rst
@@ -507,8 +507,6 @@ This includes a :func:`~sunpy.map.header_helper.meta_keywords` function that wil
 The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 All the metadata keywords that a Map will parse along with their description are listed in the :ref:`Meta Keywords Table` at the end of this page.
 
-``sunpy`` provides :func:`~sunpy.map.header_helper.make_fitswcs_header`, to assist in creating a FITS header that contains the correct metadata.
-This will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
 This function returns a `sunpy.util.MetaDict`.
 The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.

--- a/docs/intro/maps.rst
+++ b/docs/intro/maps.rst
@@ -491,7 +491,7 @@ The meta information informs `sunpy.map.Map` of the correct coordinate informati
 See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a brief demonstration of generating a Map from a data array.
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
-All the meta keywords used when creating a Map along with their description are listed below.
+All the metadata keywords that a Map will parse along with their description are listed below:
 
 `cunit1`: Units of the coordinate increments along naxis1 e.g. arcsec \**required
 `cunit2`: Units of the coordinate increments along naxis2 e.g. arcsec \**required

--- a/docs/intro/maps.rst
+++ b/docs/intro/maps.rst
@@ -493,45 +493,67 @@ See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a bri
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
 All the metadata keywords that a Map will parse along with their description are listed below:
 
-cunit1: Units of the coordinate increments along naxis1 e.g. arcsec (required)
-cunit2: Units of the coordinate increments along naxis2 e.g. arcsec (required)
-crval1: Coordinate value at reference point on naxis1 (required)
-crval2: Coordinate value at reference point on naxis2 (required)
-cdelt1: Spatial scale of pixels for naxis1, i.e. coordinate increment at reference point
-cdelt2: Spatial scale of pixels for naxis2, i.e. coordinate increment at reference point
-crpix1: Pixel coordinate at reference point naxis1
-crpix2: Pixel coordinate at reference point naxis2
-ctype1: Coordinate type projection along naxis1 of data e.g. HPLT-TAN
-ctype2: Coordinate type projection along naxis2 of data e.g. HPLN-TAN
-hgln_obs: Heliographic longitude of observation
-hglt_obs: Heliographic latitude of observation
-dsun_obs: distance to Sun from observation in metres
-rsun_obs: radius of Sun in meters from observation
-dateobs: date of observation e.g. 2013-10-28 00:00
-date_obs: date of observation e.g. 2013-10-28 00:00
-rsun_ref: reference radius of Sun in meters
-solar_r: radius of Sun in meters from observation
-radius: radius of Sun in meters from observation
-crln_obs: Carrington longitude of observation
-crlt_obs: Heliographic latitude of observation
-solar_b0: Solar B0 angle
-detector: name of detector e.g. AIA
-exptime: exposure time of observation, in seconds e.g 2
-instrume: name of instrument
-wavelnth: wavelength of observation
-waveunit: unit for which observation is taken e.g. angstom
-obsrvtry: name of observatory of observation
-telescop: name of telescope of observation
-lvl_num: FITS processing level
-crota2: Rotation of the horizontal and vertical axes in degrees
-PC1_1: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-PC1_2: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-PC2_1: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-PC2_2: Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
-CD1_1: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-CD1_2: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-CD2_1: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-CD2_2: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+.. list-table:: Frozen Delights!
+   :widths: 15 10 30
+   :header-rows: 1
+
+   * - Treat
+     - Quantity
+     - Description
+   * - Albatross
+     - 2.99
+     - On a stick!
+   * - Crunchy Frog
+     - 1.49
+     - If we took the bones out, it wouldn't be
+       crunchy, now would it?
+   * - Gannet Ripple
+     - 1.99
+     - On a stick!
+     -
+==========  =====================================================================================================
+Keyword     Description
+==========  =====================================================================================================
+cunit1      Units of the coordinate increments along naxis1 e.g. arcsec (required)
+cunit2      Units of the coordinate increments along naxis2 e.g. arcsec (required)
+crval1      Coordinate value at reference point on naxis1 (required)
+crval2      Coordinate value at reference point on naxis2 (required)
+cdelt1      Spatial scale of pixels for naxis1, i.e. coordinate increment at reference point
+cdelt2      Spatial scale of pixels for naxis2, i.e. coordinate increment at reference point
+crpix1      Pixel coordinate at reference point naxis1
+crpix2      Pixel coordinate at reference point naxis2
+ctype1      Coordinate type projection along naxis1 of data e.g. HPLT-TAN
+ctype2      Coordinate type projection along naxis2 of data e.g. HPLN-TAN
+hgln_obs    Heliographic longitude of observation
+hglt_obs    Heliographic latitude of observation
+dsun_obs    distance to Sun from observation in metres
+rsun_obs    radius of Sun in meters from observation
+dateobs     date of observation e.g. 2013-10-28 00:00
+date_obs    date of observation e.g. 2013-10-28 00:00
+rsun_ref    reference radius of Sun in meters
+solar_r     radius of Sun in meters from observation
+radius      radius of Sun in meters from observation
+crln_obs    Carrington longitude of observation
+crlt_obs    Heliographic latitude of observation
+solar_b0    Solar B0 angle
+detector    name of detector e.g. AIA
+exptime     exposure time of observation, in seconds e.g 2
+instrume    name of instrument
+wavelnth    wavelength of observation
+waveunit    unit for which observation is taken e.g. angstom
+obsrvtry    name of observatory of observation
+telescop    name of telescope of observation
+lvl_num     FITS processing level
+crota2      Rotation of the horizontal and vertical axes in degrees
+PC1_1       Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+PC1_2       Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+PC2_1       Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+PC2_2       Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+CD1_1       Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+CD1_2       Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+CD2_1       Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+CD2_2       Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+==========  =====================================================================================================
 
 ``sunpy`` provides a helper, :func:`~sunpy.map.header_helper.make_fitswcs_header`, to assist in creating a header that contains the correct metadata.
 This will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.

--- a/docs/intro/maps.rst
+++ b/docs/intro/maps.rst
@@ -532,10 +532,9 @@ All the meta keywords used when creating a Map along with their description are 
 `CD1_2`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
 `CD2_1`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
 `CD2_2`: Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
-     ...
 
-**sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
-This includes a utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` that will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
+``sunpy`` provides a helper, :func:`~sunpy.map.header_helper.make_fitswcs_header`, to assist in creating a header that contains the correct metadata.
+This will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
 This function returns a `sunpy.util.MetaDict`.
 The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -28,7 +28,7 @@ def meta_keywords():
          'cunit2': 'Units of the coordinate increments along naxis2 e.g. arcsec **required',
          ...
     """
-    return MappingProxyType(_map_meta_keywords)
+    return _map_meta_keywords.copy()
 
 
 @u.quantity_input(equivalencies=u.spectral())

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -14,7 +14,7 @@ from sunpy.util.decorators import deprecated
 __all__ = ['meta_keywords', 'make_fitswcs_header', 'get_observer_meta', 'make_heliographic_header']
 
 
-@deprecated(since="4.1.2", message="We will be removing this", alternative="sunpy.map.header_helper.META_KEYWORDS")
+@deprecated(since="5.0", message="Will be removed in 6.0", alternative="sunpy.map.header_helper.META_KEYWORDS")
 def meta_keywords():
     """
     Returns the metadata keywords that are used when creating a `sunpy.map.GenericMap`.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -9,10 +9,12 @@ from astropy.coordinates import SkyCoord
 from sunpy import log
 from sunpy.coordinates import frames, sun
 from sunpy.util import MetaDict
+from sunpy.util.decorators import deprecated
 
 __all__ = ['meta_keywords', 'make_fitswcs_header', 'get_observer_meta', 'make_heliographic_header']
 
 
+@deprecated(since="4.1.2", message="We will be removing this", alternative="sunpy.map.header_helper.META_KEYWORDS")
 def meta_keywords():
     """
     Returns the metadata keywords that are used when creating a `sunpy.map.GenericMap`.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -1,3 +1,5 @@
+from types import MappingProxyType
+
 import numpy as np
 
 import astropy.units as u
@@ -24,7 +26,7 @@ def meta_keywords():
          'cunit2': 'Units of the coordinate increments along naxis2 e.g. arcsec **required',
          ...
     """
-    return _map_meta_keywords
+    return MappingProxyType(_map_meta_keywords)
 
 
 @u.quantity_input(equivalencies=u.spectral())
@@ -381,6 +383,8 @@ _map_meta_keywords = {
     'CD2_2':
     'Matrix element CDi_j describing the rotation required to align solar North with the top of the image.'
 }
+
+META_KEYWORDS = MappingProxyType(_map_meta_keywords)
 
 
 def make_heliographic_header(date, observer_coordinate, shape, *, frame, projection_code="CAR"):

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -1,4 +1,3 @@
-from types import MappingProxyType
 
 import numpy as np
 
@@ -385,8 +384,6 @@ _map_meta_keywords = {
     'CD2_2':
     'Matrix element CDi_j describing the rotation required to align solar North with the top of the image.'
 }
-
-META_KEYWORDS = MappingProxyType(_map_meta_keywords)
 
 
 def make_heliographic_header(date, observer_coordinate, shape, *, frame, projection_code="CAR"):

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -12,7 +12,7 @@ from sunpy.util.decorators import deprecated
 __all__ = ['meta_keywords', 'make_fitswcs_header', 'get_observer_meta', 'make_heliographic_header']
 
 
-@deprecated(since="5.0", message="Will be removed in 6.0", alternative="sunpy.map.header_helper.META_KEYWORDS")
+@deprecated(since="5.0", message="Unused and will be removed in 6.0")
 def meta_keywords():
     """
     Returns the metadata keywords that are used when creating a `sunpy.map.GenericMap`.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 import astropy.units as u

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -21,7 +21,7 @@ def meta_keywords():
     --------
     Returns a dictionary of all meta keywords that are used in a `sunpy.map.GenericMap` header:
         >>> import sunpy.map
-        >>> sunpy.map.meta_keywords()
+        >>> sunpy.map.meta_keywords() # doctest: +SKIP
         {'cunit1': 'Units of the coordinate increments along naxis1 e.g. arcsec **required',
          'cunit2': 'Units of the coordinate increments along naxis2 e.g. arcsec **required',
          ...

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -9,6 +9,7 @@ import sunpy.map
 from sunpy.coordinates import frames, sun
 from sunpy.map import make_fitswcs_header
 from sunpy.map.header_helper import make_heliographic_header
+from sunpy.util.exceptions import SunpyDeprecationWarning
 from sunpy.util.metadata import MetaDict
 
 
@@ -62,8 +63,9 @@ def hpc_coord_notime():
 
 
 def test_metakeywords():
-    meta = sunpy.map.meta_keywords()
-    assert isinstance(meta, dict)
+    with pytest.warns(SunpyDeprecationWarning):
+        meta = sunpy.map.meta_keywords()
+        assert isinstance(meta, dict)
 
 
 def test_scale_conversion(map_data, hpc_coord):

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -61,11 +61,6 @@ def hpc_coord_notime():
     return SkyCoord(0*u.arcsec, 0*u.arcsec, frame=frames.Helioprojective)
 
 
-def test_metakeywords():
-    meta = sunpy.map.meta_keywords()
-    assert isinstance(meta, dict)
-
-
 def test_scale_conversion(map_data, hpc_coord):
     # The header will have cunit1/2 of arcsec
     header = make_fitswcs_header(map_data, hpc_coord, scale=[1, 2] * u.arcmin / u.pix)

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -61,6 +61,11 @@ def hpc_coord_notime():
     return SkyCoord(0*u.arcsec, 0*u.arcsec, frame=frames.Helioprojective)
 
 
+def test_metakeywords():
+    meta = sunpy.map.meta_keywords()
+    assert isinstance(meta, dict)
+
+
 def test_scale_conversion(map_data, hpc_coord):
     # The header will have cunit1/2 of arcsec
     header = make_fitswcs_header(map_data, hpc_coord, scale=[1, 2] * u.arcmin / u.pix)


### PR DESCRIPTION
This was originally #6722 but I accidentally closed it since I didn't realise that force pushing would do that. 
Would close #6562.
