### PR TITLE
Extremely minor change to plotting lines on a map example

### DIFF
--- a/examples/plotting/wcsaxes_plotting_example.py
+++ b/examples/plotting/wcsaxes_plotting_example.py
@@ -44,7 +44,7 @@ xx = np.arange(0, 500) * u.arcsec
 yy = xx
 
 # Note that the coordinates need to be in degrees rather than arcseconds.
-ax.plot(xx.to(u.deg), yy.to(u.deg),
+ax.plot((xx).to(u.deg), (yy).to(u.deg),
         color='r',
         transform=ax.get_transform("world"),
         label=f'WCS coordinate [{0*u.arcsec}, {500*u.arcsec}]')


### PR DESCRIPTION
There was some confusion in the chat by a user the other day over this example as swapping the arrays of values for a python list, rather than a ndarray, in this example breaks the plot command due to the conversion to degrees not being able to operate on a list.

Adding the parenthesis before the conversion to degree should allow users to more easily tweek this example for their own needs.