### PR TITLE
Revise Map section of the tutorial

### DIFF
--- a/changelog/6944.doc.rst
+++ b/changelog/6944.doc.rst
@@ -1,0 +1,2 @@
+Significantly revised the :ref:`map_guide` part of the tutorial to better match a tutorial in the diátaxis definition.
+This included moving the section on custom maps to the :ref:`how_to_guide` section.

--- a/changelog/6944.doc.rst
+++ b/changelog/6944.doc.rst
@@ -1,2 +1,2 @@
-Significantly revised the :ref:`map_guide` part of the tutorial to better match a tutorial in the diátaxis definition.
+Significantly revised and improved the :ref:`map_guide` part of the tutorial.
 This included moving the section on custom maps to the :ref:`how_to_guide` section.

--- a/docs/how_to/create_custom_map.rst
+++ b/docs/how_to/create_custom_map.rst
@@ -9,7 +9,7 @@ The metadata informs `sunpy.map.Map` of the correct coordinate information assoc
 See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a brief demonstration of generating a Map from a data array.
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
-sunpy provides a Map header helper function to assist in creating a header that contains the correct meta information.
+sunpy provides a Map header helper function to assist the user in creating a header that contains the correct meta information needed to create a Map.
 The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 All the metadata keywords that a Map will parse along with their description are listed in the :ref:`Meta Keywords Table` at the end of this page.
 
@@ -59,7 +59,7 @@ Here's an example of creating a header from some generic data and an `astropy.co
     rsun_obs: 965.3829548285768
 
 From this we can see now that the function returned a `sunpy.util.MetaDict` that populated the standard FITS keywords with information provided by the passed `astropy.coordinates.SkyCoord`, and the data array.
-Since the ``reference_pixel`` and keywords were not passed in the example above, the values of ``crpix`` and ``cdelt`` were set to the default values.
+Since the ``reference_pixel`` and ``scale`` keywords were not passed in the example above, the values of the ``crpix`` and ``cdelts`` keys were set to the center of the data array and 1, respectively, by default.
 
 These keywords can be passed to the function in the form of an `astropy.units.Quantity` with associated units.
 Here's another example of passing ``reference_pixel`` and ``scale`` to the function:

