### PR TITLE
Always create Axes objects in examples

### DIFF
--- a/changelog/6822.doc.rst
+++ b/changelog/6822.doc.rst
@@ -1,0 +1,1 @@
+Updated examples in the gallery to always explicitly create an Axes and use that for plotting, instead of using the Matplotlib pyplot API.

--- a/docs/dev_guide/contents/example_gallery.rst
+++ b/docs/dev_guide/contents/example_gallery.rst
@@ -37,7 +37,7 @@ Contribution Guidelines
 
   * Always create a figure instance using ``plt.figure()`` prior to creating a plot.
 
-  * Only create an axes instance if it is explicitly needed later in the example (e.g. when overplotting a coordinate on a map using ``ax.plot_coord``).
+  * Always create an Axes instance, and where possible use this to modify the plot instead of using the ``pyplot`` interface (for example use ``ax.set_label()``` instead of ``plt.xlabel()``).
 
   * If an axes instance is created, it should be explicitly passed as a keyword argument wherever possible (e.g. in `~sunpy.map.GenericMap.plot` or `~sunpy.map.GenericMap.draw_grid`).
 

--- a/docs/dev_guide/contents/example_gallery.rst
+++ b/docs/dev_guide/contents/example_gallery.rst
@@ -37,7 +37,7 @@ Contribution Guidelines
 
   * Always create a figure instance using ``plt.figure()`` prior to creating a plot.
 
-  * Always create an Axes instance, and where possible use this to modify the plot instead of using the ``pyplot`` interface (for example use ``ax.set_label()``` instead of ``plt.xlabel()``).
+  * Always create an Axes instance, and where possible use this to modify the plot instead of using the ``pyplot`` interface (for example use ``ax.set_xlabel()``` instead of ``plt.xlabel()``).
 
   * If an axes instance is created, it should be explicitly passed as a keyword argument wherever possible (e.g. in `~sunpy.map.GenericMap.plot` or `~sunpy.map.GenericMap.draw_grid`).
 

--- a/examples/acquiring_data/downloading_cutouts.py
+++ b/examples/acquiring_data/downloading_cutouts.py
@@ -74,7 +74,8 @@ files.sort()
 
 sequence = sunpy.map.Map(files, sequence=True)
 
-fig, ax = plt.subplots()
+fig = plt.figure()
+ax = fig.add_subplot(projection=sequence.maps[0])
 ani = sequence.plot(axes=ax, norm=ImageNormalize(vmin=0, vmax=5e3, stretch=SqrtStretch()))
 
 plt.show()

--- a/examples/acquiring_data/downloading_cutouts.py
+++ b/examples/acquiring_data/downloading_cutouts.py
@@ -74,7 +74,7 @@ files.sort()
 
 sequence = sunpy.map.Map(files, sequence=True)
 
-plt.figure()
-ani = sequence.plot(norm=ImageNormalize(vmin=0, vmax=5e3, stretch=SqrtStretch()))
+fig, ax = plt.subplots()
+ani = sequence.plot(axes=ax, norm=ImageNormalize(vmin=0, vmax=5e3, stretch=SqrtStretch()))
 
 plt.show()

--- a/examples/acquiring_data/querying_and_loading_SHARP_data.py
+++ b/examples/acquiring_data/querying_and_loading_SHARP_data.py
@@ -43,7 +43,7 @@ file = Fido.fetch(result)
 
 sharp_map = sunpy.map.Map(file)
 fig = plt.figure()
-ax = plt.add_subplot(projection=sharp_map)
+ax = fig.add_subplot(projection=sharp_map)
 sharp_map.plot(axes=ax, vmin=-1500, vmax=1500)
 
 plt.show()

--- a/examples/acquiring_data/querying_and_loading_SHARP_data.py
+++ b/examples/acquiring_data/querying_and_loading_SHARP_data.py
@@ -42,7 +42,8 @@ file = Fido.fetch(result)
 # Now that we have the file, we can construct a `~sunpy.map.Map` and plot it.
 
 sharp_map = sunpy.map.Map(file)
-plt.figure()
-sharp_map.plot(vmin=-1500, vmax=1500)
+fig = plt.figure()
+ax = plt.add_subplot(projection=sharp_map)
+sharp_map.plot(axes=ax, vmin=-1500, vmax=1500)
 
 plt.show()

--- a/examples/computer_vision_techniques/finding_masking_bright_pixels.py
+++ b/examples/computer_vision_techniques/finding_masking_bright_pixels.py
@@ -54,6 +54,7 @@ scaled_map = sunpy.map.Map(aia.data, aia.meta, mask=mask.mask)
 ###############################################################################
 # Let's plot the results.
 
-plt.figure()
-scaled_map.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=scaled_map)
+scaled_map.plot(axes=ax)
 plt.show()

--- a/examples/computer_vision_techniques/loop_edge_enhance.py
+++ b/examples/computer_vision_techniques/loop_edge_enhance.py
@@ -40,6 +40,7 @@ edge_map = sunpy.map.Map(edge_enhanced_im, aia_smap.meta)
 ###############################################################################
 # Let's plot the results.
 
-plt.figure()
-edge_map.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=edge_map)
+edge_map.plot(axes=ax)
 plt.show()

--- a/examples/computer_vision_techniques/mask_disk.py
+++ b/examples/computer_vision_techniques/mask_disk.py
@@ -41,7 +41,8 @@ scaled_map = sunpy.map.Map(aia.data, aia.meta, mask=mask)
 ###############################################################################
 # Let's plot the results using our modified colormap.
 
-plt.figure()
-scaled_map.plot(cmap=palette)
-scaled_map.draw_limb()
+fig = plt.figure()
+ax = fig.add_subplot(projection=scaled_map)
+scaled_map.plot(axes=ax, cmap=palette)
+scaled_map.draw_limb(axes=ax)
 plt.show()

--- a/examples/computer_vision_techniques/off_limb_enhance.py
+++ b/examples/computer_vision_techniques/off_limb_enhance.py
@@ -49,18 +49,19 @@ params = np.polyfit(rsun_array[rsun_array < 1.5],
 # Let's plot the results using LaTeX for all the text.
 
 fontsize = 14
-plt.plot(rsun_array, y, label='data')
+fig, ax = plt.subplots()
+
+ax.plot(rsun_array, y, label='data')
 best_fit = np.exp(np.poly1d(params)(rsun_array))
 label = r'best fit: {:.2f}$e^{{{:.2f}r}}$'.format(best_fit[0], params[0])
-plt.plot(rsun_array, best_fit, label=label)
-plt.yscale('log')
-plt.ylabel(r'mean DN', fontsize=fontsize)
-plt.xlabel(r'radius r ($R_{\odot}$)', fontsize=fontsize)
-plt.xticks(fontsize=fontsize)
-plt.yticks(fontsize=fontsize)
-plt.title(r'observed off limb mean DN and best fit', fontsize=fontsize)
-plt.legend(fontsize=fontsize)
-plt.tight_layout()
+ax.plot(rsun_array, best_fit, label=label)
+ax.set_yscale('log')
+ax.set_ylabel(r'mean DN', fontsize=fontsize)
+ax.set_xlabel(r'radius r ($R_{\odot}$)', fontsize=fontsize)
+ax.tick_params(axis='both', size=fontsize)
+ax.set_title(r'observed off limb mean DN and best fit', fontsize=fontsize)
+ax.legend(fontsize=fontsize)
+fig.tight_layout()
 
 plt.show()
 

--- a/examples/computer_vision_techniques/off_limb_enhance.py
+++ b/examples/computer_vision_techniques/off_limb_enhance.py
@@ -84,8 +84,9 @@ scaled_map.plot_settings['norm'] = ImageNormalize(stretch=aia.plot_settings['nor
 ###############################################################################
 # Let's plot the results.
 
-plt.figure()
-scaled_map.plot(clip_interval=(5, 99.9)*u.percent)
-scaled_map.draw_limb()
-plt.colorbar()
+fig = plt.figure()
+ax = fig.add_subplot(projection=scaled_map)
+im = scaled_map.plot(axes=ax, clip_interval=(5, 99.9)*u.percent)
+scaled_map.draw_limb(axes=ax)
+fig.colorbar(im)
 plt.show()

--- a/examples/differential_rotation/comparing_rotation_models.py
+++ b/examples/differential_rotation/comparing_rotation_models.py
@@ -63,8 +63,9 @@ for model in ['howard', 'snodgrass', 'allen', 'rigid']:
 # Note that the "rigid" model appears as the meridian again as expected for a
 # rotation of exactly one sidereal period.
 
-plt.figure()
-aiamap.plot(clip_interval=(0.5, 99.9)*u.percent)
+fig = plt.figure()
+ax = fig.add_subplot(projection=aiamap)
+aiamap.plot(axes=ax, clip_interval=(0.5, 99.9)*u.percent)
 
 colors = {
     'howard': 'red',
@@ -73,10 +74,10 @@ colors = {
     'rigid': 'white',
 }
 for model, coord in rotated_meridian.items():
-    aiamap.draw_quadrangle(coord, edgecolor=colors[model],
+    aiamap.draw_quadrangle(coord, axes=ax, edgecolor=colors[model],
                            label=model.capitalize())
-plt.legend()
 
-plt.title(f'{sidereal_period:.2f} of solar rotation')
+ax.legend()
+ax.set_title(f'{sidereal_period:.2f} of solar rotation')
 
 plt.show()

--- a/examples/example_template/example_template.py
+++ b/examples/example_template/example_template.py
@@ -34,20 +34,20 @@ x = np.linspace(-np.pi, np.pi, 300)
 xx, yy = np.meshgrid(x, x)
 z = np.cos(xx) + np.cos(yy)
 
-plt.figure()
-plt.imshow(z)
+fig, ax = plt.subplots()
+ax.imshow(z)
 plt.colorbar()
-plt.xlabel('$x$')
-plt.ylabel('$y$')
+ax.set_xlabel('$x$')
+ax.set_ylabel('$y$')
 
 ###########################################################################
 # Again it is possible to continue the discussion with a new Python string. This
 # time to introduce the next code block generates 2 separate figures.
 
-plt.figure()
-plt.imshow(z, cmap=matplotlib.colormaps['hot'])
-plt.figure()
-plt.imshow(z, cmap=matplotlib.colormaps['Spectral'], interpolation='none')
+fig, ax = plt.subplots()
+ax.imshow(z, cmap=matplotlib.colormaps['hot'])
+fig, ax = plt.subplots()
+ax.imshow(z, cmap=matplotlib.colormaps['Spectral'], interpolation='none')
 
 ##########################################################################
 # There's some subtle differences between rendered html rendered comment

--- a/examples/map/composite_map_AIA_HMI.py
+++ b/examples/map/composite_map_AIA_HMI.py
@@ -47,6 +47,6 @@ comp_map.set_levels(index=1, levels=levels)
 # magnetic field.
 
 fig = plt.figure()
-ax = fig.add_subplot(projection=comp_map)
+ax = fig.add_subplot(projection=comp_map.get_map(0))
 comp_map.plot(axes=ax)
 plt.show()

--- a/examples/map/composite_map_AIA_HMI.py
+++ b/examples/map/composite_map_AIA_HMI.py
@@ -46,6 +46,7 @@ comp_map.set_levels(index=1, levels=levels)
 # present on the AIA image and how they correspond to the line of sight
 # magnetic field.
 
-plt.figure()
-comp_map.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=comp_map)
+comp_map.plot(axes=ax)
 plt.show()

--- a/examples/map/difference_images.py
+++ b/examples/map/difference_images.py
@@ -37,7 +37,8 @@ m_seq = sunpy.map.Map([
 # AIA cadence. We adjust the plot setting to ensure the colorbar is
 # the same at each time step.
 
-fig, ax = plt.subplots()
+fig = plt.figure()
+ax = fig.add_subplot(projection=m_seq.maps[0])
 ani = m_seq.plot(axes=ax, norm=ImageNormalize(vmin=0, vmax=5e3, stretch=SqrtStretch()))
 
 plt.show()
@@ -73,7 +74,8 @@ m_seq_running = sunpy.map.Map(
 # re-normalize the intensity so that it shows up well.
 # First, we show the base difference map.
 
-fig, ax = plt.subplots()
+fig = plt.figure()
+ax = fig.add_subplot(projection=m_seq_base.maps[0])
 ani = m_seq_base.plot(axes=ax, title='Base Difference', norm=colors.Normalize(vmin=-200, vmax=200), cmap='Greys_r')
 plt.colorbar(extend='both', label=m_seq_base[0].unit.to_string())
 
@@ -82,7 +84,8 @@ plt.show()
 ###########################################################################
 # Then, we show the running difference map.
 
-fig, ax = plt.subplots()
+fig = plt.figure()
+ax = fig.add_subplot(projection=m_seq_running.maps[0])
 ani = m_seq_running.plot(axes=ax, title='Running Difference', norm=colors.Normalize(vmin=-200, vmax=200), cmap='Greys_r')
 plt.colorbar(extend='both', label=m_seq_running[0].unit.to_string())
 

--- a/examples/map/difference_images.py
+++ b/examples/map/difference_images.py
@@ -37,8 +37,8 @@ m_seq = sunpy.map.Map([
 # AIA cadence. We adjust the plot setting to ensure the colorbar is
 # the same at each time step.
 
-plt.figure()
-ani = m_seq.plot(norm=ImageNormalize(vmin=0, vmax=5e3, stretch=SqrtStretch()))
+fig, ax = plt.subplots()
+ani = m_seq.plot(axes=ax, norm=ImageNormalize(vmin=0, vmax=5e3, stretch=SqrtStretch()))
 
 plt.show()
 
@@ -73,8 +73,8 @@ m_seq_running = sunpy.map.Map(
 # re-normalize the intensity so that it shows up well.
 # First, we show the base difference map.
 
-plt.figure()
-ani = m_seq_base.plot(title='Base Difference', norm=colors.Normalize(vmin=-200, vmax=200), cmap='Greys_r')
+fig, ax = plt.subplots()
+ani = m_seq_base.plot(axes=ax, title='Base Difference', norm=colors.Normalize(vmin=-200, vmax=200), cmap='Greys_r')
 plt.colorbar(extend='both', label=m_seq_base[0].unit.to_string())
 
 plt.show()
@@ -82,8 +82,8 @@ plt.show()
 ###########################################################################
 # Then, we show the running difference map.
 
-plt.figure()
-ani = m_seq_running.plot(title='Running Difference', norm=colors.Normalize(vmin=-200, vmax=200), cmap='Greys_r')
+fig, ax = plt.subplots()
+ani = m_seq_running.plot(axes=ax, title='Running Difference', norm=colors.Normalize(vmin=-200, vmax=200), cmap='Greys_r')
 plt.colorbar(extend='both', label=m_seq_running[0].unit.to_string())
 
 plt.show()

--- a/examples/map/image_bright_regions_gallery_example.py
+++ b/examples/map/image_bright_regions_gallery_example.py
@@ -35,8 +35,9 @@ mask = aiamap.data < aiamap.max() * 0.10
 
 aiamap_mask.mask = mask
 
-plt.figure()
-aiamap_mask.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=aiamap_mask)
+aiamap_mask.plot(axes=ax)
 plt.colorbar()
 
 plt.show()
@@ -72,9 +73,10 @@ labels, n = ndimage.label(aiamap2.data)
 # the number of distinct regions. We can see that approximately 6 distinct hot
 # regions are present above the 10% of the maximum level.
 
-plt.figure()
-aiamap.plot()
-plt.contour(labels)
+fig = plt.figure()
+ax = fig.add_subplot(projection=aiamap)
+aiamap.plot(axes=ax)
+ax.contour(labels)
 plt.figtext(0.3, 0.2, f'Number of regions = {n}', color='white')
 
 plt.show()

--- a/examples/map/map_data_histogram.py
+++ b/examples/map/map_data_histogram.py
@@ -61,7 +61,7 @@ ax.legend(loc=9)
 # Finally let's overplot the one-sigma contours.
 
 fig = plt.figure()
-ax = fig.add_subplots(projection=aia_smap)
+ax = fig.add_subplot(projection=aia_smap)
 aia_smap.plot(axes=ax)
 levels = one_sigma / aia_smap.max() * u.percent * 100
 aia_smap.draw_contours(axes=ax, levels=levels, colors=['blue'])

--- a/examples/map/map_data_histogram.py
+++ b/examples/map/map_data_histogram.py
@@ -38,30 +38,31 @@ hist, bin_edges = np.histogram(aia_smap.data, bins=bins)
 # Let's plot the histogram as well as some standard values such as mean
 # upper, and lower value and the one-sigma range.
 
-plt.figure()
+fig, ax = plt.subplots()
 # Note that we have to use ``.ravel()`` here to avoid matplotlib interpreting each
 # row in the array as a different dataset to histogram.
-plt.hist(aia_smap.data.ravel(), bins=bins, label='Histogram', histtype='step')
-plt.xlabel('Intensity')
-plt.axvline(aia_smap.min(), label='Data min={:.2f}'.format(aia_smap.min()), color='black')
-plt.axvline(aia_smap.max(), label='Data max={:.2f}'.format(aia_smap.max()), color='black')
-plt.axvline(aia_smap.data.mean(),
-            label='mean={:.2f}'.format(aia_smap.data.mean()), color='green')
+ax.hist(aia_smap.data.ravel(), bins=bins, label='Histogram', histtype='step')
+ax.set_xlabel('Intensity')
+ax.axvline(aia_smap.min(), label='Data min={:.2f}'.format(aia_smap.min()), color='black')
+ax.axvline(aia_smap.max(), label='Data max={:.2f}'.format(aia_smap.max()), color='black')
+ax.axvline(aia_smap.data.mean(),
+           label='mean={:.2f}'.format(aia_smap.data.mean()), color='green')
 one_sigma = np.array([aia_smap.data.mean() - aia_smap.data.std(),
                       aia_smap.data.mean() + aia_smap.data.std()])
-plt.axvspan(one_sigma[0], one_sigma[1], alpha=0.3, color='green',
-            label='mean +/- std = [{:.2f}, {:.2f}]'.format(
-            one_sigma[0], one_sigma[1]))
-plt.axvline(one_sigma[0], color='green')
-plt.axvline(one_sigma[1], color='red')
-plt.yscale('log')
-plt.legend(loc=9)
+ax.axvspan(one_sigma[0], one_sigma[1], alpha=0.3, color='green',
+           label='mean +/- std = [{:.2f}, {:.2f}]'.format(
+           one_sigma[0], one_sigma[1]))
+ax.axvline(one_sigma[0], color='green')
+ax.axvline(one_sigma[1], color='red')
+ax.set_yscale('log')
+ax.legend(loc=9)
 
 ###############################################################################
 # Finally let's overplot the one-sigma contours.
 
-plt.figure()
-aia_smap.plot()
+fig = plt.figure()
+ax = fig.add_subplots(projection=aia_smap)
+aia_smap.plot(axes=ax)
 levels = one_sigma / aia_smap.max() * u.percent * 100
-aia_smap.draw_contours(levels=levels, colors=['blue'])
+aia_smap.draw_contours(axes=ax, levels=levels, colors=['blue'])
 plt.show()

--- a/examples/map/map_from_numpy_array.py
+++ b/examples/map/map_from_numpy_array.py
@@ -49,6 +49,6 @@ manual_map = sunpy.map.Map(data, header)
 # Let's plot the result.
 
 fig = plt.figure()
-ax = fig.add_subplots(projection=manual_map)
+ax = fig.add_subplot(projection=manual_map)
 manual_map.plot(axes=ax)
 plt.show()

--- a/examples/map/map_from_numpy_array.py
+++ b/examples/map/map_from_numpy_array.py
@@ -48,6 +48,7 @@ manual_map = sunpy.map.Map(data, header)
 ##############################################################################
 # Let's plot the result.
 
-plt.figure()
-manual_map.plot()
+fig = plt.figure()
+ax = fig.add_subplots(projection=manual_map)
+manual_map.plot(axes=ax)
 plt.show()

--- a/examples/map/map_resampling_and_superpixels.py
+++ b/examples/map/map_resampling_and_superpixels.py
@@ -30,7 +30,7 @@ aia_resampled_map = aia_map.resample(new_dimensions)
 # Let's plot the result.
 
 fig = plt.figure()
-ax = fig.add_subplots(projection=aia_resampled_map)
+ax = fig.add_subplot(projection=aia_resampled_map)
 aia_resampled_map.plot(axes=ax)
 plt.show()
 
@@ -48,6 +48,6 @@ aia_superpixel_map = aia_map.superpixel(new_dimensions)
 # Let's plot the result.
 
 fig = plt.figure()
-ax = fig.add_subplots(projection=aia_superpixel_map)
+ax = fig.add_subplot(projection=aia_superpixel_map)
 aia_superpixel_map.plot(axes=ax)
 plt.show()

--- a/examples/map/map_resampling_and_superpixels.py
+++ b/examples/map/map_resampling_and_superpixels.py
@@ -29,8 +29,9 @@ aia_resampled_map = aia_map.resample(new_dimensions)
 ##############################################################################
 # Let's plot the result.
 
-plt.figure()
-aia_resampled_map.plot()
+fig = plt.figure()
+ax = fig.add_subplots(projection=aia_resampled_map)
+aia_resampled_map.plot(axes=ax)
 plt.show()
 
 ##############################################################################
@@ -46,6 +47,7 @@ aia_superpixel_map = aia_map.superpixel(new_dimensions)
 ##############################################################################
 # Let's plot the result.
 
-plt.figure()
-aia_superpixel_map.plot()
+fig = plt.figure()
+ax = fig.add_subplots(projection=aia_superpixel_map)
+aia_superpixel_map.plot(axes=ax)
 plt.show()

--- a/examples/map/map_rotation.py
+++ b/examples/map/map_rotation.py
@@ -29,7 +29,7 @@ aia_rotated = aia_map.rotate(angle=30 * u.deg)
 # Let's now plot the results.
 
 fig = plt.figure()
-ax = fig.add_subplots(projection=aia_rotated)
+ax = fig.add_subplot(projection=aia_rotated)
 aia_rotated.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
 aia_rotated.draw_limb(axes=ax)
 aia_rotated.draw_grid(axes=ax)

--- a/examples/map/map_rotation.py
+++ b/examples/map/map_rotation.py
@@ -28,8 +28,9 @@ aia_rotated = aia_map.rotate(angle=30 * u.deg)
 ###############################################################################
 # Let's now plot the results.
 
-plt.figure()
-aia_rotated.plot(clip_interval=(1, 99.99)*u.percent)
-aia_rotated.draw_limb()
-aia_rotated.draw_grid()
+fig = plt.figure()
+ax = fig.add_subplots(projection=aia_rotated)
+aia_rotated.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
+aia_rotated.draw_limb(axes=ax)
+aia_rotated.draw_grid(axes=ax)
 plt.show()

--- a/examples/map/map_segment.py
+++ b/examples/map/map_segment.py
@@ -50,7 +50,7 @@ segment_mask |= np.isnan(all_hgs.lon)
 
 new_frame_map = sunpy.map.Map(smap.data, smap.meta, mask=segment_mask)
 fig = plt.figure()
-ax = fig.add_subplots(projection=new_frame_map)
+ax = fig.add_subplot(projection=new_frame_map)
 new_frame_map.plot(axes=ax)
 new_frame_map.draw_grid(axes=ax, color='red')
 plt.show()

--- a/examples/map/map_segment.py
+++ b/examples/map/map_segment.py
@@ -49,9 +49,10 @@ segment_mask |= np.isnan(all_hgs.lon)
 # To plot the segment separately, we create a new map with the segment as the mask.
 
 new_frame_map = sunpy.map.Map(smap.data, smap.meta, mask=segment_mask)
-plt.figure()
-new_frame_map.plot()
-new_frame_map.draw_grid(color='red')
+fig = plt.figure()
+ax = fig.add_subplots(projection=new_frame_map)
+new_frame_map.plot(axes=ax)
+new_frame_map.draw_grid(axes=ax, color='red')
 plt.show()
 
 ######################################################################

--- a/examples/map/submaps_and_cropping.py
+++ b/examples/map/submaps_and_cropping.py
@@ -30,7 +30,7 @@ swap_submap = swap_map.submap(bottom_left, top_right=top_right)
 # Let's plot the results.
 
 fig = plt.figure()
-ax = fig.add_subplots(projection=swap_submap)
+ax = fig.add_subplot(projection=swap_submap)
 image = swap_submap.plot(axes=ax)
 swap_submap.draw_limb(axes=ax)
 swap_submap.draw_grid(axes=ax)

--- a/examples/map/submaps_and_cropping.py
+++ b/examples/map/submaps_and_cropping.py
@@ -30,12 +30,12 @@ swap_submap = swap_map.submap(bottom_left, top_right=top_right)
 # Let's plot the results.
 
 fig = plt.figure()
-image = swap_submap.plot()
-swap_submap.draw_limb()
-swap_submap.draw_grid()
+ax = fig.add_subplots(projection=swap_submap)
+image = swap_submap.plot(axes=ax)
+swap_submap.draw_limb(axes=ax)
+swap_submap.draw_grid(axes=ax)
 
 # Make some room and put the title at the top of the figure
-ax = image.axes
 ax.set_position([0.1, 0.1, 0.8, 0.7])
 ax.set_title(ax.get_title(), pad=45)
 

--- a/examples/map_transformations/reprojection_aia_euvi_mosaic.py
+++ b/examples/map_transformations/reprojection_aia_euvi_mosaic.py
@@ -139,8 +139,8 @@ for w in weights:
     w[np.isnan(w)] = 0
 
 fig, ax = plt.subplots()
-ax.imshow(weights[0])
-plt.colorbar()
+im = ax.imshow(weights[0])
+fig.colorbar(im)
 
 plt.show()
 

--- a/examples/map_transformations/reprojection_aia_euvi_mosaic.py
+++ b/examples/map_transformations/reprojection_aia_euvi_mosaic.py
@@ -98,8 +98,9 @@ array, footprint = reproject_and_coadd(maps, out_wcs, shape_out,
 outmap = sunpy.map.Map((array, header))
 outmap.plot_settings = maps[0].plot_settings
 
-plt.figure()
-outmap.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=outmap)
+outmap.plot(axes=ax)
 
 plt.show()
 
@@ -137,8 +138,8 @@ weights = [(w / np.nanmax(w)) ** 3 for w in weights]
 for w in weights:
     w[np.isnan(w)] = 0
 
-plt.figure()
-plt.imshow(weights[0])
+fig, ax = plt.subplots()
+ax.imshow(weights[0])
 plt.colorbar()
 
 plt.show()
@@ -169,7 +170,7 @@ outmap.plot_settings = maps[0].plot_settings
 outmap.nickname = 'AIA + EUVI/A + EUVI/B'
 
 fig = plt.figure(figsize=(10, 5))
-ax = fig.add_subplot(projection=out_wcs)
+ax = fig.add_subplot(projection=outmap)
 im = outmap.plot(axes=ax, vmin=400)
 
 lon, lat = ax.coords

--- a/examples/map_transformations/reprojection_carrington.py
+++ b/examples/map_transformations/reprojection_carrington.py
@@ -20,8 +20,9 @@ from sunpy.map.header_helper import make_heliographic_header
 
 aia_map = sunpy.map.Map(sunpy.data.sample.AIA_193_IMAGE)
 
-plt.figure()
-aia_map.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=aia_map)
+aia_map.plot(axes=ax)
 
 ###############################################################################
 # Reproject works by transforming an input image to a desired World Coordinate
@@ -43,8 +44,9 @@ outmap = aia_map.reproject_to(carr_header)
 ###############################################################################
 # Plot the result.
 
-plt.figure()
-outmap.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=outmap)
+outmap.plot(axes=ax)
 outmap.draw_limb(color='blue')
 
 plt.show()

--- a/examples/map_transformations/reprojection_spherical_screen.py
+++ b/examples/map_transformations/reprojection_spherical_screen.py
@@ -30,9 +30,9 @@ aia_map = sunpy.map.Map(AIA_171_IMAGE)
 aia_map.plot_settings['norm'].vmin = 0
 aia_map.plot_settings['norm'].vmax = 10000
 
-plt.figure()
-plt.subplot(projection=aia_map)
-aia_map.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=aia_map)
+aia_map.plot(axes=ax)
 plt.show()
 
 ######################################################################
@@ -68,8 +68,9 @@ out_header = sunpy.map.make_fitswcs_header(
 
 outmap_default = aia_map.reproject_to(out_header)
 
-plt.figure()
-outmap_default.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=outmap_default)
+outmap_default.plot(axes=ax)
 plt.show()
 
 ######################################################################
@@ -82,8 +83,9 @@ plt.show()
 with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate):
     outmap_screen_all = aia_map.reproject_to(out_header)
 
-plt.figure()
-outmap_screen_all.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=outmap_screen_all)
+outmap_screen_all.plot(axes=ax)
 plt.show()
 
 ######################################################################
@@ -95,6 +97,7 @@ with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate,
                                              only_off_disk=True):
     outmap_screen_off_disk = aia_map.reproject_to(out_header)
 
-plt.figure()
-outmap_screen_off_disk.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=outmap_screen_off_disk)
+outmap_screen_off_disk.plot(axes=ax)
 plt.show()

--- a/examples/map_transformations/upside_down_hmi.py
+++ b/examples/map_transformations/upside_down_hmi.py
@@ -18,8 +18,9 @@ from sunpy.data.sample import HMI_LOS_IMAGE
 # than negative to positive).
 
 hmi_map = sunpy.map.Map(HMI_LOS_IMAGE)
-plt.figure()
-hmi_map.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=hmi_map)
+hmi_map.plot(axes=ax)
 
 plt.show()
 
@@ -37,7 +38,8 @@ plt.show()
 # in this case, 3 refers to bi-cubic.
 
 hmi_rotated = hmi_map.rotate(order=3)
-plt.figure()
-hmi_rotated.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=hmi_rotated)
+hmi_rotated.plot(axes=ax)
 
 plt.show()

--- a/examples/plotting/aia_example.py
+++ b/examples/plotting/aia_example.py
@@ -22,10 +22,11 @@ aiamap = sunpy.map.Map(AIA_171_IMAGE)
 # Let's plot the result. Setting the projection is necessary to ensure that
 # pixels can be converted accurately to coordinates values.
 
-plt.figure()
-aiamap.plot()
-aiamap.draw_limb()
-aiamap.draw_grid()
+fig = plt.figure()
+ax = fig.add_subplot(projection=aiamap)
+aiamap.plot(axes=ax)
+aiamap.draw_limb(axes=ax)
+aiamap.draw_grid(axes=ax)
 plt.show()
 
 ##############################################################################
@@ -34,8 +35,9 @@ plt.show()
 # ``clip_interval`` to clip out pixels with extreme values. Here, we clip out
 # the darkest 1% of pixels and the brightest 0.01% of pixels.
 
-plt.figure()
-aiamap.plot(clip_interval=(1, 99.99)*u.percent)
-aiamap.draw_limb()
-aiamap.draw_grid()
+fig = plt.figure()
+ax = fig.add_subplot(projection=aiamap)
+aiamap.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
+aiamap.draw_limb(axes=ax)
+aiamap.draw_grid(axes=ax)
 plt.show()

--- a/examples/plotting/finding_local_peaks_in_solar_data.py
+++ b/examples/plotting/finding_local_peaks_in_solar_data.py
@@ -23,8 +23,9 @@ from sunpy.map.maputils import all_pixel_indices_from_map
 # We will first create a Map using some sample data and display it.
 
 aiamap = sunpy.map.Map(AIA_193_IMAGE)
-plt.figure()
-aiamap.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=aiamap)
+aiamap.plot(axes=ax)
 plt.colorbar()
 
 ###############################################################################

--- a/examples/plotting/great_arc_example.py
+++ b/examples/plotting/great_arc_example.py
@@ -52,10 +52,9 @@ separation = intensity_coords.separation(intensity_coords[0]).to(u.arcsec)
 
 ###############################################################################
 # Plot the intensity along the arc from the start to the end point.
-
-plt.figure()
-plt.plot(separation, intensity)
-plt.xlabel(f'Separation from start of arc [{separation.unit}]')
-plt.ylabel(f'Intensity [{intensity.unit}]')
+fig, ax = plt.subplots()
+ax.plot(separation, intensity)
+ax.set_xlabel(f'Separation from start of arc [{separation.unit}]')
+ax.set_ylabel(f'Intensity [{intensity.unit}]')
 
 plt.show()

--- a/examples/plotting/map_editcolormap.py
+++ b/examples/plotting/map_editcolormap.py
@@ -32,7 +32,8 @@ aiamap.plot_settings['norm'] = colors.LogNorm(100, aiamap.max())
 # and `normalizations <https://matplotlib.org/users/colormapnorms.html>`_.
 # For more advanced normalizations see `astropy.visualization`.
 
-plt.figure()
-aiamap.plot()
+fig = plt.figure()
+ax = fig.add_subplot(projection=aiamap)
+aiamap.plot(axes=ax)
 plt.colorbar()
 plt.show()

--- a/examples/plotting/plot_equator_prime_meridian.py
+++ b/examples/plotting/plot_equator_prime_meridian.py
@@ -46,7 +46,7 @@ outmap = aia_map.reproject_to(header)
 
 fig = plt.figure()
 ax = fig.add_subplot(projection=outmap)
-outmap.plot()
+outmap.plot(axes=ax)
 drawing.equator(ax, color='blue')
 drawing.prime_meridian(ax, color='red')
 plt.show()

--- a/examples/plotting/solar_cycle_example.py
+++ b/examples/plotting/solar_cycle_example.py
@@ -46,15 +46,19 @@ noaa_predict = ts.TimeSeries(f_noaa_predict, source='noaapredictindices')
 # ranges.
 
 time_support()
-plt.figure()
-plt.plot(noaa.time, noaa.quantity('sunspot RI'), label='Sunspot Number')
-plt.plot(noaa_predict.time, noaa_predict.quantity('sunspot'),
-         color='grey', label='Near-term Prediction')
-plt.fill_between(noaa_predict.time, noaa_predict.quantity('sunspot low'),
-                 noaa_predict.quantity('sunspot high'), alpha=0.3, color='grey')
-plt.ylim(bottom=0)
-plt.ylabel('Sunspot Number')
-plt.xlabel('Year')
-plt.legend()
+fig, ax = plt.subplots()
+ax.plot(noaa.time, noaa.quantity('sunspot RI'), label='Sunspot Number')
+ax.plot(
+    noaa_predict.time, noaa_predict.quantity('sunspot'),
+    color='grey', label='Near-term Prediction'
+)
+ax.fill_between(
+    noaa_predict.time, noaa_predict.quantity('sunspot low'),
+    noaa_predict.quantity('sunspot high'), alpha=0.3, color='grey'
+)
+ax.set_ylim(bottom=0)
+ax.set_ylabel('Sunspot Number')
+ax.set_xlabel('Year')
+ax.legend()
 
 plt.show()

--- a/examples/plotting/sunpy_matplotlib_colormap.py
+++ b/examples/plotting/sunpy_matplotlib_colormap.py
@@ -35,8 +35,10 @@ Z = (Z1 - Z2) * 2
 ###############################################################################
 # Let's now plot the results with the colormap.
 
-plt.figure()
-im = plt.imshow(Z, interpolation='bilinear', cmap=sdoaia171,
-                origin='lower', extent=[-3, 3, -3, 3],
-                vmax=abs(Z).max(), vmin=-abs(Z).max())
+fig, ax = plt.subplots()
+im = ax.imshow(
+    Z, interpolation='bilinear', cmap=sdoaia171,
+    origin='lower', extent=[-3, 3, -3, 3],
+    vmax=abs(Z).max(), vmin=-abs(Z).max()
+)
 plt.show()

--- a/examples/time_series/goes_hek_m25.py
+++ b/examples/time_series/goes_hek_m25.py
@@ -35,13 +35,15 @@ flares_hek = hek_results[0]
 ###############################################################################
 # Lets plot everything together.
 
-plt.figure()
-goes.plot()
-plt.axvline(parse_time(flares_hek['event_peaktime']).datetime)
-plt.axvspan(parse_time(flares_hek['event_starttime']).datetime,
-            parse_time(flares_hek['event_endtime']).datetime,
-            alpha=0.2, label=flares_hek['fl_goescls'])
-plt.legend(loc=2)
-plt.yscale('log')
+fig, ax = plt.subplots()
+goes.plot(axes=ax)
+ax.axvline(parse_time(flares_hek['event_peaktime']).datetime)
+ax.axvspan(
+    parse_time(flares_hek['event_starttime']).datetime,
+    parse_time(flares_hek['event_endtime']).datetime,
+    alpha=0.2, label=flares_hek['fl_goescls']
+)
+ax.legend(loc=2)
+ax.set_yscale('log')
 
 plt.show()

--- a/examples/time_series/goes_xrs_example.py
+++ b/examples/time_series/goes_xrs_example.py
@@ -82,7 +82,8 @@ goes_15 = ts.TimeSeries(df, goes_15.meta, goes_15.units)
 # channel is known as the "xrsa" channel and the 1-8 angstrom channel is known
 # as the "xrsb" channel.
 
-goes_15.plot(columns=["xrsb"])
+fig, ax = plt.subplots()
+goes_15.plot(axes=ax, columns=["xrsb"])
 plt.show()
 
 ###############################################################

--- a/examples/time_series/goes_xrs_nrt_data.py
+++ b/examples/time_series/goes_xrs_nrt_data.py
@@ -66,7 +66,7 @@ goes_ts = ts.TimeSeries(goes_data, meta, units, source="xrs")
 ###############################################################################
 # Finally, we can plot the timeseries.
 
-plt.figure()
-goes_ts.plot()
+fig, ax = plt.subplots()
+goes_ts.plot(axes=ax)
 
 plt.show()

--- a/examples/time_series/power_spectra_example.py
+++ b/examples/time_series/power_spectra_example.py
@@ -33,9 +33,9 @@ freq, spectra = signal.periodogram(ts.quantity(x_ray), fs=0.25)
 ###############################################################################
 # Let's plot the results.
 
-plt.figure()
-plt.semilogy(freq, spectra)
-plt.title(f'Power Spectrum of {x_ray}')
-plt.ylabel('Power Spectral Density [{:LaTeX}]'.format(ts.units[x_ray] ** 2 / u.Hz))
-plt.xlabel('Frequency [Hz]')
+fig, ax = plt.subplots()
+ax.semilogy(freq, spectra)
+ax.set_title(f'Power Spectrum of {x_ray}')
+ax.set_ylabel('Power Spectral Density [{:LaTeX}]'.format(ts.units[x_ray] ** 2 / u.Hz))
+ax.set_xlabel('Frequency [Hz]')
 plt.show()

--- a/examples/time_series/timeseries_convolution_filter.py
+++ b/examples/time_series/timeseries_convolution_filter.py
@@ -34,11 +34,11 @@ goes_lc = goes_lc.add_column(
 ###############################################################################
 # Plotting original and smoothed timeseries.
 
-plt.figure()
-plt.xlabel('Time')
-plt.ylabel("Flux (Wm$^{-2}$")
-plt.title('Smoothing of Time Series')
-plt.plot(goes_lc.quantity('xrsa'), label='original')
-plt.plot(goes_lc.quantity('xrsa_smoothed'), label='smoothed')
-plt.legend()
+fig, ax = plt.subplots()
+ax.set_xlabel('Time')
+ax.set_ylabel("Flux (Wm$^{-2}$")
+ax.set_title('Smoothing of Time Series')
+ax.plot(goes_lc.quantity('xrsa'), label='original')
+ax.plot(goes_lc.quantity('xrsa_smoothed'), label='smoothed')
+ax.legend()
 plt.show()

--- a/examples/time_series/timeseries_example.py
+++ b/examples/time_series/timeseries_example.py
@@ -51,7 +51,9 @@ list_of_goes_ts = sunpy.timeseries.TimeSeries(goes_files, source='XRS')
 combined_goes_ts = sunpy.timeseries.TimeSeries(goes_files, source='XRS', concatenate=True)
 # Manually
 combined_goes_ts = list_of_goes_ts[0].concatenate(list_of_goes_ts[1])
-combined_goes_ts.plot()
+
+fig, ax = plt.subplots()
+combined_goes_ts.plot(axes=ax)
 
 plt.show()
 
@@ -133,7 +135,8 @@ ts_goes_trunc = ts_goes.truncate(TimeRange('2011-06-07 05:00', '2011-06-07 06:30
 # Or using strings
 ts_goes_trunc = ts_goes.truncate('2011-06-07 05:00', '2011-06-07 06:30')
 
-ts_goes_trunc.plot()
+fig, ax = plt.subplots()
+ts_goes_trunc.plot(axes=ax)
 
 plt.show()
 
@@ -147,8 +150,9 @@ df_downsampled = ts_goes_trunc.to_dataframe().resample('10T').mean()
 ts_downsampled = sunpy.timeseries.TimeSeries(df_downsampled,
                                              ts_goes_trunc.meta,
                                              ts_goes_trunc.units)
-ts_downsampled.plot()
 
+fig, ax = plt.subplots()
+ts_downsampled.plot(axes=ax)
 plt.show()
 
 ##############################################################################
@@ -176,6 +180,6 @@ units = OrderedDict([('intensity', u.W / u.m**2)])
 # Create the TimeSeries
 ts_custom = sunpy.timeseries.TimeSeries(data, meta, units)
 
-ts_custom.plot()
-
+fig, ax = plt.subplots()
+ts_custom.plot(axes=ax)
 plt.show()

--- a/examples/time_series/timeseries_peak_finding.py
+++ b/examples/time_series/timeseries_peak_finding.py
@@ -21,8 +21,8 @@ from sunpy.timeseries import TimeSeries
 goes_lc = TimeSeries(GOES_XRS_TIMESERIES)
 my_timeseries = goes_lc.truncate('2011/06/07 06:10', '2011/06/07 09:00')
 
-plt.figure()
-my_timeseries.plot()
+fig, ax = plt.subplots()
+my_timeseries.plot(axes=ax)
 
 ##############################################################################
 # To find extrema in any TimeSeries, we first define a function findpeaks that
@@ -101,14 +101,14 @@ def findpeaks(series, DELTA):
 series = my_timeseries.to_dataframe()['xrsa']
 minpeaks, maxpeaks = findpeaks(series, DELTA=1e-7)
 # Plotting the figure and extremum points
-plt.figure()
-plt.xlabel('Time')
-plt.ylabel("Flux (Wm$^{-2}$")
-plt.title('Peaks in TimeSeries')
-series.plot()
-plt.scatter(*zip(*minpeaks), color='red', label='min')
-plt.scatter(*zip(*maxpeaks), color='green', label='max')
-plt.legend()
-plt.grid(True)
+fig, ax = plt.subplots()
+ax.set_xlabel('Time')
+ax.set_ylabel("Flux (Wm$^{-2}$")
+ax.set_title('Peaks in TimeSeries')
+series.plot(axes=ax)
+ax.scatter(*zip(*minpeaks), color='red', label='min')
+ax.scatter(*zip(*maxpeaks), color='green', label='max')
+ax.legend()
+ax.grid(True)
 
 plt.show()


### PR DESCRIPTION
Our rules of thumb for gallery examples exist to "minimize verbosity and maintain consistency with the other gallery examples:". In some places consistency and verbosity are a trade off, including which flavour of the Matplotlib API we are calling.

Broadly the two options are:
1. Use `pyplot` (e.g. `plt.xlabel`) where possible, and do not create Axes objects
2. Use `Axes` all the time, even when it would be possible to use `pyplot`

1. is a bit less verbose than 2., but this comes at the cost of having two ways of doing stuff in our gallery (e.g. `plt.xlabel()` vs. `ax.set_xlabel()`. In my opinion consistency is more important than minimizing verbosity here, so I am proposing that we always create an `Axes` object.

I've converted one gallery example as an example of what this change would look like. Thoughts?