### PR TITLE
Add goes-18 as possible value for satno in xrsclient

### DIFF
--- a/changelog/7108.trivial.rst
+++ b/changelog/7108.trivial.rst
@@ -1,0 +1,1 @@
+Added missing support to find GOES-18 XRS data in XRSClient.

--- a/changelog/7108.trivial.rst
+++ b/changelog/7108.trivial.rst
@@ -1,1 +1,1 @@
-Added missing support to find GOES-18 XRS data in XRSClient.
+Added missing support to find GOES-18 XRS data in `~sunpy.net.dataretriever.XRSClient`.

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -186,7 +186,7 @@ class XRSClient(GenericClient):
     @classmethod
     def register_values(cls):
         from sunpy.net import attrs
-        goes_number = [2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+        goes_number = [2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
         adict = {attrs.Instrument: [
             ("GOES", "The Geostationary Operational Environmental Satellite Program."),
             ("XRS", "GOES X-ray Sensor")],


### PR DESCRIPTION
Currently you can only get XRS data up to 17 and 18 has been in active use for a while.

There is an open question about support for goes 18 data in timeseries due to unresolved issues with the satellite calibration but I don't think that this should stop us supporting it in Fido.

```
result = Fido.search(a.Time(tstart, tend), a.Instrument("XRS"), a.Resolution('flx1s'))

np.unique(result[0]['SatelliteNumber'])

<QueryResponseColumn name='SatelliteNumber' dtype='int32' length=2>
16
18

```