--- a/docs/how_to/create_custom_map.rst
+++ b/docs/how_to/create_custom_map.rst
@@ -1,0 +1,258 @@
+.. _how_to_custom_maps:
+
+Create Custom Maps
+==================
+
+It is also possible to create Maps using custom data (e.g. from a simulation or an observation from a data source that is not explicitly supported in **sunpy**).
+To do this, you need to provide `sunpy.map.Map` with both the data array as well as appropriate meta information.
+The meta information informs `sunpy.map.Map` of the correct coordinate information associated with the data array and should be provided to `sunpy.map.Map` in the form of a header as a `dict` or `~sunpy.util.MetaDict`.
+See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a brief demonstration of generating a Map from a data array.
+
+The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
+**sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
+This includes a :func:`~sunpy.map.header_helper.meta_keywords` function that will return a `dict` of the meta keywords used when creating a Map.
+
+.. code-block:: python
+
+    >>> from sunpy.map.header_helper import meta_keywords
+
+    >>> meta_keywords() # doctest: +SKIP
+    {'cunit1': 'Units of the coordinate increments along naxis1 e.g. arcsec **required',
+     'cunit2': 'Units of the coordinate increments along naxis2 e.g. arcsec **required',
+     'crval1': 'Coordinate value at reference point on naxis1 **required'
+     ...
+
+The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
+All the metadata keywords that a Map will parse along with their description are listed in the :ref:`Meta Keywords Table` at the end of this page.
+
+The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
+This function returns a `sunpy.util.MetaDict`.
+The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.
+
+The :func:`~sunpy.map.header_helper.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
+If neither of these are given their values default to the center of the data array and 1 arcsec, respectively.
+
+Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`:
+
+.. code-block:: python
+
+    >>> import numpy as np
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+
+    >>> from sunpy.coordinates import frames
+    >>> from sunpy.map.header_helper import make_fitswcs_header
+
+    >>> data = np.arange(0,100).reshape(10,10)
+    >>> coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime = '2013-10-28', observer = 'earth', frame = frames.Helioprojective)
+    >>> header = make_fitswcs_header(data, coord)
+    >>> for key, value in header.items():
+    ...     print(f"{key}: {value}")
+    wcsaxes: 2
+    crpix1: 5.5
+    crpix2: 5.5
+    cdelt1: 1.0
+    cdelt2: 1.0
+    cunit1: arcsec
+    cunit2: arcsec
+    ctype1: HPLN-TAN
+    ctype2: HPLT-TAN
+    crval1: 0.0
+    crval2: 0.0
+    lonpole: 180.0
+    latpole: 0.0
+    mjdref: 0.0
+    date-obs: 2013-10-28T00:00:00.000
+    rsun_ref: 695700000.0
+    dsun_obs: 148644585949.49
+    hgln_obs: 0.0
+    hglt_obs: 4.7711570596394
+    naxis: 2
+    naxis1: 10
+    naxis2: 10
+    pc1_1: 1.0
+    pc1_2: -0.0
+    pc2_1: 0.0
+    pc2_2: 1.0
+    rsun_obs: 965.3829548285768
+
+From this we can see now that the function returned a `sunpy.util.MetaDict` that populated the standard FITS keywords with information provided by the passed `astropy.coordinates.SkyCoord`, and the data array.
+Since the ``reference_pixel`` and keywords were not passed in the example above, the values of ``crpix`` and ``cdelt`` were set to the default values.
+
+These keywords can be passed to the function in the form of an `astropy.units.Quantity` with associated units.
+Here's another example of passing ``reference_pixel`` and ``scale`` to the function:
+
+.. code-block:: python
+
+    >>> header = make_fitswcs_header(data, coord,
+    ...                                        reference_pixel=u.Quantity([5, 5]*u.pixel),
+    ...                                        scale=u.Quantity([2, 2] *u.arcsec/u.pixel))
+    >>> for key, value in header.items():
+    ...     print(f"{key}: {value}")
+    wcsaxes: 2
+    crpix1: 6.0
+    crpix2: 6.0
+    cdelt1: 2.0
+    cdelt2: 2.0
+    cunit1: arcsec
+    cunit2: arcsec
+    ctype1: HPLN-TAN
+    ctype2: HPLT-TAN
+    crval1: 0.0
+    crval2: 0.0
+    lonpole: 180.0
+    latpole: 0.0
+    mjdref: 0.0
+    date-obs: 2013-10-28T00:00:00.000
+    rsun_ref: 695700000.0
+    dsun_obs: 148644585949.49
+    hgln_obs: 0.0
+    hglt_obs: 4.7711570596394
+    naxis: 2
+    naxis1: 10
+    naxis2: 10
+    pc1_1: 1.0
+    pc1_2: -0.0
+    pc2_1: 0.0
+    pc2_2: 1.0
+    rsun_obs: 965.3829548285768
+
+As we can see, a list of WCS and observer meta information is contained within the generated headers, however we may want to include other meta information including the observatory name, the wavelength and waveunit of the observation.
+Any of the keywords in the dictionary returned by :func:`~sunpy.map.header_helper.meta_keywords` can be passed to the :func:`~sunpy.map.header_helper.make_fitswcs_header` and will then populate the returned MetaDict header.
+Furthermore, the following observation keywords can be passed to the `~sunpy.map.header_helper.make_fitswcs_header` function: ``observatory``, ``instrument``, ``telescope``, ``wavelength``, ``exposure``.
+
+An example of creating a header with these additional keywords:
+
+.. code-block:: python
+
+    >>> header = make_fitswcs_header(data, coord,
+    ...                                        reference_pixel = u.Quantity([5, 5]*u.pixel),
+    ...                                        scale = u.Quantity([2, 2] *u.arcsec/u.pixel),
+    ...                                        telescope = 'Test case', instrument = 'UV detector',
+    ...                                        wavelength = 1000*u.angstrom)
+    >>> for key, value in header.items():
+    ...     print(f"{key}: {value}")
+    wcsaxes: 2
+    crpix1: 6.0
+    crpix2: 6.0
+    cdelt1: 2.0
+    cdelt2: 2.0
+    cunit1: arcsec
+    cunit2: arcsec
+    ctype1: HPLN-TAN
+    ctype2: HPLT-TAN
+    crval1: 0.0
+    crval2: 0.0
+    lonpole: 180.0
+    latpole: 0.0
+    mjdref: 0.0
+    date-obs: 2013-10-28T00:00:00.000
+    rsun_ref: 695700000.0
+    dsun_obs: 148644585949.49
+    hgln_obs: 0.0
+    hglt_obs: 4.7711570596394
+    instrume: UV detector
+    telescop: Test case
+    wavelnth: 1000.0
+    waveunit: Angstrom
+    naxis: 2
+    naxis1: 10
+    naxis2: 10
+    pc1_1: 1.0
+    pc1_2: -0.0
+    pc2_1: 0.0
+    pc2_2: 1.0
+    rsun_obs: 965.3829548285768
+
+From these header MetaDict's that are generated, we can now create a custom map:
+
+.. code-block:: python
+
+    >>> my_map = sunpy.map.Map(data, header)
+
+.. _Meta Keywords Table:
+
+.. list-table:: Meta Keywords
+   :widths: 7 30
+   :header-rows: 1
+
+   * - Keyword
+     - Description
+   * - cunit1
+     - Units of the coordinate increments along naxis1 e.g. arcsec (required)
+   * - cunit2
+     - Units of the coordinate increments along naxis2 e.g. arcsec (required)
+   * - crval1
+     - Coordinate value at reference point on naxis1 (required)
+   * - crval2
+     - Coordinate value at reference point on naxis2 (required)
+   * - cdelt1
+     - Spatial scale of pixels for naxis1, i.e. coordinate increment at reference point
+   * - cdelt2
+     - Spatial scale of pixels for naxis2, i.e. coordinate increment at reference point
+   * - crpix1
+     - Pixel coordinate at reference point naxis1
+   * - crpix2
+     - Pixel coordinate at reference point naxis2
+   * - ctype1
+     - Coordinate type projection along naxis1 of data e.g. HPLT-TAN
+   * - ctype2
+     - Coordinate type projection along naxis2 of data e.g. HPLN-TAN
+   * - hgln_obs
+     - Heliographic longitude of observation
+   * - hglt_obs
+     - Heliographic latitude of observation
+   * - dsun_obs
+     - distance to Sun from observation in metres
+   * - rsun_obs
+     - radius of Sun in meters from observation
+   * - dateobs
+     - date of observation e.g. 2013-10-28 00:00
+   * - date_obs
+     - date of observation e.g. 2013-10-28 00:00
+   * - rsun_ref
+     - reference radius of Sun in meters
+   * - solar_r
+     - radius of Sun in meters from observation
+   * - radius
+     - radius of Sun in meters from observation
+   * - crln_obs
+     - Carrington longitude of observation
+   * - crlt_obs
+     - Heliographic latitude of observation
+   * - solar_b0
+     - Solar B0 angle
+   * - detector
+     - name of detector e.g. AIA
+   * - exptime
+     - exposure time of observation, in seconds e.g 2
+   * - instrume
+     - name of instrument
+   * - wavelnth
+     - wavelength of observation
+   * - waveunit
+     - unit for which observation is taken e.g. angstom
+   * - obsrvtry
+     - name of observatory of observation
+   * - telescop
+     - name of telescope of observation
+   * - lvl_num
+     - FITS processing level
+   * - crota2
+     - Rotation of the horizontal and vertical axes in degrees
+   * - PC1_1
+     - Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+   * - PC1_2
+     - Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+   * - PC2_1
+     - Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+   * - PC2_2
+     - Matrix element PCi_j describing the rotation required to align solar North with the top of the image.
+   * - CD1_1
+     - Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+   * - CD1_2
+     - Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+   * - CD2_1
+     - Matrix element CDi_j describing the rotation required to align solar North with the top of the image.
+   * - CD2_2
+     - Matrix element CDi_j describing the rotation required to align solar North with the top of the image.

--- a/docs/how_to/create_custom_map.rst
+++ b/docs/how_to/create_custom_map.rst
@@ -1,11 +1,11 @@
 .. _how_to_custom_maps:
 
-Create Custom Maps
-==================
+Create Custom Maps by Hand
+==========================
 
-It is also possible to create Maps using custom data (e.g. from a simulation or an observation from a data source that is not explicitly supported in **sunpy**).
-To do this, you need to provide `sunpy.map.Map` with both the data array as well as appropriate meta information.
-The meta information informs `sunpy.map.Map` of the correct coordinate information associated with the data array and should be provided to `sunpy.map.Map` in the form of a header as a `dict` or `~sunpy.util.MetaDict`.
+It is possible to create Maps using custom data, e.g. from a simulation or an observation from a data source that is not explicitly supported by **sunpy**
+To do this, you need to provide `sunpy.map.Map` with both the data array as well as appropriate metadata.
+The metadata informs `sunpy.map.Map` of the correct coordinate information associated with the data array and should be provided to `sunpy.map.Map` in the form of a header as a `dict` or `~sunpy.util.MetaDict`.
 See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a brief demonstration of generating a Map from a data array.
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
@@ -13,13 +13,7 @@ sunpy provides a Map header helper function to assist in creating a header that 
 The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 All the metadata keywords that a Map will parse along with their description are listed in the :ref:`Meta Keywords Table` at the end of this page.
 
