### PR TITLE
RTD needs docs-gallery

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,4 +27,5 @@ python:
        extra_requirements:
         - all
         - docs
+        - docs-gallery
        path: .


### PR DESCRIPTION
Fixes an oversight in #7267, since of course RTD needs `docs-gallery` dependencies

Apparently RTD still declares a build passing even if a bunch of gallery examples error out