### PR TITLE
Provide a planar screen as an optional assumption for handling off-disk helioprojective coordinates

### DIFF
--- a/changelog/7115.deprecation.rst
+++ b/changelog/7115.deprecation.rst
@@ -1,0 +1,1 @@
+`~sunpy.coordinates.Helioprojective.assume_spherical_screen` has been deprecated in favor of `~sunpy.coordinates.SphericalScreen`.

--- a/changelog/7115.feature.rst
+++ b/changelog/7115.feature.rst
@@ -1,0 +1,1 @@
+Added `~sunpy.coordinates.PlanarScreen` for realizing 3D versions of coordinates in a Helioprojective frame.

--- a/docs/reference/coordinates/index.rst
+++ b/docs/reference/coordinates/index.rst
@@ -98,7 +98,6 @@ see `Thompson (2006) <https://doi.org/10.1051/0004-6361:20054262>`_
 and `Franz & Harper (2002) <https://doi.org/10.1016/S0032-0633(01)00119-2>`_
 (and `corrected version <https://www2.mps.mpg.de/homes/fraenz/systems/systems3art/systems3art.html>`_).
 
-
 Reference/API
 =============
 
@@ -122,10 +121,11 @@ The parts of the following modules that are useful to a typical user are already
 
 .. automodapi:: sunpy.coordinates.frames
 
+.. automodapi:: sunpy.coordinates.screens
+
 .. automodapi:: sunpy.coordinates.metaframes
 
 .. automodapi:: sunpy.coordinates.wcs_utils
-
 
 Attribution
 ===========

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -115,3 +115,16 @@ You can specify this by passing the ``hdus`` keyword argument to `~sunpy.map.Map
 .. code-block:: python
 
     >>> sunpy.map.Map("adapt40311_03k012_202401020800_i00005600n1.fts.gz", hdus=0)  # doctest: +SKIP
+
+New `~sunpy.coordinates.PlanarScreen` context manager
+=====================================================
+
+`~sunpy.coordinates.PlanarScreen` provides a context manager for interpreting 2D coordinates as being on the inside of a planar screen.
+The plane goes through Sun center (or some specified distance from Sun center) and is perpendicular to the vector between the specified vantage point and Sun center.
+This replaces the default assumption where 2D coordinates are mapped onto the surface of the Sun and is an alternative to `~sunpy.coordinates.SphericalScreen`.
+
+Deprecate `~sunpy.coordinates.assume_spherical_screen`
+======================================================
+
+:func:`~sunpy.coordinates.assume_spherical_screen` is now deprecated.
+Equivalent functionality is now provided by :class:`~sunpy.coordinates.SphericalScreen`.

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -123,8 +123,8 @@ New `~sunpy.coordinates.PlanarScreen` context manager
 The plane goes through Sun center (or some specified distance from Sun center) and is perpendicular to the vector between the specified vantage point and Sun center.
 This replaces the default assumption where 2D coordinates are mapped onto the surface of the Sun and is an alternative to `~sunpy.coordinates.SphericalScreen`.
 
-Deprecate `~sunpy.coordinates.assume_spherical_screen`
-======================================================
+Deprecate `~sunpy.coordinates.Helioprojective.assume_spherical_screen`
+======================================================================
 
-:func:`~sunpy.coordinates.assume_spherical_screen` is now deprecated.
+:func:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` is now deprecated.
 Equivalent functionality is now provided by :class:`~sunpy.coordinates.SphericalScreen`.

--- a/examples/map_transformations/autoalign_aia_hmi.py
+++ b/examples/map_transformations/autoalign_aia_hmi.py
@@ -53,7 +53,7 @@ map_hmi.plot(axes=ax2)
 # Note that off-disk HMI data are not retained by default because an
 # additional assumption is required to define the location of the HMI
 # emission in 3D space. We can use
-# :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` to
+# :meth:`~sunpy.coordinates.SphericalScreen` to
 # retain the off-disk HMI data. See
 # :ref:`sphx_glr_generated_gallery_map_transformations_reprojection_spherical_screen.py`
 # for more reference.

