### PR TITLE
Simplify ways to get the solar angular radius

### DIFF
--- a/docs/whatsnew/5.0.rst
+++ b/docs/whatsnew/5.0.rst
@@ -42,3 +42,26 @@ Deprecation of IO readers
 ``sunpy.io.cdf``, ``sunpy.io.file_tools`` and ``sunpy.io.jp2`` sub-modules have been deprecated, and will be removed in version 5.1.
 
 This because they are designed for internal use only, and removing it from the public API gives the developers more flexibility to modify it without impacting users.
+
+Simplified way to get the solar angular radius
+==============================================
+``sunpy.coordinates.sun.angular_radius``, which gets the angular radius of the Sun as observed from Earth at a given time, and ``sunpy.map.maputils.solar_angular_radius``, which gets the angular radius of the Sun for a given helioprojective coordinate, are both deprecated.
+
+They have been replaced with `sunpy.coordinates.sun.solar_angular_radius`, which is more general, taking a single observer coordinate as input that can be in any coordinate frame transformable to heliographic Stonyhurst.
+
+To replace uses of ``sunpy.coordinates.sun.angular_radius``, do::
+
+    >>> from sunpy.coordinates.sun import solar_angular_radius, get_earth
+    >>> solar_angular_radius(get_earth("2023-04-16"))
+    <Angle 956.08106379 arcsec>
+
+
+To replace uses of ``sunpy.map.maputils.solar_angular_radius``, do::
+
+    >>> import astropy.units as u
+    >>> from sunpy.coordinates import Helioprojective
+    >>> from sunpy.coordinates.sun import solar_angular_radius
+    >>>
+    >>> my_coord = Helioprojective(0*u.arcsec, 0*u.arcsec, observer=get_earth("2023-04-16"))
+    >>> solar_angular_radius(my_coord.observer)
+    <Angle 956.08106379 arcsec>

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -28,7 +28,7 @@ from sunpy import log
 from sunpy.sun import constants
 from sunpy.time import parse_time
 from sunpy.time.time import _variables_for_parse_time_docstring
-from sunpy.util.decorators import add_common_docstring
+from sunpy.util.decorators import add_common_docstring, deprecated
 from .ephemeris import get_earth
 from .frames import HeliographicStonyhurst
 from .transformations import _SOLAR_NORTH_POLE_HCRS, _SUN_DETILT_MATRIX
