### PR TITLE
Add a function to calculate the solar eclipse amount for an observer

### DIFF
--- a/changelog/7142.doc.rst
+++ b/changelog/7142.doc.rst
@@ -1,0 +1,1 @@
+Added an example (:ref:`sphx_glr_generated_gallery_showcase_eclipse_amount.py`) to show how to obtain information about a solar eclipse using :func:`sunpy.coordinates.sun.eclipse_amount`.

--- a/changelog/7142.feature.1.rst
+++ b/changelog/7142.feature.1.rst
@@ -1,0 +1,1 @@
+Added a keyword option (``quiet``) for :func:`~sunpy.coordinates.get_body_heliographic_stonyhurst` to silence the normal reporting of the light-travel-time correction when ``observer`` is specified.

--- a/changelog/7142.feature.2.rst
+++ b/changelog/7142.feature.2.rst
@@ -1,0 +1,1 @@
+Added the function :func:`sunpy.coordinates.sun.eclipse_amount` to calculate the solar-eclipse amount for an observer.

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -27,3 +27,10 @@ The people who have contributed to the code for this release are:
 -  No one who matters  *
 
 Where a * indicates that this release contains their first contribution to sunpy.
+
+Calculating the amount of solar eclipse
+=======================================
+In anticipation of the upcoming `"Great North American Eclipse" <https://en.wikipedia.org/wiki/Solar_eclipse_of_April_8,_2024>`__ on April 8, 2024, there is a new function :func:`sunpy.coordinates.sun.eclipse_amount` that returns how much of the Sun is occulted by the Moon at the specified observer location and time.
+The output can be used to determine the start/end times of partial eclipse and of totality.
+
+.. minigallery:: sunpy.coordinates.sun.eclipse_amount

--- a/examples/showcase/eclipse_amount.py
+++ b/examples/showcase/eclipse_amount.py
@@ -1,0 +1,94 @@
+"""
+===================================
+Obtaining solar-eclipse information
+===================================
+
+How to obtain information about a solar eclipse
+
+The function :func:`sunpy.coordinates.sun.eclipse_amount` returns how much of
+the Sun is occulted by the Moon at the specified time(s).  This example
+showcases how one can use the the output of this function to calculate the
+start/end times of an eclipse and to plot the eclipse amount as a function of
+time.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.dates import DateFormatter
+
+import astropy.units as u
+from astropy.coordinates import EarthLocation, solar_system_ephemeris
+from astropy.time import Time
+
+from sunpy.coordinates import sun
+
+##############################################################################
+# Define a location near San Antonio, Texas, that falls on both the path of
+# the 2023 annular eclipse and the path of the 2024 total eclipse.
+
+location = EarthLocation.from_geodetic(-98.5*u.deg, 29.6*u.deg)
+max2023 = Time('2023-10-14 16:54')
+max2024 = Time('2024-04-08 18:35')
+
+##############################################################################
+# Define a function to calculate start/end eclipse times and plot the eclipse
+# timeseries within +/- 2 hours of the time of interest.
+
+def plot_eclipse_timeseries(location, time):
+    # Define an array of observation times centered around the time of interest
+    times = time + np.concatenate([np.arange(-120, -5) * u.min,
+                                   np.arange(-300, 300) * u.s,
+                                   np.arange(5, 121) * u.min])
+
+    # Create an observer coordinate for the time array
+    observer = location.get_itrs(times)
+
+    # Calculate the eclipse amounts using a JPL ephemeris
+    with solar_system_ephemeris.set('de440s'):
+        amount = sun.eclipse_amount(observer)
+        amount_minimum = sun.eclipse_amount(observer, minimum=True)
+
+    # Calculate the start/end points of partial/total solar eclipse
+    partial = np.flatnonzero(amount > 0)
+    if len(partial) > 0:
+        print("Eclipse detected:")
+        start_partial, end_partial = times[partial[[0, -1]]]
+        print(f"  Partial solar eclipse starts at {start_partial} UTC")
+
+        total = np.flatnonzero(amount_minimum == 1)
+        if len(total) > 0:
+            start_total, end_total = times[total[[0, -1]]]
+            print(f"  Total solar eclipse starts at {start_total} UTC\n"
+                  f"  Total solar eclipse ends at {end_total} UTC")
+        print(f"  Partial solar eclipse ends at {end_partial} UTC")
+
+    # Plot the eclipse timeseries
+    fig = plt.figure(layout="constrained")
+    ax = fig.add_subplot()
+
+    ax.plot(times.datetime64, amount)
+
+    ax.set_ylim(0, 105)
+
+    ax.xaxis.set_major_formatter(DateFormatter('%I:%M %p', tz='US/Central'))
+    ax.tick_params('x', rotation=90)
+
+    ax.set_title(f"{time.strftime('%Y %B %d')}")
+    ax.set_ylabel("Eclipse percentage")
+    ax.set_xlabel("Local time (US/Central)")
+    ax.grid()
+
+
+##############################################################################
+# Plot the timeseries for the 2023 annular eclipse.  Note that the eclipse
+# amount reaches a maximum of only ~90%, as expected.
+
+plot_eclipse_timeseries(location, max2023)
+
+##############################################################################
+# Plot the timeseries for the 2024 total eclipse.  Since the eclipse amount
+# reaches 100%, the above function also calculates the start/end of total
+# eclipse.
+
+plot_eclipse_timeseries(location, max2024)
+
+plt.show()

--- a/examples/showcase/eclipse_amount.py
+++ b/examples/showcase/eclipse_amount.py
@@ -45,7 +45,7 @@ def plot_eclipse_timeseries(location, time):
     # Calculate the eclipse amounts using a JPL ephemeris
     with solar_system_ephemeris.set('de440s'):
         amount = sun.eclipse_amount(observer)
-        amount_minimum = sun.eclipse_amount(observer, minimum=True)
+        amount_minimum = sun.eclipse_amount(observer, moon_radius='minimum')
 
     # Calculate the start/end points of partial/total solar eclipse
     partial = np.flatnonzero(amount > 0)

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -34,7 +34,8 @@ __all__ = ['get_body_heliographic_stonyhurst', 'get_earth',
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())
-def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include_velocity=False):
+def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include_velocity=False,
+                                     quiet=False):
     """
     Return a `~sunpy.coordinates.frames.HeliographicStonyhurst` frame for the location of a
     solar-system body at a specified time.  The location can be corrected for light travel time
