### PR TITLE
Join HISTORY cards with newline characters

### DIFF
--- a/changelog/6911.bugfix.rst
+++ b/changelog/6911.bugfix.rst
@@ -1,0 +1,2 @@
+Multi-line ``HISTORY`` and ``COMMENT`` keys metadata dictionaries are now correctly split into
+multiple history and comment cards when writing a FITS file.

--- a/changelog/6911.feature.rst
+++ b/changelog/6911.feature.rst
@@ -1,0 +1,2 @@
+Joined ``HISTORY`` keys with newline characters when parsing ``HISTORY`` cards from
+FITS header.

--- a/docs/guide/history_comments.rst
+++ b/docs/guide/history_comments.rst
@@ -1,0 +1,13 @@
+.. _history_comments:
+
+***********************************************************
+How `HISTORY` and `COMMENT` FITS Keys are Handled in SunPy
+***********************************************************
+
+In FITS files, there are often multiple entries for both the ``HISTORY`` and ``COMMENT`` keys.
+For example, when applying a prep routine to an image, a ``HISTORY`` entry may be added to the FITS header for every step in the prep pipeline.
+Because the metadata associated with each `~sunpy.map.GenericMap` acts like a dictionary, where each key must be unique, these repeated ``HISTORY`` and ``COMMENT`` keys cannot be represented as separate entries in `~sunpy.map.util.MetaDict`.
+Thus, when a FITS file with multiple ``HISTORY`` keys is read into a Map object, all the values corresponding to ``HISTORY`` are joined together with newline characters ``\n`` and stored as a single ``history`` entry in `~sunpy.map.util.MetaDict`.
+When writing the resulting Map to a FITS file, ``history`` is split along the ``\n`` characters and each entry is written to a separate ``HISTORY`` key in the resulting FITS header.
+The same is true for ``COMMENT`` keys.
+See `this pull request <https://github.com/sunpy/sunpy/pull/6911>`_ for additional details.

--- a/docs/guide/history_comments.rst
+++ b/docs/guide/history_comments.rst
@@ -10,4 +10,4 @@ Because the metadata associated with each `~sunpy.map.GenericMap` acts like a di
 Thus, when a FITS file with multiple ``HISTORY`` keys is read into a Map object, all the values corresponding to ``HISTORY`` are joined together with newline characters ``\n`` and stored as a single ``history`` entry in `~sunpy.util.MetaDict`.
 When writing the resulting Map to a FITS file, ``history`` is split along the ``\n`` characters and each entry is written to a separate ``HISTORY`` key in the resulting FITS header.
 The same is true for ``COMMENT`` keys.
-See `this pull request <https://github.com/sunpy/sunpy/pull/6911>`_ for additional details.
+See `this pull request <https://github.com/sunpy/sunpy/pull/6911>`__ for additional details.

--- a/docs/guide/history_comments.rst
+++ b/docs/guide/history_comments.rst
@@ -1,13 +1,13 @@
 .. _history_comments:
 
 ***********************************************************
-How `HISTORY` and `COMMENT` FITS Keys are Handled in SunPy
+How "HISTORY" and "COMMENT" FITS Keys are Handled in SunPy
 ***********************************************************
 
 In FITS files, there are often multiple entries for both the ``HISTORY`` and ``COMMENT`` keys.
 For example, when applying a prep routine to an image, a ``HISTORY`` entry may be added to the FITS header for every step in the prep pipeline.
-Because the metadata associated with each `~sunpy.map.GenericMap` acts like a dictionary, where each key must be unique, these repeated ``HISTORY`` and ``COMMENT`` keys cannot be represented as separate entries in `~sunpy.map.util.MetaDict`.
-Thus, when a FITS file with multiple ``HISTORY`` keys is read into a Map object, all the values corresponding to ``HISTORY`` are joined together with newline characters ``\n`` and stored as a single ``history`` entry in `~sunpy.map.util.MetaDict`.
+Because the metadata associated with each `~sunpy.map.GenericMap` acts like a dictionary, where each key must be unique, these repeated ``HISTORY`` and ``COMMENT`` keys cannot be represented as separate entries in `~sunpy.util.MetaDict`.
+Thus, when a FITS file with multiple ``HISTORY`` keys is read into a Map object, all the values corresponding to ``HISTORY`` are joined together with newline characters ``\n`` and stored as a single ``history`` entry in `~sunpy.util.MetaDict`.
 When writing the resulting Map to a FITS file, ``history`` is split along the ``\n`` characters and each entry is written to a separate ``HISTORY`` key in the resulting FITS header.
 The same is true for ``COMMENT`` keys.
 See `this pull request <https://github.com/sunpy/sunpy/pull/6911>`_ for additional details.

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -18,3 +18,4 @@ Although there are code snippets in various bits of the guides, these are to hel
    installation
    logger
    helioviewer
