### PR TITLE
Raise actual error message from failed read

### DIFF
--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -160,8 +160,7 @@ class MapFactory(BasicRegistrationFactory):
         try:
             pairs = read_file(os.fspath(fname), **kwargs)
         except Exception as e:
-            msg = f"Failed to read {fname}"
-            raise IOError(msg) from e
+            raise IOError(f"Failed to read {fname}\n{e}") from e
 
         new_pairs = []
         for pair in pairs:


### PR DESCRIPTION
We don't actually raise the error message when we fail to load a file and its annoying.