### PR TITLE
Add maputils function to fully pixelate a coordinate path

### DIFF
--- a/changelog/6840.deprecation.rst
+++ b/changelog/6840.deprecation.rst
@@ -1,0 +1,2 @@
+The utility function :func:`sunpy.map.extract_along_coord` is deprecated.
+Use :func:`sunpy.map.pixelate_coord_path`, and then pass its output to :func:`sunpy.map.sample_at_coords`.

--- a/changelog/6840.feature.rst
+++ b/changelog/6840.feature.rst
@@ -1,0 +1,1 @@
+Added the utility function :func:`sunpy.map.pixelate_coord_path` to fully pixelate a coordinate path according to the pixels of a given map.

--- a/changelog/6882.breaking.rst
+++ b/changelog/6882.breaking.rst
@@ -1,0 +1,1 @@
+Changed the output of :func:`sunpy.map.sample_at_coords` to return the sampled values as `~astropy.units.Quantity` with the appropriate units instead of merely numbers.

--- a/examples/plotting/great_arc_example.py
+++ b/examples/plotting/great_arc_example.py
@@ -41,13 +41,12 @@ ax = fig.add_subplot(projection=m)
 m.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
 ax.plot_coord(great_arc.coordinates(), color='c')
 
-plt.show()
-
 ###############################################################################
 # Now we can get the intensity along the great arc coordinates, along with the
 # angular distance from the start of the arc
 coords = great_arc.coordinates()
-intensity, intensity_coords = sunpy.map.extract_along_coord(m, coords)
+intensity_coords = sunpy.map.pixelate_coord_path(m, coords)
+intensity = sunpy.map.sample_at_coords(m, intensity_coords)
 separation = intensity_coords.separation(intensity_coords[0]).to(u.arcsec)
 
 ###############################################################################

