### PR TITLE
Edit sunpy.io._cdf.read_cdf to avoid Pandas PerformanceWarning: DataFrame is highly fragmented (fix #7246)

### DIFF
--- a/changelog/7247.bugfix.rst
+++ b/changelog/7247.bugfix.rst
@@ -1,0 +1,1 @@
+Improved code when loading CDF files to improve performance and avoid raising of pandas performance warnings.

--- a/sunpy/io/_cdf.py
+++ b/sunpy/io/_cdf.py
@@ -60,7 +60,7 @@ def read_cdf(fname):
             continue
         # TODO: use to_astropy_time() instead here when we drop pandas in timeseries
         index = CDFepoch.to_datetime(index)
-        df = pd.DataFrame(index=pd.DatetimeIndex(name=index_key, data=index))
+        df_dict = {}
         units = {}
 
         for var_key in sorted(var_keys):
@@ -111,13 +111,13 @@ def read_cdf(fname):
             elif data.ndim == 2:
                 # Multiple columns, give each column a unique label
                 for i, col in enumerate(data.T):
-                    df[var_key + f'_{i}'] = col
+                    df_dict[var_key + f'_{i}'] = col
                     units[var_key + f'_{i}'] = unit
             else:
                 # Single column
-                df[var_key] = data
+                df_dict[var_key] = data
                 units[var_key] = unit
-
+        df = pd.DataFrame(df_dict, index=pd.DatetimeIndex(name=index_key, data=index))
         all_ts.append(GenericTimeSeries(data=df, units=units, meta=meta))
 
     if not len(all_ts):


### PR DESCRIPTION
## PR Description

As described in #7246, when reading cdf files with a lot of variables, for each variable `PerformanceWarning: DataFrame is highly fragmented.` is raised by Pandas, as each variable is added to a DataFrame using `df[var_key] = data`.

This PR changes the function `sunpy.io._cdf.read_cdf` so that it gathers the data for all variables in a dictionary throughout the for-loop (over each variable), and in the end concat it to the desired DataFrame, which according to some comments online is memory wise more efficient.

This gets rid of the PerformanceWarnings, and it seems to run a little bit faster on my machine, for the above example using `%timeit -n1 -r3` it's `7.69 s ± 10.8 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)` vs. `6.79 s ± 67.5 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)`. 

I don't have any official statement that this fix is really better or the way to go, but as it removes annoying warnings and seems to be not slower, maybe it's worthwhile to implement it.

Fixes #7246 