### PR TITLE
Update GBMClient to match different version files

### DIFF
--- a/changelog/7148.bugfix.rst
+++ b/changelog/7148.bugfix.rst
@@ -1,1 +1,1 @@
-Updated the baseurl of the GBMClient to match on files other than those that end with version 0 (i.e. V0.pha)
+Updated the url of the `~sunpy.net.dataretriever.GBMClient` to match on files other than those that end with version 0 (i.e., V0.pha).

--- a/changelog/7148.bugfix.rst
+++ b/changelog/7148.bugfix.rst
@@ -1,0 +1,1 @@
+Updated the baseurl of the GBMClient to match on files other than those that end with version 0 (i.e. V0.pha)

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -48,7 +48,10 @@ class GBMClient(GenericClient):
     <BLANKLINE>
 
     """
-    baseurl = r'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/%Y/%m/%d/current/glg_(\w){5}_(\w){2}_%y%m%d_v00.pha'
+    # baseurl = r'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/%Y/%m/%d/current/glg_(\w){5}_(\w){2}_%y%m%d_v00.pha'
+    # pattern = '{}/daily/{year:4d}/{month:2d}/{day:2d}/current/glg_{Resolution:5}_{Detector:2}_{:6d}{}'
+
+    baseurl = r'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/%Y/%m/%d/current/glg_(\w){5}_(\w){2}_%y%m%d_.*\.pha'
     pattern = '{}/daily/{year:4d}/{month:2d}/{day:2d}/current/glg_{Resolution:5}_{Detector:2}_{:6d}{}'
 
     @property

--- a/sunpy/net/dataretriever/sources/fermi_gbm.py
+++ b/sunpy/net/dataretriever/sources/fermi_gbm.py
@@ -48,8 +48,6 @@ class GBMClient(GenericClient):
     <BLANKLINE>
 
     """
-    # baseurl = r'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/%Y/%m/%d/current/glg_(\w){5}_(\w){2}_%y%m%d_v00.pha'
-    # pattern = '{}/daily/{year:4d}/{month:2d}/{day:2d}/current/glg_{Resolution:5}_{Detector:2}_{:6d}{}'
 
     baseurl = r'https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily/%Y/%m/%d/current/glg_(\w){5}_(\w){2}_%y%m%d_.*\.pha'
     pattern = '{}/daily/{year:4d}/{month:2d}/{day:2d}/current/glg_{Resolution:5}_{Detector:2}_{:6d}{}'


### PR DESCRIPTION
Fixes #7147 

```python
>>> res_gbm = Fido.search(a.Time("2014-10-14 00:00", "2014-10-15"), a.Instrument.gbm, a.Resolution.cspec, a.Detector("n5")
Results from 1 Provider:

2 Results from the GBMClient:
Source: https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/daily

       Start Time               End Time        Instrument Physobs Source Provider Resolution Detector
----------------------- ----------------------- ---------- ------- ------ -------- ---------- --------
2014-10-14 00:00:00.000 2014-10-14 23:59:59.999        GBM    flux  FERMI     NASA      cspec       n5
2014-10-15 00:00:00.000 2014-10-15 23:59:59.999        GBM    flux  FERMI     NASA      cspec       n5
```