### PR TITLE
Fix typing errors in sunpy.map

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,5 +50,12 @@ repos:
     hooks:
       - id: codespell
         args: ['--config setup.cfg']
+
+  -   repo: https://github.com/pre-commit/mirrors-mypy
+      rev: 'v1.4.0'  # Use the sha / tag you want to point at
+      hooks:
+      -   id: mypy
+          args: [--config-file, pyproject.toml]
+          additional_dependencies: [dask, numpy, packaging]
 ci:
   autofix_prs: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,3 +146,25 @@ extend-ignore = [
 
 [tool.ruff.pydocstyle]
 convention = "numpy"
+
+[tool.mypy]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = ["sunpy.map.*"]
+ignore_errors = false
+
+[[tool.mypy.overrides]]
+module = [
+  "astroquery.*",
+  "astropy.*",
+  "hypothesis.*",
+  "matplotlib.*",
+  "parfive.*",
+  "pandas.*",
+  "pytest.*",
+  "reproject.*",
+  "skimage.*",
+  "sunpy_sphinx_theme.*",
+]
+ignore_missing_imports = true

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 import astropy.units as u
@@ -33,7 +35,7 @@ def meta_keywords():
 def make_fitswcs_header(data,
                         coordinate,
                         reference_pixel: u.pix = None,
-                        scale: u.arcsec/u.pix = None,
+                        scale: u.arcsec/u.pix = None, # type: ignore[valid-type]
                         rotation_angle: u.deg = None,
                         rotation_matrix=None,
                         instrument=None,
@@ -248,7 +250,7 @@ def _get_wcs_meta(coordinate, projection_code):
 
 
 @u.quantity_input
-def get_observer_meta(observer, rsun: (u.Mm, None) = None):
+def get_observer_meta(observer, rsun: Optional[u.Mm] = None):
     """
     Function to get observer meta from coordinate frame.
 

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -29,12 +29,12 @@ from sunpy.util.io import is_url, parse_path, possibly_a_path
 from sunpy.util.metadata import MetaDict
 from sunpy.util.types import DatabaseEntryType
 
-SUPPORTED_ARRAY_TYPES = (np.ndarray,)
+SUPPORTED_ARRAY_TYPES: tuple[type, ...]
 try:
     import dask.array
-    SUPPORTED_ARRAY_TYPES += (dask.array.Array,)
+    SUPPORTED_ARRAY_TYPES = (np.ndarray, dask.array.Array,)
 except ImportError:
-    pass
+    SUPPORTED_ARRAY_TYPES = (np.ndarray, )
 
 __all__ = ['Map', 'MapFactory']
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -9,6 +9,7 @@ import numbers
 import textwrap
 import itertools
 import webbrowser
+from typing import Union, Callable
 from tempfile import NamedTemporaryFile
 from collections import namedtuple
 
@@ -62,6 +63,8 @@ from sunpy.visualization.colormaps import cm as sunpy_cm
 TIME_FORMAT = config.get("general", "time_format")
 PixelPair = namedtuple('PixelPair', 'x y')
 SpatialPair = namedtuple('SpatialPair', 'axis1 axis2')
+
+_width_height_type = Union[u.pix, u.deg]
 
 _META_FIX_URL = 'https://docs.sunpy.org/en/stable/code_ref/map.html#fixing-map-metadata'
 
@@ -170,7 +173,7 @@ class GenericMap(NDData):
     SpatialPair(axis1=Unit("arcsec"), axis2=Unit("arcsec"))
     >>> aia.peek()   # doctest: +SKIP
     """
-    _registry = dict()
+    _registry: dict[type["GenericMap"], Callable] = {}
     # This overrides the default doc for the meta attribute
     meta = MetaData(doc=_meta_doc, copy=False)
     # Enabling the GenericMap reflected operators is a bit subtle.  The GenericMap
@@ -1777,7 +1780,7 @@ class GenericMap(NDData):
         return new_map
 
     @u.quantity_input
-    def submap(self, bottom_left, *, top_right=None, width: (u.deg, u.pix) = None, height: (u.deg, u.pix) = None):
+    def submap(self, bottom_left, *, top_right=None, width: _width_height_type = None, height: _width_height_type = None):
         """
         Returns a submap defined by a rectangle.
 
@@ -2214,7 +2217,7 @@ class GenericMap(NDData):
         )
 
     @u.quantity_input
-    def draw_quadrangle(self, bottom_left, *, width: (u.deg, u.pix) = None, height: (u.deg, u.pix) = None,
+    def draw_quadrangle(self, bottom_left, *, width: _width_height_type = None, height: _width_height_type = None,
                         axes=None, top_right=None, **kwargs):
         """
         Draw a quadrangle defined in world coordinates on the plot using Astropy's
@@ -2741,8 +2744,8 @@ class GenericMap(NDData):
             return outmap, footprint
         return outmap
 
-
-GenericMap.__doc__ += textwrap.indent(_notes_doc, "    ")
+if GenericMap.__doc__ is not None:
+    GenericMap.__doc__ += textwrap.indent(_notes_doc, "    ")
 
 
 class InvalidHeaderInformation(ValueError):


### PR DESCRIPTION
This PR:

- Adds configuration and pre-commit-config for running `mypy`
- Fixes errors in `sunpy.map`.

It would be nice to at least not have any typing errors across the library - whether we want to wholesale add typing is out of scope for this PR.

If people are happy with getting rid of typing errors, I can go through and do this for the rest of the library.