### PR TITLE
Clean up old MPL compatibility code

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -12,6 +12,7 @@ import webbrowser
 from tempfile import NamedTemporaryFile
 from collections import namedtuple
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backend_bases import FigureCanvasBase
@@ -356,7 +357,7 @@ class GenericMap(NDData):
         # Use a grayscale colormap with histogram equalization (and red for bad values)
         # Make a copy of the colormap to avoid modifying the matplotlib instance when
         # doing set_bad() (copy not needed when min mpl is 3.5, as already a copy)
-        cmap = copy.copy(sunpy_cm._get_mpl_cmap('gray'))
+        cmap = copy.copy(matplotlib.colormaps['gray'])
         cmap.set_bad(color='red')
         norm = ImageNormalize(stretch=HistEqStretch(finite_data))
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -5,6 +5,7 @@ import re
 import tempfile
 import contextlib
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -34,7 +35,6 @@ from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.exceptions import SunpyMetadataWarning
 from sunpy.util.metadata import ModifiedItem
-from sunpy.visualization.colormaps.cm import _get_mpl_cmap
 from .conftest import make_simple_map
 from .strategies import matrix_meta
 
@@ -278,7 +278,7 @@ def test_units(generic_map):
 
 
 def test_cmap(generic_map):
-    assert generic_map.cmap == _get_mpl_cmap('gray')
+    assert generic_map.cmap == matplotlib.colormaps['gray']
 
 
 def test_coordinate_frame(aia171_test_map):

--- a/sunpy/visualization/colormaps/cm.py
+++ b/sunpy/visualization/colormaps/cm.py
@@ -4,34 +4,14 @@ This module provides a set of colormaps specific for solar data.
 from copy import deepcopy
 
 import matplotlib
-import matplotlib.cm as mplcm
 import matplotlib.pyplot as plt
 import numpy as np
-from packaging import version
 
 import astropy.units as u
 
 from sunpy.visualization.colormaps import color_tables as ct
 
 __all__ = ['show_colormaps', 'cmlist']
-
-# Helper functions for Matplotlib colormap that avoid deprecation warnings
-# in MPL >= 3.6 Once MPL 3.5.0 (where matplotlib.colormaps was introduced)
-# is our min version these can be removed and we can just use matplotlib.colormaps
-
-
-def _get_mpl_cmap(name):
-    if version.parse(matplotlib.__version__) >= version.parse("3.5"):
-        return matplotlib.colormaps[name]
-    else:
-        return mplcm.get_cmap(name)
-
-
-def _register_cmap(name, cmap):
-    if version.parse(matplotlib.__version__) >= version.parse("3.5"):
-        matplotlib.colormaps.register(cmap, name=name)
-    else:
-        return mplcm.register_cmap(name, cmap)
 
 
 sdoaia94 = ct.aia_color_table(94*u.angstrom)
@@ -73,9 +53,9 @@ goesrsuvi304 = ct.suvi_color_table(304*u.angstrom)
 # LASCO images. These are not the same as those used in SSWIDL.  This is
 # because the SSWIDL color scaling for LASCO level 0.5 and 1.0 is highly
 # compressed and does not display the data well.
-soholasco2 = deepcopy(_get_mpl_cmap("gist_heat"))
+soholasco2 = deepcopy(matplotlib.colormaps["gist_heat"])
 soholasco2.name = 'SOHO LASCO C2'
-soholasco3 = deepcopy(_get_mpl_cmap("bone"))
+soholasco3 = deepcopy(matplotlib.colormaps["bone"])
 soholasco3.name = 'SOHO LASCO C3'
 
 # These are the SSWIDL color tables.
@@ -105,7 +85,7 @@ traceWL = ct.trace_color_table('WL')
 
 hmimag = ct.hmi_mag_color_table()
 
-kcor = deepcopy(_get_mpl_cmap("gist_gray"))
+kcor = deepcopy(matplotlib.colormaps["gist_gray"])
 kcor.name = 'MLSO KCor'
 
 rhessi = ct.rhessi_color_table()
@@ -182,7 +162,7 @@ cmlist = {
 
 # Register the colormaps with matplotlib so matplotlib.colormaps['sdoaia171'] works
 for name, cmap in cmlist.items():
-    _register_cmap(name=name, cmap=cmap)
+    matplotlib.colormaps.register(cmap, name=name)
 
 
 def show_colormaps(search=None):

--- a/sunpy/visualization/colormaps/tests/test_cm.py
+++ b/sunpy/visualization/colormaps/tests/test_cm.py
@@ -1,3 +1,4 @@
+import matplotlib
 import pytest
 
 import astropy.units as u
@@ -5,13 +6,12 @@ import astropy.units as u
 import sunpy.visualization.colormaps as cm
 import sunpy.visualization.colormaps.color_tables as ct
 from sunpy.tests.helpers import figure_test
-from sunpy.visualization.colormaps.cm import _get_mpl_cmap
 
 
 # Checks that colormaps are imported by MPL
 def test_get_cmap():
     for cmap in cm.cmlist.keys():
-        assert cm.cmlist[cmap] == _get_mpl_cmap(cmap)
+        assert cm.cmlist[cmap] == matplotlib.colormaps[cmap]
 
 
 def test_invalid_show_cmaps():


### PR DESCRIPTION
Just some maintenance now we depend on Matplotlib >= 3.5.