### PR TITLE
Change "Reprojecting Images to Different Observers"  example to avoid using custom wcs header until necessary

### DIFF
--- a/changelog/6853.doc.rst
+++ b/changelog/6853.doc.rst
@@ -1,0 +1,1 @@
+Changed the reprojecting images to different observers example (:ref:`sphx_glr_generated_gallery_map_transformations_reprojection_different_observers.py`) to avoid using custom wcs headers where possible.

--- a/examples/map_transformations/reprojection_different_observers.py
+++ b/examples/map_transformations/reprojection_different_observers.py
@@ -63,11 +63,15 @@ plt.legend([limb_aia[0], limb_euvi[0]],
            ['Limb as seen by AIA', 'Limb as seen by EUVI A'])
 
 ######################################################################
-# Due to a mismatch between the solar radius as defined in ``map_aia``
-# and ``map_euvi``, our reprojection will not behave correctly on pixels
-# very near the limb. This can be prevented by equating the two radii.
+# Data providers can set the radius at which emission in the map is assumed
+# to have come from. Most maps use a default value for photospheric
+# radius (including EUVI maps), but some maps (including AIA maps) are set
+# to a slightly different value. A mismatch in solar radius means a reprojection
+# will not work correctly on pixels near the limb. This can be prevented by
+# replacing the value for the solar radius in the AIA map with the default value,
+# thereby assuming that the emission in both maps is emitted at the same radius.
 
-map_euvi.meta['rsun_ref'] = map_aia.meta['rsun_ref']
+map_aia.wcs.wcs.aux.rsun_ref = sunpy.sun.constants.radius.to_value('m')
 
 ######################################################################
 # We can reproject the EUVI map to the AIA observer wcs using

--- a/examples/map_transformations/reprojection_different_observers.py
+++ b/examples/map_transformations/reprojection_different_observers.py
@@ -68,10 +68,9 @@ plt.legend([limb_aia[0], limb_euvi[0]],
 # radius (including EUVI maps), but some maps (including AIA maps) are set
 # to a slightly different value. A mismatch in solar radius means a reprojection
 # will not work correctly on pixels near the limb. This can be prevented by
-# replacing the value for the solar radius in the AIA map with the default value,
-# thereby assuming that the emission in both maps is emitted at the same radius.
+# modifying the values for rsun on one map to match the other.
 
-map_aia.wcs.wcs.aux.rsun_ref = sunpy.sun.constants.radius.to_value('m')
+map_euvi.meta['rsun_ref'] = map_aia.meta['rsun_ref']
 
 ######################################################################
 # We can reproject the EUVI map to the AIA observer wcs using


### PR DESCRIPTION
This changes the Reprojecting Images to Different Observers example to avoid making a custom wcs until necessary (doesn't use it for euvi but does for mars). 

I think there has been repeated confusion amongst users that see this example and assume a custom output wcs is necessary.

To avoid the reprojected image having NaNs on the limb, we still force the rsun for the two maps to match before reprojecting.
 
This however only partly deals with #6585 , I think a diataxis style explanation page is still needed, this example is now begging for a: "for a full explanation of why this is necessary go here" kind of deal but I am not sure I am the man for that page. I can definitely start it if people want, get the ball rolling (in a new PR,) but will probably need help from more savy reprojecters to weigh in.