### PR TITLE
Patch broken import for private io modules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -224,6 +224,8 @@ filterwarnings =
     # https://github.com/h5py/h5py/issues/2243 for upstream issues about this warning being
     # emitted
     ignore:`product` is deprecated as of NumPy 1.25.0:DeprecationWarning
+    # Depecreated for 5.0 - IO modules
+    ignore:.*module is deprecated, as it was designed for internal use
 
 [pycodestyle]
 max_line_length = 110

--- a/sunpy/io/cdf.py
+++ b/sunpy/io/cdf.py
@@ -1,7 +1,6 @@
-from _cdf import *  # NOQA
-
 from sunpy.util.exceptions import warn_deprecated
 from . import _cdf
+from ._cdf import *  # NOQA
 
 __doc__ = _cdf.__doc__
 __all__ = _cdf.__all__

--- a/sunpy/io/file_tools.py
+++ b/sunpy/io/file_tools.py
@@ -1,7 +1,6 @@
-from _file_tools import *  # noqa: F403
-
 from sunpy.util.exceptions import warn_deprecated
 from . import _file_tools
+from ._file_tools import *  # NOQA
 
 __doc__ = _file_tools.__doc__
 __all__ = _file_tools.__all__

--- a/sunpy/io/jp2.py
+++ b/sunpy/io/jp2.py
@@ -1,7 +1,6 @@
-from _jp2 import *  # noqa: F403
-
 from sunpy.util.exceptions import warn_deprecated
 from . import _jp2
+from ._jp2 import *  # NOQA
 
 __doc__ = _jp2.__doc__
 __all__ = _jp2.__all__

--- a/sunpy/io/tests/test_cdf.py
+++ b/sunpy/io/tests/test_cdf.py
@@ -1,3 +1,5 @@
+import importlib
+
 import numpy as np
 
 import astropy.units as u
@@ -22,3 +24,8 @@ def test_read_cdf():
     assert col.unit == u.Unit("1 / (cm2 MeV s sr)")
     # Check that fillvals are replaced by NaN
     assert np.sum(np.isnan(col)) == 189
+
+
+def test_old_import():
+    lib = importlib.import_module("sunpy.io.cdf")
+    assert lib.read_cdf is read_cdf

--- a/sunpy/io/tests/test_filetools.py
+++ b/sunpy/io/tests/test_filetools.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import importlib
 
 import numpy as np
 import pytest
@@ -138,3 +139,8 @@ def test_write_file_fits_bytes():
     assert np.all(np.equal(outpair[0], aiapair[0]))
     assert outpair[1] == aiapair[1]
     os.remove("aia_171_image_bytes.fits")
+
+
+def test_old_import():
+    lib = importlib.import_module("sunpy.io.file_tools")
+    assert lib.read_file is sunpy.io.read_file

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -1,3 +1,5 @@
+import importlib
+
 import numpy as np
 
 from sunpy.data.test import get_test_filepath
@@ -43,3 +45,8 @@ def test_simple_write(tmpdir):
     # Sanity check that reading back the jp2 returns coherent data
     jp2_readback = _jp2.read(outfile)
     assert header['DATE'] == jp2_readback[0].header['DATE']
+
+
+def test_old_import():
+    lib = importlib.import_module("sunpy.io.jp2")
+    assert lib.read is _jp2.read


### PR DESCRIPTION
This should make the modules actually importable now.

Fixes https://github.com/sunpy/sunpy/issues/6373