### PR TITLE
Tweak to example because of order of operations

### DIFF
--- a/examples/plotting/wcsaxes_plotting_example.py
+++ b/examples/plotting/wcsaxes_plotting_example.py
@@ -40,11 +40,11 @@ my_map.plot(axes=ax, clip_interval=(1, 99.9)*u.percent)
 
 # sphinx_gallery_defer_figures
 
-xx = np.arange(0, 500)
+xx = np.arange(0, 500) * u.arcsec
 yy = xx
 
 # Note that the coordinates need to be in degrees rather than arcseconds.
-ax.plot(xx*u.arcsec.to(u.deg), yy*u.arcsec.to(u.deg),
+ax.plot(xx.to(u.deg), yy.to(u.deg),
         color='r',
         transform=ax.get_transform("world"),
         label=f'WCS coordinate [{0*u.arcsec}, {500*u.arcsec}]')


### PR DESCRIPTION
This gallery example uses the pattern `xx*u.arcsec.to(u.deg)`, which formally means multiplying `xx` by the conversion factor of arcseconds to degrees (`u.arcsec.to(u.deg)`).  However, that means if `xx` is not a NumPy array, that multiplication raises an error.

A safer code pattern to use is to have parentheses `(xx*u.arcsec).to(u.deg)` so that `xx` gets elevated to a `Quantity` first, and then converted.

But, to avoid adding parentheses, this PR simply moves the `*u.arcsec` into the definition of `xx`.