### PR TITLE
Add a check for out-of-bounds sampling by `sunpy.map.sample_at_coords()`

### DIFF
--- a/changelog/7206.bugfix.rst
+++ b/changelog/7206.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with :func:`~sunpy.map.sample_at_coords()` where sampling outside the bounds of the map would sometimes not error and instead return strange pixel values.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -140,6 +140,8 @@ def sample_at_coords(smap, coordinates):
     Uses nearest-neighbor interpolation of coordinates in map, as
     it effectively uses array indexing.
 
+    An error is raised if any of the coordinates fall outside the map bounds.
+
     Parameters
     ----------
     smap : `~sunpy.map.GenericMap`
@@ -156,6 +158,9 @@ def sample_at_coords(smap, coordinates):
     --------
     .. minigallery:: sunpy.map.sample_at_coords
     """
+    if not all(contains_coordinate(smap, coordinates)):
+        raise ValueError('At least one coordinate is not within the bounds of the map.')
+
     return u.Quantity(smap.data[smap.wcs.world_to_array_index(coordinates)], smap.unit)
 
 
@@ -580,6 +585,12 @@ def pixelate_coord_path(smap, coord_path, *, bresenham=False):
     -----
     If a pixel intersects the coordinate path at only its corner, it may not be
     returned due to the limitations of floating-point comparisons.
+
+    If part of the coordinate path lies outside of the bounds of the map, this
+    function will still return pixel coordinates that are consistent with the WCS of
+    the map, but attempting to obtain the map data at these pixel coordinates
+    (e.g., using :func:`~sunpy.map.sample_at_coords`) will raise an error, as these
+    pixels are not "real" and have no corresponding data.
 
     Returns
     -------

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -219,6 +219,12 @@ def test_data_at_coordinates(aia171_test_map, aia_test_arc):
     assert_quantity_allclose(data[-1], intensity_along_arc[-1])
 
 
+def test_sample_out_of_bounds(aia171_test_map):
+    point = aia171_test_map.pixel_to_world([-1, 1]*u.pix, [-1, 1]*u.pix)
+    with pytest.raises(ValueError, match='At least one coordinate is not within the bounds of the map.'):
+        sample_at_coords(aia171_test_map, point)
+
+
 def test_contains_solar_center(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map, sub_smap):
     assert contains_solar_center(aia171_test_map)
     assert not contains_solar_center(all_off_disk_map)


### PR DESCRIPTION
Closes #7205 

This PR adds a check for out-of-bounds sampling by `sunpy.map.sample_at_coords()`.  Currently, if the supplied coordinate corresponds to negative array indices, those indices will then get interpreted as negative indexing (i.e., indexing from the end) rather than an out-of-bounds request.

This omission gained new relevance with the replacement of `extract_along_coord()` by `pixelate_coord_path()`+`sample_at_coords()`, because `extract_along_coord()` had such a check.