### PR TITLE
Bump minimum required Glymur version

### DIFF
--- a/changelog/7164.feature.rst
+++ b/changelog/7164.feature.rst
@@ -1,0 +1,1 @@
+The minimum required version of ``Glymur`` (an optional dependency for reading JPEG2000 files) has been increase to 0.9.1.

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ image =
   # !=1.10.0 due to https://github.com/scipy/scipy/issues/17718
   scipy>=1.7.0,!=1.10.0
 jpeg2000 =
-  glymur>=0.8.18,!=0.9.0,!=0.9.5
+  glymur>=0.9.1,!=0.9.5
   lxml>=4.8.0
 map =
   matplotlib>=3.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     oldestdeps: cdflib<0.3.20
     oldestdeps: dask[array]<2021.5.0
     oldestdeps: drms<0.7
-    oldestdeps: glymur<0.9.0
+    oldestdeps: glymur<0.9.2
     oldestdeps: h5netcdf<0.12
     oldestdeps: matplotlib<3.6.0
     oldestdeps: numpy<1.22.0


### PR DESCRIPTION
This is needed for the oldesdeps tests to work on macOS. Glymur 0.9.1 was released in Jan 2020, so this complies with our dependency support policy.