### PR TITLE
Prevent `Cache.download()` deleting an expired file before knowing that it can download a new version of the file

### DIFF
--- a/changelog/7265.bugfix.rst
+++ b/changelog/7265.bugfix.rst
@@ -1,0 +1,2 @@
+Now `~sunpy.data.cache.Cache` will not delete a stale file if the download fails.
+It will now return the "stale" file if the download fails.

--- a/sunpy/data/data_manager/__init__.py
+++ b/sunpy/data/data_manager/__init__.py
@@ -2,3 +2,5 @@ from sunpy.data.data_manager.cache import Cache
 from sunpy.data.data_manager.downloader import ParfiveDownloader
 from sunpy.data.data_manager.manager import DataManager
 from sunpy.data.data_manager.storage import SqliteStorage
+
+__all__ = ['Cache', 'DataManager', 'ParfiveDownloader', 'SqliteStorage']

--- a/sunpy/data/data_manager/cache.py
+++ b/sunpy/data/data_manager/cache.py
@@ -93,7 +93,7 @@ class Cache:
              })
             return file_path
         except Exception as e:
-                warn_user(f"{e} \n Due to the above error, you might now have a stale version of the canche file.")
+                warn_user(f"{e} \n Due to the above error, you might now be working with a stale version of the file in cache.")
 
     def _has_expired(self, details):
         """

--- a/sunpy/data/data_manager/cache.py
+++ b/sunpy/data/data_manager/cache.py
@@ -77,13 +77,18 @@ class Cache:
                 return Path(details['file_path'])
         try:
             if(details and redownload):
+                # if file is in cache and it has to be redownloaded
+                # then remove the file and delete the details from the storage
                 os.remove(details['file_path'])
                 self._storage.delete_by_key('url', details['url'])
+
             file_path, file_hash, url = self._download_and_hash(urls, namespace)
 
             if(details and self._has_expired(details)):
-                   os.remove(details['file_path'])
-                   self._storage.delete_by_key('url', details['url'])
+                # if file is in cache and the cache has expired
+                # then remove the file and delete the details from the storage
+                os.remove(details['file_path'])
+                self._storage.delete_by_key('url', details['url'])
 
             self._storage.store({
                 'file_hash': file_hash,
@@ -91,6 +96,7 @@ class Cache:
                 'url': url,
                 'time': datetime.now().isoformat(),
              })
+            
             return file_path
         except Exception as e:
                 warn_user(f"{e} \n Due to the above error, you might now be working with a stale version of the file in cache.")

--- a/sunpy/data/data_manager/cache.py
+++ b/sunpy/data/data_manager/cache.py
@@ -76,19 +76,15 @@ class Cache:
             if not (redownload or self._has_expired(details)):
                 return Path(details['file_path'])
         try:
-            if(details and redownload):
-                # if file is in cache and it has to be redownloaded
-                # then remove the file and delete the details from the storage
-                os.remove(details['file_path'])
-                self._storage.delete_by_key('url', details['url'])
 
             file_path, file_hash, url = self._download_and_hash(urls, namespace)
 
-            if(details and self._has_expired(details)):
-                # if file is in cache and the cache has expired
-                # then remove the file and delete the details from the storage
-                os.remove(details['file_path'])
-                self._storage.delete_by_key('url', details['url'])
+            if details:
+                if redownload or self._has_expired(details):    
+                    # if file is in cache and it has to be redownloaded or the cache has expired
+                    # then remove the file and delete the details from the storage
+                    os.remove(details['file_path'])
+                    self._storage.delete_by_key('url', details['url'])
 
             self._storage.store({
                 'file_hash': file_hash,
@@ -99,7 +95,11 @@ class Cache:
             
             return file_path
         except Exception as e:
-                warn_user(f"{e} \n Due to the above error, you might now be working with a stale version of the file in cache.")
+                warn_user(f"{e} \n Due to the above error, you might now be working
+                           with a stale version of the file in cache.")
+                if details:
+                    
+                    return Path(details['file_path'])
 
     def _has_expired(self, details):
         """

--- a/sunpy/data/data_manager/cache.py
+++ b/sunpy/data/data_manager/cache.py
@@ -72,7 +72,7 @@ class Cache:
         if present and not redownload and not self._has_expired(present):
             return Path(present['file_path'])
         try:
-            file_path, file_hash, url = self._download_and_hash(url, namespace)
+            file_path, file_hash, url = self._download_and_hash(urls, namespace)
             if present and (redownload or self._has_expired(present)):
                 os.remove(present['file_path'])
                 self._storage.delete_by_key('url', present['url'])