-The `astropy.coordinates.SkyCoord` is defined by the user and contains information on the reference frame, reference coordinate, and observer location.
-This function returns a `sunpy.util.MetaDict`.
-The `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` must contain an observation time.
-
-The :func:`~sunpy.map.header_helper.make_fitswcs_header` function also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
-If neither of these are given their values default to the center of the data array and 1 arcsec, respectively.
-
+:func:`~sunpy.map.header_helper.make_fitswcs_header` also takes optional keyword arguments including ``reference_pixel`` and ``scale`` that describe the pixel coordinate at the reference coordinate (defined by the `~astropy.coordinates.SkyCoord`) and the spatial scale of the pixels, respectively.
 Here's an example of creating a header from some generic data and an `astropy.coordinates.SkyCoord`:
 
 .. code-block:: python
@@ -31,9 +25,9 @@ Here's an example of creating a header from some generic data and an `astropy.co
     >>> from sunpy.coordinates import frames
     >>> from sunpy.map.header_helper import make_fitswcs_header
 
-    >>> data = np.arange(0,100).reshape(10,10)
-    >>> coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime = '2013-10-28', observer = 'earth', frame = frames.Helioprojective)
-    >>> header = make_fitswcs_header(data, coord)
+    >>> data = np.arange(0, 100).reshape(10, 10)
+    >>> reference_coord = SkyCoord(0*u.arcsec, 0*u.arcsec, obstime = '2013-10-28', observer = 'earth', frame = frames.Helioprojective)
+    >>> header = make_fitswcs_header(data, reference_coord)
     >>> for key, value in header.items():
     ...     print(f"{key}: {value}")
     wcsaxes: 2

--- a/docs/how_to/create_custom_map.rst
+++ b/docs/how_to/create_custom_map.rst
@@ -9,19 +9,7 @@ The meta information informs `sunpy.map.Map` of the correct coordinate informati
 See this :ref:`sphx_glr_generated_gallery_map_map_from_numpy_array.py` for a brief demonstration of generating a Map from a data array.
 
 The keys required for the header information follow the `FITS standard <https://fits.gsfc.nasa.gov/fits_dictionary.html>`__.
