### PR TITLE
Alllow oldestdeps tox runs on macOS arm

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,12 +50,16 @@ deps =
     oldestdeps: h5netcdf<0.12
     oldestdeps: matplotlib<3.6.0
     oldestdeps: numpy<1.22.0
-    oldestdeps: pandas<1.3.0
+    oldestdeps: pandas<1.3.0; platform_system!='Darwin' or platform_machine!='arm64'
+    # pandas 1.4.0 is the first with wheels for macOS arm64
+    oldestdeps: pandas<1.5.0; platform_system=='Darwin' and platform_machine=='arm64'
     oldestdeps: parfive<1.3.0
     oldestdeps: pytest-xdist<2.1
     oldestdeps: pytest<7.0
     oldestdeps: python-dateutil<2.9.0
-    oldestdeps: scikit-image<0.19.0
+    oldestdeps: scikit-image<0.19.0; platform_system!='Darwin' or platform_machine!='arm64'
+    # scikit-image 0.20 is the first with wheels for macOS arm64
+    oldestdeps: scikit-image<0.21.0; platform_system=='Darwin' and platform_machine=='arm64'
     oldestdeps: scipy<1.8.0
     oldestdeps: sqlalchemy<2.0.0
     oldestdeps: tqdm<4.33.0


### PR DESCRIPTION
This shouldn't affect CI, but is a nice to have so I (and others) can run the oldestdeps tox environment locally on osxarm machines.