### PR TITLE
Fix inappropriate x limits in "Flare times on a GOES XRS plot" example

### DIFF
--- a/changelog/7219.doc.rst
+++ b/changelog/7219.doc.rst
@@ -1,1 +1,0 @@
-Fixed the inappropriate x limits in "Flare times on a GOES XRS plot" example

--- a/changelog/7219.doc.rst
+++ b/changelog/7219.doc.rst
@@ -1,0 +1,1 @@
+Fixed the inappropriate x limits in "Flare times on a GOES XRS plot" example

--- a/examples/time_series/goes_hek_m25.py
+++ b/examples/time_series/goes_hek_m25.py
@@ -46,5 +46,6 @@ ax.axvspan(
 )
 ax.legend(loc=2)
 ax.set_yscale('log')
+ax.set_xlim(tr.start.to_datetime(), tr.end.to_datetime())
 
 plt.show()


### PR DESCRIPTION
Fixes the x limits in the "Flare times on a GOES XRS plot" example to the time of interest rather than for the entire day. Closes https://github.com/sunpy/sunpy/issues/7218.
