### PR TITLE
Pin importlib-resources in doc build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,8 @@ docs =
   ruamel.yaml
   sphinx
   sphinx-automodapi
+  # Remove next line when fixed in towncrier; see https://github.com/twisted/towncrier/issues/528
+  importlib-resources<6
   sphinx-changelog
   sphinx-copybutton
   sphinx-design


### PR DESCRIPTION
This should fix one of the warnings showing up the doc build (see https://github.com/twisted/towncrier/issues/528 for more info). Lets see if it fixes the doc build althogether.