-**sunpy** provides a Map header helper function to assist in creating a header that contains the correct meta information.
-This includes a :func:`~sunpy.map.header_helper.meta_keywords` function that will return a `dict` of the meta keywords used when creating a Map.
-
-.. code-block:: python
-
-    >>> from sunpy.map.header_helper import meta_keywords
-
-    >>> meta_keywords() # doctest: +SKIP
-    {'cunit1': 'Units of the coordinate increments along naxis1 e.g. arcsec **required',
-     'cunit2': 'Units of the coordinate increments along naxis2 e.g. arcsec **required',
-     'crval1': 'Coordinate value at reference point on naxis1 **required'
-     ...
-
+sunpy provides a Map header helper function to assist in creating a header that contains the correct meta information.
 The utility function :func:`~sunpy.map.header_helper.make_fitswcs_header` will return a header with the appropriate FITS keywords once the Map data array and an `astropy.coordinates.SkyCoord` or `sunpy.coordinates.frames` is provided.
 All the metadata keywords that a Map will parse along with their description are listed in the :ref:`Meta Keywords Table` at the end of this page.
 
@@ -168,7 +156,34 @@ From these header MetaDict's that are generated, we can now create a custom map:
 
 .. code-block:: python
 
+    >>> import sunpy.map
     >>> my_map = sunpy.map.Map(data, header)
+    >>> my_map
+    <sunpy.map.mapbase.GenericMap object at ...>
+    SunPy Map
+    ---------
+    Observatory:                 Test case
+    Instrument:          UV detector
+    Detector:
+    Measurement:                 1000.0 Angstrom
+    Wavelength:          1000.0 Angstrom
+    Observation Date:    2013-10-28 00:00:00
+    Exposure Time:               Unknown
+    Dimension:           [10. 10.] pix
+    Coordinate System:   helioprojective
+    Scale:                       [2. 2.] arcsec / pix
+    Reference Pixel:     [5. 5.] pix
+    Reference Coord:     [0. 0.] arcsec
+    array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
+           [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+           [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+           [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+           [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+           [50, 51, 52, 53, 54, 55, 56, 57, 58, 59],
+           [60, 61, 62, 63, 64, 65, 66, 67, 68, 69],
+           [70, 71, 72, 73, 74, 75, 76, 77, 78, 79],
+           [80, 81, 82, 83, 84, 85, 86, 87, 88, 89],
+           [90, 91, 92, 93, 94, 95, 96, 97, 98, 99]])
 
 .. _Meta Keywords Table:
 

--- a/docs/how_to/create_custom_map.rst
+++ b/docs/how_to/create_custom_map.rst
@@ -66,9 +66,9 @@ Here's another example of passing ``reference_pixel`` and ``scale`` to the funct
 
 .. code-block:: python
 
-    >>> header = make_fitswcs_header(data, coord,
-    ...                                        reference_pixel=u.Quantity([5, 5]*u.pixel),
-    ...                                        scale=u.Quantity([2, 2] *u.arcsec/u.pixel))
+    >>> reference_pixel = u.Quantity([5, 5], u.pixel)
+    >>> scale = u.Quantity([2, 2], u.arcsec/u.pixel)
+    >>> header = make_fitswcs_header(data, reference_coord, reference_pixel=reference_pixel, scale=scale)
     >>> for key, value in header.items():
     ...     print(f"{key}: {value}")
     wcsaxes: 2
@@ -107,11 +107,10 @@ An example of creating a header with these additional keywords:
 
 .. code-block:: python
 
-    >>> header = make_fitswcs_header(data, coord,
-    ...                                        reference_pixel = u.Quantity([5, 5]*u.pixel),
-    ...                                        scale = u.Quantity([2, 2] *u.arcsec/u.pixel),
-    ...                                        telescope = 'Test case', instrument = 'UV detector',
-    ...                                        wavelength = 1000*u.angstrom)
+    >>> header = make_fitswcs_header(data, reference_coord, reference_pixel=reference_pixel, scale=scale,
+    ...                              telescope='Test case',
+    ...                              instrument='UV detector',
+    ...                              wavelength=1000*u.angstrom)
     >>> for key, value in header.items():
     ...     print(f"{key}: {value}")
     wcsaxes: 2

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -19,6 +19,8 @@ If you're starting fresh you might want to check out the :ref:`tutorial` first.
    transform_coords
    create_a_map
    remote_data_manager
+   create_custom_map
+
 
 
 Quick Reference
@@ -38,7 +40,7 @@ For more complete code examples, see the how-to guides above.
    * - save a map to a FITS file
      - `my_map.save('another_file.fits') <sunpy.map.GenericMap.save>`
    * - get a quicklook summary of a map
-     - `my_map.quicklook() <sunpy.map.GenericMap.quicklook>`
+     - `my_map.quicklook() <sunpy.map.GenericMap.quicklook>`, `my_map.peek() <sunpy.map.GenericMap.peek>`
    * - plot a map
      - `my_map.plot() <sunpy.map.GenericMap.plot>`
    * - access the underlying data array of a map

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -48,9 +48,9 @@ For more complete code examples, see the how-to guides above.
    * - access the map metadata
      - `my_map.meta <sunpy.map.GenericMap.meta>`
    * - make a copy of the map data array
-     - `my_map.data.copy()`
+     - `my_map.data.copy() <np.ndarray.copy>`
    * - make a copy of the whole map
-     - `copy.deepcopy(my_map)`
+     - `copy.deepcopy(my_map) <copy.deepcopy>`
    * - access the observer location
      - `my_map.observer_coordinate <sunpy.map.GenericMap.observer_coordinate>`
    * - remove the roll angle

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -48,7 +48,7 @@ For more complete code examples, see the how-to guides above.
    * - access the map metadata
      - `my_map.meta <sunpy.map.GenericMap.meta>`
    * - make a copy of the map data array
-     - `my_map.data.copy() <np.ndarray.copy>`
+     - `my_map.data.copy() <numpy.ndarray.copy>`
    * - make a copy of the whole map
      - `copy.deepcopy(my_map) <copy.deepcopy>`
    * - access the observer location

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -45,6 +45,10 @@ For more complete code examples, see the how-to guides above.
      - `my_map.data <sunpy.map.GenericMap.data>`
    * - access the map metadata
      - `my_map.meta <sunpy.map.GenericMap.meta>`
+   * - make a copy of the map data array
+     - `my_map.data.copy()`
+   * - make a copy of the whole map
+     - `copy.deepcopy(my_map)`
    * - access the observer location
      - `my_map.observer_coordinate <sunpy.map.GenericMap.observer_coordinate>`
    * - remove the roll angle

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -21,7 +21,7 @@ You can either read it without running any code, or copy and paste the code snip
 Each chapter of the tutorial provides a self-contained set of codes.
 
 Later chapters build on the concepts introduced in earlier chapters.
-The one exception is the two chapters that explore Maps and Timeseries - these are independent, but depend on all earlier chapters.
+The one exception is the two chapters that explore Maps and TimeSeries - these are independent, but depend on all earlier chapters.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -30,25 +30,13 @@ To create a `~sunpy.map.Map` from a sample AIA image,
 
 .. code-block:: python
 
-    >>> import sunpy
     >>> import sunpy.map
     >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
 
-**sunpy** automatically detects the type of file (e.g. FITS), the instrument associated with it (e.g. AIA, EIT, LASCO), and finds the FITS keywords it needs to interpret the coordinate system.
-If the type of FITS file is not recognized then **sunpy** will try some default FITS keywords and return a `~sunpy.map.GenericMap`, but results may vary.
+sunpy automatically detects the type of file (e.g. FITS) as well as the the instrument associated with it (e.g. AIA, EIT, LASCO).
+To make sure this has all worked correctly, we can take a quick look at ``my_map``,
 
-.. _inspecting-maps:
-
-Inspecting Maps
-===============
-
-A Map contains a number of data-associated attributes.
-To get a quick look at your Map simply type:
-
-.. code-block:: python
-
-    >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
     >>> my_map  # doctest: +REMOTE_DATA
     <sunpy.map.sources.sdo.AIAMap object at ...>
     SunPy Map
@@ -79,9 +67,13 @@ To get a quick look at your Map simply type:
            [-128.03072  , -128.03072  , -128.03072  , ..., -128.03072  ,
             -128.03072  , -128.03072  ]], dtype=float32)
 
-This will show a representation of the data as well as some of its associated attributes.
-Typing the above command in a Jupyter Notebook will show a rich HTML view of the table along with two plots of your data.
-The HTML view can also be accessed using the :func:`~sunpy.map.GenericMap.quicklook` method, which will open the view in your default browser.
+This should show a representation of the data as well as some of its associated attributes.
+If you are in a Jupyter Notebook, this will show a rich HTML view of the table along with several quick-look plots.
+
+.. _inspecting-maps:
+
+Inspecting Maps
+===============
 
 A number of other attributes are also available.
 For example, the `~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`, `~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`).

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -192,6 +192,7 @@ This observer coordinate is also provided as an attribute,
         (-0.00406308, 0.04787238, 1.51846026e+11)>
 
 This tells us the location of the spacecraft, in this case SDO, when it recorded this particular observation, as derived from the FITS metadata.
+
 Map has several additional coordinate-related attributes that provide the coordinates of the center and corners of the Map,
 
 .. code-block:: python
@@ -381,7 +382,7 @@ Overlaying Contours and Coordinates
 
 When plotting images, we often want to highlight certain features or overlay certain data points.
 There are several methods attached to Map that make this task easy.
-For example, we can draw contours corresponding to particularly percentages of our data..
+For example, we can draw contours around the brightest 0.5% percent of pixels in the image:
 
 .. plot::
     :include-source:

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -191,7 +191,7 @@ This observer coordinate is also provided as an attribute,
     <SkyCoord (HeliographicStonyhurst: obstime=2011-06-07T06:33:02.770, rsun=696000.0 km): (lon, lat, radius) in (deg, deg, m)
         (-0.00406308, 0.04787238, 1.51846026e+11)>
 
-This tells us the location of the spacecraft, in this case SDO, when it recorded this partiuclar observation, as derived from the FITS metadata.
+This tells us the location of the spacecraft, in this case SDO, when it recorded this particular observation, as derived from the FITS metadata.
 Map has several additional coordinate-related attributes that provide the coordinates of the center and corners of the Map,
 
 .. code-block:: python
