### PR TITLE
Pass a scalar to skimage contour

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2607,6 +2607,12 @@ class GenericMap(NDData):
         from skimage import measure
 
         level = self._process_levels_arg(level)
+        if level.size != 1:
+            raise ValueError("level must be a single scalar value")
+        else:
+            # _process_levels_arg converts level to a 1D array, but
+            # find_contours expects a scalar below
+            level = level[0]
 
         contours = measure.find_contours(self.data, level=level, **kwargs)
         contours = [self.wcs.array_index_to_world(c[:, 0], c[:, 1]) for c in contours]

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1305,6 +1305,8 @@ def test_contour(simple_map):
     assert contour.obstime == simple_map.date
     assert u.allclose(contour.Tx, [0, -1, 0, 1, 0] * u.arcsec, atol=1e-10 * u.arcsec)
     assert u.allclose(contour.Ty, [0.5, 0, -0.5, 0, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
+    with pytest.raises(ValueError, match='level must be a single scalar value'):
+        simple_map.contour([1.5, 2.5])
 
 
 def test_contour_units(simple_map):


### PR DESCRIPTION
Should fix the `oldestdeps` tests (e.g. see https://github.com/sunpy/sunpy/actions/runs/4771491361/jobs/8483459723 for a failing run). Also add an error if more than one level is given to `contour`, as it can only do one level at a time anyway.