### PR TITLE
Add a max pin for opencv in oldesdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ deps =
     oldestdeps: h5netcdf<0.12
     oldestdeps: matplotlib<3.6.0
     oldestdeps: numpy<1.22.0
+    oldestdeps: opencv-python<4.8.0.72
     oldestdeps: pandas<1.3.0; platform_system!='Darwin' or platform_machine!='arm64'
     # pandas 1.4.0 is the first with wheels for macOS arm64
     oldestdeps: pandas<1.5.0; platform_system=='Darwin' and platform_machine=='arm64'


### PR DESCRIPTION
This should fix the `oldesdeps` test run. I think it was failing due to a bad interaction between an old version of `numpy` and a new verison of `opencv`. This adds a max pin to `opencv` in tox to avoid this issue.