### PR TITLE
Use 'test' extra to isntall for tests on cibuildwheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@main
     with:
       sdist: false
-      test_extras: 'dev'
+      test_extras: 'test'
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
       targets: |


### PR DESCRIPTION
After `cairo` was introduced as a documentation dependency, [the wheel build started failing](https://github.com/sunpy/sunpy/actions/runs/4751488173/jobs/8440901890). We should only need to install the test (not the full dev) deps for tests, so change that and hopefully it fixes the wheel build.