### PR TITLE
Use type hints with single dispatch in time.py

### DIFF
--- a/sunpy/map/_units.py
+++ b/sunpy/map/_units.py
@@ -1,5 +1,13 @@
 import astropy.units as u
+import numpy as np
 
 # TODO: Remove in astropy 5.1 (hopefully)
 maxwell = u.def_unit(['Mx', 'Maxwell', 'maxwell'], 1e-8 * u.si.Wb, prefixes=True, doc="Maxwell: CGS unit for magnetic flux")
 u.add_enabled_units([maxwell])
+
+muSH = u.def_unit(
+        "muSH",
+        represents=((2 * np.pi * u.solRad**2)/1000000),
+        prefixes=True,
+        doc="Provide millionths of solar hemisphere units")
+u.add_enabled_units([muSH])

--- a/sunpy/map/_units.py
+++ b/sunpy/map/_units.py
@@ -1,13 +1,5 @@
 import astropy.units as u
-import numpy as np
 
 # TODO: Remove in astropy 5.1 (hopefully)
 maxwell = u.def_unit(['Mx', 'Maxwell', 'maxwell'], 1e-8 * u.si.Wb, prefixes=True, doc="Maxwell: CGS unit for magnetic flux")
 u.add_enabled_units([maxwell])
-
-muSH = u.def_unit(
-        "muSH",
-        represents=((2 * np.pi * u.solRad**2)/1000000),
-        prefixes=True,
-        doc="Provide millionths of solar hemisphere units")
-u.add_enabled_units([muSH])

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -71,7 +71,7 @@ TIME_FORMAT_LIST = [
 _ONE_DAY_TIMEDELTA = TimeDelta(1 * u.day)
 
 
-def is_time_equal(t1, t2):
+def is_time_equal(t1 :u.nanosecond, t2 :u.nanosecond) -> bool:
     """
     Work around for https://github.com/astropy/astropy/issues/6970.
 
@@ -296,7 +296,7 @@ def _variables_for_parse_time_docstring():
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())
-def parse_time(time_string, *, format=None, **kwargs):
+def parse_time(time_string : str, *, format:str=None, **kwargs) -> astropy.time.Time:
     """
     Takes a time input and will parse and return a `astropy.time.Time`.
 


### PR DESCRIPTION
## PR Description
Adds type annotation(type-hinting) and `@singledispatch` for few function 

## TODO
- [ ] changelog
- [ ] single dispatch for `is_time` 
- [ ] single dispatch for `is_time_in_given_format `

Fixes #3201 
<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->