@@ -302,7 +302,7 @@ First, let's create a basic plot of our Map, including a colorbar,
     We imported `matplotlib.pyplot` in order to create the figure and the axis we plotted on our map onto.
     Under the hood, sunpy uses of `matplotlib` to visualize the image meaning that plots built with sunpy can be further customized using `matplotlib`.
     **However, for the purposes of this tutorial, you do not need to be familiar with Matplotlib.**
-    Fore a series of detailed examples showing how to heavily customize your Map plots, see the :ref:`Plotting section of the Example Gallery <sphx_glr_generated_gallery_plotting>`.
+    Fore a series of detailed examples showing how to heavily customize your Map plots, see the :ref:`Plotting section of the Example Gallery <sphx_glr_generated_gallery_plotting>` as well as the documentation for `astropy.visualization.wcsaxes`.
 
 Note that the title and colormap have been set by sunpy based on the observing instrument and wavelength.
 Furthermore, the tick and axes labels have been automatically set based on the coordinate system of the Map.
@@ -445,7 +445,7 @@ The following example shows how to plot some points on our Map, including the ce
 Cropping Maps and Combining Pixels
 ==================================
 
-It analyzing images of the Sun, we often want to choose a smaller portion of the full disk to look at more closely.
+In analyzing images of the Sun, we often want to choose a smaller portion of the full disk to look at more closely.
 Let's use the region of interest we defined above to crop out that portion of our image.
 
 .. plot::
@@ -482,7 +482,7 @@ For example, we can combine 4 pixels in each dimension such that our new superpi
 Map Sequences
 =============
 
-While `~sunpy.map.GenericMap` can only contain a two-dimensional array and metadata corresponding to a single observation, a `~sunpy.map.MapSequence` is comprisded of an ordered list of maps.
+While `~sunpy.map.GenericMap` can only contain a two-dimensional array and metadata corresponding to a single observation, a `~sunpy.map.MapSequence` is comprised of an ordered list of maps.
 By default, the Maps are ordered by their observation date, from earliest to latest date.
 A `~sunpy.map.MapSequence` can be created by supplying multiple existing maps:
 

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -37,6 +37,8 @@ To create a `~sunpy.map.Map` from a sample AIA image,
 sunpy automatically detects the type of file (e.g. FITS) as well as the the instrument associated with it (e.g. AIA, EIT, LASCO).
 To make sure this has all worked correctly, we can take a quick look at ``my_map``,
 
+.. code-block:: python
+
     >>> my_map  # doctest: +REMOTE_DATA
     <sunpy.map.sources.sdo.AIAMap object at ...>
     SunPy Map
@@ -72,57 +74,66 @@ If you are in a Jupyter Notebook, this will show a rich HTML view of the table a
 
 .. _inspecting-maps:
 
-Inspecting Maps
-===============
+Inspecting Map Metadata
+=======================
 
-A number of other attributes are also available.
-For example, the `~sunpy.map.GenericMap.date`, `~sunpy.map.GenericMap.exposure_time`, `~sunpy.map.GenericMap.center` and others (see `~sunpy.map.GenericMap`).
-The full list can be found on `~sunpy.map.GenericMap`:
-
-.. code-block:: python
-
-    >>> map_date = my_map.date  # doctest: +REMOTE_DATA
-    >>> map_exptime = my_map.exposure_time  # doctest: +REMOTE_DATA
-    >>> map_center = my_map.center  # doctest: +REMOTE_DATA
-
-To get a list of all of the attributes check the documentation by typing:
+The metadata for a Map is exposed via attributes on the Map.
+These attributes can be accessed by typing `my_map.<attribute-name>`.
+For example, to access the date of the observation,
 
 .. code-block:: python
 
-    >>> help(my_map)  # doctest: +SKIP
+    >>> my_map.date  # doctest: +REMOTE_DATA
+    <Time object: scale='utc' format='isot' value=2011-06-07T06:33:02.770>
 
-Many attributes and functions of the map classes accept and return `~astropy.units.quantity.Quantity` or `~astropy.coordinates.SkyCoord` objects.
-Please refer to :ref:`units-sunpy` and :ref:`coordinates-sunpy` for more details.
-
-The metadata for the map is accessed by:
+Notice that this is an `~astropy.time.Time` object which we discussed in the previous section :ref:`time-in-sunpy`.
+Similarly, we can access the exposure time of the image,
 
 .. code-block:: python
 
-    >>> header = my_map.meta  # doctest: +REMOTE_DATA
+    >>> my_map.exposure_time  # doctest: +REMOTE_DATA
+    <Quantity 0.234256 s>
 
-This references the metadata dictionary with the header information as read from the source file.
-To see if the metadata of a Map source has been modified, see :ref:`sphx_glr_generated_gallery_map_map_metadata_modification.py` for a demonstration.
+Notice that this returns an `~astropy.units.Quantity` object which we discussed in the previous section :ref:`units-sunpy`.
+The full list of attributes can be found on `~sunpy.map.GenericMap`.
+These metadata attributes are all derived from the underlying FITS metadata, but are represented as rich Python objects, rather than simple strings or floating point numbers.
 
 .. _map-data:
 
 Map Data
 ========
 
-The data in a Map object is accessible through the `~sunpy.map.GenericMap.data` attribute.
-The data is stored as a NumPy `~numpy.ndarray`.
+The data in a Map is stored as a `numpy.ndarray` object and is accessible through the `~sunpy.map.GenericMap.data` attribute:
+
+.. code-block:: python
+
+    >>> my_map.data  # doctest: +REMOTE_DATA
+    array([[ -95.92475  ,    7.076416 ,   -1.9656711, ..., -127.96519  ,
+        -127.96519  , -127.96519  ],
+       [ -96.97533  ,   -5.1167884,    0.       , ...,  -98.924576 ,
+        -104.04137  , -127.919716 ],
+       [ -93.99607  ,    1.0189276,   -4.0757103, ...,   -5.094638 ,
+         -37.95505  , -127.87541  ],
+       ...,
+       [-128.01454  , -128.01454  , -128.01454  , ..., -128.01454  ,
+        -128.01454  , -128.01454  ],
+       [-127.899666 , -127.899666 , -127.899666 , ..., -127.899666 ,
+        -127.899666 , -127.899666 ],
+       [-128.03072  , -128.03072  , -128.03072  , ..., -128.03072  ,
+        -128.03072  , -128.03072  ]], dtype=float32)
+
+This array can then be indexed like any other NumPy array.
 For example, to get the 0th element in the array:
 
 .. code-block:: python
 
     >>> my_map.data[0, 0]  # doctest: +REMOTE_DATA
     -95.92475
-    >>> my_map.data[0][0]  # doctest: +REMOTE_DATA
-    -95.92475
 
