### PR TITLE
Only run PR CI on PRs targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
       - '!*pre*'
       - '!*post*'
   pull_request:
+    branches:
+        - 'main'
   # Allow manual runs through the web UI
   workflow_dispatch:
 


### PR DESCRIPTION
Since we don't wait for CI on backport PRs anyway, doesn't seem to be any point running it.