--- a/examples/units_and_coordinates/map_slit_extraction.py
+++ b/examples/units_and_coordinates/map_slit_extraction.py
@@ -28,13 +28,13 @@ line_coords = SkyCoord([-1024, -908], [20, 633], unit=(u.arcsec, u.arcsec),
 
 
 ###############################################################################
-# Next we call the `sunpy.map.extract_along_coord` function with the map and
-# the coordinates we want to extract.
-# This function returns two items, the first is a numpy array of all the
-# intensities and the second is a `~astropy.coordinates.SkyCoord` object of the
-# same length, which describes the world coordinates of each pixel that has
-# been extracted.
-intensity, intensity_coords = sunpy.map.extract_along_coord(aia_map, line_coords)
+# Next we call the :func:`sunpy.map.pixelate_coord_path` function with the map
+# and the coordinate path to obtain the coordinates of the map pixels that
+# intersect that path.  We pass those coordinates to
+# :func:`sunpy.map.sample_at_coords` to extract the values for those map
+# pixels.
+intensity_coords = sunpy.map.pixelate_coord_path(aia_map, line_coords)
+intensity = sunpy.map.sample_at_coords(aia_map, intensity_coords)
 
 
 ###############################################################################
@@ -45,7 +45,7 @@ angular_separation = intensity_coords.separation(intensity_coords[0]).to(u.arcse
 
 ###############################################################################
 # Finally let's plot the results.
-fig = plt.figure()
+fig = plt.figure(figsize=(10, 4))
 ax1 = fig.add_subplot(121, projection=aia_map)
 aia_map.plot(axes=ax1)
 ax1.plot_coord(intensity_coords)

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -10,6 +10,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 from sunpy.coordinates import Helioprojective, sun
+from sunpy.util.decorators import deprecated
 
 __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'all_corner_coords_from_map',
@@ -455,6 +456,9 @@ def _bresenham(*, x1, y1, x2, y2):
     return np.array(res)
 
 
+@deprecated("5.0", message="The extract_along_coord function is deprecated and may be removed in "
+                           "version 5.1. Use pixelate_coord_path, and then pass its output to "
+                           "sample_at_coords.")
 def extract_along_coord(smap, coord):
     """
     Extract pixel values from a map along a path that approximates a coordinate path.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -148,11 +148,10 @@ def sample_at_coords(smap, coordinates):
 
     Returns
     -------
-    `numpy.array`
-        A `numpy.array` corresponding to the data obtained from the map,
-        at the input coordinates.
+    `~astropy.units.Quantity`
+        An array of the map data at the input coordinates.
     """
-    return smap.data[smap.wcs.world_to_array_index(coordinates)]
+    return u.Quantity(smap.data[smap.wcs.world_to_array_index(coordinates)], smap.unit)
 
 
 def _edge_coordinates(smap):

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -150,6 +150,10 @@ def sample_at_coords(smap, coordinates):
     -------
     `~astropy.units.Quantity`
         An array of the map data at the input coordinates.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.map.sample_at_coords
     """
     return u.Quantity(smap.data[smap.wcs.world_to_array_index(coordinates)], smap.unit)
 
@@ -481,10 +485,6 @@ def extract_along_coord(smap, coord):
     The provided coordinates are first rounded to the nearest corresponding pixel,
     which means that the coordinates used for calculations may be shifted relative
     to the provided coordinates by up to half a pixel.
-
-    Examples
-    --------
-    .. minigallery:: sunpy.map.extract_along_coord
     """
     if not len(coord.shape) or coord.shape[0] < 2:
         raise ValueError('At least two points are required for extracting intensity along a '
@@ -573,6 +573,10 @@ def pixelate_coord_path(smap, coord_path):
     -------
     `~astropy.coordinates.SkyCoord`
          The coordinates for the pixels that intersect with the coordinate path.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.map.pixelate_coord_path
     """
     if not len(coord_path.shape) or coord_path.shape[0] < 2:
         raise ValueError("The coordinate path must have at least two points.")

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -458,7 +458,9 @@ def _bresenham(*, x1, y1, x2, y2):
 
 @deprecated("5.0", message="The extract_along_coord function is deprecated and may be removed in "
                            "version 5.1. Use pixelate_coord_path, and then pass its output to "
-                           "sample_at_coords.")
+                           "sample_at_coords. pixelate_coord_path uses a different line algorithm "
+                           "by default, but you can specify bresenham=True to use the same line "
+                           "algorithm as extract_along_coord.")
 def extract_along_coord(smap, coord):
     """
     Extract pixel values from a map along a path that approximates a coordinate path.

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -24,6 +24,7 @@ from sunpy.map.maputils import (
     is_all_on_disk,
     map_edges,
     on_disk_bounding_coordinates,
+    pixelate_coord_path,
     sample_at_coords,
     solar_angular_radius,
 )
@@ -302,3 +303,21 @@ def test_extract_along_coord_out_of_bounds_exception(aia171_test_map):
     point = aia171_test_map.pixel_to_world([-1, 1]*u.pix, [-1, 1]*u.pix)
     with pytest.raises(ValueError, match='At least one coordinate is not within the bounds of the map.*'):
         _ = extract_along_coord(aia171_test_map, point)
+
+
+@pytest.mark.parametrize('x, y, sampled_x, sampled_y',
+                         [([1, 5], [1, 1], [1, 2, 3, 4, 5], [1, 1, 1, 1, 1]),
+                          ([1, 5], [1, 2], [1, 2, 3, 3, 4, 5], [1, 1, 1, 2, 2, 2]),
+                          ([1, 5], [1, 3], [1, 2, 2, 3, 4, 4, 5], [1, 1, 2, 2, 2, 3, 3]),
+                          ([1, 5], [1.0, 4.0], [1, 2, 2, 3, 3, 4, 4, 5], [1, 1, 2, 2, 3, 3, 4, 4]),
+                          ([1, 5], [1.0, 3.6], [1, 2, 2, 3, 3, 4, 5, 5], [1, 1, 2, 2, 3, 3, 3, 4]),
+                          ([1, 5], [1.4, 3.6], [1, 1, 2, 3, 3, 4, 5, 5], [1, 2, 2, 2, 3, 3, 3, 4])])
+def test_pixelate_coord_path(aia171_test_map, x, y, sampled_x, sampled_y):
+    # Also test the x<->y transpose
+    for xx, yy, sxx, syy in [(x, y, sampled_x, sampled_y), (y, x, sampled_y, sampled_x)]:
+        # Using the AIA test map for a "real" WCS, but the actual WCS is irrelevant for this test
+        line = aia171_test_map.wcs.pixel_to_world(xx, yy)
+        sampled_coords = pixelate_coord_path(aia171_test_map, line)
+        sampled_pixels = aia171_test_map.wcs.world_to_pixel(sampled_coords)
+        assert np.allclose(sampled_pixels[0], sxx)
+        assert np.allclose(sampled_pixels[1], syy)

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -321,3 +321,21 @@ def test_pixelate_coord_path(aia171_test_map, x, y, sampled_x, sampled_y):
         sampled_pixels = aia171_test_map.wcs.world_to_pixel(sampled_coords)
         assert np.allclose(sampled_pixels[0], sxx)
         assert np.allclose(sampled_pixels[1], syy)
+
+
+@pytest.mark.parametrize('x, y, sampled_x, sampled_y',
+                         [([1, 5], [1, 1], [1, 2, 3, 4, 5], [1, 1, 1, 1, 1]),
+                          ([1, 5], [1, 2], [1, 2, 3, 4, 5], [1, 1, 1, 2, 2]),
+                          ([1, 5], [1, 3], [1, 2, 3, 4, 5], [1, 1, 2, 2, 3]),
+                          ([1, 5], [1.0, 4.0], [1, 2, 3, 4, 5], [1, 2, 2, 3, 4]),
+                          ([1, 5], [1.0, 3.6], [1, 2, 3, 4, 5], [1, 2, 2, 3, 4]),
+                          ([1, 5], [1.4, 3.6], [1, 2, 3, 4, 5], [1, 2, 2, 3, 4])])
+def test_pixelate_coord_path_bresenham(aia171_test_map, x, y, sampled_x, sampled_y):
+    # Also test the x<->y transpose
+    for xx, yy, sxx, syy in [(x, y, sampled_x, sampled_y), (y, x, sampled_y, sampled_x)]:
+        # Using the AIA test map for a "real" WCS, but the actual WCS is irrelevant for this test
+        line = aia171_test_map.wcs.pixel_to_world(xx, yy)
+        sampled_coords = pixelate_coord_path(aia171_test_map, line, bresenham=True)
+        sampled_pixels = aia171_test_map.wcs.world_to_pixel(sampled_coords)
+        assert np.allclose(sampled_pixels[0], sxx)
+        assert np.allclose(sampled_pixels[1], syy)

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -28,6 +28,7 @@ from sunpy.map.maputils import (
     sample_at_coords,
     solar_angular_radius,
 )
+from sunpy.util.exceptions import SunpyDeprecationWarning
 
 
 @pytest.fixture
@@ -280,7 +281,8 @@ def test_extract_along_coord(aia171_test_map):
     nmax = max(*aia171_test_map.data.shape)
     top_right = aia171_test_map.pixel_to_world((nmax-1)*u.pix, (nmax-1)*u.pix)
     line = SkyCoord([aia171_test_map.bottom_left_coord, top_right])
-    intensity, line_discrete = extract_along_coord(aia171_test_map, line)
+    with pytest.warns(SunpyDeprecationWarning):
+        intensity, line_discrete = extract_along_coord(aia171_test_map, line)
     pix_diag = np.array([(i, i) for i in range(nmax)])
     intensity_diag = u.Quantity(
         [aia171_test_map.data[i[0], i[1]] for i in pix_diag],
@@ -294,15 +296,18 @@ def test_extract_along_coord(aia171_test_map):
 
 def test_extract_along_coord_one_point_exception(aia171_test_map):
     with pytest.raises(ValueError, match='At least two points are required*'):
-        _ = extract_along_coord(aia171_test_map, aia171_test_map.bottom_left_coord)
+        with pytest.warns(SunpyDeprecationWarning):
+            _ = extract_along_coord(aia171_test_map, aia171_test_map.bottom_left_coord)
     with pytest.raises(ValueError, match='At least two points are required*'):
-        _ = extract_along_coord(aia171_test_map, SkyCoord([aia171_test_map.bottom_left_coord]))
+        with pytest.warns(SunpyDeprecationWarning):
+            _ = extract_along_coord(aia171_test_map, SkyCoord([aia171_test_map.bottom_left_coord]))
 
 
 def test_extract_along_coord_out_of_bounds_exception(aia171_test_map):
     point = aia171_test_map.pixel_to_world([-1, 1]*u.pix, [-1, 1]*u.pix)
     with pytest.raises(ValueError, match='At least one coordinate is not within the bounds of the map.*'):
-        _ = extract_along_coord(aia171_test_map, point)
+        with pytest.warns(SunpyDeprecationWarning):
+            _ = extract_along_coord(aia171_test_map, point)
 
 
 @pytest.mark.parametrize('x, y, sampled_x, sampled_y',

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -212,9 +212,9 @@ def test_data_at_coordinates(aia171_test_map, aia_test_arc):
         aia171_test_map.world_to_pixel(aia_test_arc.coordinates())), dtype=int)
     x = pixels[0, :]
     y = pixels[1, :]
-    intensity_along_arc = aia171_test_map.data[y, x]
-    np.testing.assert_almost_equal(data[0], intensity_along_arc[0], decimal=1)
-    np.testing.assert_almost_equal(data[-1], intensity_along_arc[-1], decimal=1)
+    intensity_along_arc = aia171_test_map.data[y, x] * aia171_test_map.unit
+    assert_quantity_allclose(data[0], intensity_along_arc[0])
+    assert_quantity_allclose(data[-1], intensity_along_arc[-1])
 
 
 def test_contains_solar_center(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map, sub_smap):


### PR DESCRIPTION
This PR adds a new maputils function – `pixelate_coord_path()` – that fully pixelates a coordinate path.  `extract_along_coord()` tries to do that, but has issues (see #6826 and #6802).  Here's a comparison of the pixel paths:
![download (76)](https://user-images.githubusercontent.com/991759/224523991-361abbe7-3210-44a3-8640-40a87ab6b209.png)

TODO:
- [x] Add a unit test
- [x] Deprecate `extract_along_coord()`
- [x] Update examples
- [x] Add a changelog entry
- [x] Add a note that a path passing through a four-corners point may not pick up all four pixels due to floating-point comparisons