### PR TITLE
Deprecate parsing EVE "averages" files

### DIFF
--- a/changelog/6857.deprecation.rst
+++ b/changelog/6857.deprecation.rst
@@ -1,0 +1,3 @@
+Parsing SDO/EVE level 0CS average files is deprecated, and will be removed in sunpy 6.0.
+Parsing this data is untested, and we cannot find a file to test it with.
+If you know where level 0CS 'averages' files can be found, please get in touch at https://community.openastronomy.org/c/sunpy/5.

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -14,6 +14,7 @@ import sunpy.io
 from sunpy.time import parse_time
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
 from sunpy.util.decorators import deprecate_positional_args_since
+from sunpy.util.exceptions import warn_deprecated
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
 
@@ -267,6 +268,12 @@ class EVESpWxTimeSeries(GenericTimeSeries):
         """
         Parses an EVE Averages file.
         """
+        warn_deprecated(
+            "Parsing SDO/EVE level 0CS average files is deprecated, and will be removed in "
+            "sunpy 6.0. Parsing this data is untested, and we cannot find a file to test it with. "
+            "If you know where level 0CS 'averages' files can be found, please get in touch at "
+            "https://community.openastronomy.org/c/sunpy/5."
+        )
         return "", read_csv(filepath, sep=",", index_col=0, parse_dates=True)
 
     @staticmethod


### PR DESCRIPTION
This is currently un-tested, and I can't find an "averages" file anywhere on the internet. In addition a bit of git blame archeology didn't reveal anything about EVE 0CS "averages" files, so I think it's best to deprecate this, and if anyone out there is using it they can shout and hopefully provide a file for us to test it with.