### PR TITLE
Fixed backticks in a changelog entry

### DIFF
--- a/changelog/6820.bugfix.rst
+++ b/changelog/6820.bugfix.rst
@@ -1,1 +1,1 @@
-:meth:`sunpy.map.GenericMap.submap` can now handle a '~astropy.coordinates.BaseCoordinateFrame' as input.
+:meth:`sunpy.map.GenericMap.submap` can now handle a `~astropy.coordinates.BaseCoordinateFrame` as input.


### PR DESCRIPTION
I missed this in the changelog entry for #6820.  That changelog entry hasn't gotten into any release yet, so this PR doesn't need its own changelog entry.