### PR TITLE
Add module to use SkyCoord for SPICE computations

### DIFF
--- a/changelog/7237.doc.rst
+++ b/changelog/7237.doc.rst
@@ -1,0 +1,1 @@
+Added an example (:ref:`sphx_glr_generated_gallery_units_and_coordinates_spice.py`) for how to perform `SPICE <https://naif.jpl.nasa.gov/naif/>`__ computations using the `~astropy.coordinates.SkyCoord` API.

--- a/changelog/7237.feature.rst
+++ b/changelog/7237.feature.rst
@@ -1,0 +1,1 @@
+Added the module `sunpy.coordinates.spice` to enable the use of the `~astropy.coordinates.SkyCoord` API to perform computations using `SPICE <https://naif.jpl.nasa.gov/naif/>`__ kernels.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,6 +200,7 @@ intersphinx_mapping = {
     "parfive": ("https://parfive.readthedocs.io/en/stable/", None),
     "reproject": ("https://reproject.readthedocs.io/en/stable/", None),
     "skimage": ("https://scikit-image.org/docs/stable/", None),
+    "spiceypy": ("https://spiceypy.readthedocs.io/en/stable/", None),
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/latest/", None),
     "sunkit_image": ("https://docs.sunpy.org/projects/sunkit-image/en/stable/", None),
     "sunkit_instruments": ("https://docs.sunpy.org/projects/sunkit-instruments/en/stable/", None),

--- a/docs/reference/coordinates/index.rst
+++ b/docs/reference/coordinates/index.rst
@@ -8,6 +8,7 @@ This sub-package contains:
 * A robust framework for working with solar-physics coordinate systems
 * Functions to obtain the locations of solar-system bodies (`sunpy.coordinates.ephemeris`)
 * Functions to calculate Sun-specific coordinate information (`sunpy.coordinates.sun`)
+* Bridge module to enable the use of the `~astropy.coordinates.SkyCoord` API to perform computations using `SPICE <https://naif.jpl.nasa.gov/naif/>`__ kernels (`sunpy.coordinates.spice`)
 
 The SunPy coordinate framework extends the
 :ref:`Astropy coordinates framework <astropy:astropy-coordinates>`.
@@ -92,6 +93,8 @@ Reference/API
 .. automodapi:: sunpy.coordinates
 
 .. automodapi:: sunpy.coordinates.ephemeris
+
+.. automodapi:: sunpy.coordinates.spice
 
 .. automodapi:: sunpy.coordinates.sun
 

--- a/docs/whatsnew/5.1.rst
+++ b/docs/whatsnew/5.1.rst
@@ -34,3 +34,15 @@ In anticipation of the upcoming `"Great North American Eclipse" <https://en.wiki
 The output can be used to determine the start/end times of partial eclipse and of totality.
 
 .. minigallery:: sunpy.coordinates.sun.eclipse_amount
+
+Computations using SPICE kernels
+================================
+The `SPICE <https://naif.jpl.nasa.gov/naif/>`__ observation geometry information system is being increasingly used by space missions to describe the locations of spacecraft and the time-varying orientations of reference frames.
+The new `sunpy.coordinates.spice` module enables the use of the `~astropy.coordinates.SkyCoord` API to perform SPICE computations such as the location of bodies or the transformation of a vector from one coordinate frame to another coordinate frame.
+Although SPICE kernels can define coordinate frames that are very similar to the frames that `sunpy.coordinates` already provides, there will very likely be slight differences.
+Using `sunpy.coordinates.spice` will ensure that the definitions are exactly what the mission specifies and that the results are identical to other implementations of SPICE (e.g., CSPICE or Icy).
+
+.. note::
+    `sunpy.coordinates.spice` requires the optional dependency `~spiceypy.spiceypy` to be installed.
+
+.. minigallery:: sunpy.coordinates.spice.initialize

--- a/examples/units_and_coordinates/spice.py
+++ b/examples/units_and_coordinates/spice.py
@@ -166,10 +166,11 @@ print(stix_fov)
 
 ###############################################################################
 # More usefully, every coordinate in a SPICE frame has a
-# ``to_helioprojective()`` method that converts the coordinate to
-# `~sunpy.coordinates.Helioprojective` with the ``observer`` at the center of
-# the SPICE frame.  For the 'SOLO_STIX_ILS' frame, the center is Solar Orbiter,
-# which is exactly what we want.
+# :meth:`~sunpy.coordinates.spice.SpiceBaseCoordinateFrame.to_helioprojective`
+# method that converts the coordinate to `~sunpy.coordinates.Helioprojective`
+# with the ``observer`` at the center of te SPICE frame.  For the
+# 'SOLO_STIX_ILS' frame, the center is Solar Orbiter, which is exactly what we
+# want.
 
 print(stix_fov.to_helioprojective())
 

--- a/examples/units_and_coordinates/spice.py
+++ b/examples/units_and_coordinates/spice.py
@@ -1,0 +1,144 @@
+"""
+============================================
+Coordinates computations using SPICE kernels
+============================================
+
+How to use SPICE kernels provided by space missions to perform coordinates
+computations
+
+The `SPICE <https://naif.jpl.nasa.gov/naif/>`__ observation geometry information
+system is being increasingly used by space missions to describe the locations of
+spacecraft and the time-varying orientations of reference frames.  Here are two
+examples of mission SPICE kernels:
+
+* `Solar Orbiter <https://www.cosmos.esa.int/web/spice/solar_orbiter>`__
+* `Parker Solar Probe <https://sppgway.jhuapl.edu/ancil_products>`__
+
+The `sunpy.coordinates.spice` module enables the use of the
+`~astropy.coordinates.SkyCoord` to API to perform SPICE computations such as the
+location of bodies or the transformation of a vector from one coordinate frame
+to another coordinate frame.  Although SPICE kernels can define coordinate
+frames that are very similar to the frames that `sunpy.coordinates` already
+provides, there will very likely be slight differences.  Using
+`sunpy.coordinates.spice` will ensure that the definitions are exactly what the
+mission specifies and that the results are identical to other implementations
+of SPICE (e.g., CSPICE or Icy).
+
+.. note::
+    This example requires the optional dependency `~spiceypy.spiceypy` to be
+    installed.
+
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.dates import DateFormatter
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+from sunpy.coordinates import spice
+from sunpy.data import cache
+from sunpy.time import parse_time
+
+###############################################################################
+# Download a small subset (~30 MB) of the Solar Orbiter SPICE kernel set that
+# corresponds to about a day of the mission.
+
+obstime = parse_time('2022-10-12') + np.arange(720) * u.min
+
+kernel_urls = [
+    "ck/solo_ANC_soc-sc-fof-ck_20180930-21000101_V03.bc",
+    "ck/solo_ANC_soc-stix-ck_20180930-21000101_V03.bc",
+    "ck/solo_ANC_soc-flown-att_20221011T142135-20221012T141817_V01.bc",
+    "fk/solo_ANC_soc-sc-fk_V09.tf",
+    "fk/solo_ANC_soc-sci-fk_V08.tf",
+    "lsk/naif0012.tls",
+    "pck/pck00010.tpc",
+    "sclk/solo_ANC_soc-sclk_20231015_V01.tsc",
+    "spk/de421.bsp",
+    "spk/solo_ANC_soc-orbit-stp_20200210-20301120_280_V1_00288_V01.bsp",
+]
+kernel_urls = [f"http://spiftp.esac.esa.int/data/SPICE/SOLAR-ORBITER/kernels/{url}"
+               for url in kernel_urls]
+
+kernel_files = [cache.download(url) for url in kernel_urls]
+
+###############################################################################
+# Initialize `sunpy.coordinates.spice` with these kernels, which will create
+# classes for `~astropy.coordinates.SkyCoord` to use.
+
+spice.initialize(kernel_files)
+
+###############################################################################
+# We can request the location of the spacecraft in any SPICE frame.  Here, we
+# request it in 'SOLO_HEEQ', which is Stonyhurst heliographic coordinates.
+
+spacecraft = spice.get_body('Solar Orbiter', obstime, spice_frame='SOLO_HEEQ')
+print(spacecraft[:4])
+
+###############################################################################
+# Plot the radial distance from the Sun over the time range.
+
+fig = plt.figure()
+ax = fig.add_subplot()
+ax.plot(obstime.datetime64, spacecraft.distance.to('AU'))
+ax.xaxis.set_major_formatter(DateFormatter('%H:%M'))
+ax.set_xlabel('2022 October 12 (UTC)')
+ax.set_ylabel('Radial distance (AU)')
+ax.set_title('Solar Orbiter distance from Sun center')
+
+###############################################################################
+# We can then transform the coordinate to a different SPICE frame.  When
+# specifying the frame for `~astropy.coordinates.SkyCoord`, SPICE frame names
+# should be prepended with ``'spice_'``.  Here, we transform it to 'SOLO_GAE'.
+
+spacecraft_gae = spacecraft.spice_SOLO_GAE
+print(spacecraft_gae[:4])
+
+###############################################################################
+# Plot the radial distance from the Earth over the time range.
+
+fig = plt.figure()
+ax = fig.add_subplot()
+ax.plot(obstime.datetime64, spacecraft_gae.distance.to('AU'))
+ax.xaxis.set_major_formatter(DateFormatter('%H:%M'))
+ax.set_xlabel('2022 October 12 (UTC)')
+ax.set_ylabel('Radial distance (AU)')
+ax.set_title('Solar Orbiter distance from Earth center')
+
+###############################################################################
+# Finally, we can leverage the Solar Orbiter SPICE kernels to look at
+# instrument pointing.  Let's define a coordinate that points directly along
+# the line of sight of the STIX instrument.
+
+stix_ils = SkyCoord(np.repeat(0*u.deg, len(obstime)),
+                    np.repeat(0*u.deg, len(obstime)),
+                    frame='spice_SOLO_STIX_ILS', obstime=obstime)
+print(stix_ils[:4])
+
+###############################################################################
+# We can transform that line of sight to the SPICE frame 'SOLO_SUN_RTN', which
+# is helioprojective coordinates as observed from Solar Orbiter.  The latitude
+# and longitude values of the resulting coordinate are the pitch and yaw
+# offsets from disk center, respectively.
+
+stix_ils_rtn = stix_ils.spice_SOLO_SUN_RTN
+print(stix_ils_rtn[:4])
+
+###############################################################################
+# Plot the pitch/yaw offsets over the time range.
+
+fig, ax = plt.subplots(2, 1)
+ax[0].plot(obstime.datetime64, stix_ils_rtn.lat.to('arcsec'))
+ax[0].xaxis.set_major_formatter(DateFormatter('%H:%M'))
+ax[0].set_xlabel('2022 October 12 (UTC)')
+ax[0].set_ylabel('Pitch offset (arcsec)')
+ax[1].plot(obstime.datetime64, stix_ils_rtn.lon.to('arcsec'))
+ax[1].xaxis.set_major_formatter(DateFormatter('%H:%M'))
+ax[1].set_xlabel('2022 October 12 (UTC)')
+ax[1].set_ylabel('Yaw offset (arcsec)')
+ax[0].set_title('Pointing offset of STIX from disk center')
+
+plt.show()
+
+# sphinx_gallery_thumbnail_number = 3

--- a/examples/units_and_coordinates/spice.py
+++ b/examples/units_and_coordinates/spice.py
@@ -71,6 +71,14 @@ kernel_files = [cache.download(url) for url in kernel_urls]
 spice.initialize(kernel_files)
 
 ###############################################################################
+# The above call automatically installs all SPICE frames defined in the
+# kernels, but you may also want to use one of the built-in SPICE frames (e.g.,
+# inertial frames or body-fixed frames).  Here, we manually install the
+# 'IAU_SUN' built-in SPICE frame for potential later use.
+
+spice.install_frame('IAU_SUN')
+
+###############################################################################
 # We can request the location of the spacecraft in any SPICE frame.  Here, we
 # request it in 'SOLO_HEEQ', which is Stonyhurst heliographic coordinates.
 

--- a/examples/units_and_coordinates/spice.py
+++ b/examples/units_and_coordinates/spice.py
@@ -4,7 +4,7 @@ Coordinates computations using SPICE kernels
 ============================================
 
 How to use SPICE kernels provided by space missions to perform coordinates
-computations
+computations.
 
 The `SPICE <https://naif.jpl.nasa.gov/naif/>`__ observation geometry information
 system is being increasingly used by space missions to describe the locations of
@@ -15,7 +15,7 @@ examples of mission SPICE kernels:
 * `Parker Solar Probe <https://sppgway.jhuapl.edu/ancil_products>`__
 
 The `sunpy.coordinates.spice` module enables the use of the
-`~astropy.coordinates.SkyCoord` to API to perform SPICE computations such as the
+`~astropy.coordinates.SkyCoord` API to perform SPICE computations such as the
 location of bodies or the transformation of a vector from one coordinate frame
 to another coordinate frame.  Although SPICE kernels can define coordinate
 frames that are very similar to the frames that `sunpy.coordinates` already
@@ -92,7 +92,7 @@ ax.set_title('Solar Orbiter distance from Sun center')
 # specifying the frame for `~astropy.coordinates.SkyCoord`, SPICE frame names
 # should be prepended with ``'spice_'``.  Here, we transform it to 'SOLO_GAE'.
 
-spacecraft_gae = spacecraft.spice_SOLO_GAE
+spacecraft_gae = spacecraft.transform_to("spice_SOLO_GAE")
 print(spacecraft_gae[:4])
 
 ###############################################################################
@@ -122,7 +122,7 @@ print(stix_ils[:4])
 # and longitude values of the resulting coordinate are the pitch and yaw
 # offsets from disk center, respectively.
 
-stix_ils_rtn = stix_ils.spice_SOLO_SUN_RTN
+stix_ils_rtn = stix_ils.transform_to("spice_SOLO_SUN_RTN")
 print(stix_ils_rtn[:4])
 
 ###############################################################################

--- a/examples/units_and_coordinates/spice.py
+++ b/examples/units_and_coordinates/spice.py
@@ -110,22 +110,14 @@ ax.set_title('Solar Orbiter distance from Earth center')
 ###############################################################################
 # We can also leverage the Solar Orbiter SPICE kernels to look at instrument
 # pointing.  Let's define a coordinate that points directly along the line of
-# sight of the STIX instrument.  To be precise, in this frame, 0 degrees
-# longitude is in the anti-Sun direction, so this coordinate is actually
-# anti-parallel to the instrument line of sight.
+# sight of the STIX instrument.  For the 'SOLO_STIX_ILS' frame, 0 degrees
+# longitude is in the anti-Sun direction, while 180 degrees longitude is in the
+# Sun direction.
 
 stix_ils = SkyCoord(np.repeat(0*u.deg, len(obstime)),
                     np.repeat(0*u.deg, len(obstime)),
                     frame='spice_SOLO_STIX_ILS', obstime=obstime)
 print(stix_ils[:4])
-
-###############################################################################
-# We can query the instrument field of view (FOV) via SPICE, which will be in
-# this same frame.  This call returns the corners of the rectangular FOV of the
-# STIX instrument, and you can see they are centered around 180 degrees
-# longitude, which is the direction of the Sun in this frame.
-
-print(spice.get_fov('SOLO_STIX', obstime[0]))
 
 ###############################################################################
 # We can transform that line of sight to the SPICE frame 'SOLO_SUN_RTN', which
@@ -153,5 +145,24 @@ ax[1].set_ylabel('Yaw offset (arcsec)')
 ax[0].set_title('Pointing offset of STIX from disk center')
 
 plt.show()
+
+###############################################################################
+# Finally, we can query the instrument field of view (FOV) via SPICE, which
+# will be in the 'SOLO_STIX_ILS' frame.  This call returns the corners of the
+# rectangular FOV of the STIX instrument, and you can see they are centered
+# around 180 degrees longitude, which is the direction of the Sun in this
+# frame.
+
+stix_fov = spice.get_fov('SOLO_STIX', obstime[0])
+print(stix_fov)
+
+###############################################################################
+# More usefully, every coordinate in a SPICE frame has a
+# ``to_helioprojective()`` method that converts the coordinate to
+# `~sunpy.coordinates.Helioprojective` with the ``observer`` at the center of
+# the SPICE frame.  For the 'SOLO_STIX_ILS' frame, the center is Solar Orbiter,
+# which is exactly what we want.
+
+print(stix_fov.to_helioprojective())
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/units_and_coordinates/spice.py
+++ b/examples/units_and_coordinates/spice.py
@@ -52,6 +52,7 @@ kernel_urls = [
     "ck/solo_ANC_soc-flown-att_20221011T142135-20221012T141817_V01.bc",
     "fk/solo_ANC_soc-sc-fk_V09.tf",
     "fk/solo_ANC_soc-sci-fk_V08.tf",
+    "ik/solo_ANC_soc-stix-ik_V02.ti",
     "lsk/naif0012.tls",
     "pck/pck00010.tpc",
     "sclk/solo_ANC_soc-sclk_20231015_V01.tsc",
@@ -107,9 +108,11 @@ ax.set_ylabel('Radial distance (AU)')
 ax.set_title('Solar Orbiter distance from Earth center')
 
 ###############################################################################
-# Finally, we can leverage the Solar Orbiter SPICE kernels to look at
-# instrument pointing.  Let's define a coordinate that points directly along
-# the line of sight of the STIX instrument.
+# We can also leverage the Solar Orbiter SPICE kernels to look at instrument
+# pointing.  Let's define a coordinate that points directly along the line of
+# sight of the STIX instrument.  To be precise, in this frame, 0 degrees
+# longitude is in the anti-Sun direction, so this coordinate is actually
+# anti-parallel to the instrument line of sight.
 
 stix_ils = SkyCoord(np.repeat(0*u.deg, len(obstime)),
                     np.repeat(0*u.deg, len(obstime)),
@@ -117,10 +120,20 @@ stix_ils = SkyCoord(np.repeat(0*u.deg, len(obstime)),
 print(stix_ils[:4])
 
 ###############################################################################
+# We can query the instrument field of view (FOV) via SPICE, which will be in
+# this same frame.  This call returns the corners of the rectangular FOV of the
+# STIX instrument, and you can see they are centered around 180 degrees
+# longitude, which is the direction of the Sun in this frame.
+
+print(spice.get_fov('SOLO_STIX', obstime[0]))
+
+###############################################################################
 # We can transform that line of sight to the SPICE frame 'SOLO_SUN_RTN', which
-# is helioprojective coordinates as observed from Solar Orbiter.  The latitude
-# and longitude values of the resulting coordinate are the pitch and yaw
-# offsets from disk center, respectively.
+# is similar to helioprojective coordinates as observed from Solar Orbiter,
+# except that the disk center is at 180 degrees longitude instead of 0 degrees
+# longitude.  Given how the line-of-sight coordinate is defined above, the
+# latitude and longitude values of the resulting coordinate are the pitch and
+# yaw offsets from disk center, respectively.
 
 stix_ils_rtn = stix_ils.transform_to("spice_SOLO_SUN_RTN")
 print(stix_ils_rtn[:4])

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,6 +108,7 @@ tests =
   pytest-mpl>=0.12 # First version to support our figure tests
   pytest-xdist>=2.0
   pytest>=6.0
+  %(spice)s
 docs =
   hvpy>=1.0.1
   packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,8 @@ net =
   python-dateutil>=2.8.0
   tqdm>=4.32.1
   zeep>=3.4.0
+spice =
+  spiceypy
 timeseries =
   cdflib>=0.3.20,!=0.4.0,!=1.0.0
   h5netcdf>=0.11
@@ -119,6 +121,7 @@ docs =
   sphinx-design
   sphinx-gallery>=0.13.0 # First to allow us to use a different backend while scraping the images
   sphinxext-opengraph
+  %(spice)s  # because importing sunpy.coordinates.spice raises an error if spiceypy is not installed
   sunpy-sphinx-theme>=2.0.0rc1
   sphinx-hoverxref
 docs-gallery =

--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -34,6 +34,7 @@ dependencies:
   - jplephem
   - lxml
   - opencv
+  - spiceypy
 
   # Testing
   - hvpy

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -1,8 +1,9 @@
 """
-Experimental module to use the SkyCoord API for SPICE computations
+Bridge module to use the SkyCoord API for SPICE computations
 
-.. warning::
-    This module is under development, so may be subject to significant change.
+.. note::
+    This module requires the optional dependency `~spiceypy.spiceypy` to be
+    installed.
 
 The `SPICE <https://naif.jpl.nasa.gov/naif/>`__ observation geometry information
 system is being increasingly used by space missions to describe the locations of
@@ -19,10 +20,6 @@ as computed via SPICE.
 
 See :ref:`sphx_glr_generated_gallery_units_and_coordinates_spice.py` for an
 example of how to use this module.
-
-.. note::
-    This module requires the optional dependency `~spiceypy.spiceypy` to be
-    installed.
 
 Notes
 -----

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -24,8 +24,9 @@ in `sunpy.coordinates`, every SPICE-based coordinate has the method
 This method returns a coordinate in the `~sunpy.coordinates.Helioprojective`
 frame with the ``observer`` frame attribute appropriately set.
 
-See :ref:`sphx_glr_generated_gallery_units_and_coordinates_spice.py` for an
-example of how to use this module.
+Be aware that when converting a SPICE-based coordinate to/from a built-in frame,
+there can be small inconsistencies due to differing planetary ephemerides and
+models for various orientations.
 
 Notes
 -----
@@ -34,6 +35,10 @@ Notes
 * Transformations of velocities are not yet supported.
 * SPICE frame names are rendered as uppercase, except for plus/minus characters,
   which are replaced with lowercase ``'p'``/``'n'`` characters.
+
+Examples
+--------
+.. minigallery:: sunpy.coordinates.spice.initialize
 """
 # Developer notes:
 # * We create a public SkyCoord frame for each SPICE frame that is defined in
@@ -418,6 +423,11 @@ def get_fov(instrument, time, *, resolution=100):
     Rectangular and polygonal FOVs are represented by their vertices.  Circular FOVs
     are approximated by a series of points.  This function does not yet support
     elliptical FOVs.
+
+    .. note::
+        The FOV determined from SPICE kernels may not be as accurate as the FOV
+        obtained from other sources of information, particularly if the instrument
+        is an imager.
 
     Parameters
     ----------

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -1,5 +1,5 @@
 """
-Bridge module to use the SkyCoord API for SPICE computations
+Bridge module to use the SkyCoord API for SPICE computations.
 
 .. note::
     This module requires the optional dependency `~spiceypy.spiceypy` to be

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -1,0 +1,173 @@
+"""
+Experimental module to use the SkyCoord API for SPICE computations
+
+.. warning::
+    This module is under development, so may be subject to significant change.
+
+The `SPICE <https://naif.jpl.nasa.gov/naif/>`__ observation geometry information
+system is being increasingly used by space missions to describe the locations of
+spacecraft and the time-varying orientations of reference frames.
+While the `~spiceypy.spiceypy` package provides a Python interface for
+performing SPICE computations, its API is very different from that of
+`~astropy.coordinates.SkyCoord`.
+
+This module "wraps" `~spiceypy.spiceypy` functionality so that relevant SPICE
+computations can be accessed using the `~astropy.coordinates.SkyCoord` API.
+When loading a set of kernels, a frame class and corresponding transformations
+are created for each SPICE frame.  One can also query the location of a body
+as computed via SPICE.
+
+.. note::
+    This module requires the optional dependency `~spiceypy.spiceypy` to be
+    installed.
+
+Notes
+-----
+* All transformations from one SPICE frame to another SPICE frame go through
+  `~astropy.coordinates.ICRS` as the intermediate frame, even if the origin
+  shift to/from the solar-system barycenter is unnatural.  This also means that
+  it is not possible to transform a 2D coordinate between frames because there
+  is always an origin shift.
+* Transformations of velocities are not yet supported.
+* There is currently no support for time arrays.
+"""
+
+try:
+    import spiceypy
+except ImportError:
+    raise ImportError("This module requires the optional dependency `spiceypy`.")
+
+import astropy.units as u
+from astropy.coordinates import ICRS, SkyCoord, frame_transform_graph
+from astropy.coordinates.representation import CartesianRepresentation
+from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
+from astropy.time import Time
+
+from sunpy import log
+from sunpy.coordinates import SunPyBaseCoordinateFrame
+from sunpy.time import parse_time
+from sunpy.time.time import _variables_for_parse_time_docstring
+from sunpy.util.decorators import add_common_docstring
+
+__all__ = ['get_body', 'initialize']
+
+
+# Note that this epoch is very slightly different from the typical definition of J2000.0 (in TT)
+_ET_REF_EPOCH = Time('J2000', scale='tdb')
+
+_CLASS_TYPES = {2: 'PCK', 3: 'CK', 4: 'TK', 5: 'dynamic', 6: 'switch'}
+
+
+# Defined for future use
+class _SpiceBaseCoordinateFrame(SunPyBaseCoordinateFrame):
+    pass
+
+
+def _convert_to_et(time):
+    return (time - _ET_REF_EPOCH).to_value('s')
+
+
+def _install_frame(frame_id):
+    frame_name = spiceypy.frmnam(frame_id)
+    # TODO: Sanitize/escape the frame name of special characters
+
+    frame_center, class_num, _ = spiceypy.frinfo(frame_id)
+    log.info(f"Installing {frame_name} {_CLASS_TYPES[class_num]} frame ({frame_id}) "
+             f"as 'spice_{frame_name}'")
+
+    spice_frame = type(f"spice_{frame_name}",
+                       (_SpiceBaseCoordinateFrame,),
+                       {})
+    # Force the capitalization
+    # TODO: Consider adding the alias of all lowercase
+    spice_frame.name = spice_frame.__name__
+
+    # TODO: Figure out how to handle array time
+    # TODO: Does it matter what time is used for J2000 ET?
+
+    @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ICRS, spice_frame)
+    def icrs_to_spice(from_icrs_coord, to_spice_frame):
+        et = _convert_to_et(to_spice_frame.obstime)
+        matrix = spiceypy.pxfrm2('J2000', frame_name, 0, et)
+        icrs_offset = spiceypy.spkezp(frame_center, et, 'J2000', 'none', 0)[0] << u.km
+        shifted_old_pos = from_icrs_coord.cartesian - CartesianRepresentation(icrs_offset)
+        new_pos = shifted_old_pos.transform(matrix)
+        return to_spice_frame.realize_frame(new_pos)
+
+    @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, spice_frame, ICRS)
+    def spice_to_icrs(from_spice_coord, to_icrs_frame):
+        et = _convert_to_et(from_spice_coord.obstime)
+        matrix = spiceypy.pxfrm2(frame_name, 'J2000', et, 0)
+        shifted_new_pos = from_spice_coord.cartesian.transform(matrix)
+        icrs_offset = spiceypy.spkezp(frame_center, et, 'J2000', 'none', 0)[0] << u.km
+        new_pos = shifted_new_pos + CartesianRepresentation(icrs_offset)
+        return to_icrs_frame.realize_frame(new_pos)
+
+    frame_transform_graph._add_merged_transform(spice_frame, ICRS, spice_frame)
+
+
+# TODO: Support multiple calls to initialize()
+
+def initialize(kernels):
+    """
+    Load one more more SPICE kernels and create corresponding frame classes.
+
+    .. warning::
+        As currently implemented, do not run this more than once per Python
+        session.
+
+    Parameters
+    ----------
+    kernels : `str`, `list` of `str`
+         One or more SPICE kernel files
+
+    Notes
+    -----
+    If a kernel file is a meta-kernel, make sure that the relative paths therein
+    are correct for the current working directory, which may not be the same as the
+    location of the meta-kernel file.
+    """
+    spiceypy.furnsh(kernels)
+
+    for class_num in _CLASS_TYPES.keys():
+        frames = spiceypy.kplfrm(class_num)
+        for frame_id in frames:
+            _install_frame(frame_id)
+
+
+# TODO: Add support for array time
+# TODO: Add support for light travel time correction
+
+@add_common_docstring(**_variables_for_parse_time_docstring())
+def get_body(body, time, *, spice_frame_name='J2000'):
+    """
+    Get the location of a body via SPICE.
+
+    Parameters
+    ----------
+    body : `int`, `str`
+        The NAIF body ID, or a string that is resolvable to a body ID
+    time : {parse_time_types}
+        Time to use in a parse_time-compatible format.
+    spice_frame_name : `str`
+        The SPICE frame to use for the returned coordinate.  Defaults to ``'J2000'``,
+        which is equivalent to Astropy's `~astropy.coordinates.ICRS`.
+
+    Notes
+    -----
+    No adjustment is made for light travel time to an observer.
+    """
+    body_id = body if isinstance(body, int) else spiceypy.bodn2c(body)
+    obstime = parse_time(time)
+
+    frame_center = spiceypy.frinfo(spiceypy.namfrm(spice_frame_name))[0]
+
+    pos = spiceypy.spkezp(body_id,
+                          _convert_to_et(obstime),
+                          spice_frame_name,
+                          'none',
+                          frame_center)[0] << u.km
+
+    frame_name = 'icrs' if spice_frame_name == 'J2000' else f"spice_{spice_frame_name}"
+
+    return SkyCoord(CartesianRepresentation(pos), frame=frame_name, obstime=obstime)

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -145,7 +145,10 @@ def initialize(kernels):
     order to load multiple sets of kernels.  However, there may be unexpected
     behavior if this function is called after the frame classes start being used.
     """
-    spiceypy.furnsh(kernels)
+    if not isinstance(kernels, list):
+        kernels = [kernels]
+    # furnsh() needs path strings
+    spiceypy.furnsh([str(kernel) for kernel in kernels])
 
     # Remove all existing SPICE frame classes
     if spice_frame_classes:

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -122,6 +122,10 @@ class SpiceBaseCoordinateFrame(SunPyBaseCoordinateFrame):
 
         The center of the frame center is used as the ``observer`` of the
         `~sunpy.coordinates.Helioprojective` frame.
+
+        Examples
+        --------
+        .. minigallery:: sunpy.coordinates.spice.SpiceBaseCoordinate.to_helioprojective
         """
         et = _convert_to_et(self.obstime)
 
