### PR TITLE
Fixed a bug with the wrong pixels being used by `extract_along_coord()`

### DIFF
--- a/changelog/6817.bugfix.rst
+++ b/changelog/6817.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with :func:`~sunpy.map.extract_along_coord` where some of the pixels sampled were not in fact the closest pixels to the coordinate line segments.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -443,10 +443,10 @@ def _bresenham(*, x1, y1, x2, y2):
         if (x == x2) and (y == y2):
             break
         e2 = 2 * err
-        if e2 > -dy:
+        if e2 >= -dy:
             err = err - dy
             x += sx
-        if e2 < dx:
+        if e2 <= dx:
             err = err + dx
             y += sy
     return np.array(res)

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -302,3 +302,20 @@ def test_extract_along_coord_out_of_bounds_exception(aia171_test_map):
     point = aia171_test_map.pixel_to_world([-1, 1]*u.pix, [-1, 1]*u.pix)
     with pytest.raises(ValueError, match='At least one coordinate is not within the bounds of the map.*'):
         _ = extract_along_coord(aia171_test_map, point)
+
+
+@pytest.mark.parametrize('x, y, sampled_x, sampled_y',
+                         [([1, 5], [1, 1], [1, 2, 3, 4, 5], [1, 1, 1, 1, 1]),
+                          ([1, 5], [1, 2], [1, 2, 3, 4, 5], [1, 1, 2, 2, 2]),
+                          ([1, 5], [1, 3], [1, 2, 3, 4, 5], [1, 2, 2, 3, 3]),
+                          ([1, 5], [1, 4], [1, 2, 3, 4, 5], [1, 2, 3, 3, 4]),
+                          ([1, 5], [1, 5], [1, 2, 3, 4, 5], [1, 2, 3, 4, 5])])
+def test_extract_along_coord_sampled_pixels(aia171_test_map, x, y, sampled_x, sampled_y):
+    # Also test the x<->y transpose
+    for xx, yy, sxx, syy in [(x, y, sampled_x, sampled_y), (y, x, sampled_y, sampled_x)]:
+        # Using the AIA test map for a "real" WCS, but the actual WCS is irrelevant for this test
+        line = aia171_test_map.wcs.pixel_to_world(xx, yy)
+        _, sampled_coords = extract_along_coord(aia171_test_map, line)
+        sampled_pixels = aia171_test_map.wcs.world_to_pixel(sampled_coords)
+        assert np.allclose(sampled_pixels[0], sxx)
+        assert np.allclose(sampled_pixels[1], syy)


### PR DESCRIPTION
`extract_along_coord()` uses Bresenham's line algorithm to select the closest pixels to the line, but there is a bug in the implementation: due to the wrong use of `>` instead of `>=`, some wrong pixels were being used ~when the slope was exactly +/-2 or +/-1/2~ for virtually all slopes.

The following images are taken from the discussion in #6815:

Before this PR (two incorrect pixels were chosen):
![222276584-a195b528-96e5-43df-986e-f0d2697e9095](https://user-images.githubusercontent.com/991759/222336508-a4bad3c2-e831-44d5-b5b8-a6a60c2b95db.png)

After this PR:
![222304190-fec51d51-6f3b-4697-bc18-50da21108e94](https://user-images.githubusercontent.com/991759/222336519-9a2ae6ab-1f19-42c1-9282-a92702a982f1.png)