### PR TITLE
Use secrets.GITHUB_TOKEN for Cron jobs

### DIFF
--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -19,4 +19,4 @@ jobs:
       - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 4.0
       - run: gh workflow run ci.yml --repo sunpy/sunpy --ref 4.1
     env:
-      GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Not sure if this will help or if the reason a custom token was used was because it needs specific permissions that the standard token lacks.