### PR TITLE
Remove setup.py

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,8 +16,8 @@
         "in-dir={env_dir} python -mpip install {wheel_file}[all]"
     ],
     "build_command": [
-        "python -mpip install -U setuptools wheel extension_helpers numpy opencv-python",
-        "python setup.py build",
+        "python -mpip install -U build",
+        "python -m build",
         "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ requires = [
          ]
 build-backend = 'setuptools.build_meta'
 
+[tool.setuptools_scm]
+write_to = "sunpy/_version.py"
+
 # Until we have h5py binaries we can't test wheels on Python 3.11
 [tool.cibuildwheel]
 test-skip = "cp311-*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,16 @@ timeseries =
 visualization =
   matplotlib>=3.5.0
   mpl-animators>=1.0.0
+all =
+  %(asdf)s
+  %(dask)s
+  %(database)s
+  %(image)s
+  %(jpeg2000)s
+  %(map)s
+  %(net)s
+  %(timeseries)s
+  %(visualization)s
 tests =
   hvpy>=1.0.1
   hypothesis>=6.0.0  # Included in pytest-astropy. 6.0 is the first version to support disabling function-scoped fixture warning
@@ -113,6 +123,10 @@ docs =
   sphinxext-opengraph
   sunpy-sphinx-theme
   sphinx-hoverxref
+dev =
+  %(all)s
+  %(tests)s
+  %(docs)s
 
 [options.packages.find]
 exclude = sunpy._dev

--- a/setup.cfg
+++ b/setup.cfg
@@ -141,6 +141,9 @@ asdf.extensions =
 # the Py_LIMITED_API version hex in _pyana.c should match the version specified here
 py_limited_api = cp39
 
+[extension-helpers]
+use_extension_helpers = true
+
 [tool:pytest]
 testpaths = "sunpy" "docs"
 norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "examples" "sunpy[/\]_dev" ".jupyter" ".history" "tools" "sunpy[\/]extern" "benchmarks"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,10 @@
 #!/usr/bin/env python
 from setuptools import setup  # isort:skip
 import os
-from itertools import chain
 
 from extension_helpers import get_extensions
 
-try:
-    # Recommended for setuptools 61.0.0+
-    # (though may disappear in the future)
-    from setuptools.config.setupcfg import read_configuration
-except ImportError:
-    from setuptools.config import read_configuration
-
-################################################################################
-# Programmatically generate some extras combos.
-################################################################################
-extras = read_configuration("setup.cfg")['options']['extras_require']
-
-# Dev is everything
-extras['dev'] = list(chain(*extras.values()))
-
-# All is everything but tests and docs
-exclude_keys = ("tests", "docs", "dev")
-ex_extras = dict(filter(lambda i: i[0] not in exclude_keys, extras.items()))
-# Concatenate all the values together for 'all'
-extras['all'] = list(chain.from_iterable(ex_extras.values()))
-
 setup(
-    extras_require=extras,
     use_scm_version={'write_to': os.path.join('sunpy', '_version.py')},
     ext_modules=get_extensions(),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-from setuptools import setup  # isort:skip
-
-from extension_helpers import get_extensions
-
-setup(ext_modules=get_extensions())

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 from setuptools import setup  # isort:skip
-import os
 
 from extension_helpers import get_extensions
 
-setup(
-    use_scm_version={'write_to': os.path.join('sunpy', '_version.py')},
-    ext_modules=get_extensions(),
-)
+setup(ext_modules=get_extensions())


### PR DESCRIPTION
Two misc cleanups to `setup.py`:

- Specify the extras using `setup.cfg`, instead of using python code
- Use `pyproject.toml` for `setuptools_scm`.