### PR TITLE
Change the output of `sample_at_coords()` to have units

### DIFF
--- a/changelog/6882.breaking.rst
+++ b/changelog/6882.breaking.rst
@@ -1,0 +1,1 @@
+Changed the output of :func:`sunpy.map.sample_at_coords` to return the sampled values as `~astropy.units.Quantity` with the appropriate units instead of merely numbers.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -148,11 +148,10 @@ def sample_at_coords(smap, coordinates):
 
     Returns
     -------
-    `numpy.array`
-        A `numpy.array` corresponding to the data obtained from the map,
-        at the input coordinates.
+    `~astropy.units.Quantity`
+        An array of the map data at the input coordinates.
     """
-    return smap.data[smap.wcs.world_to_array_index(coordinates)]
+    return u.Quantity(smap.data[smap.wcs.world_to_array_index(coordinates)], smap.unit)
 
 
 def _edge_coordinates(smap):

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -212,9 +212,9 @@ def test_data_at_coordinates(aia171_test_map, aia_test_arc):
         aia171_test_map.world_to_pixel(aia_test_arc.coordinates())), dtype=int)
     x = pixels[0, :]
     y = pixels[1, :]
-    intensity_along_arc = aia171_test_map.data[y, x]
-    np.testing.assert_almost_equal(data[0], intensity_along_arc[0], decimal=1)
-    np.testing.assert_almost_equal(data[-1], intensity_along_arc[-1], decimal=1)
+    intensity_along_arc = aia171_test_map.data[y, x] * aia171_test_map.unit
+    assert_quantity_allclose(data[0], intensity_along_arc[0])
+    assert_quantity_allclose(data[-1], intensity_along_arc[-1])
 
 
 def test_contains_solar_center(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map, sub_smap):


### PR DESCRIPTION
For some reason, `sunpy.map.maputils.sample_at_coords()` doesn't return a `Quantity` when sampling pixel values.  This PR fixes that oversight, although this is an API change that could break code in the wild without any practical way to have a deprecation period.