### PR TITLE
Fix bug in get_horizons_coord time dictionary arg

### DIFF
--- a/changelog/7106.bugfix.rst
+++ b/changelog/7106.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug in `sunpy.coordinates.get_horizons_coord` when specifying the time using a dictionary, the returned times now match the supplied times.
+Fix bug in `sunpy.coordinates.get_horizons_coord` when specifying a time range via a dictionary that could cause the returned times to be slightly different from the supplied times.

--- a/changelog/7106.bugfix.rst
+++ b/changelog/7106.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in `sunpy.coordinates.get_horizons_coord` when specifying the time using a dictionary, the returned times now match the supplied times.

--- a/changelog/7106.bugfix.rst
+++ b/changelog/7106.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug in `sunpy.coordinates.get_horizons_coord` when specifying a time range via a dictionary that could cause the returned times to be slightly different from the supplied times.
+Fix bug in :func:`~sunpy.coordinates.get_horizons_coord` when specifying a time range via a dictionary that could cause the returned times to be slightly different from the supplied times.

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -327,7 +327,7 @@ def get_horizons_coord(body, time='now', id_type=None, *, include_velocity=False
 
     if isinstance(time, dict):
         obstime_tdb = parse_time(result['datetime_jd'], format='jd', scale='tdb')
-        obstime = obstime_tdb.utc
+        obstime = Time(obstime_tdb, format='isot', scale='utc')
     else:
         # JPL HORIZONS results are sorted by observation time, so this sorting needs to be undone.
         # Calling argsort() on an array returns the sequence of indices of the unsorted list to put the

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -326,7 +326,8 @@ def get_horizons_coord(body, time='now', id_type=None, *, include_velocity=False
     log.debug(f"See the raw output from the JPL HORIZONS query at {query.uri}")
 
     if isinstance(time, dict):
-        obstime = parse_time(result['datetime_jd'], format='jd', scale='tdb')
+        obstime_tdb = parse_time(result['datetime_jd'], format='jd', scale='tdb')
+        obstime = obstime_tdb.utc
     else:
         # JPL HORIZONS results are sorted by observation time, so this sorting needs to be undone.
         # Calling argsort() on an array returns the sequence of indices of the unsorted list to put the

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -303,7 +303,7 @@ def get_horizons_coord(body, time='now', id_type=None, *, include_velocity=False
         if set(time.keys()) != set(['start', 'stop', 'step']):
             raise ValueError('time dictionary must have the keys ["start", "stop", "step"]')
         epochs = time
-        jpl_fmt = '%Y-%m-%d %H:%M:%S'
+        jpl_fmt = '%Y-%m-%d %H:%M:%S.%f'
         epochs['start'] = parse_time(epochs['start']).tdb.strftime(jpl_fmt)
         epochs['stop'] = parse_time(epochs['stop']).tdb.strftime(jpl_fmt)
     else:

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -18,6 +18,7 @@ from astropy.coordinates.representation import (
     CartesianRepresentation,
     SphericalRepresentation,
 )
+from astropy.time import Time
 
 from sunpy import log
 from sunpy.time import parse_time

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -1,6 +1,7 @@
 
 import pytest
 from hypothesis import HealthCheck, given, settings
+from numpy.testing import assert_array_equal
 
 import astropy.units as u
 from astropy.constants import c as speed_of_light
@@ -126,6 +127,7 @@ def test_get_horizons_coord_dict_time():
     e = get_horizons_coord('Geocenter', time_dict)
     e_ref = get_horizons_coord('Geocenter', time_ref)
 
+    assert_array_equal(e_ref.obstime.utc.isot, e.obstime.utc.isot)
     assert_quantity_allclose(e.lon, e_ref.lon, atol=1e-9*u.deg)
     assert_quantity_allclose(e.lat, e_ref.lat)
     assert_quantity_allclose(e.radius, e_ref.radius)

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -127,6 +127,8 @@ def test_get_horizons_coord_dict_time():
     e = get_horizons_coord('Geocenter', time_dict)
     e_ref = get_horizons_coord('Geocenter', time_ref)
 
+    assert e.obstime.format == 'isot'
+    assert e.obstime.scale == 'utc'
     assert_array_equal(e_ref.obstime.utc.isot, e.obstime.utc.isot)
     assert_quantity_allclose(e.lon, e_ref.lon, atol=1e-9*u.deg)
     assert_quantity_allclose(e.lat, e_ref.lat)


### PR DESCRIPTION
## PR Description

Fix small bug in get_horizons_coord when time is specified using the dictionary format. Update code to pass full time spec (including milliseconds) to astroquery.

Closes #7105 
