### PR TITLE
Add Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/changelog/7068.trivial.rst
+++ b/changelog/7068.trivial.rst
@@ -1,0 +1,1 @@
+Add a Dependabot config file to auto-update GitHub action versions.


### PR DESCRIPTION
## PR Description

I looked at recent runs of GitHub workflows and found deprecation warnings caused by out-of-date action versions (like `actions/checkout@v2`). [[recent example](https://github.com/sunpy/sunpy/actions/runs/5240553682)]

Rather than manually updating the versions once, this PR introduces a Dependabot configuration that will automatically submit PRs on a monthly basis to keep actions up-to-date. If this PR merges, you can expect Dependabot to begin opening PRs to update action versions used in GitHub workflows (for example `actions/checkout@v2` will get bumped to v3).

I think I've followed the contributing guidelines, but please let me know if I've missed anything.

Thanks, and see you at SciPy 2023!