@@ -37,7 +37,8 @@ __author__ = "Albert Y. Shih"
 __email__ = "ayshih@gmail.com"
 
 __all__ = [
-    "angular_radius", "sky_position", "carrington_rotation_number",
+    "angular_radius", "solar_angular_radius",
+    "sky_position", "carrington_rotation_number",
     "carrington_rotation_time",
     "true_longitude", "apparent_longitude", "true_latitude", "apparent_latitude",
     "mean_obliquity_of_ecliptic", "true_rightascension", "true_declination",
@@ -47,6 +48,30 @@ __all__ = [
 ]
 
 
+def solar_angular_radius(observer):
+    """
+    Calculates the solar angular radius as seen from a given observer coordinate.
+
+    The tangent vector from the observer to the edge of the Sun forms a
+    right-angle triangle with the radius of the Sun as the far side and the
+    Sun-observer distance as the hypotenuse.  Thus, the sine of the angular
+    radius of the Sun is ratio of these two distances.
+
+    Parameters
+    ----------
+    observer : `~astropy.coordinates.SkyCoord`
+        The input observer coordinate(s).
+
+    Returns
+    -------
+    angle : `~astropy.units.Quantity`
+        The solar angular radius.
+    """
+    observer = observer.transform_to(HeliographicStonyhurst())
+    return _angular_radius(observer.rsun, observer.radius)
+
+
+@deprecated(since="5.0", alternative="sunpy.coordinates.sun.solar_angular_radius(get_earth(t))")
 @add_common_docstring(**_variables_for_parse_time_docstring())
 def angular_radius(t='now'):
     """
@@ -468,7 +493,7 @@ def print_params(t='now'):
     """
     print('Solar Ephemeris for {} UTC\n'.format(parse_time(t).utc))
     print('Distance = {}'.format(earth_distance(t)))
-    print('Semidiameter = {}'.format(angular_radius(t)))
+    print('Semidiameter = {}'.format(solar_angular_radius(get_earth(t))))
     print('True (long, lat) = ({}, {})'.format(true_longitude(t).to_string(),
                                                true_latitude(t).to_string()))
     print('Apparent (long, lat) = ({}, {})'.format(apparent_longitude(t).to_string(),

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -20,7 +20,7 @@ from sunpy.coordinates.frames import (
     HeliographicStonyhurst,
     Helioprojective,
 )
-from sunpy.coordinates.sun import angular_radius
+from sunpy.coordinates.sun import solar_angular_radius
 from sunpy.time import parse_time
 from sunpy.util.exceptions import SunpyUserWarning
 
@@ -434,7 +434,7 @@ def test_hgc_incomplete_observer():
 
 def test_angular_radius():
     coord = Helioprojective(0*u.deg, 0*u.deg, 5*u.km, obstime="2010/01/01T00:00:00", observer="earth")
-    assert_quantity_allclose(coord.angular_radius, angular_radius(coord.obstime))
+    assert_quantity_allclose(coord.angular_radius, solar_angular_radius(coord))
 
 
 def test_angular_radius_no_observer():

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -110,6 +110,7 @@ def _verify_coordinate_helioprojective(coordinates):
                          "but must be in the Helioprojective frame.")
 
 
+@deprecated(since="5.0", alternative="sunpy.coordinates.sun.solar_angular_radius(coordinates.observer)")
 def solar_angular_radius(coordinates):
     """
     Calculates the solar angular radius as seen by the observer.
@@ -206,7 +207,7 @@ def contains_full_disk(smap):
 
     # Test if all the edge pixels are more than one solar radius distant
     # and that the whole map is not all off disk.
-    return np.all(coordinate_angles > solar_angular_radius(edge_of_world)) and contains_solar_center(smap)
+    return np.all(coordinate_angles > sun.solar_angular_radius(edge_of_world.observer)) and contains_solar_center(smap)
 
 
 def contains_solar_center(smap):
@@ -253,7 +254,7 @@ def coordinate_is_on_solar_disk(coordinates):
     _verify_coordinate_helioprojective(coordinates)
     # Calculate the angle of every pixel from the center of the Sun and compare it the angular
     # radius of the Sun.
-    return np.sqrt(coordinates.Tx ** 2 + coordinates.Ty ** 2) < solar_angular_radius(coordinates)
+    return np.sqrt(coordinates.Tx ** 2 + coordinates.Ty ** 2) < sun.solar_angular_radius(coordinates.observer)
 
 
 def is_all_off_disk(smap):
@@ -287,7 +288,7 @@ def is_all_off_disk(smap):
 
     # Test if all the edge pixels are more than one solar radius distant
     # and that the solar center is
-    return np.all(coordinate_angles > solar_angular_radius(edge_of_world)) and ~contains_solar_center(smap)
+    return np.all(coordinate_angles > sun.solar_angular_radius(edge_of_world.observer)) and ~contains_solar_center(smap)
 
 
 def is_all_on_disk(smap):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -236,13 +236,16 @@ def test_rsun_meters(generic_map):
 
 def test_rsun_obs_without_rsun_ref(generic_map):
     assert_quantity_allclose(generic_map.rsun_obs,
-                             sun.angular_radius(generic_map.date))
+                             sun.solar_angular_radius(generic_map.observer_coordinate))
 
 
 def test_rsun_obs_with_rsun_ref(generic_map):
     generic_map.meta['rsun_ref'] = sunpy.sun.constants.radius.to_value(u.m)
     # The following should not raise a warning because we can calculate it exactly
-    assert_quantity_allclose(generic_map.rsun_obs, sun.angular_radius(generic_map.date))
+    assert_quantity_allclose(
+        generic_map.rsun_obs,
+        sun.solar_angular_radius(generic_map.observer_coordinate)
+    )
 
 
 def test_coordinate_system(generic_map):

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -145,7 +145,8 @@ def test_map_edges(all_off_disk_map):
 
 def test_solar_angular_radius(aia171_test_map):
     on_disk = aia171_test_map.center
-    sar = solar_angular_radius(on_disk)
+    with pytest.warns(SunpyDeprecationWarning, match='The solar_angular_radius function is deprecated'):
+        sar = solar_angular_radius(on_disk)
     assert isinstance(sar, u.Quantity)
     np.testing.assert_almost_equal(sar.to(u.arcsec).value, 971.80181131, decimal=1)
 
@@ -243,8 +244,9 @@ def test_verify_coordinate_helioprojective(aia171_test_map, all_off_disk_map, al
 
 
 def test_functions_raise_non_frame_coords(non_helioprojective_skycoord):
-    with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
-        solar_angular_radius(non_helioprojective_skycoord)
+    with pytest.warns(SunpyDeprecationWarning, match='The solar_angular_radius function is deprecated'):
+        with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
+            solar_angular_radius(non_helioprojective_skycoord)
     with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
         coordinate_is_on_solar_disk(non_helioprojective_skycoord)
 


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy/issues/4516. This deprecates the previous two ways we had to calculate the angular radius, and replaces it with a new function. Before the inputs to the two functions were:

1. Time (to get angular radius seen by earth)
2. Coordinate (but had to be helioprojective, and took the observer attribute)

The new function takes a coordinate as input, so is much more generic. See the what's new entry for how to migrate from the old functions to the new.