### PR TITLE
Explicitly raise error trying to set LASCOMap.nickname

### DIFF
--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -148,6 +148,10 @@ class LASCOMap(GenericMap):
         filter = self.meta.get('filter', '')
         return f'{self.instrument}-{self.detector} {filter}'
 
+    @nickname.setter
+    def nickname(self, value):
+        raise AttributeError("Cannot manually set nickname for LASCOMap")
+
     @property
     def measurement(self):
         # TODO: This needs to do more than white-light.  Should give B, pB, etc.

--- a/sunpy/map/sources/tests/test_lasco_source.py
+++ b/sunpy/map/sources/tests/test_lasco_source.py
@@ -63,6 +63,9 @@ def test_nickname(lasco_map):
     assert lasco_map.nickname == {'C2': 'LASCO-C2 Orange',
                                   'C3': 'LASCO-C3 Clear'}[lasco_map.detector]
 
+    with pytest.raises(AttributeError, match="Cannot manually set nickname for LASCOMap"):
+        lasco_map.nickname = 'new nickname'
+
 
 def test_observatory(lasco_map):
     """Tests the observatory property of the LASCOMap object."""


### PR DESCRIPTION
Because `GenericMap.nickname` has a setter, any child classes need to override the setter if it's not possible to set the property to satisfy `mypy` type checking.

I don't think this needs a changlog entry or backporting, as the behaviour before was the same (modulo the error message):
```python
AttributeError: property 'nickname' of 'LASCOMap' object has no setter
```

Pulled out of https://github.com/sunpy/sunpy/pull/7075 for easier review.