### PR TITLE
Monkey patch get_ftp_size with dummy in SRS client to prevent showing errors

### DIFF
--- a/changelog/7081.trivial.rst
+++ b/changelog/7081.trivial.rst
@@ -1,0 +1,1 @@
+Remove extraneous warnings when downloading SRS data (`sunpy.net.attrs.Instrument.srs_table`).

--- a/changelog/7081.trivial.rst
+++ b/changelog/7081.trivial.rst
@@ -1,1 +1,1 @@
-Remove extraneous warnings when downloading SRS data (`sunpy.net.attrs.Instrument.srs_table`).
+Remove extraneous warnings when downloading SRS data.

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -177,8 +177,8 @@ class SRSClient(GenericClient):
 
         parfive.downloader.get_ftp_size = dummy_get_ftp
 
-        dl = super().fetch(qres, path=None, overwrite=False,
-                           progress=True, downloader=None, wait=True, **kwargs)
+        dl = super().fetch(qres, path=path, overwrite=overwrite,
+                           progress=progress, downloader=downloader, wait=wait, **kwargs)
 
         parfive.downloader.get_ftp_size = orig_get_ftp
         return dl


### PR DESCRIPTION
## PR Description

When downloading SRS data the terminal is flooded with nasty looking error messages but they don't actually affect the download. This PR stops these error being raised by monkey patching the offending call `get_ftp_size` with a dummy function. For some reason it seems that the getting the size of a file is disabled on the NOAA server hence the 550 error on these calls.

Before:
```python
from sunpy.net import Fido, attrs as a
srs_query = Fido.search(a.Time('2022-12-15', '2022-12-16'), a.Instrument.srs_table)
srs_files = Fido.fetch(srs_query)
Files Downloaded:   0%|                                                                                                                                                                                                                                                                                                                             | 0/2 [00:00<?, ?file/s]Failed to get size of FTP file
Traceback (most recent call last):
  File "/Users/sm/.virtualenvs/arccnet/lib/python3.9/site-packages/parfive/utils.py", line 93, in get_ftp_size
    size = await client.stat(filepath)
  File "/Users/sm/.virtualenvs/arccnet/lib/python3.9/site-packages/aioftp/client.py", line 820, in stat
    code, info = await self.command("MLST " + str(path), "2xx")
  File "/Users/sm/.virtualenvs/arccnet/lib/python3.9/site-packages/aioftp/client.py", line 272, in command
    self.check_codes(expected_codes, code, info)
  File "/Users/sm/.virtualenvs/arccnet/lib/python3.9/site-packages/aioftp/client.py", line 224, in check_codes
    raise errors.StatusCodeError(expected_codes, received_code, info)
aioftp.errors.StatusCodeError: Waiting for ('2xx',) but got 550 [' Permission denied.']
                                    Failed to get size of FTP file
Traceback (most recent call last):
  File "/Users/sm/.virtualenvs/arccnet/lib/python3.9/site-packages/parfive/utils.py", line 93, in get_ftp_size
    size = await client.stat(filepath)
  File "/Users/sm/.virtualenvs/arccnet/lib/python3.9/site-packages/aioftp/client.py", line 820, in stat
    code, info = await self.command("MLST " + str(path), "2xx")
  File "/Users/sm/.virtualenvs/arccnet/lib/python3.9/site-packages/aioftp/client.py", line 272, in command
    self.check_codes(expected_codes, code, info)
  File "/Users/sm/.virtualenvs/arccnet/lib/python3.9/site-packages/aioftp/client.py", line 224, in check_codes
    raise errors.StatusCodeError(expected_codes, received_code, info)
aioftp.errors.StatusCodeError: Waiting for ('2xx',) but got 550 [' Permission denied.']
Files Downloaded: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.29file/s]
```

After (having deleted the previously downloaded files)

```
from sunpy.net import Fido, attrs as a
srs_query = Fido.search(a.Time('2022-12-15', '2022-12-16'), a.Instrument.srs_table)
srs_files = Fido.fetch(srs_query)
Files Downloaded: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.41file/s]
Files Downloaded: 0file [00:00, ?file/s]
```
