### PR TITLE
Add sphinx-hoverxref dependency to the conda environment file

### DIFF
--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -56,6 +56,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-design
   - sphinx-gallery
+  - sphinx-hoverxref
   - towncrier
 
   # Installation


### PR DESCRIPTION
I neglected to add `sphinx-hoverxref` to the conda environment file after #6612 was merged.