### PR TITLE
Wrong ref type for class solar_system_ephemeris

### DIFF
--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -64,7 +64,7 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include
     apparent location of the body will shift in tandem with the Sun.
 
     For planets other than Earth, Astropy's built-in ephemeris is not as accurate as JPL
-    ephemerides, so one can use `~astropy.coordinates.solar_system.solar_system_ephemeris` to switch
+    ephemerides, so one can use `astropy.coordinates.solar_system_ephemeris` to switch
     to a JPL ephemeris. See :ref:`astropy-coordinates-solarsystem` for more information, and see
     :ref:`sphx_glr_generated_gallery_units_and_coordinates_venus_transit.py` for an example.
 

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -64,7 +64,7 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include
     apparent location of the body will shift in tandem with the Sun.
 
     For planets other than Earth, Astropy's built-in ephemeris is not as accurate as JPL
-    ephemerides, so one can use :func:`astropy.coordinates.solar_system_ephemeris` to switch
+    ephemerides, so one can use `~astropy.coordinates.solar_system.solar_system_ephemeris` to switch
     to a JPL ephemeris. See :ref:`astropy-coordinates-solarsystem` for more information, and see
     :ref:`sphx_glr_generated_gallery_units_and_coordinates_venus_transit.py` for an example.
 


### PR DESCRIPTION
I didn't notice the doc failure from when I merged: https://github.com/sunpy/sunpy/pull/6786