### PR TITLE
Tweak to the development conda environment file to avoid triggering a Python upgrade

### DIFF
--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -16,7 +16,7 @@ dependencies:
   - packaging
   - pandas
   - parfive
-  - python
+  # - python  # Commented out to avoid triggering an upgrade
   - python_abi
   - python-dateutil
   - reproject


### PR DESCRIPTION
Our development conda environment file lists Python as a direct dependency – which of course it is – but that has the undesirable consequence that it makes it difficult to create a conda environment with a Python version other than the latest one.  If you first create a conda environment with the desired Python version and then call `conda/mamba env update -f sunpy-dev-env.yml`, it will cheerily upgrade the Python version.  (`conda env update` doesn't have the same options as `conda update` to control updating behavior.)  The simple fix is to de-list Python from the environment file as a direct dependency, and of course Python will still be an indirect dependency many times over.