### PR TITLE
Pin drms to < 0.7

### DIFF
--- a/changelog/7308.trivial.rst
+++ b/changelog/7308.trivial.rst
@@ -1,0 +1,1 @@
+Pinned the ``drms`` requirement to ``< 0.7`` to avoid breaking changes in ``drms`` version 0.7.

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ map =
   scipy>=1.7.0,!=1.10.0
 net =
   beautifulsoup4>=4.8.0
-  drms>=0.6.1
+  drms>=0.6.1,<0.7.0
   python-dateutil>=2.8.0
   tqdm>=4.32.1
   zeep>=3.4.0


### PR DESCRIPTION
An alternative to https://github.com/sunpy/sunpy/pull/7307 to get 5.1 out the door, not sure if someone wants to review and merge https://github.com/sunpy/sunpy/pull/7307 instead though?