-The first index is for the y direction while the second index is for the x direction.
+The first index corresponds to the y direction and the second to the x direction in the two-dimensional pixel coordinate system.
 For more information about indexing, please refer to the `numpy documentation <https://numpy.org/doc/stable/user/basics.indexing.html#indexing-on-ndarrays>`__.
 
-Data attributes like `~numpy.ndarray.dtype` and `~sunpy.map.GenericMap.dimensions` are accessible through a GenericMap object:
+Data attributes like dimensionality and type are also accessible as attributes on ``my_map``:
 
 .. code-block:: python
 
@@ -131,26 +142,7 @@ Data attributes like `~numpy.ndarray.dtype` and `~sunpy.map.GenericMap.dimension
     >>> my_map.dtype  # doctest: +REMOTE_DATA
     dtype('float32')
 
-Here, the dimensions attribute is similar to the `~numpy.ndarray.shape` attribute, however returning an `~astropy.units.quantity.Quantity`.
-
-You can store the data of a `~sunpy.map.GenericMap` object in a separate `~numpy.ndarray` by either of the following actions:
-
-.. code-block:: python
-
-    >>> var = my_map.data  # doctest: +REMOTE_DATA
-    >>> var = my_map.data.copy()  # doctest: +REMOTE_DATA
-
-To create a complete copy of a Map object that is entirely independent of the original, use the built-in `copy.deepcopy` function:
-
-.. code-block:: python
-
-    >>> import copy   # doctest: +REMOTE_DATA
-    >>> my_map_deepcopy = copy.deepcopy(my_map)   # doctest: +REMOTE_DATA
-
-A deepcopy ensures that any changes in the original Map object are not reflected in the copied object and vice versa.
-Note that this copies the data of the Map object as well as all of the other attributes and methods.
-
-Some basic statistical functions are built into Map objects:
+Additional, there are several methods that provide basic summary statistics of the data:
 
 .. code-block:: python
 
@@ -160,14 +152,6 @@ Some basic statistical functions are built into Map objects:
     192130.17
     >>> my_map.mean()  # doctest: +REMOTE_DATA
     427.02252
-
-All the other `~numpy.ndarray` functions and attributes can be accessed through the data array directly.
-For example:
-
-.. code-block:: python
-
-    >>> my_map.data.std()  # doctest: +REMOTE_DATA
-    826.41016
 
 .. _plotting-maps:
 

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -32,7 +32,7 @@ To create a `~sunpy.map.Map` from a sample AIA image,
     >>> import sunpy.map
     >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
     >>> sunpy.data.sample.AIA_171_IMAGE  # doctest: +REMOTE_DATA
-    PosixPath('.../sunpy/AIA20110607_063302_0171_lowres.fits')
+    PosixPath('.../AIA20110607_063302_0171_lowres.fits')
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
 
 In many cases sunpy automatically detects the type of file as well as the the instrument associated with it.

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -535,14 +535,14 @@ It is often useful to return the image data in a `~sunpy.map.MapSequence` as a s
 
 .. code-block:: python
 
-    >>> map_seq_array = map_seq.as_array()   # doctest: +REMOTE_DATA
+    >>> map_seq_array = map_seq.as_array()  # doctest: +REMOTE_DATA
 
 Since all of the maps in our sequence of the same shape, the first two dimensions of our combined array will be the same as the component maps while the last dimension will correspond to the number of maps in the map sequence.
 We can confirm this by looking at the shape of the above array.
 
 .. code-block:: python
 
-    >>> map_seq_array.shape
+    >>> map_seq_array.shape  # doctest: +REMOTE_DATA
     (1024, 1024, 2)
 
 .. warning::

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -14,12 +14,12 @@ By the end of this tutorial, you will learn how to create a Map, access the unde
 Additionally, you will learn how to combine multiple Maps into a `~sunpy.map.MapSequence` or a `~sunpy.map.CompositeMap`.
 Lastly, you will learn how to create Maps from data sources not supported in sunpy.
 
-.. note:: In this section and in :ref:`timeseries_guide`, we will use the sample data included with
-          sunpy. These data are primarily useful for demonstration purposes or simple debugging.
-          These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and
-          ``sunpy.data.sample.RHESSI_IMAGE`` and are automatically downloaded to your computer as
-          you need them. Once downloaded, these sample data files will be paths to their location
-          on your computer.
+.. note::
+
+    In this section and in :ref:`timeseries_guide`, we will use the sample data included with sunpy.
+    These data are primarily useful for demonstration purposes or simple debugging.
+    These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE`` and are automatically downloaded to your computer as you need them.
+    Once downloaded, these sample data files will be paths to their location on your computer.
 
 .. _creating-maps:
 
@@ -155,10 +155,10 @@ Additional, there are several methods that provide basic summary statistics of t
 
 .. _plotting-maps:
 
-Plotting Maps
-=============
+Visualizing Maps
+================
 
-The `~sunpy.map.GenericMap` object has a built-in plot method such that it is easy to quickly view your map.
+The Map object has a built-in plot method such that it is easy to quickly view your map.
 sunpy makes use of `Matplotlib <https://matplotlib.org/>`_ for all of its plotting - as such, it tries to follow the Matplotlib plotting philosophy.
 We refer the reader to the `Matplotlib usage documentation <https://matplotlib.org/stable/users/explain/api_interfaces.html>`__ to learn more about the Matplotlib and to become familiar with the basics.
 To be consistent with Matplotlib, sunpy has developed a standard plotting interface which supports both simple and advanced Matplotlib usage.

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -4,51 +4,39 @@
 Maps
 ****
 
-Map objects in **sunpy** are two-dimensional data associated with a coordinate system.
-This class offers many advantages over using packages such as `astropy.io.fits` to open 2D solar data in Python.
-**sunpy** Maps be used with any image with two spatial axes that has FITS standard compliant metadata.
-There are also 19 sources (see :ref:`map` for a complete list) that provide instrument-specific information when plotting and in some cases interpret missing metadata when it is missing from the original file.
+In this section of the tutorial, you will learn about the `Map <sunpy.map.GenericMap>` object, the primary data structure provided by sunpy.
+Map objects hold two-dimensional data along with the accompanying metadata.
+They can be used with any two-dimensional data array with two spatial axes and FITS-compliant metadata.
+As you will see in this tutorial, the primary advantage of using a Map object over just a bare NumPy array is the ability to perform coordinate aware operations on the underlying array, such as rotating the Map to remove the roll angle of an instrument or cropping a Map to a specific field of view.
+Additionally, because Map is capable of ingesting data from many different sources, it provides a common interface for any two-dimensional data product.
 
