### PR TITLE
Unshallow clone for RTD to avoid removal of setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,8 @@ build:
   tools:
     python: "mambaforge-4.10"
   jobs:
+    post_checkout:
+      - git fetch --unshallow || true
     pre_install:
       - git update-index --assume-unchanged .rtd-environment.yml docs/conf.py
 


### PR DESCRIPTION
Hello,
Some time ago we added an optional feature to allow users to unshallow their Git repository when cloning them as part of the build process. This feature is going to be removed, as it is now user-configurable.

With the introduction of build process customization via build.jobs and build.commands, this feature is not required anymore and we are deprecating it. You now have the ability to unshallow the Git repository clone without contacting support, along with other git-related options.

We are sending you this email because you are a maintainer of the following projects that have this "feature flag" enabled and you should unshallow your clone now by using the configuration file:

https://readthedocs.org/projects/sunpy/
Note this feature flag will be completely removed on August 28th. Unshallow your clone before that date to avoid unexpected build failures. Please, refer to the example we have in the documentation to unshallow your clone via the configuration file if your projects still require it.

Keep documenting,
Read the Docs