--- a/sunpy/data/data_manager/tests/conftest.py
+++ b/sunpy/data/data_manager/tests/conftest.py
@@ -15,14 +15,12 @@ DB_TESTDATA_FILE = Path(__file__).parent / 'db_testdata.csv'
 
 @pytest.fixture
 def downloader():
-    downloader = mocks.MockDownloader()
-    return downloader
+    return mocks.MockDownloader()
 
 
 @pytest.fixture
 def storage():
-    storage = InMemStorage()
-    return storage
+    return InMemStorage()
 
 
 @pytest.fixture
@@ -41,8 +39,7 @@ def cache(tmp_path, downloader, storage, mocker):
     m = mock.Mock()
     m.headers = {'Content-Disposition': 'test_file'}
     mocker.patch('sunpy.data.data_manager.cache.urlopen', return_value=m)
-    cache = Cache(downloader, storage, tmp_path)
-    return cache
+    return Cache(downloader, storage, tmp_path)
 
 
 @pytest.fixture

--- a/sunpy/data/data_manager/tests/test_cache.py
+++ b/sunpy/data/data_manager/tests/test_cache.py
@@ -1,3 +1,8 @@
+from unittest.mock import patch
+
+import pytest
+
+from sunpy.util.exceptions import SunpyUserWarning
 from .mocks import MOCK_HASH
 
 
@@ -40,3 +45,20 @@ def test_get_by_hash_fail(cache):
     cache.download('http://example.com/file_name')
     details = cache.get_by_hash('wrong_hash')
     assert details is None
+
+def test_check_old_file_is_not_removed(cache, mocker):
+    # Checks that https://github.com/sunpy/sunpy/issues/7249 is fixed
+
+    # First check that the file is downloaded
+    cache.download('http://example.com/file_name')
+    first_details = cache.get_by_hash(MOCK_HASH)
+    assert first_details['file_path'].endswith('file_name')
+
+    # Force a redownload and check that the old file is not removed
+    with patch('sunpy.data.data_manager.cache.Cache._download_and_hash') as download:
+        download.side_effect = IOError
+        with pytest.warns(SunpyUserWarning, match="Due to the above error, you"):
+            path = cache.download('http://example.com/file_name', redownload=True)
+        assert download.call_count == 1
+    second_details = cache.get_by_hash(MOCK_HASH)
+    assert first_details['file_path'] == second_details['file_path'] == str(path)

--- a/sunpy/data/data_manager/tests/test_manager.py
+++ b/sunpy/data/data_manager/tests/test_manager.py
@@ -15,7 +15,7 @@ def test_basic(storage, downloader, data_function):
     assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
-def test_download_cache(manager, storage, downloader, data_function):
+def test_download_cache(storage, downloader, data_function):
     """
     Test calling function multiple times does not redownload.
     """
@@ -32,7 +32,7 @@ def test_file_tampered(manager, storage, downloader, data_function):
     Test calling function multiple times does not redownload.
     """
     data_function()
-    write_to_test_file(manager._tempdir + '/sunpy.test_file', 'b')
+    write_to_test_file(f'{manager._tempdir}/sunpy.test_file', 'b')
     with pytest.warns(SunpyUserWarning):
         data_function()
 
@@ -63,7 +63,7 @@ def test_skip_all(manager, storage, downloader, data_function):
     assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
-def test_override_file(manager, storage, downloader, data_function, tmpdir):
+def test_override_file(manager, data_function, tmpdir):
     """
     Test the override_file functionality.
     """
@@ -83,16 +83,15 @@ def test_override_file(manager, storage, downloader, data_function, tmpdir):
     # Outside the context manager file is default
     folder = tmpdir.strpath
     data_function(default_tester)
-    write_to_test_file(str(Path(folder+'/another_file')), 'a')
+    write_to_test_file(str(Path(f'{folder}/another_file')), 'a')
 
     with manager.override_file('test_file', f'file://{folder}/another_file'):
         # Inside the file is replaced
         data_function(override_file_tester)
 
-    # TODO: this combined with the check above fails on windows
-    # with manager.override_file('test_file', f'{folder}/another_file'):
-    #     # Inside the file is replaced
-    #     data_function(override_file_tester)
+    with manager.override_file('test_file', f'{folder}/another_file'):
+        # Inside the file is replaced
+        data_function(override_file_tester)
 
     # check the function works with hash provided
     with manager.override_file('test_file', f'file://{folder}/another_file', MOCK_HASH):


### PR DESCRIPTION
## PR Description

I've attempted to handle issue #7249. The expired file won't be deleted until the file is successfully downloaded and if the download fails(for some reason) an error warning is emitted about working with an expired file in cache.

Fixes https://github.com/sunpy/sunpy/issues/7249 