@@ -270,6 +274,10 @@ def initialize(kernels):
     This function has simple support for being called multiple times in a session in
     order to load multiple sets of kernels.  However, there may be unexpected
     behavior if this function is called after the frame classes start being used.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.coordinates.spice.initialize
     """
     if not isinstance(kernels, list):
         kernels = [kernels]
@@ -315,6 +323,10 @@ def install_frame(spice_frame):
     ----------
     spice_frame : `str`, `int`
         The SPICE frame name or frame ID to be installed.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.coordinates.spice.install_frame
     """
     if isinstance(spice_frame, str):
         frame_name = spice_frame.upper()
@@ -351,6 +363,10 @@ def get_body(body, time, *, spice_frame='J2000', observer=None):
         If `None`, the returned coordinate is the instantaneous or “true” location.
         If not `None`, the returned coordinate is the astrometric location (i.e.,
         accounts for light travel time to the specified observer).
+
+    Examples
+    --------
+    .. minigallery:: sunpy.coordinates.spice.get_body
     """
     body_name = spiceypy.bodc2n(body) if isinstance(body, int) else body
     obstime = parse_time(time)
@@ -412,6 +428,10 @@ def get_fov(instrument, time, *, resolution=100):
         Time to use in a parse_time-compatible format.
     resolution : `int`
         Number of points to use for a circular FOV.  Defaults to 100.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.coordinates.spice.get_fov
     """
     instrument_name = spiceypy.bodc2n(instrument) if isinstance(instrument, int) else instrument
     obstime = parse_time(time)

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -35,6 +35,20 @@ Notes
 * SPICE frame names are rendered as uppercase, except for plus/minus characters,
   which are replaced with lowercase ``'p'``/``'n'`` characters.
 """
+# Developer notes:
+# * We create a public SkyCoord frame for each SPICE frame that is defined in
+#   the kernels, but this does not include built-in SPICE frames (e.g., inertial
+#   frames or IAU_* frames).
+# * We also create a private SkyCoord frame for each unique SPICE frame center.
+#   Each SPICE frame defines its center, and typically many frames share the
+#   same center.  By creating these private frames for frame centers, we can
+#   transform 2D coordinates between frames that share the same center because
+#   the origin does not change.
+# * Any transformation that involves a change in frame center (including even
+#   a change in the body ID that still maps to the same location) will be
+#   treated as a change in origin, and the transformation is routed through
+#   ICRS.  ICRS is a safe frame to use because the SPICE built-in inertial
+#   frame 'J2000' is ICRS, despite its name.
 
 import numpy as np
 

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -17,6 +17,9 @@ When loading a set of kernels, a frame class and corresponding transformations
 are created for each SPICE frame.  One can also query the location of a body
 as computed via SPICE.
 
+See :ref:`sphx_glr_generated_gallery_units_and_coordinates_spice.py` for an
+example of how to use this module.
+
 .. note::
     This module requires the optional dependency `~spiceypy.spiceypy` to be
     installed.

--- a/sunpy/coordinates/tests/test_spice.py
+++ b/sunpy/coordinates/tests/test_spice.py
@@ -2,7 +2,7 @@ import pytest
 import spiceypy
 
 import astropy.units as u
-from astropy.coordinates import SkyCoord, frame_transform_graph
+from astropy.coordinates import ConvertError, SkyCoord, UnitSphericalRepresentation, frame_transform_graph
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import download_file
 
@@ -66,6 +66,23 @@ def test_transformation_array_time(spice_test):
     assert_quantity_allclose(new_coord.x, [1.49128669e8, 1.49085802e+08]*u.km - coord.x)
     assert_quantity_allclose(new_coord.y, -coord.y)
     assert_quantity_allclose(new_coord.z, coord.z)
+
+
+def test_transformation_2d_okay(spice_test):
+    coord = SkyCoord(30*u.deg, 45*u.deg, frame='spice_HCI', obstime='2023-10-17')
+    new_coord = coord.spice_HEE
+
+    assert isinstance(new_coord.data, UnitSphericalRepresentation)
+
+
+def test_transformation_2d_not_okay(spice_test):
+    coord = SkyCoord(30*u.deg, 45*u.deg, frame='spice_HCI', obstime='2023-10-17')
+    with pytest.raises(ConvertError, match="due to a shift in origin"):
+        assert coord.icrs
+
+    coord = SkyCoord(30*u.deg, 45*u.deg, frame='icrs', obstime='2023-10-17')
+    with pytest.raises(ConvertError, match="due to a shift in origin"):
+        assert coord.spice_HCI
 
 
 def test_get_body(spice_test):

--- a/sunpy/coordinates/tests/test_spice.py
+++ b/sunpy/coordinates/tests/test_spice.py
@@ -1,0 +1,82 @@
+import pytest
+import spiceypy
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord, frame_transform_graph
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.data import download_file
+
+from sunpy.coordinates import spice
+
+
+@pytest.mark.remote_data
+def setup_module():
+    # We use the cache for the SPK file because it's also used in other tests (does cache work?)
+    global spk
+    spk = download_file("https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp",
+                        cache=True)
+
+    # Leapseconds (LSK) and physical constants (PCK)
+    lsk = download_file("https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls")
+    pck = download_file("https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/pck00011_n0066.tpc")
+
+    # Use frames (FK) from SunSPICE
+    fk = download_file("https://soho.nascom.nasa.gov/solarsoft/packages/sunspice/data/heliospheric.tf")
+
+    spice.initialize([spk, lsk, pck, fk])
+
+@pytest.mark.remote_data
+def test_frame_creation():
+    expected = {"spice_ECLIPDATE", "spice_GSE", "spice_HCI", "spice_HEE", "spice_HEEQ", "spice_GEORTN"}
+    assert expected.issubset(frame_transform_graph.get_names())
+
+
+@pytest.mark.remote_data
+def test_transformation():
+    coord = SkyCoord(1e7*u.km, 1e6*u.km, 1e5*u.km, representation_type='cartesian',
+                     frame='spice_GSE', obstime='2023-10-17')
+    new_coord = coord.spice_HEE
+    new_coord.representation_type ='cartesian'
+
+    assert_quantity_allclose(new_coord.x, 1.49128669e8*u.km - coord.x)
+    assert_quantity_allclose(new_coord.y, -coord.y)
+    assert_quantity_allclose(new_coord.z, coord.z)
+
+
+@pytest.mark.remote_data
+def test_get_body():
+    # Regression test
+    earth_by_id = spice.get_body(399, '2023-10-17')
+    earth_by_name = spice.get_body('earth', '2023-10-17')
+
+    assert earth_by_id.name == 'icrs'
+    assert_quantity_allclose(earth_by_id.ra, 21.3678774*u.deg)
+    assert_quantity_allclose(earth_by_id.dec, 8.9883346*u.deg)
+    assert_quantity_allclose(earth_by_id.distance, 1.47846987e8*u.km)
+
+    assert earth_by_name == earth_by_id
+
+
+@pytest.mark.remote_data
+def test_get_body_spice_frame():
+    # Regression test
+    moon_gse = spice.get_body('moon', '2023-10-17', spice_frame_name='GSE')
+    moon_gse.representation_type = 'cartesian'
+    moon_hee = spice.get_body('moon', '2023-10-17', spice_frame_name='HEE')
+    moon_hee.representation_type = 'cartesian'
+
+    assert moon_gse.name == 'spice_GSE'
+    assert_quantity_allclose(moon_gse.x, 349769.2488428*u.km)
+    assert_quantity_allclose(moon_gse.y, 171312.08978192*u.km)
+    assert_quantity_allclose(moon_gse.z, -14990.88338588*u.km)
+
+    assert moon_hee.name == 'spice_HEE'
+    assert_quantity_allclose(moon_hee.x, 1.487789e+08*u.km)
+    assert_quantity_allclose(moon_hee.y, -171312.08978202*u.km)
+    assert_quantity_allclose(moon_hee.z, -14990.88338588*u.km)
+
+
+@pytest.mark.remote_data
+def teardown_module():
+    # The fact that we need to do this suggests that the cache is not persistent across tests...
+    spiceypy.unload(spk)

--- a/sunpy/coordinates/tests/test_spice.py
+++ b/sunpy/coordinates/tests/test_spice.py
@@ -103,7 +103,7 @@ def test_get_body_observer(spice_test):
     earth = spice.get_body('earth', '2023-10-17')
     venus = spice.get_body('venus', '2023-10-17')
     venus_earth = spice.get_body('venus', '2023-10-17', observer=earth)
-    venus_earth_hci = spice.get_body('venus', '2023-10-17', observer=earth, spice_frame_name='HCI')
+    venus_earth_hci = spice.get_body('venus', '2023-10-17', observer=earth, spice_frame='HCI')
 
     assert_quantity_allclose(venus_earth.separation_3d(venus), 11237.0641158*u.km)
     assert_quantity_allclose(venus_earth_hci.separation_3d(venus), 11237.0641158*u.km)
@@ -112,7 +112,7 @@ def test_get_body_observer(spice_test):
 def test_get_body_array_time(spice_test):
     # Regression test
     obstime = parse_time(['2013-10-17', '2013-10-18'])
-    earth = spice.get_body(399, obstime, spice_frame_name='HCI')
+    earth = spice.get_body(399, obstime, spice_frame='HCI')
 
     assert len(earth) == 2
     assert earth[0].obstime == obstime[0]
@@ -124,9 +124,9 @@ def test_get_body_array_time(spice_test):
 
 def test_get_body_spice_frame(spice_test):
     # Regression test
-    moon_gse = spice.get_body('moon', '2023-10-17', spice_frame_name='GSE')
+    moon_gse = spice.get_body('moon', '2023-10-17', spice_frame='GSE')
     moon_gse.representation_type = 'cartesian'
-    moon_hee = spice.get_body('moon', '2023-10-17', spice_frame_name='HEE')
+    moon_hee = spice.get_body('moon', '2023-10-17', spice_frame='HEE')
     moon_hee.representation_type = 'cartesian'
 
     assert moon_gse.name == 'spice_GSE'

--- a/sunpy/coordinates/tests/test_spice.py
+++ b/sunpy/coordinates/tests/test_spice.py
@@ -81,6 +81,17 @@ def test_get_body(spice_test):
     assert earth_by_name == earth_by_id
 
 
+def test_get_body_observer(spice_test):
+    # Regression test
+    earth = spice.get_body('earth', '2023-10-17')
+    venus = spice.get_body('venus', '2023-10-17')
+    venus_earth = spice.get_body('venus', '2023-10-17', observer=earth)
+    venus_earth_hci = spice.get_body('venus', '2023-10-17', observer=earth, spice_frame_name='HCI')
+
+    assert_quantity_allclose(venus_earth.separation_3d(venus), 11237.0641158*u.km)
+    assert_quantity_allclose(venus_earth_hci.separation_3d(venus), 11237.0641158*u.km)
+
+
 def test_get_body_array_time(spice_test):
     # Regression test
     obstime = parse_time(['2013-10-17', '2013-10-18'])

--- a/sunpy/coordinates/tests/test_spice.py
+++ b/sunpy/coordinates/tests/test_spice.py
@@ -36,6 +36,14 @@ def test_frame_creation(spice_test):
     assert expected.issubset(frame_transform_graph.get_names())
 
 
+def test_double_initialize(spice_test):
+    # Smoke test for an issue with calling initialize() more than once a session
+    spice.initialize([])
+
+    expected = {"spice_ECLIPDATE", "spice_GSE", "spice_HCI", "spice_HEE", "spice_HEEQ", "spice_GEORTN"}
+    assert expected.issubset(frame_transform_graph.get_names())
+
+
 def test_transformation(spice_test):
     coord = SkyCoord(1e7*u.km, 1e6*u.km, 1e5*u.km, representation_type='cartesian',
                      frame='spice_GSE', obstime='2023-10-17')

--- a/sunpy/coordinates/tests/test_spice.py
+++ b/sunpy/coordinates/tests/test_spice.py
@@ -53,6 +53,28 @@ def test_double_initialize(spice_test):
     assert expected.issubset(frame_transform_graph.get_names())
 
 
+def test_install_frame(spice_test):
+    # Installing by ID is already tested through a successful initialize()
+
+    assert "spice_IAU_SUN" not in frame_transform_graph.get_names()
+    spice.install_frame('IAU_SUN')
+    assert "spice_IAU_SUN" in frame_transform_graph.get_names()
+
+    assert "spice_IAU_EARTH" not in frame_transform_graph.get_names()
+    spice.install_frame('iau_earth')
+    assert "spice_IAU_EARTH" in frame_transform_graph.get_names()
+
+
+def test_install_frame_bad_id(spice_test):
+    with pytest.raises(ValueError, match="not a valid SPICE frame ID"):
+        spice.install_frame(999999)
+
+
+def test_install_frame_bad_name(spice_test):
+    with pytest.raises(ValueError, match="not a valid SPICE frame name"):
+        spice.install_frame('NOT_A_FRAME_NAME')
+
+
 def test_transformation(spice_test):
     coord = SkyCoord(1e7*u.km, 1e6*u.km, 1e5*u.km, representation_type='cartesian',
                      frame='spice_GSE', obstime='2023-10-17')

--- a/sunpy/util/tests/test_sysinfo.py
+++ b/sunpy/util/tests/test_sysinfo.py
@@ -56,13 +56,14 @@ def test_missing_dependencies_by_extra():
                                                    'jpeg2000',
                                                    'map',
                                                    'net',
+                                                   'spice',
                                                    'tests',
                                                    'timeseries',
                                                    'visualization'])
     missing = missing_dependencies_by_extra(exclude_extras=["all"])
     assert sorted(list(missing.keys())) == sorted(['asdf', 'required', 'dask', 'database', 'dev', 'docs',
                                                    'docs-gallery', 'image', 'jpeg2000', 'map', 'net',
-                                                   'tests', 'timeseries', 'visualization'])
+                                                   'spice', 'tests', 'timeseries', 'visualization'])
 
 
 def test_resolve_requirement_versions():


### PR DESCRIPTION
At the recent DASH meeting, there was a lot interest expressed in having SunPy support SPICE kernels at some level.  The now-archived `astrospice` package covered a little of what people use SPICE for, but is still missing many things.

This PR wraps the SPICE computations using the API of our coordinates framework (i.e., using `SkyCoord`).  Here's an example using Solar Orbiter's predicted set of SPICE kernels:
```python
>>> import astropy.units as u
>>> from astropy.coordinates import SkyCoord

>>> from sunpy.coordinates import spice

# Load the meta-kernel and create lots of frames
>>> spice.initialize('solo_ANC_soc-pred-mk.tm')
...
INFO: Installing SOLO_STIX_ILS CK frame (-144851) as 'spice_SOLO_STIX_ILS' [sunpy.coordinates.spice]
...
INFO: Installing SOLO_EUI_FSI_ILS CK frame (-144211) as 'spice_SOLO_EUI_FSI_ILS' [sunpy.coordinates.spice]
...
INFO: Installing SOLO_HEE_NASA dynamic frame (-144982) as 'spice_SOLO_HEE_NASA' [sunpy.coordinates.spice]
...
INFO: Installing SOLO_GSM dynamic frame (-144962) as 'spice_SOLO_GSM' [sunpy.coordinates.spice]
...

# Use SPICE to get the location of Solar Orbiter in a particular SPICE frame
>>> solo = spice.get_body('SOLO', '2024-01-01', spice_frame='SOLO_HEE_NASA')
>>> solo
<SkyCoord (spice_SOLO_HEE_NASA: obstime=2024-01-01T00:00:00.000): (lon, lat, distance) in (deg, deg, km)
    (-17.54823605, 4.15617429, 1.42506511e+08)>

# Transform the location to a different SPICE frame
>>> solo.spice_SOLO_GSM
<SkyCoord (spice_SOLO_GSM: obstime=2024-01-01T00:00:00.000): (lon, lat, distance) in (deg, deg, km)
    (73.47437224, 26.6713468, 45577871.53062959)>

# Retrieve the instrument line-of-sight (boresight) for STIX
>>> stix_ils = SkyCoord(0*u.deg, 0*u.deg, frame='spice_SOLO_STIX_ILS', obstime='2024-01-01')
>>> stix_ils
<SkyCoord (spice_SOLO_STIX_ILS: obstime=2024-01-01T00:00:00.000): (lon, lat) in (deg, deg)
    (0., 0.)>

# Transform the STIX boresight to the instrument frame of EUI FSI
>>> stix_ils.spice_SOLO_EUI_FSI_ILS
<SkyCoord (spice_SOLO_EUI_FSI_ILS: obstime=2024-01-01T00:00:00.000): (lon, lat) in (deg, deg)
    (-0.03, 0.035)>
```

TODO for this PR:

- [x] Better document the existence of `to_helioprojective()`
- [x] Write a unit tests for `get_fov()`
- [x] Write a unit test for `to_helioprojective()`
- [x] Add more implementation-approach details so that other developers can actually understand and maintain this
- [x] Add a way to install a built-in SPICE frame (`install_frame()`)

Deferred to future PRs:

- Create custom test SPICE kernels rather than downloading "live" ones so that at least some of the tests can be run offline
- Figure out whether the transformation of velocities is consistent with how Astropy does it
- Add support for elliptical FOVs (I'd like a "live" instrument kernel that actually defines such an FOV)