### PR TITLE
Improve handling of WISPR maps

### DIFF
--- a/changelog/7180.feature.rst
+++ b/changelog/7180.feature.rst
@@ -1,0 +1,1 @@
+Added new default colormap scalings for WISPR Maps. Plots are now clipped at zero, and `~astropy.visualization.AsinhStretch` is used for the scaling to ensure coronal details are visible despite the much-brighter stars. Parsing of the ``detector`` and ``level`` fields of the FITS headers is also improved.

--- a/sunpy/map/sources/psp.py
+++ b/sunpy/map/sources/psp.py
@@ -36,7 +36,14 @@ class WISPRMap(GenericMap):
         lvl = self.meta.get('level', None)
         if lvl is None:
             return
-        return int(lvl[1])
+        # Chop off the leading 'L'
+        lvl = lvl[1:]
+        try:
+            return int(lvl)
+        except ValueError:
+            # The int conversion will fail for L2b files, and we should fail
+            # safe if the user chooses to customize this with other values.
+            return lvl
 
     @property
     def name(self):

--- a/sunpy/map/sources/psp.py
+++ b/sunpy/map/sources/psp.py
@@ -31,6 +31,17 @@ class WISPRMap(GenericMap):
     def name(self):
         return 'WISPR ' + super().name
 
+    @property
+    def detector(self):
+        detector = self.meta.get('detector', "")
+        if detector == 1:
+            return "Inner"
+        if detector == 2:
+            return "Outer"
+        # Official data products will only be 1 or 2, but we should fail safe
+        # if users customize this value themselves.
+        return detector
+
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """Determines if header corresponds to an WISPR image"""

--- a/sunpy/map/sources/psp.py
+++ b/sunpy/map/sources/psp.py
@@ -2,6 +2,9 @@
 Parker Solar Probe subclass definitions.
 """
 
+from astropy.visualization import AsinhStretch
+from astropy.visualization.mpl_normalize import ImageNormalize
+
 from sunpy.map import GenericMap
 
 __all__ = ['WISPRMap']
@@ -20,6 +23,14 @@ class WISPRMap(GenericMap):
     * `WISPR Instrument Page <https://wispr.nrl.navy.mil//>`__
     * `Instrument Paper <https://doi.org/10.1007/s11214-014-0114-y>`__
     """
+
+    def __init__(self, data, header, **kwargs):
+        super().__init__(data, header, **kwargs)
+
+        self.plot_settings['norm'] = ImageNormalize(
+            stretch=AsinhStretch(a=0.001), clip=True,
+            vmin=0)
+
     @property
     def processing_level(self):
         lvl = self.meta.get('level', None)

--- a/sunpy/map/sources/psp.py
+++ b/sunpy/map/sources/psp.py
@@ -17,6 +17,12 @@ class WISPRMap(GenericMap):
     The The Wide-field Imager for Parker Solar Probe (WISPR) is a white light
     telescope onboard the Parker Solar Probe (PSP) spacecraft.
 
+    Notes
+    -----
+    By default, plotting of this map will set the lower bound to zero
+    (i.e., clip out negative values for pixels).  You can change this bound
+    by modifying ``.plot_settings['norm'].vmin``.
+
     References
     ----------
     * `PSP science gateway <https://sppgway.jhuapl.edu//>`__
@@ -28,22 +34,23 @@ class WISPRMap(GenericMap):
         super().__init__(data, header, **kwargs)
 
         self.plot_settings['norm'] = ImageNormalize(
-            stretch=AsinhStretch(a=0.001), clip=True,
-            vmin=0)
+            stretch=AsinhStretch(a=0.001), vmin=0)
 
     @property
     def processing_level(self):
         lvl = self.meta.get('level', None)
         if lvl is None:
             return
-        # Chop off the leading 'L'
-        lvl = lvl[1:]
+        # Chop off the leading 'L' if present
+        if lvl[0] == 'L':
+            lvl = lvl[1:]
         try:
