### PR TITLE
Use Python 3.10 for source build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
     needs: [publish]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@main
     with:
+      python-version: "3.10"
       test_extras: 'all,tests'
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false


### PR DESCRIPTION
This will hopefully fix the source / universal wheel build job.