--- a/examples/map_transformations/reprojection_align_aia_hmi.py
+++ b/examples/map_transformations/reprojection_align_aia_hmi.py
@@ -59,7 +59,7 @@ out_hmi = map_hmi.reproject_to(map_aia.wcs)
 # Note that off-disk HMI data are not retained by default because an
 # additional assumption is required to define the location of the HMI
 # emission in 3D space. We can use
-# :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` to
+# :meth:`~sunpy.coordinates.SphericalScreen` to
 # retain the off-disk HMI data. See
 # :ref:`sphx_glr_generated_gallery_map_transformations_reprojection_spherical_screen.py`
 # for more reference.

--- a/examples/map_transformations/reprojection_spherical_screen.py
+++ b/examples/map_transformations/reprojection_spherical_screen.py
@@ -19,7 +19,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 import sunpy.map
-from sunpy.coordinates import Helioprojective
+from sunpy.coordinates import SphericalScreen
 from sunpy.data.sample import AIA_171_IMAGE
 
 ######################################################################
@@ -79,7 +79,7 @@ plt.show()
 # not obvious in this plot due to the relatively small field of view
 # of AIA (compared to, say, a coronagraph).
 
-with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate):
+with SphericalScreen(aia_map.observer_coordinate):
     outmap_screen_all = aia_map.reproject_to(out_header)
 
 fig = plt.figure()
@@ -92,8 +92,7 @@ plt.show()
 # be used for only off-disk parts of the image, and continue to map
 # on-disk parts of the image to the surface of the Sun.
 
-with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate,
-                                             only_off_disk=True):
+with SphericalScreen(aia_map.observer_coordinate, only_off_disk=True):
     outmap_screen_off_disk = aia_map.reproject_to(out_header)
 
 fig = plt.figure()

--- a/examples/plotting/lasco_overlay.py
+++ b/examples/plotting/lasco_overlay.py
@@ -16,7 +16,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 import sunpy.data.sample
-from sunpy.coordinates import Helioprojective
+from sunpy.coordinates import SphericalScreen
 from sunpy.map import Map
 from sunpy.util.config import get_and_create_download_dir
 
@@ -36,7 +36,7 @@ aia_map = Map(sunpy.data.sample.AIA_171_IMAGE)
 # Note that off-disk AIA data are not retained by default because an
 # additional assumption is required to define the location of the AIA
 # emission in 3D space. We can use
-# :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` to
+# :meth:`~sunpy.coordinates.SphericalScreen` to
 # retain the off-disk AIA data. See
 # :ref:`sphx_glr_generated_gallery_map_transformations_reprojection_spherical_screen.py`
 # for more reference.
@@ -51,9 +51,9 @@ projected_header = sunpy.map.make_fitswcs_header(aia_map.data.shape,
                                                  scale=u.Quantity(aia_map.scale),
                                                  instrument=aia_map.instrument,
                                                  wavelength=aia_map.wavelength)
-# We use `assume_spherical_screen` to ensure that the off limb AIA pixels are reprojected
+# We use `SphericalScreen` to ensure that the off limb AIA pixels are reprojected
 # otherwise it will only be the on disk pixels that are reprojected.
-with Helioprojective.assume_spherical_screen(aia_map.observer_coordinate):
+with SphericalScreen(aia_map.observer_coordinate):
     aia_reprojected = aia_map.reproject_to(projected_header)
 
 ###############################################################################

--- a/examples/plotting/mplcairo_plotting.py
+++ b/examples/plotting/mplcairo_plotting.py
@@ -48,17 +48,17 @@ import astropy.units as u
 
 import sunpy.data.sample
 import sunpy.map
-from sunpy.coordinates import Helioprojective
+from sunpy.coordinates import SphericalScreen
 
 ###############################################################################
 # Let's load two maps for blending. We reproject the second map to the
 # coordinate frame of the first map for proper compositing, taking care to use
-# the :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen`
+# the :meth:`~sunpy.coordinates.Helioprojective.Spherical`
 # context manager in order to preserve off-disk data.
 
 a171 = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 a131 = sunpy.map.Map(sunpy.data.sample.AIA_131_IMAGE)
-with Helioprojective.assume_spherical_screen(a171.observer_coordinate):
+with SphericalScreen(a171.observer_coordinate):
     a131 = a131.reproject_to(a171.wcs)
 
 ###############################################################################

