### PR TITLE
Use minimum supported deps in figure tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,10 +69,11 @@ deps =
     online: pytest-rerunfailures
     online: pytest-timeout
     # Figure tests need a tightly controlled environment
+    # These are pinned to the minimum version that we support
     figure-!devdeps: astropy==5.1.0
     figure-!devdeps: matplotlib==3.5.2
     figure-!devdeps: mpl-animators==1.0.0
-    figure-!devdeps: numpy<1.24
+    figure-!devdeps: numpy<1.22
 extras =
     all
     tests


### PR DESCRIPTION
Replaces https://github.com/sunpy/sunpy/pull/6678, by adding a comment that these should be set to minimum supported versions, and reducing the numpy version to adhere to this.