### PR TITLE
Install pre-releases in devdeps tox runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ setenv =
     PARFIVE_HIDE_PROGRESS = True
     NO_VERIFY_HELIO_SSL = 1
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+pip_pre =
+    devdeps: true
 deps =
     # devdeps is intended to be used to install the latest developer version of key dependencies.
     devdeps: astropy>=0.0.dev0


### PR DESCRIPTION
The failing devdeps circleCI build is because stable Matplotlib is being installed, and none of the other nightly wheels seem to be being used either. Lets see if this fixes it.