### PR TITLE
add asdf-astropy dev to devdeps tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     # devdeps is intended to be used to install the latest developer version of key dependencies.
     devdeps: astropy>=0.0.dev0
     devdeps: git+https://github.com/asdf-format/asdf
+    devdeps: git+https://github.com/astropy/asdf-astropy
     devdeps: git+https://github.com/astropy/reproject
     devdeps: git+https://github.com/Cadair/parfive
     devdeps: git+https://github.com/sunpy/mpl-animators


### PR DESCRIPTION
## PR Description

This PR adds the development version of asdf-astropy to the devdeps CI job.

The devdeps job is currently failing on the main branch:
https://github.com/sunpy/sunpy/actions/runs/6492397090/job/17631279505

The failures appear to be due to testing against astropy 6.0 and the released version of asdf-astropy (0.4.0).
astropy 6.0 includes moving of several classes which conflict with asdf-astropy 0.4.0 (which needs to have accurate class paths to convert these objects to asdf). These changes are addressed in a few asdf-astropy PRs that have not yet made it into a release:
https://github.com/astropy/asdf-astropy/pull/181
https://github.com/astropy/asdf-astropy/pull/207

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->
