### PR TITLE
Fix warnings for doc example build

### DIFF
--- a/examples/map_transformations/reprojection_aia_euvi_mosaic.py
+++ b/examples/map_transformations/reprojection_aia_euvi_mosaic.py
@@ -175,7 +175,7 @@ im = outmap.plot(axes=ax, vmin=400)
 
 lon, lat = ax.coords
 lon.set_coord_type("longitude")
-lon.coord_wrap = 180
+lon.coord_wrap = 180 * u.deg
 lon.set_format_unit(u.deg)
 lat.set_coord_type("latitude")
 lat.set_format_unit(u.deg)

--- a/examples/plotting/finegrained_plot.py
+++ b/examples/plotting/finegrained_plot.py
@@ -49,7 +49,7 @@ lat.set_ticks_visible(False)
 lat.set_ticklabel_visible(False)
 lon.set_ticklabel_visible(False)
 
-lon.coord_wrap = 180
+lon.coord_wrap = 180 * u.deg
 lon.set_major_formatter('dd')
 
 # Plot the Heliographic Stonyhurst grid

--- a/examples/units_and_coordinates/AIA_limb_STEREO.py
+++ b/examples/units_and_coordinates/AIA_limb_STEREO.py
@@ -71,7 +71,7 @@ overlay.grid()
 x, y = overlay
 
 # Wrap the longitude at 180 deg rather than the default 360.
-x.set_coord_type('longitude', 180.)
+x.set_coord_type('longitude', 180*u.deg)
 
 # Set the tick spacing
 x.set_ticks(spacing=250*u.arcsec)


### PR DESCRIPTION
Passing this without a unit is now deprecated. 