--- a/examples/plotting/mplcairo_plotting.py
+++ b/examples/plotting/mplcairo_plotting.py
@@ -53,7 +53,7 @@ from sunpy.coordinates import SphericalScreen
 ###############################################################################
 # Let's load two maps for blending. We reproject the second map to the
 # coordinate frame of the first map for proper compositing, taking care to use
-# the :meth:`~sunpy.coordinates.Helioprojective.Spherical`
+# the :class:`~sunpy.coordinates.SphericalScreen`
 # context manager in order to preserve off-disk data.
 
 a171 = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)

--- a/examples/plotting/three_map_composite.py
+++ b/examples/plotting/three_map_composite.py
@@ -13,7 +13,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 import sunpy.data.sample
-from sunpy.coordinates import Helioprojective
+from sunpy.coordinates import SphericalScreen
 from sunpy.map import Map
 
 ###############################################################################
@@ -32,7 +32,7 @@ aia = Map(sunpy.data.sample.AIA_171_IMAGE)
 # overlaid. Next, zoom in around the solar flare so the RHESSI contours are
 # visible. Also, specify the RHESSI contour levels to be plotted.
 
-with Helioprojective.assume_spherical_screen(eit.observer_coordinate):
+with SphericalScreen(eit.observer_coordinate):
     aia = aia.reproject_to(eit.wcs)
 
 bottom_left = [200, -800] * u.arcsec

--- a/examples/showcase/stereoscopic_3d.py
+++ b/examples/showcase/stereoscopic_3d.py
@@ -20,7 +20,7 @@ from astropy.coordinates import SkyCoord
 
 import sunpy.data.sample
 import sunpy.map
-from sunpy.coordinates import Helioprojective
+from sunpy.coordinates import SphericalScreen
 
 ##############################################################################
 # Download co-temporal SDO/AIA image STEREO/EUVI images.  The EUVI map does
@@ -57,7 +57,7 @@ def reproject_to_1au(in_map):
         ),
         scale=(2.2, 2.2)*u.arcsec/u.pixel
     )
-    with Helioprojective.assume_spherical_screen(in_map.observer_coordinate):
+    with SphericalScreen(in_map.observer_coordinate):
         return in_map.reproject_to(header)
 
 

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -23,7 +23,7 @@ from ._transformations import _make_sunpy_graph, propagate_with_solar_surface, t
 from .ephemeris import *
 from .frames import *
 from .metaframes import *
-from .screens import *
+from .screens import PlanarScreen, SphericalScreen
 from .wcs_utils import *
 
 __doc__ += _make_sunpy_graph()

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -23,6 +23,7 @@ from ._transformations import _make_sunpy_graph, propagate_with_solar_surface, t
 from .ephemeris import *
 from .frames import *
 from .metaframes import *
+from .screens import *
 from .wcs_utils import *
 
 __doc__ += _make_sunpy_graph()

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -28,7 +28,7 @@ from astropy.utils.data import download_file
 from sunpy import log
 from sunpy.sun.constants import radius as _RSUN
 from sunpy.time.time import _variables_for_parse_time_docstring
-from sunpy.util.decorators import add_common_docstring, deprecated
+from sunpy.util.decorators import add_common_docstring, deprecated, sunpycontextmanager
 from sunpy.util.exceptions import warn_user
 from .frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy
 
@@ -671,7 +671,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     _assumed_screen = None
 
     @classmethod
-    @contextmanager
+    @sunpycontextmanager
     @deprecated('6.0', alternative='sunpy.coordinates.screens.SphericalScreen')
     def assume_spherical_screen(cls, center, only_off_disk=False):
         try:

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -28,7 +28,7 @@ from astropy.utils.data import download_file
 from sunpy import log
 from sunpy.sun.constants import radius as _RSUN
 from sunpy.time.time import _variables_for_parse_time_docstring
-from sunpy.util.decorators import add_common_docstring, sunpycontextmanager
+from sunpy.util.decorators import add_common_docstring, deprecated
 from sunpy.util.exceptions import warn_user
 from .frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy
 
@@ -672,24 +672,11 @@ class Helioprojective(SunPyBaseCoordinateFrame):
 
     @classmethod
     @contextmanager
