### PR TITLE
Map: protect against `norm` being set to `None` for `plot()` method

### DIFF
--- a/changelog/7261.bugfix.rst
+++ b/changelog/7261.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with :meth:`sunpy.map.GenericMap.plot` where setting ``norm`` to ``None`` would result in an error.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2526,7 +2526,7 @@ class GenericMap(NDData):
         msg = ('Cannot manually specify {0}, as the norm '
                'already has {0} set. To prevent this error set {0} on '
                '`m.plot_settings["norm"]` or the norm passed to `m.plot`.')
-        if 'norm' in imshow_args:
+        if imshow_args.get('norm', None) is not None:
             norm = imshow_args['norm']
             if 'vmin' in imshow_args:
                 if norm.vmin is not None:

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1153,6 +1153,12 @@ def test_as_mpl_axes_aia171(aia171_test_map):
     assert all([ct1 == ct2 for ct1, ct2 in zip(ax.wcs.wcs.ctype, aia171_test_map.wcs.wcs.ctype)])
 
 
+def test_plot_with_norm_none(aia171_test_map):
+    # Confirm that norm == None does not raise an error, see https://github.com/sunpy/sunpy/pull/7261
+    ax = plt.subplot(projection=aia171_test_map)
+    aia171_test_map.plot(axes=ax, norm=None, vmin=0, vmax=0)
+
+
 def test_validate_meta(generic_map):
     """Check to see if_validate_meta displays an appropriate error"""
     with pytest.warns(SunpyMetadataWarning) as w:


### PR DESCRIPTION
See #7259 