### PR TITLE
Made sunpy.io readers private

### DIFF
--- a/sunpy/database/tables.py
+++ b/sunpy/database/tables.py
@@ -19,7 +19,7 @@ import sunpy
 import sunpy.net.vso.legacy_response
 from sunpy import config
 from sunpy.io import _fits
-from sunpy.io import file_tools as sunpy_filetools
+from sunpy.io import _file_tools as sunpy_filetools
 from sunpy.io.header import FileHeader
 from sunpy.time import parse_time
 from sunpy.util.types import DatabaseEntryType

--- a/sunpy/io/__init__.py
+++ b/sunpy/io/__init__.py
@@ -1,1 +1,1 @@
-from sunpy.io.file_tools import *
+from sunpy.io._file_tools import *

--- a/sunpy/io/_cdf.py
+++ b/sunpy/io/_cdf.py
@@ -2,17 +2,17 @@ import cdflib
 import numpy as np
 import pandas as pd
 from cdflib.epochs import CDFepoch
-
+import warnings
 import astropy.units as u
 
 from sunpy import log
 from sunpy.timeseries import GenericTimeSeries
 from sunpy.util.exceptions import warn_user
 
-__all__ = ['read_cdf']
+__all__ = ['_read_cdf']
 
 
-def read_cdf(fname):
+def _read_cdf(fname):
     """
     Read a CDF file that follows the ISTP/IACG guidelines.
 
@@ -31,8 +31,8 @@ def read_cdf(fname):
     ----------
     Space Physics Guidelines for CDF https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html
     """
+    warnings.warn("_read_cdf is depricated and it is meant to be used for internal uses only",DeprecationWarning)
     cdf = cdflib.CDF(str(fname))
-
     # Extract the time varying variables
     cdf_info = cdf.cdf_info()
     meta = cdf.globalattsget()

--- a/sunpy/io/_file_tools.py
+++ b/sunpy/io/_file_tools.py
@@ -4,16 +4,16 @@ This module provides a generic file reader.
 import re
 import gzip
 import pathlib
-
+import warnings
 try:
     from . import _fits as fits
 except ImportError:
     fits = None
 
 try:
-    from . import jp2
+    from . import _jp2
 except ImportError:
-    jp2 = None
+    _jp2 = None
 
 try:
     from . import ana
@@ -21,7 +21,7 @@ except ImportError:
     ana = None
 
 
