### PR TITLE
fix asdf schema examples

### DIFF
--- a/changelog/7292.trivial.rst
+++ b/changelog/7292.trivial.rst
@@ -1,0 +1,1 @@
+Fix example formatting in a few asdf schemas.

--- a/sunpy/io/special/asdf/resources/schemas/geocentricsolarmagnetospheric-1.0.0.yaml
+++ b/sunpy/io/special/asdf/resources/schemas/geocentricsolarmagnetospheric-1.0.0.yaml
@@ -13,7 +13,9 @@ examples:
         !<tag:sunpy.org:sunpy/coordinates/frames/geocentricsolarmagnetospheric-1.0.0>
           frame_attributes:
             magnetic_model: igrf13
-
+  -
+    - A Geocentric Solar Magnetospheric frame with an obstime
+    - |
         !<tag:sunpy.org:sunpy/coordinates/frames/geocentricsolarmagnetospheric-1.0.0>
           frame_attributes:
             magnetic_model: igrf13

--- a/sunpy/io/special/asdf/resources/schemas/geomagnetic-1.0.0.yaml
+++ b/sunpy/io/special/asdf/resources/schemas/geomagnetic-1.0.0.yaml
@@ -13,7 +13,9 @@ examples:
         !<tag:sunpy.org:sunpy/coordinates/frames/geomagnetic-1.0.0>
           frame_attributes:
             magnetic_model: igrf13
-
+  -
+    - A Geomagnetic frame with an obstime
+    - |
         !<tag:sunpy.org:sunpy/coordinates/frames/geomagnetic-1.0.0>
           frame_attributes:
             magnetic_model: igrf13

--- a/sunpy/io/special/asdf/resources/schemas/solarmagnetic-1.0.0.yaml
+++ b/sunpy/io/special/asdf/resources/schemas/solarmagnetic-1.0.0.yaml
@@ -14,7 +14,7 @@ examples:
           frame_attributes:
             magnetic_model: igrf13
   -
-    - A Solar Magnetic frame with and obstime
+    - A Solar Magnetic frame with an obstime
     - |
         !<tag:sunpy.org:sunpy/coordinates/frames/solarmagnetic-1.0.0>
           frame_attributes:

--- a/sunpy/io/special/asdf/resources/schemas/solarmagnetic-1.0.0.yaml
+++ b/sunpy/io/special/asdf/resources/schemas/solarmagnetic-1.0.0.yaml
@@ -13,7 +13,9 @@ examples:
         !<tag:sunpy.org:sunpy/coordinates/frames/solarmagnetic-1.0.0>
           frame_attributes:
             magnetic_model: igrf13
-
+  -
+    - A Solar Magnetic frame with and obstime
+    - |
         !<tag:sunpy.org:sunpy/coordinates/frames/solarmagnetic-1.0.0>
           frame_attributes:
             magnetic_model: igrf13


### PR DESCRIPTION
Downstream testing in asdf revealed a few issues with the examples included in a few sunpy schemas.
https://github.com/asdf-format/asdf/actions/runs/6828518321/job/18572820175?pr=1677

This PR fixes the examples (formatting them so the asdf pytest plugin can load and test the examples).

The issue appears to be that the tests are running against the installed version of sunpy:
```
[gw0] [  0%] PASSED ../../.tox/py311/lib/python3.11/site-packages/sunpy/coordinates
```
whereas the configuration for the asdf schemas test assumes testing against the checked out code:
https://github.com/sunpy/sunpy/blob/cfb7ed4c5b0411cb157a3cea6d56220e5c7b126b/setup.cfg#L162

I don't see a way to configure the current sunpy ci to allow the asdf pytest plugin to run the tests without adding a job that doesn't using `--pyargs` and tests against the checked out code. This is a limitation of the asdf pytest plugin and should be addressed there likely even if a workaround can be found.

I'm going to open this PR for review with the knowledge that the CI is not testing the asdf schemas so that hopefully the schema issues can be addressed and a later PR can update the CI to test the schemas.