### PR TITLE
Let codepsell autofix stuff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,6 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
-        args: ['--config setup.cfg']
+        args: ['--config setup.cfg --write-changes']
 ci:
   autofix_prs: false


### PR DESCRIPTION
This sets `codespell` to fix stuff in place. I think the true positive rate is much > the false positive rate, so much nicer to be able to do `pre-commit.ci autofix` on a PR and have it apply the `codespell` fixes for you, and in the rare case it gets something wrong manually add an exception in the config.