### PR TITLE
Parse more `wavelnth` comments for units

### DIFF
--- a/sunpy/io/_fits.py
+++ b/sunpy/io/_fits.py
@@ -353,10 +353,14 @@ def extract_waveunit(header):
     elif wavelnth_comment is not None:
         # supported formats (where $UNIT is the unit like "nm" or "Angstrom"):
         #   "Observed wavelength ($UNIT)"
+        #   "Wavelength of obs ($UNIT)"
         #   "[$UNIT] ..."
-        parentheses_pattern = r'Observed wavelength \((\w+?)\)$'
-        brackets_pattern = r'^\[(\w+?)\]'
-        for pattern in [parentheses_pattern, brackets_pattern]:
+        patterns = [
+            r'Observed wavelength \((\w+?)\)$',
+            r'Wavelength of obs \((\w+?)\)$',
+            r'^\[(\w+?)\]',
+        ]
+        for pattern in patterns:
             m = re.search(pattern, wavelnth_comment)
             if m is not None:
                 waveunit = m.group(1)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -16,6 +16,7 @@ TEST_RHESSI_IMAGE = get_test_filepath('hsi_image_20101016_191218.fits')
 TEST_AIA_IMAGE = get_test_filepath('aia_171_level1.fits')
 TEST_EIT_HEADER = get_test_filepath('EIT_header/efz20040301.000010_s.header')
 TEST_SWAP_HEADER = get_test_filepath('SWAP/resampled1_swap.header')
+TEST_GONG_HEADER = get_test_filepath('gong_synoptic.header')
 # Some of the tests images contain an invalid BLANK keyword
 # ignore the warning raised by this
 pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in header")
@@ -42,7 +43,8 @@ def test_read_hdus(fname, hdus, length):
      (MQ_IMAGE, 'angstrom'),
      (NA_IMAGE, 'm'),
      (TEST_SWAP_HEADER, 'angstrom'),
-     (SVSM_IMAGE, 'nm')]
+     (SVSM_IMAGE, 'nm'),
+     (TEST_GONG_HEADER, 'nm'),]
 )
 def test_extract_waveunit(fname, waveunit):
     if Path(fname).suffix == '.header':

--- a/sunpy/map/sources/tests/test_gong_synoptic_source.py
+++ b/sunpy/map/sources/tests/test_gong_synoptic_source.py
@@ -28,7 +28,7 @@ def test_observatory(gong_synoptic):
 
 def test_measurement(gong_synoptic):
     """Tests the measurement property of the GongSynopticMap object."""
-    assert gong_synoptic.measurement == 676.8
+    assert gong_synoptic.measurement == 676.8 * u.nm
 
 
 def test_date(gong_synoptic):


### PR DESCRIPTION
This adds yet another possible case when extracting the wavelength unit from the key comment on `WAVELNTH` in `extract_waveunit`. The inspiration for this is #7220, specifically this comment: https://github.com/sunpy/sunpy/pull/7220#discussion_r1364771658