-__all__ = ['read_file', 'read_file_header', 'write_file', 'detect_filetype']
+__all__ = ['_read_file', '_read_file_header', '_write_file', '_detect_filetype']
 
 # File formats supported by SunPy
 _known_extensions = {
@@ -48,12 +48,12 @@ class Readers(dict):
 # Map the readers
 _readers = Readers({
     'fits': fits,
-    'jp2': jp2,
+    'jp2': _jp2,
     'ana': ana
 })
 
 
-def read_file(filepath, filetype=None, **kwargs):
+def _read_file(filepath, filetype=None, **kwargs):
     """
     Automatically determine the filetype and read the file.
 
@@ -75,6 +75,7 @@ def read_file(filepath, filetype=None, **kwargs):
     pairs : `list`
         A list of (data, header) tuples.
     """
+    warnings.warn("_read_file is depricated and it is meant to be used for internal uses only",DeprecationWarning)
     # Convert Path objects to strings as the filepath can also be a URL
     filepath = str(filepath)
     # Use the explicitly passed filetype
@@ -91,7 +92,7 @@ def read_file(filepath, filetype=None, **kwargs):
     return _readers[readername].read(filepath, **kwargs)
 
 
-def read_file_header(filepath, filetype=None, **kwargs):
+def _read_file_header(filepath, filetype=None, **kwargs):
     """
     Reads the header from a given file.
 
@@ -112,6 +113,7 @@ def read_file_header(filepath, filetype=None, **kwargs):
     headers : `list`
         A list of headers.
     """
+    warnings.warn("_read_file_header is depricated and it is meant to be used for internal use only",DeprecationWarning)
     # Use the explicitly passed filetype
     if filetype is not None:
         return _readers[filetype].get_header(filepath, **kwargs)
@@ -126,7 +128,7 @@ def read_file_header(filepath, filetype=None, **kwargs):
     return _readers[readername].get_header(filepath, **kwargs)
 
 
-def write_file(fname, data, header, filetype='auto', **kwargs):
+def _write_file(fname, data, header, filetype='auto', **kwargs):
     """
     Write a file from a data & header pair using one of the defined file types.
 
@@ -148,6 +150,7 @@ def write_file(fname, data, header, filetype='auto', **kwargs):
     -----
     * This routine currently only supports saving a single HDU.
     """
+    warnings.warn("_write_file is depricated and it is meant to be used for internal use only",DeprecationWarning)
     if filetype == 'auto':
         # Get the extension without the leading dot
         filetype = pathlib.Path(fname).suffix[1:]
@@ -175,16 +178,16 @@ def _detect_filetype(filepath):
     filetype : `str`
         The type of file.
     """
-
-    if detect_filetype(filepath) in _readers.keys():
-        return detect_filetype(filepath)
+    warnings.warn("_detect_filetype is depricated and it is meant to be used for internal use only",DeprecationWarning)
+    if _detect_filetype(filepath) in _readers.keys():
+        return _detect_filetype(filepath)
 
     # Raise an error if an unsupported filetype is encountered
     raise UnrecognizedFileTypeError("The requested filetype is not currently "
                                     "supported by SunPy.")
 
 
-def detect_filetype(filepath):
+def _detect_filetype(filepath):
     """
     Attempts to determine the type of file a given filepath is.
 
@@ -198,7 +201,7 @@ def detect_filetype(filepath):
     filetype : `str`
         The type of file.
     """
-
+    warnings.warn("_detect_filetype is depricated and it is meant to be used for internal use only",DeprecationWarning)
     # Open file and read in first two lines
     with open(filepath, 'rb') as fp:
         line1 = fp.readline()

--- a/sunpy/io/_fits.py
+++ b/sunpy/io/_fits.py
@@ -38,17 +38,17 @@ import math
 import traceback
 import collections
 import collections.abc
-
+import warnings
 from astropy.io import fits
 
 from sunpy.io.header import FileHeader
 from sunpy.util.exceptions import warn_metadata, warn_user
 from sunpy.util.io import HDPair
 
-__all__ = ['header_to_fits', 'read', 'get_header', 'write', 'extract_waveunit', 'format_comments_and_history']
+__all__ = ['_header_to_fits', '_read', '_get_header', '_write', '_extract_waveunit', '_format_comments_and_history']
 
 
-def read(filepath, hdus=None, memmap=None, **kwargs):
+def _read(filepath, hdus=None, memmap=None, **kwargs):
     """
     Read a fits file.
 
@@ -74,6 +74,7 @@ def read(filepath, hdus=None, memmap=None, **kwargs):
     Also all comments in the original file are concatenated into a single
     "comment" key in the returned FileHeader.
     """
+    warnings.warn("_read is depricated and it is meant to be used for internal use only",DeprecationWarning)
     with fits.open(filepath, ignore_blank=True, memmap=memmap, **kwargs) as hdulist:
         if hdus is not None:
             if isinstance(hdus, int):
@@ -85,7 +86,7 @@ def read(filepath, hdus=None, memmap=None, **kwargs):
         for h in hdulist:
             h.verify('silentfix+warn')
 
-        headers = get_header(hdulist)
+        headers = _get_header(hdulist)
         pairs = []
 
         for i, (hdu, header) in enumerate(zip(hdulist, headers)):
@@ -102,7 +103,7 @@ def read(filepath, hdus=None, memmap=None, **kwargs):
     return pairs
 
 
-def get_header(afile):
+def _get_header(afile):
     """
     Read a fits file and return just the headers for all HDU's.
 
@@ -116,6 +117,7 @@ def get_header(afile):
     `list`
         A list of `sunpy.io.header.FileHeader` headers.
     """
+    warnings.warn("_get_header is depricated and it is meant to be used for internal uses only",DeprecationWarning)
     if isinstance(afile, fits.HDUList):
         hdulist = afile
         close = False
@@ -127,14 +129,14 @@ def get_header(afile):
     try:
         headers = []
         for hdu in hdulist:
-            headers.append(format_comments_and_history(hdu.header))
+            headers.append(_format_comments_and_history(hdu.header))
     finally:
         if close:
             hdulist.close()
     return headers
 
 
-def format_comments_and_history(input_header):
+def _format_comments_and_history(input_header):
     """
     Combine ``COMMENT`` and ``HISTORY`` cards into single
     entries. Extract ``KEYCOMMENTS`` into a single entry
@@ -149,6 +151,8 @@ def format_comments_and_history(input_header):
     -------
     `sunpy.io.header.FileHeader`
     """
+    warnings.warn("_format_comments_and_history is depricated and it is meant to be used for internal use only",DeprecationWarning)
+
     try:
         comment = "".join(input_header['COMMENT']).strip()
     except KeyError:
@@ -168,13 +172,13 @@ def format_comments_and_history(input_header):
         if card.comment != '':
             keydict.update({card.keyword: card.comment})
     header['KEYCOMMENTS'] = keydict
-    waveunit = extract_waveunit(header)
+    waveunit = _extract_waveunit(header)
     if waveunit is not None:
         header['WAVEUNIT'] = waveunit
     return header
 
 
-def write(fname, data, header, hdu_type=None, **kwargs):
+def _write(fname, data, header, hdu_type=None, **kwargs):
     """
     Take a data header pair and write a FITS file.
 
@@ -197,8 +201,9 @@ def write(fname, data, header, hdu_type=None, **kwargs):
     """
     # Copy header so the one in memory is left alone
     header = header.copy()
+    warnings.warn("_write is depricated and it is meant to be used for internal use only",DeprecationWarning)
 
-    fits_header = header_to_fits(header)
+    fits_header = _header_to_fits(header)
 
     if isinstance(fname, str):
         fname = os.path.expanduser(fname)
@@ -228,10 +233,12 @@ def write(fname, data, header, hdu_type=None, **kwargs):
     hdul.writeto(fname, **fitskwargs)
 
 
-def header_to_fits(header):
+def _header_to_fits(header):
     """
     Convert a header dict to a `~astropy.io.fits.Header`.
     """
+    warnings.warn("_header_to_fits is depricated and it is meant to be used for internal use only",DeprecationWarning)
+
     # Copy the header to avoid modifying it in place
     header = header.copy()
     # The comments need to be added to the header separately from the normal
@@ -285,7 +292,7 @@ def header_to_fits(header):
     return fits_header
 
 
-def extract_waveunit(header):
+def _extract_waveunit(header):
     """
     Attempt to read the wavelength unit from a given FITS header.
 
@@ -325,6 +332,7 @@ def extract_waveunit(header):
     # 3. parse wavelnth_comment
     # 3.1 "[$UNIT] ..." -> $UNIT
     # 3.2 "Observed wavelength ($UNIT)" -> $UNIT
+    warnings.warn("_extract_waveunit is depricated and it is meant to be used for internal uses only",DeprecationWarning)
     def parse_waveunit_comment(waveunit_comment):
         if waveunit_comment == 'in meters':
             return 'm'

--- a/sunpy/io/_jp2.py
+++ b/sunpy/io/_jp2.py
@@ -3,17 +3,17 @@ This module provides a JPEG 2000 file reader.
 """
 import os
 from xml.etree import cElementTree as ET
-
+import warnings
 import numpy as np
 
 from sunpy.io.header import FileHeader
 from sunpy.util.io import HDPair, string_is_float
 from sunpy.util.xml import xml_to_dict
 
-__all__ = ['read', 'get_header', 'write']
+__all__ = ['_read', '_get_header', '_write']
 
 
-def read(filepath, **kwargs):
+def _read(filepath, **kwargs):
     """
     Reads a JPEG2000 file.
 
@@ -29,15 +29,17 @@ def read(filepath, **kwargs):
     `list`
         A list of (data, header) tuples.
     """
+    warnings.warn("_read is depricated and it is meant to be used for internal use only",DeprecationWarning)
+
     # Put import here to speed up sunpy.io import time
     from glymur import Jp2k
 
-    header = get_header(filepath)
+    header = _get_header(filepath)
     data = Jp2k(filepath)[...][::-1]
     return [HDPair(data, header[0])]
 
 
-def get_header(filepath):
+def _get_header(filepath):
     """
     Reads the header from the file.
 
@@ -51,6 +53,7 @@ def get_header(filepath):
     `list`
         A list of one header read from the file.
     """
+    warnings.warn("_get_header is depricated and it is meant to be used for internal use only",DeprecationWarning)
     # Put import here to speed up sunpy.io import time
     from glymur import Jp2k
     jp2 = Jp2k(filepath)
@@ -75,7 +78,7 @@ def get_header(filepath):
     return [FileHeader(pydict)]
 
 
-def header_to_xml(header):
+def _header_to_xml(header):
     """
     Converts image header metadata into an XML Tree that can be inserted into
     a JP2 file header.
@@ -92,6 +95,7 @@ def header_to_xml(header):
         in the form <key>value</key> derived from the key/value
         pairs in the given header dictionary
     """
+    warnings.warn("_header_to_xml is depricated and it is meant to be used for internal use only",DeprecationWarning)
     # glymur uses lxml and will crash if trying to use
     # python's builtin xml.etree
     import lxml.etree as ET
@@ -121,7 +125,7 @@ def header_to_xml(header):
     return fits
 
 
-def generate_jp2_xmlbox(header):
+def _generate_jp2_xmlbox(header):
     """
     Generates the JP2 XML box to be inserted into the jp2 file.
 
@@ -135,19 +139,20 @@ def generate_jp2_xmlbox(header):
     `XMLBox`
         XML box containing FITS metadata to be used in jp2 headers
     """
+    warnings.warn("_get_header is depricated and it is meant to be used for internal use only",DeprecationWarning)
     # glymur uses lxml and will crash if trying to use
     # python's builtin xml.etree
     import lxml.etree as ET
     from glymur import jp2box
 
-    header_xml = header_to_xml(header)
+    header_xml = _header_to_xml(header)
     meta = ET.Element("meta")
     meta.append(header_xml)
     tree = ET.ElementTree(meta)
     return jp2box.XMLBox(xml=tree)
 
 
-def write(fname, data, header, **kwargs):
+def _write(fname, data, header, **kwargs):
     """
     Take a data header pair and write a JP2 file.
 
@@ -168,6 +173,7 @@ def write(fname, data, header, **kwargs):
     uint8 values to support the JPEG2000 format.
     """
     from glymur import Jp2k
+    warnings.warn("_write is depricated and it is meant to be used for internal use only",DeprecationWarning)
 
     tmpname = fname + "tmp.jp2"
     jp2_data = np.uint8(data)
@@ -176,7 +182,7 @@ def write(fname, data, header, **kwargs):
     # Append the XML data to the header information stored in jp2.box
     meta_boxes = jp2.box
     target_index = len(meta_boxes) - 1
-    fits_box = generate_jp2_xmlbox(header)
+    fits_box = _generate_jp2_xmlbox(header)
     meta_boxes.insert(target_index, fits_box)
 
     # Rewrites the jp2 file on disk with the xml data in the header

--- a/sunpy/io/tests/test_cdf.py
+++ b/sunpy/io/tests/test_cdf.py
@@ -3,7 +3,7 @@ import numpy as np
 import astropy.units as u
 
 from sunpy.data.test import get_test_filepath
-from sunpy.io.cdf import read_cdf
+from sunpy.io._cdf import read_cdf
 from sunpy.timeseries import GenericTimeSeries
 
 filepath = get_test_filepath('solo_L2_epd-ept-north-hcad_20200713_V02.cdf')

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from sunpy.data.test import get_test_filepath
-from sunpy.io import _fits, jp2
+from sunpy.io import _fits, _jp2
 from sunpy.io.header import FileHeader
 from sunpy.tests.helpers import skip_glymur
 
@@ -11,7 +11,7 @@ TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
 
 @skip_glymur
 def test_read():
-    data, header = jp2.read(AIA_193_JP2)[0]
+    data, header = _jp2.read(AIA_193_JP2)[0]
     assert isinstance(data, np.ndarray)
     assert data.shape == (410, 410)
     assert isinstance(header, FileHeader)
@@ -19,17 +19,17 @@ def test_read():
 
 @skip_glymur
 def test_read_header():
-    header = jp2.get_header(AIA_193_JP2)[0]
+    header = _jp2.get_header(AIA_193_JP2)[0]
     assert isinstance(header, FileHeader)
 
 
 @skip_glymur
 def test_read_memmap():
-    data, _ = jp2.read(AIA_193_JP2, memmap=True)[0]
+    data, _ = _jp2.read(AIA_193_JP2, memmap=True)[0]
     # The data is shared, with what, I am unclear
     assert data.base is not None
     # Keyword is not passed in the function call
-    data, _ = jp2.read(AIA_193_JP2, memmap=False)[0]
+    data, _ = _jp2.read(AIA_193_JP2, memmap=False)[0]
     assert data.base is not None
 
 
@@ -37,9 +37,9 @@ def test_read_memmap():
 def test_simple_write(tmpdir):
     data, header = _fits.read(TEST_AIA_IMAGE)[0]
     outfile = tmpdir / "test.jp2"
-    jp2.write(str(outfile), data, header)
+    _jp2.write(str(outfile), data, header)
     assert outfile.exists()
 
     # Sanity check that reading back the jp2 returns coherent data
-    jp2_readback = jp2.read(outfile)
+    jp2_readback = _jp2.read(outfile)
     assert header['DATE'] == jp2_readback[0].header['DATE']

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -10,7 +10,7 @@ from astropy.wcs import WCS
 
 from sunpy import log
 from sunpy.data import cache
-from sunpy.io.file_tools import read_file
+from sunpy.io._file_tools import read_file
 from sunpy.io.header import FileHeader
 from sunpy.map.compositemap import CompositeMap
 from sunpy.map.mapbase import GenericMap, MapMetaValidationError

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -14,7 +14,7 @@ from astropy.time import Time, TimeDelta
 import sunpy.io
 from sunpy import log
 from sunpy.extern import parse
-from sunpy.io.file_tools import UnrecognizedFileTypeError
+from sunpy.io._file_tools import UnrecognizedFileTypeError
 from sunpy.time import is_time_in_given_format, parse_time
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
 from sunpy.util.exceptions import warn_user

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -125,7 +125,7 @@ def test_read_cdf_empty_variable():
     filename = Fido.fetch(result[0, 0])
 
     # Temporarily reset sunpy.io.cdf registry of known unit conversions
-    import sunpy.io.cdf as sunpy_cdf
+    import sunpy.io._cdf as sunpy_cdf
     known_units = sunpy_cdf._known_units
     sunpy_cdf._known_units = {}
 

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -17,7 +17,7 @@ from astropy.table import Table
 from astropy.time import Time
 
 import sunpy
-from sunpy.io.file_tools import UnrecognizedFileTypeError, detect_filetype, read_file
+from sunpy.io._file_tools import UnrecognizedFileTypeError, detect_filetype, read_file
 from sunpy.io.header import FileHeader
 from sunpy.timeseries.sources import source_names
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
@@ -142,7 +142,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                 if detect_filetype(fname) == 'cdf':
                     # Put import here to ensure there is no import dependency
                     # on cdflib for TimeSeries
-                    from sunpy.io.cdf import read_cdf
+                    from sunpy.io._cdf import read_cdf
                     return read_cdf(os.fspath(fname), **kwargs)
             except UnrecognizedFileTypeError:
                 pass


### PR DESCRIPTION
Makes the following modules in sunpy.io private
1. JPEG2000
2. CDF
3. FITS
4. File tools

1.Adds depreciation warning for the functions that are present inside these modules
2.Changes the names of funcitons present inside these modules and inside respective __all__ list to have underscore before them
3.Modifies the names of moduels to have underscore before them