@@ -52,6 +53,9 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include
         travel time to the specified observer)
     include_velocity : `bool`, optional
         If True, include the body's velocity in the output coordinate.  Defaults to False.
+    quiet : `bool`, optional
+        If True, the function will not emit logger output for light-travel-time corrections.
+        Defaults to False.
 
     Returns
     -------
@@ -115,11 +119,13 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include
             light_travel_time = distance / speed_of_light
             emitted_time = obstime - light_travel_time
 
-        if light_travel_time.isscalar:
-            ltt_string = f"{light_travel_time.to_value('s'):.2f}"
-        else:
-            ltt_string = f"{light_travel_time.to_value('s')}"
-        log.info(f"Apparent body location accounts for {ltt_string} seconds of light travel time")
+        if not quiet:
+            if light_travel_time.isscalar:
+                ltt_string = f"{light_travel_time.to_value('s'):.2f}"
+            else:
+                ltt_string = f"{light_travel_time.to_value('s')}"
+            log.info(f"Apparent body location accounts for {ltt_string} "
+                     "seconds of light travel time")
 
     if include_velocity:
         pos, vel = get_body_barycentric_posvel(body, emitted_time)

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -752,6 +752,10 @@ def eclipse_amount(observer, *, minimum=False):
     solar eclipses.  See
     `this page <https://eclipse.gsfc.nasa.gov/SEmono/reference/radius.html>`__
     for relevant discussion.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.coordinates.sun.eclipse_amount
     """
     # TODO: Find somewhere more appropriate to define these constants
     # The radius of the Moon to use (in units of Earth radii)

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -4,6 +4,7 @@ Sun-specific coordinate calculations
 import numpy as np
 
 import astropy.units as u
+from astropy.constants import R_earth
 from astropy.constants import c as speed_of_light
 from astropy.coordinates import (
     ITRS,
@@ -30,7 +31,7 @@ from sunpy.time import parse_time
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
 from ._transformations import _SOLAR_NORTH_POLE_HCRS, _SUN_DETILT_MATRIX
-from .ephemeris import get_earth
+from .ephemeris import get_body_heliographic_stonyhurst, get_earth
 from .frames import HeliographicStonyhurst
 
 __author__ = "Albert Y. Shih"
@@ -43,7 +44,7 @@ __all__ = [
     "mean_obliquity_of_ecliptic", "true_rightascension", "true_declination",
     "true_obliquity_of_ecliptic", "apparent_rightascension", "apparent_declination",
     "print_params",
-    "B0", "L0", "P", "earth_distance", "orientation"
+    "B0", "L0", "P", "earth_distance", "orientation", "eclipse_amount"
 ]
 
 
@@ -716,3 +717,89 @@ def _sun_north_angle_to_z(frame):
         angle = angle[0]
 
     return Angle(angle)
+
+
+def eclipse_amount(observer, *, minimum=False):
+    """
+    Return the percentage of the Sun that is eclipsed by the Moon.
+
+    The occultation of the solar disk by the Moon is calculated using the
+    simplifying assumption that the Moon has a constant radius.  Since the Moon has
+    an irregular profile of peaks and valleys, the output can be slightly inaccurate
+    for the start/end of partial solar eclipses (a.k.a. penumbral contacts) and the
+    start/end of total solar eclipses (a.k.a. umbral contacts).
+
+    Parameters
+    ----
+    observer : `~astropy.coordinates.SkyCoord`
+        The observer location and observation time
+    minimum : `bool`
+        Option to use a mean minimum radius for the Moon (R_moon / R_earth =
+        0.272281) rather than the IAU mean radius (R_moon / R_earth = 0.2725076).
+        Defaults to `False`.
+
+    Notes
+    -----
+    The apparent location of the Moon accounts for the effect of light travel time.
+
+    The location of the Moon is appreciably inaccurate with Astropy's built-in
+    ephemeris, so it is highly recommended to use a JPL ephemeris instead.  See
+    :ref:`astropy-coordinates-solarsystem`.
+
+    Using the mean minimum radius for the Moon (``minimum=True``) will result in
+    slightly more accurate estimates of the start/end of total solar eclipses, at
+    the expense of slightly more inaccurate estimates for the amount of partial
+    solar eclipses.  See
+    `this page <https://eclipse.gsfc.nasa.gov/SEmono/reference/radius.html>`__
+    for relevant discussion.
+    """
+    # TODO: Find somewhere more appropriate to define these constants
+    # The radius of the Moon to use (in units of Earth radii)
+    k = 0.272281 if minimum else 0.2725076
+    R_moon = k * R_earth
+
+    # Get the light-travel-time adjusted location of the Moon
+    moon = get_body_heliographic_stonyhurst('moon', observer.obstime, observer=observer, quiet=True)
+
+    # Get Cartesian vectors relative to the observer
+    observer = observer.transform_to(moon)
+    v_sun = -observer.cartesian
+    v_moon = moon.cartesian - observer.cartesian
+    d_moon = v_moon.norm()
+
+    # Sun's angular radius (s), Moon's angular radius (m), and angular separation (d)
+    s = np.arcsin(constants.radius / observer.radius).value
+    m = np.arcsin(R_moon / d_moon).value
+    d = np.arccos(v_sun.dot(v_moon) / (observer.radius * d_moon)).value
+
+    # Elevate scalars to arrays
+    s, m, d = np.atleast_1d(s), np.atleast_1d(m), np.atleast_1d(d)
+
+    # Pre-calculate cosines, sines, and areas of the Sun and Moon
+    cs, ss = np.cos(s), np.sin(s)
+    cm, sm = np.cos(m), np.sin(m)
+    cd, sd = np.cos(d), np.sin(d)
+    area_s = 2 * np.pi * (1 - cs)
+    area_m = 2 * np.pi * (1 - cm)
+
+    # Calculate the area of the intersection of two spherical caps
+    # Tovchigrechko & Vakser (2001), eq. 4, https://doi.org/10.1110/ps.8701
+    # See also https://math.stackexchange.com/a/4028073
+    with np.errstate(invalid='ignore'):
+        area_int = 2 * (np.pi
+                        - np.arccos((cd - cs * cm) / (ss * sm))
+                        - np.arccos((cm - cd * cs) / (sd * ss)) * cs
+                        - np.arccos((cs - cd * cm) / (sd * sm)) * cm)
+
+    # The above formula does not handle the edge cases
+    area_int[d >= s + m] = 0  # zero eclipse
+    area_int[m >= s + d] = area_s[m >= s + d]  # total eclipse
+    area_int[s >= m + d] = area_m[s >= m + d]  # annular eclipse
+
+    # Divide by the area of the Sun to get the eclipse fraction
+    fraction = area_int / area_s
+
+    # Clip the result to remove <0% and >100% due to numerical precision
+    fraction = np.clip(fraction, 0, 1)
+
+    return u.Quantity(fraction.reshape(observer.data.shape)).to(u.percent)

--- a/sunpy/coordinates/tests/conftest.py
+++ b/sunpy/coordinates/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from astropy.coordinates import solar_system_ephemeris
+
+
+@pytest.fixture
+def use_DE440s():
+    # This fixture is for test functions that want to use the JPL DE440s ephemeris
+    old_ephemeris = solar_system_ephemeris.get()
+    try:
+        solar_system_ephemeris.set('de440s')
+    except ValueError:
+        pytest.skip("The installed version of Astropy cannot set the ephemeris to DE440s")
+
+    yield
+
+    solar_system_ephemeris.set(old_ephemeris)

--- a/sunpy/coordinates/tests/test_ephemeris.py
+++ b/sunpy/coordinates/tests/test_ephemeris.py
@@ -135,27 +135,14 @@ def test_get_horizons_coord_dict_time():
     assert_quantity_allclose(e.radius, e_ref.radius)
 
 
-@pytest.fixture
-def use_DE440s():
-    # This class is for test functions that need the Astropy ephemeris to be set to DE432s
-    pytest.importorskip("astroquery")
-
-    old_ephemeris = solar_system_ephemeris.get()
-    try:
-        solar_system_ephemeris.set('de440s')
-    except ValueError:
-        pytest.skip("The installed version of Astropy cannot set the ephemeris to DE440s")
-
-    yield
-
-    solar_system_ephemeris.set(old_ephemeris)
-
-
 @pytest.mark.remote_data
 @given(obstime=times(n=50))
 @settings(deadline=5000, max_examples=1,
           suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_consistency_with_horizons(use_DE440s, obstime):
+    # get_horizons_coord() depends on astroquery
+    pytest.importorskip("astroquery")
+
     # Check that the high-accuracy Astropy ephemeris has been set
     assert solar_system_ephemeris.get() == 'de440s'
 

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -519,3 +519,36 @@ def test_carrington_rotation_str():
     # Check that by default a human parseable string is returned
     t = sun.carrington_rotation_time(2210)
     assert str(t) == '2018-10-26 20:48:16.137'
+
+
+# For 2024 Apr 8, at 29.6 deg N, 98.5 deg W, one eclipse calculator has:
+#   Partial eclipse begins: 17:14:49 UTC
+#   Totality begins: 18:33:44 UTC
+#   Maximum eclipse: 18:34:38 UTC
+#   Totality ends: 18:35:32 UTC
+#   Partial eclipse ends: 19:56:00 UTC
+# https://www.timeanddate.com/eclipse/in/@29.6,-98.5?iso=20240408
+
+@pytest.mark.remote_data
+@pytest.mark.filterwarnings("ignore:Tried to get polar motions for times after IERS data is valid.")
+@pytest.mark.filterwarnings("ignore:.*times are outside of range covered by IERS table.")
+def test_eclipse_amount(use_DE440s):
+    location = EarthLocation.from_geodetic(-98.5*u.deg, 29.6*u.deg)
+
+    # We use the mean lunar radius (the default) for penumbral contacts
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 17:14:48'))) == 0
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 17:14:53'))) > 0
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 19:55:58'))) > 0
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 19:56:01'))) == 0
+
+@pytest.mark.remote_data
+@pytest.mark.filterwarnings("ignore:Tried to get polar motions for times after IERS data is valid.")
+@pytest.mark.filterwarnings("ignore:.*times are outside of range covered by IERS table.")
+def test_eclipse_amount_minimum(use_DE440s):
+    location = EarthLocation.from_geodetic(-98.5*u.deg, 29.6*u.deg)
+
+    # We use the mean minimum lunar radius for umbral contacts
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:33:43')), minimum=True) < 1
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:33:45')), minimum=True) == 1
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:35:31')), minimum=True) == 1
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:35:35')), minimum=True) < 1

--- a/sunpy/coordinates/tests/test_sun.py
+++ b/sunpy/coordinates/tests/test_sun.py
@@ -548,7 +548,7 @@ def test_eclipse_amount_minimum(use_DE440s):
     location = EarthLocation.from_geodetic(-98.5*u.deg, 29.6*u.deg)
 
     # We use the mean minimum lunar radius for umbral contacts
-    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:33:43')), minimum=True) < 1
-    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:33:45')), minimum=True) == 1
-    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:35:31')), minimum=True) == 1
-    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:35:35')), minimum=True) < 1
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:33:43')), moon_radius="minimum") < 1
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:33:45')), moon_radius="minimum") == 1
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:35:31')), moon_radius="minimum") == 1
+    assert sun.eclipse_amount(location.get_itrs(Time('2024-04-08 18:35:35')), moon_radius="minimum") < 1


### PR DESCRIPTION
Go go solar eclipse!

Checking with other resources indicates that we can use our coordinates framework to calculate the start/end of total solar eclipses to within a few seconds.

To do:
- [x] Verify accuracy
- [x] Unit tests
- [x] Gallery example
- [x] Changelog entry
- [x] Add a docstring note recommending the use of a JPL ephemeris
- [x] Add an option to `get_body_heliographic_stonyhurst()` to silence the info message for the light-travel-time correction?