### PR TITLE
Fix statement about orientation of HMI images

### DIFF
--- a/examples/map_transformations/upside_down_hmi.py
+++ b/examples/map_transformations/upside_down_hmi.py
@@ -28,7 +28,7 @@ plt.show()
 # Now rotate the image such that solar North is pointed up.
 # We have to do this because the HMI instrument is mounted upside-down
 # relative to the AIA instrument on the SDO satellite, which means most
-# of the images are taken with solar North pointed up.
+# of the images are taken with solar North pointed down.
 # The roll angle of the instrument is reported in the FITS header
 # keyword ``CROTA2`` (see Figure 17 of
 # `Couvidat et al. (2016) <https://dx.doi.org/10.1007/s11207-016-0957-3>`_,


### PR DESCRIPTION
Argh.  Apparently this error was in the text as originally added nearly four years ago (#3573).