-Part of the philosophy of the Map object is to provide most of the basic functionality that a scientist would want.
-Therefore, a Map also contains a number of methods such as resizing or grabbing a subview.
-See `~sunpy.map.mapbase.GenericMap` for summaries of all attributes and methods.
+By the end of this tutorial, you will learn how to create a Map, access the underlying data and metadata, and the basics visualizing a Map.
+Additionally, you will learn how to combine multiple Maps into a `~sunpy.map.MapSequence` or a `~sunpy.map.CompositeMap`.
+Lastly, you will learn how to create Maps from data sources not supported in sunpy.
 
-:ref:`creating-maps` and :ref:`inspecting-maps` demonstrate how to create a Map object and view a summary of the data in the object.
-:ref:`map-data` describes how data is stored and accessed in a Map, and :ref:`plotting-maps` introduces some basics of visualizing Map data in **sunpy**.
-:ref:`map-sequences` and :ref:`composite-maps` detail how **sunpy** can handle multiple Maps from similar and different instruments.
-Lastly, :ref:`custom-maps` shows how you can create Maps from data sources not supported in **sunpy**.
+.. note:: In this section and in :ref:`timeseries_guide`, we will use the sample data included with
+          sunpy. These data are primarily useful for demonstration purposes or simple debugging.
+          These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and
+          ``sunpy.data.sample.RHESSI_IMAGE`` and are automatically downloaded to your computer as
+          you need them. Once downloaded, these sample data files will be paths to their location
+          on your computer.
 
 .. _creating-maps:
 
 Creating Maps
 =============
 
-To make things easy, **sunpy** can download sample data which are used throughout the docs.
-These files have names like ``sunpy.data.sample.AIA_171_IMAGE`` and ``sunpy.data.sample.RHESSI_IMAGE``.
-To create a `~sunpy.map.Map` from a sample AIA image, type the following into your Python shell:
+To create a `~sunpy.map.Map` from a sample AIA image,
 
 .. code-block:: python
 
     >>> import sunpy
     >>> import sunpy.map
     >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
-
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
-
-The variable ``my_map`` is an `~sunpy.map.sources.AIAMap` object.
-To create a Map from a local FITS file try the following:
-
-.. code-block:: python
-
-    >>> my_map = sunpy.map.Map('/mydirectory/mymap.fits')   # doctest: +SKIP
 
 **sunpy** automatically detects the type of file (e.g. FITS), the instrument associated with it (e.g. AIA, EIT, LASCO), and finds the FITS keywords it needs to interpret the coordinate system.
 If the type of FITS file is not recognized then **sunpy** will try some default FITS keywords and return a `~sunpy.map.GenericMap`, but results may vary.
-**sunpy** can also create Maps using the JPEG 2000 files from `helioviewer.org <https://helioviewer.org/>`__.
-
-The :ref:`sphx_glr_generated_gallery_acquiring_data` section of the Example Gallery has several examples of retrieving data using the `~sunpy.net.Fido` tool.
-For more details, check out the :ref:`acquiring_data` guide.
-See :ref:`sphx_glr_generated_gallery_saving_and_loading_data_genericmap_in_fits.py` for a demonstration of saving a map as a FITS file and `~sunpy.map.GenericMap.save` for more details on saving.
 
 .. _inspecting-maps:
 

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -4,13 +4,13 @@
 Maps
 ****
 
-In this section of the tutorial, you will learn about the `Map <sunpy.map.GenericMap>` object, the primary data structure provided by sunpy.
+In this section of the tutorial, you will learn about the `Map <sunpy.map.GenericMap>` object.
 Map objects hold two-dimensional data along with the accompanying metadata.
 They can be used with any two-dimensional data array with two spatial axes and FITS-compliant metadata.
 As you will see in this tutorial, the primary advantage of using a Map object over just a bare NumPy array is the ability to perform coordinate aware operations on the underlying array, such as rotating the Map to remove the roll angle of an instrument or cropping a Map to a specific field of view.
 Additionally, because Map is capable of ingesting data from many different sources, it provides a common interface for any two-dimensional data product.
 
-By the end of this tutorial, you will learn how to create a Map, access the underlying data and metadata, convert physical coordinates to the world coordinate of a Map, and the basics visualizing a Map.
+By the end of this tutorial, you will learn how to create a Map, access the underlying data and metadata, convert between physical coordinates and pixel coordinates of a Map, and the basics of visualizing a Map.
 Additionally, you will learn how to combine multiple Maps into a `~sunpy.map.MapSequence` or a `~sunpy.map.CompositeMap`.
 
 .. note::
@@ -31,9 +31,11 @@ To create a `~sunpy.map.Map` from a sample AIA image,
 
     >>> import sunpy.map
     >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
+    >>> sunpy.data.sample.AIA_171_IMAGE  # doctest: +REMOTE_DATA
+    PosixPath('.../sunpy/AIA20110607_063302_0171_lowres.fits')
     >>> my_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA
 
-sunpy automatically detects the type of file as well as the the instrument associated with it.
+In many cases sunpy automatically detects the type of file as well as the the instrument associated with it.
 In this case, we have a FITS file from the AIA instrument onboard SDO.
 To make sure this has all worked correctly, we can take a quick look at ``my_map``,
 
@@ -99,7 +101,7 @@ For example, to access the date of the observation,
     >>> my_map.date  # doctest: +REMOTE_DATA
     <Time object: scale='utc' format='isot' value=2011-06-07T06:33:02.770>
 
-Notice that this is an `~astropy.time.Time` object which we discussed in the previous section :ref:`time-in-sunpy`.
+Notice that this is an `~astropy.time.Time` object which we discussed in the previous :ref:`time-in-sunpy` section of the tutorial.
 Similarly, we can access the exposure time of the image,
 
 .. code-block:: python
@@ -107,9 +109,9 @@ Similarly, we can access the exposure time of the image,
     >>> my_map.exposure_time  # doctest: +REMOTE_DATA
     <Quantity 0.234256 s>
 
-Notice that this returns an `~astropy.units.Quantity` object which we discussed in the previous section :ref:`units-sunpy`.
+Notice that this returns an `~astropy.units.Quantity` object which we discussed in the previous :ref:`units-sunpy` section of the tutorial.
 The full list of attributes can be found in the reference documentation for `~sunpy.map.GenericMap`.
-These metadata attributes are all derived from the underlying FITS metadata, but are represented as rich Python objects, rather than simple strings or floating point numbers.
+These metadata attributes are all derived from the underlying FITS metadata, but are represented as rich Python objects, rather than simple strings or numbers.
 
 .. _map-data:
 
