### PR TITLE
Pass `CODECOV_TOKEN` to uploader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           - libopenjp2-7
       envs: |
         - linux: py311
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test:
     needs: [core]
@@ -48,6 +50,8 @@ jobs:
         - windows: py310
         - macos: py39
         - linux: py39-oldestdeps
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   docs:
     needs: [core]
@@ -96,6 +100,8 @@ jobs:
               - libopenjp2-7
               - graphviz
         - linux: py39-online
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   cron:
     if: |
@@ -118,6 +124,8 @@ jobs:
         - linux: py311-devdeps
         - linux: py39-conda
           libraries: ''
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     # Build wheels when pushing to any branch except main


### PR DESCRIPTION
As noted in https://github.com/astropy/astropy/issues/14347 this should hopefully make the upload more reliable, and less prone to:

> There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}

@nabobalis Can you get the `CODECOV_TOKEN` from codecov and add it to the repository secrets?