+   history_comments

--- a/sunpy/io/_fits.py
+++ b/sunpy/io/_fits.py
@@ -150,11 +150,11 @@ def format_comments_and_history(input_header):
     `sunpy.io.header.FileHeader`
     """
     try:
-        comment = "".join(input_header['COMMENT']).strip()
+        comment = "\n".join(input_header['COMMENT']).strip()
     except KeyError:
         comment = ""
     try:
-        history = "".join(input_header['HISTORY']).strip()
+        history = "\n".join(input_header['HISTORY']).strip()
     except KeyError:
         history = ""
 

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -205,3 +205,24 @@ def test_split_multiline_comment_history_entries():
     for k, v in header_dict.items():
         for v_fits, v_dict in zip(fits_header[k.upper()], v.split("\n")):
             assert v_fits == v_dict
+
+
+def test_roundtrip_comment_history_entries(tmpdir):
+    # Construct FITS file from header with multiple history and comment cards
+    header = fits.Header.fromtextfile(get_test_filepath("solo_L1_eui-fsi304-image_20201021T145510206_V03.header"))
+    data = np.random.rand(header['NAXIS2'], header['NAXIS1'])
+    outfilename = str(tmpdir / 'roundtrip-comments-history-astropy.fits')
+    fits.writeto(outfilename, data, header)
+    # Check roundtripping
+    (dh_pair, ) = _fits.read(outfilename)
+    header_dict = dh_pair.header
+    assert header_dict["HISTORY"] == "\n".join(header["HISTORY"])
+    assert header_dict["COMMENT"] == "\n".join(header["COMMENT"])
+    outfilename = str(tmpdir / 'roundtrip-comments-history-sunpy.fits')
+    _fits.write(outfilename, data, header_dict)
+    with fits.open(outfilename) as hdul:
+        header_rt = hdul[0].header
+    for key in ("HISTORY", "COMMENT"):
+        assert len(header_rt[key]) == len(header[key])
+        for card_rt, card in zip(header_rt[key], header[key]):
+            assert card_rt == card

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -125,8 +125,7 @@ def test_write_with_metadict_header_astropy(tmpdir):
         data, header = fits_file[0].data, fits_file[0].header
     meta_header = MetaDict(OrderedDict(header))
     temp_file = tmpdir / "temp.fits"
-    with pytest.warns(SunpyMetadataWarning, match='The meta key comment is not valid ascii'):
-        _fits.write(str(temp_file), data, meta_header)
+    _fits.write(str(temp_file), data, meta_header)
     assert temp_file.exists()
     fits_file.close()
 
@@ -182,3 +181,27 @@ def test_read_memmap():
 
     data, _ = _fits.read(TEST_AIA_IMAGE, memmap=False)[0]
     assert data.base is None
+
+
+def test_merge_multiple_comment_history_entries():
+    header = fits.Header()
+    history = "First history entry\nSecond history entry"
+    comment = "First comment\nSecond comment"
+    for hist in history.split("\n"):
+        header.add_history(hist)
+    for com in comment.split("\n"):
+        header.add_comment(com)
+    file_header = _fits.format_comments_and_history(header)
+    assert file_header["HISTORY"] == history
+    assert file_header["COMMENT"] == comment
+
+
+def test_split_multiline_comment_history_entries():
+    header_dict = {
+        "history": "First history entry\nSecond history entry",
+        "comment": "First comment\nSecond comment",
+    }
+    fits_header = _fits.header_to_fits(header_dict)
+    for k, v in header_dict.items():
+        for v_fits, v_dict in zip(fits_header[k.upper()], v.split("\n")):
+            assert v_fits == v_dict


### PR DESCRIPTION
Fixes #6908

When the `HISTORY` keys in the FITS header were joined previously, there was no character separating them which made `HISTORY` keys with many entries difficult to read. This just adds a newline character between each separate key to make the joined `HISTORY` entry easier to read.