### PR TITLE
Removed specifying/preserving the rotation matrix in reprojection examples

### DIFF
--- a/changelog/7114.doc.rst
+++ b/changelog/7114.doc.rst
@@ -1,0 +1,1 @@
+Removed the specification of a non-identity rotation matrix in two reprojection examples.

--- a/examples/map_transformations/reprojection_different_observers.py
+++ b/examples/map_transformations/reprojection_different_observers.py
@@ -125,7 +125,6 @@ mars_header = sunpy.map.make_fitswcs_header(
     out_shape,
     mars_ref_coord,
     scale=u.Quantity(map_aia.scale),
-    rotation_matrix=map_aia.rotation_matrix,
     instrument="AIA",
     wavelength=map_aia.wavelength
 )

--- a/examples/map_transformations/reprojection_spherical_screen.py
+++ b/examples/map_transformations/reprojection_spherical_screen.py
@@ -54,7 +54,6 @@ out_header = sunpy.map.make_fitswcs_header(
     out_shape,
     out_ref_coord,
     scale=u.Quantity(aia_map.scale),
-    rotation_matrix=aia_map.rotation_matrix,
     instrument=aia_map.instrument,
     wavelength=aia_map.wavelength
 )


### PR DESCRIPTION
Some of our reprojection examples create custom headers, and they specify the rotation matrix from the source map.  While there's no reason that shouldn't be done, the reprojection is for the view from a wholly new observer, which has no connection to the rotation of the source map.  For AIA maps, it doesn't really matter because the rotation matrix is close to the identity matrix.  For other sources, where source maps can be "upside down", that can be unnecessarily confusing.

This PR removes the specifications of the rotation matrix.