### PR TITLE
Don't assume all rotation matrix keywords are present

### DIFF
--- a/changelog/7004.bugfix.rst
+++ b/changelog/7004.bugfix.rst
@@ -1,1 +1,1 @@
-`sunpy.map.GenericMap.rotation_matrix` now correctly applies the correct default values if any FITS rotation matrix keywords are missing from the header.
+`sunpy.map.GenericMap.rotation_matrix` now applies the default values if any FITS rotation matrix keywords are missing from the header.

--- a/changelog/7004.bugfix.rst
+++ b/changelog/7004.bugfix.rst
@@ -1,0 +1,1 @@
+`sunpy.map.GenericMap.rotation_matrix` now correctly applies the correct default values if any FITS rotation matrix keywords are missing from the header.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1319,13 +1319,20 @@ class GenericMap(NDData):
         It general it does not have to be a pure rotation matrix, and can encode
         other transformations e.g., skews for non-orthgonal coordinate systems.
         """
-        if 'PC1_1' in self.meta:
-            return np.array([[self.meta['PC1_1'], self.meta['PC1_2']],
-                             [self.meta['PC2_1'], self.meta['PC2_2']]])
-
-        elif 'CD1_1' in self.meta:
-            cd = np.array([[self.meta['CD1_1'], self.meta['CD1_2']],
-                           [self.meta['CD2_1'], self.meta['CD2_2']]])
+        if any(key in self.meta for key in ['PC1_1', 'PC1_2', 'PC2_1', 'PC2_2']):
+            return np.array(
+                [
+                    [self.meta.get('PC1_1', 1), self.meta.get('PC1_2', 0)],
+                    [self.meta.get('PC2_1', 0), self.meta.get('PC2_2', 1)]
+                ]
+            )
+        elif any(key in self.meta for key in ['CD1_1', 'CD1_2', 'CD2_1', 'CD2_2']):
+            cd = np.array(
+                [
+                    [self.meta.get('CD1_1', 0), self.meta.get('CD1_2', 0)],
+                    [self.meta.get('CD2_1', 0), self.meta.get('CD2_2', 0)]
+                ]
+            )
 
             cdelt = u.Quantity(self.scale).value
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -330,6 +330,37 @@ def test_rotation_matrix_crota(aia171_test_map):
                                          [3.38820761e-04, 9.99999943e-01]]))
 
 
+_PC_KEYWORDS = ['PC1_1', 'PC1_2', 'PC2_1', 'PC2_2']
+_CD_KEYWORDS = ['CD1_1', 'CD1_2', 'CD2_1', 'CD2_2']
+
+@pytest.mark.parametrize('key', ['PC', 'CD'])
+@pytest.mark.parametrize('i', [1, 2])
+@pytest.mark.parametrize('j', [1, 2])
+def test_rotation_matrix_defaults(generic_map, i, j, key):
+    # Check that missing rotation keywords are set to correct defaults
+    #
+    # Relevant bit of the FITS standard:
+    #
+    # > PCi_j – [floating point; defaults: 1.0 when i = j, 0.0 otherwise]
+    # > if any CDi_j keywords are present in the HDU, all other unspecified CDi_j keywords shall default to zero
+    for keyword in _PC_KEYWORDS + _CD_KEYWORDS:
+        if keyword in generic_map.meta:
+            del generic_map.meta[keyword]
+
+    keyword = f'{key}{i}_{j}'
+    # Abitrary number
+    generic_map.meta[keyword] = 1.2
+    if key == 'CD':
+        expected = np.zeros((2, 2))
+        expected[i-1, j-1] = 0.12
+    elif key == 'PC':
+        expected = np.eye(2)
+        expected[i-1, j-1] = 1.2
+
+    rot_mat = generic_map.rotation_matrix
+    np.testing.assert_equal(rot_mat, expected)
+
+
 def test_rotation_matrix_cd_cdelt():
     data = np.ones([6, 6], dtype=np.float64)
     header = {

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -348,7 +348,7 @@ def test_rotation_matrix_defaults(generic_map, i, j, key):
             del generic_map.meta[keyword]
 
     keyword = f'{key}{i}_{j}'
-    # Abitrary number
+    # Arbitrary number
     generic_map.meta[keyword] = 1.2
     if key == 'CD':
         expected = np.zeros((2, 2))


### PR DESCRIPTION
This updates metadata handling in `rotation_matrix` to correctly apply the default values specified in the FITS standard.