### PR TITLE
Replace some TOC headings with raw html to fix sidebar.

### DIFF
--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -7,8 +7,8 @@ Topic Guides
 These guides provide a set of in-depth explanations for various parts of the ``sunpy`` core package.
 They assumes you have some knowledge of what ``sunpy`` is and how it works - if you're starting fresh you might want to check out the :ref:`tutorial` first.
 
-How to use the guides
----------------------
+**How to use the guides**
+
 The guides are designed to be read in a standalone manner, without running code at the same time.
 Although there are code snippets in various bits of the guides, these are to help explanation, and are not structured in a way that they can be run as you're reading each guide.
 

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -20,9 +20,7 @@ If you're starting fresh you might want to check out the :ref:`tutorial` first.
    create_a_map
    remote_data_manager
 
-
-Quick Reference
----------------
+**Quick Reference**
 
 The following table is meant as a quick reference.
 For more complete code examples, see the how-to guides above.

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -8,14 +8,14 @@ Welcome to the introductory tutorial for the ``sunpy`` core package.
 ``sunpy`` is a community-developed, free and open-source solar data analysis environment.
 It is meant to provide the core functionality and tools to analyze solar data with Python.
 
-Who this is for
----------------
+**Who this is for**
+
 This tutorial assumes you know how to run code in Python, but doesn't make any assumptions beyond that.
 ``sunpy`` depends heavily on other packages in the scientific Python ecosystem, inclduing Astropy, NumPy, and Matplotlib.
 This tutorial explains the basics of these packages needed to use ``sunpy``, but is not a comprehensive tutorial to these packages and references their own introductoriy tutorials where relevant.
 
-How to use this tutorial
-------------------------
+**How to use this tutorial**
+
 This tutorial is designed to be read from start to finish.
 You can either read it without running any code, or copy and paste the code snippets as you read.
 Each chapter of the tutorial provides a self-contained set of codes.


### PR DESCRIPTION
This partially solves #6989

The issue is caused by headings in the tutorial/how to page becoming top level toc entries, by turning these into raw html headings this behaviour is avoided.

The issue also has a comment regarding the coords TOC but this can't be tackled till after #6954 