### PR TITLE
When instantiating a frame, use `obstime` from `observer` if `obstime` not otherwise provided

### DIFF
--- a/changelog/7186.feature.rst
+++ b/changelog/7186.feature.rst
@@ -1,0 +1,1 @@
+When creating a coordinate or coordinate frame without specifying ``obstime``, the ``obstime`` value from the ``observer`` frame attribute will be used if present.

--- a/sunpy/coordinates/ephemeris.py
+++ b/sunpy/coordinates/ephemeris.py
@@ -95,18 +95,6 @@ def get_body_heliographic_stonyhurst(body, time='now', observer=None, *, include
         (63.03105777, -5.20656151, 1.6251161)
      (d_lon, d_lat, d_radius) in (arcsec / s, arcsec / s, km / s)
         (-0.02323686, 0.00073376, -1.4798387)>
-
-    Transform that same location and velocity of Mars to a different frame using
-    `~astropy.coordinates.SkyCoord`.
-
-    >>> from astropy.coordinates import SkyCoord
-    >>> from sunpy.coordinates import Helioprojective
-    >>> SkyCoord(mars).transform_to(Helioprojective(observer=earth))
-    <SkyCoord (Helioprojective: obstime=2001-02-03T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2012-06-06T04:07:29.000, rsun=695700.0 km): (lon, lat, radius) in (deg, deg, AU)
-        (6.2686056e-15, -0.00766698, 1.01475668)>): (Tx, Ty, distance) in (arcsec, arcsec, AU)
-        (-298654.73268523, -21726.6154073, 1.40134156)
-     (d_Tx, d_Ty, d_distance) in (arcsec / s, arcsec / s, km / s)
-        (-0.01663438, -0.00058027, -15.08908184)>
     """
     obstime = parse_time(time)
 

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -133,6 +133,10 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
         if not kwargs.pop('wrap_longitude', True):
             self._wrap_angle = None
 
+        # If obstime is not provided but observer has an obstime, use that as the obstime
+        if 'obstime' not in kwargs and 'observer' in kwargs and getattr(kwargs['observer'], 'obstime', None) is not None:
+            kwargs['obstime'] = kwargs['observer'].obstime
+
         super().__init__(*args, **kwargs)
 
         # If obstime is specified, treat the default observer (None) as explicitly set

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -231,6 +231,17 @@ def test_hpc_low_precision_float_warning():
         hpc.make_3d()
 
 
+def test_hpc_obstime_from_observer():
+    # Test that observer.obstime is used for obstime if obstime is not provided
+    observer = HeliographicStonyhurst(obstime='2023-09-08')
+    hpc = Helioprojective(observer=observer)
+    assert hpc.obstime == observer.obstime
+
+    # Test that obstime is None if observer does not have an obstime
+    hpc = Helioprojective(observer='earth')
+    assert hpc.obstime is None
+
+
 # ==============================================================================
 # ## Heliographic Tests
 # ==============================================================================


### PR DESCRIPTION
See title and #7185 

I also removed a docstring example from `get_body_heliographic_stonyhurst()` because it's unclear what the intended transformation is given the mismatch in `obstime`.  The example doesn't show off anything about `get_body_heliographic_stonyhurst()` anyway.