@@ -155,7 +157,7 @@ Data attributes like dimensionality and type are also accessible as attributes o
     >>> my_map.dtype  # doctest: +REMOTE_DATA
     dtype('float32')
 
-Additional, there are several methods that provide basic summary statistics of the data:
+Additionally, there are several methods that provide basic summary statistics of the data:
 
 .. code-block:: python
 
@@ -208,7 +210,7 @@ Map has several additional coordinate-related attributes that provide the coordi
         (1235.21095899, 1227.39598836)>
 
 But what if we wanted to know what pixel these physical coordinates correspond to?
-Thankfully, each Map has an associated World Coordinate System, or WCS, which is derived from the underlying metadata and expressed as an `astropy.wcs.WCS` object.
+Each Map has an associated World Coordinate System, or WCS, which is derived from the underlying metadata and expressed as an `astropy.wcs.WCS` object.
 The WCS is accessible as an attribute:
 
 .. code-block:: python
@@ -268,6 +270,7 @@ Visualizing Maps
 
     # This is here to put my_map in the scope of the plot directives.
     # This avoids repeating code in the example source code that is actually displayed.
+    # This snippet of code is not visible in the rendered documentation.
     import sunpy.map
     import sunpy.data.sample
     from astropy.coordinates import SkyCoord
@@ -298,14 +301,14 @@ First, let's create a basic plot of our Map, including a colorbar,
 
     We imported `matplotlib.pyplot` in order to create the figure and the axis we plotted on our map onto.
     Under the hood, sunpy uses of `matplotlib` to visualize the image meaning that plots built with sunpy can be further customized using `matplotlib`.
-    **However, for the purposes of this tutorial, you do not need to be familiar with matplotlib.**
+    **However, for the purposes of this tutorial, you do not need to be familiar with Matplotlib.**
     Fore a series of detailed examples showing how to heavily customize your Map plots, see the :ref:`Plotting section of the Example Gallery <sphx_glr_generated_gallery_plotting>`.
 
-Note that the title and colormap have been determined based on the accompanying metadata.
+Note that the title and colormap have been set by sunpy based on the observing instrument and wavelength.
 Furthermore, the tick and axes labels have been automatically set based on the coordinate system of the Map.
 
 Looking at the plot above, you likely notice that the resulting image is a bit dim.
-To fix this, we can use the ``clip_interval`` keyword to clip out the dimmest 1% and the brightest 0.5% of pixels.
+To fix this, we can use the ``clip_interval`` keyword to automatically adjust the colorbar limits to clip out the dimmest 1% and the brightest 0.5% of pixels.
 
 .. plot::
     :include-source:
@@ -314,7 +317,7 @@ To fix this, we can use the ``clip_interval`` keyword to clip out the dimmest 1%
     import astropy.units as u
     fig = plt.figure()
     ax = fig.add_subplot(projection=my_map)
-    my_map.plot(axes=ax, clip_interval=(1,99.5)*u.percent)
+    my_map.plot(axes=ax, clip_interval=(1, 99.5)*u.percent)
     plt.colorbar()
     plt.show()
 
@@ -489,7 +492,7 @@ A `~sunpy.map.MapSequence` can be created by supplying multiple existing maps:
     >>> map_seq = sunpy.map.Map([my_map, another_map], sequence=True)  # doctest: +REMOTE_DATA
 
 A map sequence can be indexed in the same manner as a list.
-For example, the following should return the same quicklook view as in :ref:`creating-maps`.
+For example, the following returns the same information as in :ref:`creating-maps`.
 
 .. code-block:: python
 

--- a/docs/tutorial/timeseries.rst
+++ b/docs/tutorial/timeseries.rst
@@ -21,10 +21,7 @@ Lastly, :ref:`ts-metadata` describes how to view and extract information from th
 Creating a TimeSeries
 =====================
 
-A TimeSeries object can be created from local files.
-For convenience, **sunpy** can download several example time series of observational data.
-These files have names like ``sunpy.data.sample.EVE_TIMESERIES`` and ``sunpy.data.sample.GOES_XRS_TIMESERIES``.
-To create the sample `sunpy.timeseries.sources.goes.XRSTimeSeries`, type the following into your interactive Python shell:
+To create a `TimeSeries` from some sample GOES XRS data:
 
 .. code-block:: python
 

--- a/docs/tutorial/timeseries.rst
+++ b/docs/tutorial/timeseries.rst
@@ -21,7 +21,7 @@ Lastly, :ref:`ts-metadata` describes how to view and extract information from th
 Creating a TimeSeries
 =====================
 
-To create a `TimeSeries` from some sample GOES XRS data:
+To create a `~sunpy.timeseries.TimeSeries` from some sample GOES XRS data:
 
 .. code-block:: python
 

--- a/examples/showcase/where_is_stereo.py
+++ b/examples/showcase/where_is_stereo.py
@@ -38,7 +38,6 @@ obstime = parse_time('now')
 
 hee_frame = HeliocentricEarthEcliptic(obstime=obstime)
 
-
 def get_first_orbit(coord):
     lon = coord.transform_to(hee_frame).spherical.lon
     shifted = Longitude(lon - lon[0])
@@ -46,7 +45,6 @@ def get_first_orbit(coord):
     if ends.size > 0:
         return coord[:ends[0]]
     return coord
-
 
 ##############################################################################
 # Obtain the locations and trajectories of the various planets and spacecraft.
@@ -68,7 +66,6 @@ mission_coords = {mission: get_first_orbit(get_horizons_coord(mission, {'start':
                                                                         'step': '1d'}))
                   for mission in missions}
 
-
 ##############################################################################
 # Define a convenience function for converting coordinates to plot positions
 # in the ecliptic plane.
@@ -80,7 +77,6 @@ def coord_to_heexy(coord):
 
 ##############################################################################
 # Set Matplotlib settings to the desired appearance and initialize the axes.
-
 
 mpl.rcParams.update({'figure.facecolor': 'black',
                      'axes.edgecolor': 'white',
@@ -169,3 +165,8 @@ for mission, coord in mission_coords.items():
     ax.text(x + 0.05, y, mission_labels[mission], color=color)
 
 plt.show()
+
+# This is necessary to reset the Matplotlib settings after plotting for our documentation.
+# You don't need this in your own code.
+mpl.rcParams.update(mpl.rcParamsDefault)
+mpl.rcParams.update({'axes.titlecolor': 'black'})


### PR DESCRIPTION
Fixes #6875
Fixes #5573

This significantly rewrites the Map section of the tutorial. In particular, in restructures the tutorial to be shorter and include material more focused on new users to Map. It also moves the section on creating custom maps to the "how-to guide" section.