-    def assume_screen(cls, screen):
-        """
-        Context manager to interpret 2D coordinates as being on some surface.
-        """
-        try:
-            old_assumed_screen = cls._assumed_screen  # nominally None
-            cls._assumed_screen = screen
-            yield
-        finally:
-            cls._assumed_screen = old_assumed_screen
-
-    @classmethod
-    @contextmanager
+    @deprecated('6.0', alternative='sunpy.coordinates.screens.SphericalScreen')
     def assume_spherical_screen(cls, center, only_off_disk=False):
-        # TODO: this should issue a deprecation warning
         try:
             old_assumed_screen = cls._assumed_screen  # nominally None
-            from sunpy.coordinates.screens import SphericalScreen
+            from sunpy.coordinates import SphericalScreen
             sph_screen = SphericalScreen(center, only_off_disk=only_off_disk)
             cls._assumed_screen = sph_screen
             yield

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -583,7 +583,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
             warn_user("The conversion of these 2D helioprojective coordinates to 3D is all NaNs "
                       "because off-disk coordinates need an additional assumption to be mapped to "
                       "calculate distance from the observer. Consider using the context manager "
-                      "`Helioprojective.assume_spherical_screen()`.")
+                      "`SphericalScreen()`.")
 
         return self.realize_frame(SphericalRepresentation(lon=lon,
                                                           lat=lat,

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -684,11 +684,17 @@ class Helioprojective(SunPyBaseCoordinateFrame):
             cls._assumed_screen = old_assumed_screen
 
     @classmethod
+    @contextmanager
     def assume_spherical_screen(cls, center, only_off_disk=False):
         # TODO: this should issue a deprecation warning
-        from sunpy.coordinates.screens import SphericalScreen
-        sph_screen = SphericalScreen(center, only_off_disk=only_off_disk)
-        cls.assume_screen(sph_screen)
+        try:
+            old_assumed_screen = cls._assumed_screen  # nominally None
+            from sunpy.coordinates.screens import SphericalScreen
+            sph_screen = SphericalScreen(center, only_off_disk=only_off_disk)
+            cls._assumed_screen = sph_screen
+            yield
+        finally:
+            cls._assumed_screen = old_assumed_screen
 
 
 @add_common_docstring(**_frame_parameters())

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -61,7 +61,7 @@ class SphericalScreen(BaseScreen):
 
     Examples
     --------
-    .. minigallery:: sunpy.coordinates.Helioprojective.SphericalScreen
+    .. minigallery:: sunpy.coordinates.SphericalScreen
 
     >>> import astropy.units as u
     >>> from sunpy.coordinates import Helioprojective, SphericalScreen

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -53,7 +53,7 @@ class SphericalScreen(BaseScreen):
 
     Examples
     --------
-    .. minigallery:: sunpy.coordinates.Helioprojective.assume_spherical_screen
+    .. minigallery:: sunpy.coordinates.Helioprojective.SphericalScreen
 
     >>> import astropy.units as u
     >>> from sunpy.coordinates import Helioprojective, SphericalScreen

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -113,7 +113,6 @@ class PlanarScreen(BaseScreen):
 
     The plane goes through Sun center and is perpendicular to the vector between the
     specified vantage point and Sun center.
-
     This replaces the default assumption where 2D coordinates are mapped onto the surface of the
     Sun.
 
@@ -127,6 +126,36 @@ class PlanarScreen(BaseScreen):
     only_off_disk : `bool`, optional
         If `True`, apply this assumption only to off-disk coordinates, with on-disk coordinates
         still mapped onto the surface of the Sun.  Defaults to `False`.
+
+    Examples
+    --------
+
+    >>> import astropy.units as u
+    >>> from sunpy.coordinates import Helioprojective, PlanarScreen
+    >>> h = Helioprojective(range(7)*u.arcsec*319, [0]*7*u.arcsec,
+    ...                     observer='earth', obstime='2020-04-08')
+    >>> print(h.make_3d())
+    <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+        [(   0., 0., 0.99660825), ( 319., 0., 0.99687244),
+            ( 638., 0., 0.99778472), ( 957., 0., 1.00103285),
+            (1276., 0.,        nan), (1595., 0.,        nan),
+            (1914., 0.,        nan)]>
+
+    >>> with PlanarScreen(h.observer):
+    ...     print(h.make_3d())
+    <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+        [(   0., 0., 1.00125872), ( 319., 0., 1.00125992),
+            ( 638., 0., 1.00126351), ( 957., 0., 1.0012695 ),
+            (1276., 0., 1.00127788), (1595., 0., 1.00128866),
+            (1914., 0., 1.00130183)]>
+
+    >>> with PlanarScreen(h.observer, distance_from_center=1*u.R_sun):
+    ...     print(h.make_3d())
+    <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+        [(   0., 0., 0.99660825), ( 319., 0., 0.99660944),
+            ( 638., 0., 0.99661302), ( 957., 0., 0.99661898),
+            (1276., 0., 0.99662732), (1595., 0., 0.99663805),
+            (1914., 0., 0.99665116)]>
     """
 
     @u.quantity_input

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -1,0 +1,129 @@
+"""
+Screen class definitions for making assumptions about off-disk emission
+"""
+import numpy as np
+
+from astropy.coordinates.representation import CartesianRepresentation, UnitSphericalRepresentation
+
+from sunpy.coordinates import HeliographicStonyhurst
+
+__all__ = ['SphericalScreen', 'PlanarScreen']
+
+
+class BaseScreen:
+
+    def __init__(self, type, only_off_disk=False):
+        self.type = type
+        self.only_off_disk = only_off_disk
+
+    def calculate_distance(self):
+        raise NotImplementedError
+
+
+class SphericalScreen(BaseScreen):
+    """
+    Context manager to interpret 2D coordinates as being on the inside of a spherical screen.
+
+    The radius of the screen is the distance between the specified ``center`` and Sun center.
+    This ``center`` does not have to be the same as the observer location for the coordinate
+    frame.  If they are the same, then this context manager is equivalent to assuming that the
+    helioprojective "zeta" component is zero.
+
+    This replaces the default assumption where 2D coordinates are mapped onto the surface of the
+    Sun.
+
+    Parameters
+    ----------
+    center : `~astropy.coordinates.SkyCoord`
+        The center of the spherical screen
+    only_off_disk : `bool`, optional
+        If `True`, apply this assumption only to off-disk coordinates, with on-disk coordinates
+        still mapped onto the surface of the Sun.  Defaults to `False`.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.coordinates.Helioprojective.assume_spherical_screen
+
+    >>> import astropy.units as u
+    >>> from sunpy.coordinates import Helioprojective
+    >>> h = Helioprojective(range(7)*u.arcsec*319, [0]*7*u.arcsec,
+    ...                     observer='earth', obstime='2020-04-08')
+    >>> print(h.make_3d())
+    <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+        [(   0., 0., 0.99660825), ( 319., 0., 0.99687244),
+            ( 638., 0., 0.99778472), ( 957., 0., 1.00103285),
+            (1276., 0.,        nan), (1595., 0.,        nan),
+            (1914., 0.,        nan)]>
+
+    >>> with Helioprojective.assume_spherical_screen(h.observer):
+    ...     print(h.make_3d())
+    <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+        [(   0., 0., 1.00125872), ( 319., 0., 1.00125872),
+            ( 638., 0., 1.00125872), ( 957., 0., 1.00125872),
+            (1276., 0., 1.00125872), (1595., 0., 1.00125872),
+            (1914., 0., 1.00125872)]>
+
+    >>> with Helioprojective.assume_spherical_screen(h.observer, only_off_disk=True):
+    ...     print(h.make_3d())
+    <Helioprojective Coordinate (obstime=2020-04-08T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
+        [(   0., 0., 0.99660825), ( 319., 0., 0.99687244),
+            ( 638., 0., 0.99778472), ( 957., 0., 1.00103285),
+            (1276., 0., 1.00125872), (1595., 0., 1.00125872),
+            (1914., 0., 1.00125872)]>
+    """
+
+    def __init__(self, center, **kwargs):
+        super().__init__('spherical', **kwargs)
+        self.center = center
+
+    @property
+    def center_hgs(self):
+        hgs_frame = HeliographicStonyhurst(obstime=self.center.obstime)
+        return self.center.transform_to(hgs_frame)
+
+    @property
+    def radius(self):
+        return self.center_hgs.radius
+
+    def calculate_distance(self, frame):
+        sphere_center = self.center.transform_to(frame).cartesian
+        c = sphere_center.norm()**2 - self.radius**2
+        rep = frame.represent_as(UnitSphericalRepresentation)
+        b = -2 * sphere_center.dot(rep)
+        # Ignore sqrt of NaNs
+        with np.errstate(invalid='ignore'):
+            distance = ((-1*b) + np.sqrt(b**2 - 4*c)) / 2  # use the "far" solution
+        return distance
+
+
+class PlanarScreen(BaseScreen):
+    """
+    Context manager to interpret 2D coordinates as being on the inside of a planar screen.
+
+    The plane goes through Sun center and is perpendicular to the vector between the
+    specified vantage point and Sun center.
+
+    This replaces the default assumption where 2D coordinates are mapped onto the surface of the
+    Sun.
+
+    Parameters
+    ----------
+    vantage_point : `~astropy.coordinates.SkyCoord`
+        The vantage point that defines the orientation of the plane.
+    only_off_disk : `bool`, optional
+        If `True`, apply this assumption only to off-disk coordinates, with on-disk coordinates
+        still mapped onto the surface of the Sun.  Defaults to `False`.
+    """
+
+    def __init__(self, vantage_point, **kwargs):
+        super().__init__('planar', **kwargs)
+        self.vantage_point = vantage_point
+
+    def calculate_distance(self, frame):
+        direction = self.vantage_point.transform_to(frame).cartesian
+        direction = CartesianRepresentation(1, 0, 0) * frame.observer.radius - direction
+        direction /= direction.norm()
+        d_from_plane = frame.observer.radius * direction.x
+        rep = frame.represent_as(UnitSphericalRepresentation)
+        distance = d_from_plane / rep.dot(direction)
+        return distance

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -11,7 +11,7 @@ from astropy.coordinates.representation import CartesianRepresentation, UnitSphe
 from sunpy.coordinates import HeliographicStonyhurst, Helioprojective
 from sunpy.util.decorators import ACTIVE_CONTEXTS
 
-__all__ = ['SphericalScreen', 'PlanarScreen']
+__all__ = ['BaseScreen', 'SphericalScreen', 'PlanarScreen']
 
 
 class BaseScreen(abc.ABC):

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -525,11 +525,11 @@ def off_limb_coord():
 def test_screen_classes(off_limb_coord, screen_class):
     # Smoke test for spherical screen
     with pytest.warns(SunpyUserWarning, match='The conversion of these 2D helioprojective coordinates to 3D is all NaNs'):
-            olc_3d = off_limb_coord.make_3d()
+            olc_3d = off_limb_coord[0].make_3d()
     assert np.isnan(olc_3d.distance).all()
-    sph_screen = screen_class(off_limb_coord.observer)
+    sph_screen = screen_class(off_limb_coord[0].observer)
     with sph_screen:
-        olc_3d = off_limb_coord.make_3d()
+        olc_3d = off_limb_coord[0].make_3d()
     assert not np.isnan(olc_3d.distance).all()
 
 

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -538,6 +538,7 @@ def test_assume_spherical_screen_deprecated(off_limb_coord):
         with Helioprojective.assume_spherical_screen(off_limb_coord.observer):
             _ = off_limb_coord.make_3d()
 
+
 @pytest.mark.parametrize(('only_off_disk', 'distance_from_center', 'distance'), [
     (False, 0*u.m, [0.98331616, 0.98329512, 0.98331616]*u.AU),
     (True, 0*u.m, [0.98331616, 0.97910333, 0.98331616]*u.AU),
@@ -545,5 +546,15 @@ def test_assume_spherical_screen_deprecated(off_limb_coord):
 ])
 def test_planar_screen(off_limb_coord, only_off_disk, distance_from_center, distance):
     with PlanarScreen(off_limb_coord.observer, distance_from_center=distance_from_center, only_off_disk=only_off_disk):
+        olc_3d = off_limb_coord.make_3d()
+    assert u.quantity.allclose(olc_3d.distance, distance)
+
+
+@pytest.mark.parametrize(('only_off_disk', 'distance'), [
+    (False, [0.98329304, 0.98329304, 0.98329304]*u.AU),
+    (True, [0.98329304, 0.97910333, 0.98329304]*u.AU),
+])
+def test_spherical_screen(off_limb_coord, only_off_disk, distance):
+    with SphericalScreen(off_limb_coord.observer, only_off_disk=only_off_disk):
         olc_3d = off_limb_coord.make_3d()
     assert u.quantity.allclose(olc_3d.distance, distance)

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2731,7 +2731,7 @@ class GenericMap(NDData):
         .. minigallery:: sunpy.map.GenericMap.reproject_to
         """
         # Check if both context managers are active
-        if ACTIVE_CONTEXTS.get('propagate_with_solar_surface', False) and ACTIVE_CONTEXTS.get('SphericalScreen', False):
+        if ACTIVE_CONTEXTS.get('propagate_with_solar_surface', False) and ACTIVE_CONTEXTS.get('assume_spherical_screen', False):
             warn_user("Using propagate_with_solar_surface and SphericalScreen together result in loss of off-disk data.")
 
         try:

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1917,7 +1917,7 @@ class GenericMap(NDData):
             "coordinate frame contain NaN values and cannot be used to crop the map. "
             "The most common reason for NaN values is transforming off-disk 2D "
             "coordinates without specifying an assumption (e.g., via the"
-            "`Helioprojective.assume_spherical_screen()` context manager) that allows "
+            "`sunpy.coordinates.SphericalScreen()` context manager) that allows "
             "such coordinates to be interpreted as 3D coordinates."
         )
         if np.any(np.isnan(pixel_corners)):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2505,7 +2505,7 @@ class GenericMap(NDData):
         beyond the solar disk may not appear, which may also inhibit Matplotlib's
         autoscaling of the plot limits.  The plot limits can be set manually.
         To preserve the off-disk parts of the map, using the
-        :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` context
+        :meth:`~sunpy.coordinates.SphericalScreen` context
         manager may be appropriate.
         """
         # Todo: remove this when deprecate_positional_args_since is removed
@@ -2731,8 +2731,8 @@ class GenericMap(NDData):
         .. minigallery:: sunpy.map.GenericMap.reproject_to
         """
         # Check if both context managers are active
-        if ACTIVE_CONTEXTS.get('propagate_with_solar_surface', False) and ACTIVE_CONTEXTS.get('assume_spherical_screen', False):
-            warn_user("Using propagate_with_solar_surface and assume_spherical_screen together result in loss of off-disk data.")
+        if ACTIVE_CONTEXTS.get('propagate_with_solar_surface', False) and ACTIVE_CONTEXTS.get('SphericalScreen', False):
+            warn_user("Using propagate_with_solar_surface and SphericalScreen together result in loss of off-disk data.")
 
         try:
             import reproject

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -11,8 +11,8 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
+import sunpy.coordinates
 import sunpy.map
-from sunpy.coordinates import frames
 from sunpy.coordinates._transformations import propagate_with_solar_surface
 from sunpy.tests.helpers import figure_test
 from sunpy.util.exceptions import SunpyUserWarning
@@ -135,7 +135,7 @@ def test_rsun_mismatch_warning(aia171_test_map, hpc_header):
 
 def test_reproject_to_warn_using_contexts(aia171_test_map, hpc_header):
     with propagate_with_solar_surface():
-        with frames.Helioprojective.assume_spherical_screen(aia171_test_map.observer_coordinate):
+        with sunpy.coordinates.SphericalScreen(aia171_test_map.observer_coordinate):
             # Check if a warning is raised if both context managers are used at the same time.
-            with pytest.warns(UserWarning, match="Using propagate_with_solar_surface and assume_spherical_screen together result in loss of off-disk data."):
+            with pytest.warns(UserWarning, match="Using propagate_with_solar_surface and SphericalScreen together result in loss of off-disk data."):
                 aia171_test_map.reproject_to(hpc_header)


### PR DESCRIPTION
Expanding beyond `assume_spherical_screen()` (see #4003), this PR adds a planar screen as an optional assumption for handling off-disk helioprojective coordinates.

![screen_comparison](https://github.com/sunpy/sunpy/assets/991759/43ccf08d-58fa-41b0-89aa-a686c0af22fb)

See also #6411