### PR TITLE
Exclude older astropy bugfix releases that are not compatible with matplotlib 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ include_package_data = True
 setup_requires =
   setuptools_scm
 install_requires =
-  astropy>=5.0.1
+  astropy>=5.0.6,!=5.1.0
   numpy>=1.21.0
   packaging>=19.0
   parfive[ftp]>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ include_package_data = True
 setup_requires =
   setuptools_scm
 install_requires =
+  # Exclude versions of astropy which are incompatible with matplotlib 3.7
   astropy>=5.0.6,!=5.1.0
   numpy>=1.21.0
   packaging>=19.0


### PR DESCRIPTION
The versions of `astropy` that do not include astropy/astropy#13880 have a WCSAxes that is not compatible with `matplotlib` 3.7 (see also #6946).  That PR is in bugfix releases 5.0.6 and 5.1.1, so this PR changes the dependency requirements so that earlier bugfix releases in the 5.0 or 5.1 lines are not allowed.

See https://github.com/sunpy/sunpy/issues/7149#issuecomment-1681245997