### PR TITLE
Fix agg warning filter w/ Matplotlib 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -192,6 +192,9 @@ filterwarnings =
     ignore:Distutils was imported before Setuptools
     # Figure tests use agg backend so show doesn't work but we use it in peek
     ignore:Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.
+    # Warning changed in Matplotlib 3.8; when that's our min dep, warning filter on line
+    # above can probably be removed
+    ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning
     # Some tests use data that have dates in the future and ERFA does not like.
     ignore:ERFA function "d2dtf"*
     ignore:ERFA function "dtf2d"*


### PR DESCRIPTION
Should fix tests with Matplotlib 3.8. I put no changelog needed as this isn't user facing.