### PR TITLE
Catch when the `annotate` keyword for `GenericMap.plot()` is not boolean

### DIFF
--- a/changelog/7163.trivial.rst
+++ b/changelog/7163.trivial.rst
@@ -1,0 +1,1 @@
+Raise an error with a helpful message when :meth:`sunpy.map.GenericMap.plot` is called with a non-boolean value for the ``annotate`` keyword, because the user is probably trying to specify the axes.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2469,6 +2469,11 @@ class GenericMap(NDData):
         :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` context
         manager may be appropriate.
         """
+        # Users sometimes assume that the first argument is `axes` instead of `annotate`
+        if not isinstance(annotate, bool):
+            raise TypeError("You have provided a non-boolean value for the `annotate` parameter. "
+                            "If you are specifying the axes, use `axes=...` to pass it in.")
+
         # Set the default approach to autoalignment
         if autoalign not in [False, True, 'pcolormesh']:
             raise ValueError("The value for `autoalign` must be False, True, or 'pcolormesh'.")

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1647,3 +1647,9 @@ def test_only_cd():
     cd_map = sunpy.map.Map((data, header))
     np.testing.assert_allclose(u.Quantity(cd_map.scale).value, np.array([5, 13]))
     np.testing.assert_allclose(cd_map.rotation_matrix, np.array([[3/5, -4/5], [5/13, 12/13]]))
+
+
+def test_plot_annotate_nonboolean(aia171_test_map):
+    ax = plt.subplot(projection=aia171_test_map)
+    with pytest.raises(TypeError, match="non-boolean value"):
+        aia171_test_map.plot(ax)


### PR DESCRIPTION
Twice in the past month, we've had a user call `GenericMap.plot()` assuming that the first argument as `axes` (e.g., `my_map.plot(ax)`), but the first argument is actually `annotate`.  This can result in confusing plotting behavior or outright errors.  This PR catches this common error.

In the future, we can switch `GenericMap.plot()` to accept keyword-only arguments, but that of course would be an API change, so can't be backported.