-            return int(lvl)
+            lvl = int(lvl)
         except ValueError:
             # The int conversion will fail for L2b files, and we should fail
             # safe if the user chooses to customize this with other values.
-            return lvl
+            pass
+        return lvl
 
     @property
     def name(self):

--- a/sunpy/map/sources/tests/test_wispr_source.py
+++ b/sunpy/map/sources/tests/test_wispr_source.py
@@ -303,8 +303,8 @@ def test_unit(wispr_map):
 
 
 def test_norm_clip(wispr_map):
-    # Tests that the default normalizer has clipping enabled
-    assert wispr_map.plot_settings['norm'].clip
+    # Tests that the default normalizer has clipping disabled
+    assert not wispr_map.plot_settings['norm'].clip
 
 
 def test_name(wispr_map):

--- a/sunpy/map/sources/tests/test_wispr_source.py
+++ b/sunpy/map/sources/tests/test_wispr_source.py
@@ -280,7 +280,13 @@ def test_level_number(wispr_map):
 
 
 def test_detector(wispr_map):
-    assert wispr_map.detector == 2
+    assert wispr_map.detector == 'Outer'
+
+    wispr_map.meta['DETECTOR'] = 1
+    assert wispr_map.detector == 'Inner'
+
+    wispr_map.meta['DETECTOR'] = 'other_val'
+    assert wispr_map.detector == 'other_val'
 
 
 def test_unit(wispr_map):
@@ -293,7 +299,7 @@ def test_norm_clip(wispr_map):
 
 
 def test_name(wispr_map):
-    assert wispr_map.name == 'WISPR 2 2020-01-25 00:02:29'
+    assert wispr_map.name == 'WISPR Outer 2020-01-25 00:02:29'
 
 
 def test_wcs(wispr_map):

--- a/sunpy/map/sources/tests/test_wispr_source.py
+++ b/sunpy/map/sources/tests/test_wispr_source.py
@@ -294,8 +294,8 @@ def test_unit(wispr_map):
 
 
 def test_norm_clip(wispr_map):
-    # Tests that the default normalizer has clipping disabled
-    assert not wispr_map.plot_settings['norm'].clip
+    # Tests that the default normalizer has clipping enabled
+    assert wispr_map.plot_settings['norm'].clip
 
 
 def test_name(wispr_map):

--- a/sunpy/map/sources/tests/test_wispr_source.py
+++ b/sunpy/map/sources/tests/test_wispr_source.py
@@ -275,8 +275,17 @@ def test_exposure_time(wispr_map):
     assert wispr_map.exposure_time == u.Quantity(700, 's')
 
 
-def test_level_number(wispr_map):
+def test_processing_level(wispr_map):
     assert wispr_map.processing_level == 1
+
+    for value, expected in [
+            ('L1', 1),
+            ('L2', 2),
+            ('L2b', '2b'),
+            ('L3', 3),
+            ('LW', 'W')]:
+        wispr_map.meta['level'] = value
+        assert wispr_map.processing_level == expected
 
 
 def test_detector(wispr_map):


### PR DESCRIPTION
At @Cadair 's suggestion, this PR adds nice default colorbar vmin/vmax values for PSP/WISPR maps. Without this, the bright stars cause the automatic bounds to leave the faint coronal structures mostly invisible.

The range of brightness values in a WISPR image varies significantly through each encounter, so no one set of vmin/vmax defaults will be perfect, but I've found these values to be generally good defaults in my own work.

Also offers nicer names for the two detectors---WISPR is two imagers, an inner and an outer FOV. The FITS `detector` value is `1` or `2` to indicate the source imager, but providing labels of `Inner` and `Outer` for e.g. plot titles is nicer and more in line with how the community seems to refer to the two.

Before:
`wispr_map.peek()`
![image](https://github.com/sunpy/sunpy/assets/23462789/45e4c449-8a4b-4c3e-b6a0-4f5b1e080dbb)

After:
`wispr_map.peek()`
![image](https://github.com/sunpy/sunpy/assets/23462789/726db232-3791-42f8-a769-306fd7fc8dca)
