### PR TITLE
Fix colormap name in map tutorial

### DIFF
--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -333,7 +333,7 @@ This default colormap is available as an attribute,
 .. code-block:: python
 
     >>> my_map.cmap.name  # doctest: +REMOTE_DATA
-    'SDO AIA 171.0 Angstrom'
+    'sdoaia171'
 
 When visualizing a Map, you can change the colormap using the ``cmap`` keyword argument.
 For example, you can use the 'inferno' colormap from `matplotlib`:

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ deps =
     online: astroquery
     online: pytest-rerunfailures
     online: pytest-timeout
+    online: matplotlib>=3.8
     # Figure tests need a tightly controlled environment
     # These are pinned to the minimum version that we support
     figure-!devdeps: astropy==5.1.1


### PR DESCRIPTION
I'm guessing this change came in Matplotlib 3.8 because of https://github.com/matplotlib/matplotlib/pull/25479/.