### PR TITLE
Now pass max_splits into the downloader for JSOC only fetches

### DIFF
--- a/changelog/6921.bugfix.rst
+++ b/changelog/6921.bugfix.rst
@@ -1,0 +1,1 @@
+Pass in "max_splits" to Parfive to prevent multi connections to JSOC for JSOC only queries.

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -385,6 +385,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         # Avoid more than one connection for JSOC only requests.
         from sunpy.net.jsoc import JSOCClient
 
+        max_splits = kwargs.get('max_splits', 5)
         is_jsoc_only = False
         for query_result in query_results:
             if isinstance(query_result, UnifiedResponse):
@@ -394,8 +395,8 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         if downloader is None:
             if is_jsoc_only:
                 max_conn = 1
-                kwargs['max_splits'] = 1
-            downloader = Downloader(max_conn=max_conn, progress=progress, overwrite=overwrite)
+                max_splits = 1
+            downloader = Downloader(max_conn=max_conn, progress=progress, overwrite=overwrite, max_splits=max_splits)
         elif not isinstance(downloader, parfive.Downloader):
             raise TypeError("The downloader argument must be a parfive.Downloader instance.")
 

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -482,7 +482,7 @@ class JSOCClient(BaseClient):
         max_splits = kwargs.get('max_splits', 1)
         if max_splits != 1:
             log.info(f"Setting max_splits to it's maximum allowed value of 1 for requests made by the JSOCClient.")
-        kwargs['max_splits'] = 1
+            max_splits = 1
 
         # Convert Responses to a list if not already
         if isinstance(requests, str) or not isiterable(requests):
@@ -532,7 +532,7 @@ class JSOCClient(BaseClient):
             # Private communication from JSOC say we should not use more than one connection.
             if max_conn != self.default_max_conn:
                 log.info(f"Setting max parallel downloads to 1 for the JSOC client.")
-            downloader = Downloader(progress=progress, overwrite=overwrite, max_conn=1)
+            downloader = Downloader(progress=progress, overwrite=overwrite, max_conn=1, max_splits=max_splits)
 
         urls = []
         for request in requests:
@@ -540,7 +540,7 @@ class JSOCClient(BaseClient):
                 if request.protocol == 'as-is' or request.method == 'url-tar':
                     urls.extend(list(request.urls.url))
                 else:
-                    for index, data in request.data.iterrows():
+                    for _, data in request.data.iterrows():
                         url_dir = request.request_url + '/'
                         urls.append(urllib.parse.urljoin(url_dir, data['filename']))
 

--- a/sunpy/util/parfive_helpers.py
+++ b/sunpy/util/parfive_helpers.py
@@ -18,7 +18,7 @@ sunpy_headers = {
 }
 
 
-if parfive_version < Version("2.0a0"):
+if parfive_version < Version("2.0.0"):
     # Overload the parfive downloader class to set the User-Agent string
     class Downloader(parfive.Downloader):
         @wraps(parfive.Downloader.__init__)
@@ -30,7 +30,6 @@ if parfive_version < Version("2.0a0"):
             progress = os.environ.get("PARFIVE_HIDE_PROGESS", None)
             if progress:
                 kwargs["progress"] = False
-
             super().__init__(*args, **kwargs)
 
 else:
@@ -48,5 +47,4 @@ else:
             # when we depend on 2+ we should remove this.
             headers = kwargs.pop("headers", {})
             kwargs["config"].headers = {**kwargs["config"].headers, **headers}
-
             super().__init__(*args, **kwargs)


### PR DESCRIPTION
We never prevented more than one connection to the JSOC and I think this is why we now hit the rate limit.

Hopefully fixes https://github.com/sunpy/sunpy/issues/6510 again