### PR TITLE
Omitting .svg files from pre-commit checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -273,7 +273,7 @@ exclude_lines =
   pragma: py{ignore_python_version}
 
 [codespell]
-skip = *.asdf,*.fits,*.fts,*.header,*.json,*.xsh,*cache*,*egg*,*extern*,.git,.idea,.tox,_build,*truncated
+skip = *.asdf,*.fits,*.fts,*.header,*.json,*.xsh,*cache*,*egg*,*extern*,.git,.idea,.tox,_build,*truncated,*.svg
 ignore-words-list =
     alog,
     nd,


### PR DESCRIPTION
.svg files were having trouble with pre-commit. So added skip for all .svg files