### PR TITLE
Prioritize hgln_obs over crln_obs when extracting observer information from FITS headers

### DIFF
--- a/changelog/7188.bugfix.rst
+++ b/changelog/7188.bugfix.rst
@@ -1,0 +1,2 @@
+When directly instantiating a `~astropy.wcs.WCS` from a FITS header that contains both Stonyhurst and Carrington heliographic coordinates for the observer location, the Stonyhurst coordinates will now be prioritized.
+This behavior is now consistent with the `~sunpy.map.Map` class, which has always prioritized Stonyhurst coordinates over Carrington coordinates.

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -399,3 +399,51 @@ def test_obsgeo_invalid(obsgeo):
 
     with pytest.raises(ValueError):
         obsgeo_to_frame(obsgeo, None)
+
+
+def test_observer_hgln_crln_priority():
+    """
+    When extracting the observer information from a FITS header, ensure
+    Stonyhurst (HG) coordinates are preferred over Carrington (CR) if present.
+    Going through `Map` and `WCS` seem to follow (at least slightly) different
+    code paths, so test them both.
+    """
+    data = np.ones([6, 6], dtype=np.float64)
+    header = {'CRVAL1': 0,
+              'CRVAL2': 0,
+              'CRPIX1': 5,
+              'CRPIX2': 5,
+              'CDELT1': 10,
+              'CDELT2': 10,
+              'CUNIT1': 'arcsec',
+              'CUNIT2': 'arcsec',
+              'PC1_1': 0,
+              'PC1_2': -1,
+              'PC2_1': 1,
+              'PC2_2': 0,
+              'NAXIS1': 6,
+              'NAXIS2': 6,
+              'CTYPE1': 'HPLN-TAN',
+              'CTYPE2': 'HPLT-TAN',
+              'date-obs': '1970-01-01T00:00:00',
+              'mjd-obs': 40587,
+              'hglt_obs': 0,
+              'hgln_obs': 0,
+              'crlt_obs': 2,
+              'crln_obs': 2,
+              'dsun_obs': 10,
+              'rsun_ref': 690000000}
+    generic_map = sunpy.map.Map((data, header))
+
+    c = generic_map.pixel_to_world(0*u.pix, 0*u.pix)
+    assert c.observer.lon == 0 * u.deg
+    # Note: don't test whether crlt or hglt is used---according to
+    # _set_wcs_aux_obs_coord, those are expected to always be the same and so
+    # the same one is always used
+
+    c = generic_map.wcs.pixel_to_world(0, 0)
+    assert c.observer.lon == 0 * u.deg
+
+    wcs = WCS(header)
+    c = wcs.pixel_to_world(0, 0)
+    assert c.observer.lon == 0 * u.deg

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -405,10 +405,9 @@ def test_observer_hgln_crln_priority():
     """
     When extracting the observer information from a FITS header, ensure
     Stonyhurst (HG) coordinates are preferred over Carrington (CR) if present.
-    Going through `Map` and `WCS` seem to follow (at least slightly) different
-    code paths, so test them both.
+    Note that `Map` creates a custom FITS header with a sanitized observer
+    location, so it is separately tested in the map module.
     """
-    data = np.ones([6, 6], dtype=np.float64)
     header = {'CRVAL1': 0,
               'CRVAL2': 0,
               'CRPIX1': 5,
@@ -433,17 +432,9 @@ def test_observer_hgln_crln_priority():
               'crln_obs': 2,
               'dsun_obs': 10,
               'rsun_ref': 690000000}
-    generic_map = sunpy.map.Map((data, header))
-
-    c = generic_map.pixel_to_world(0*u.pix, 0*u.pix)
+    wcs = WCS(header)
+    c = wcs.pixel_to_world(0, 0)
     assert c.observer.lon == 0 * u.deg
     # Note: don't test whether crlt or hglt is used---according to
     # _set_wcs_aux_obs_coord, those are expected to always be the same and so
     # the same one is always used
-
-    c = generic_map.wcs.pixel_to_world(0, 0)
-    assert c.observer.lon == 0 * u.deg
-
-    wcs = WCS(header)
-    c = wcs.pixel_to_world(0, 0)
-    assert c.observer.lon == 0 * u.deg

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -129,6 +129,7 @@ def solar_wcs_frame_mapping(wcs):
                              attrs[1] * u.deg,
                              attrs[2] * u.m,
                              **kwargs)
+            break
 
     # Read the observer out of obsgeo for ground based observers
     if observer is None:

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -100,6 +100,10 @@ def solar_wcs_frame_mapping(wcs):
     dateobs = wcs.wcs.dateavg or wcs.wcs.dateobs or None
 
     # Get observer coordinate from the WCS auxiliary information
+    # Note: the order of the entries is important, as it determines which set
+    # of header keys is given priority below. Stonyhurst should usually be
+    # prioritized, as it is defined more consistently across implementations,
+    # and so it should occur before Carrington here.
     required_attrs = {HeliographicStonyhurst: ['hgln_obs', 'hglt_obs', 'dsun_obs'],
                       HeliographicCarrington: ['crln_obs', 'hglt_obs', 'dsun_obs']}
 


### PR DESCRIPTION
Fix as proposed in #7184

Thanks @ayshih for confirming this should be right!