### PR TITLE
Updates to the conda environment file

### DIFF
--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -9,11 +9,11 @@ dependencies:
   - beautifulsoup4
   - cdflib
   - drms
-  - glymur
   - h5netcdf
   - matplotlib-base
   - mpl_animators
   - numpy
+  - packaging
   - pandas
   - parfive
   - python
@@ -29,7 +29,10 @@ dependencies:
 
   # Optional
   - astroquery
+  - dask
+  - glymur
   - jplephem
+  - lxml
   - opencv
 
   # Testing


### PR DESCRIPTION
@nabobalis noted some direct dependencies were missing from the conda environment file.  They are also indirect dependencies, so were already being installed, but might as well be explicit.  Also, moved glymur to the optional-dependencies section.