### PR TITLE
Add a context manager for imposing a solar-radius value

### DIFF
--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -21,6 +21,7 @@ below (see `astropy.coordinates.builtin_frames`).
 from . import sun
 from ._transformations import _make_sunpy_graph, propagate_with_solar_surface, transform_with_sun_center
 from .ephemeris import *
+from .frameattributes import impose_solar_radius
 from .frames import *
 from .metaframes import *
 from .wcs_utils import *

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -27,11 +27,10 @@ from astropy.time import Time
 from astropy.utils.data import download_file
 
 from sunpy import log
-from sunpy.sun.constants import radius as _RSUN
 from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
 from sunpy.util.exceptions import warn_user
-from .frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy
+from .frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy, SolarRadiusAttribute
 
 _J2000 = Time('J2000.0', scale='tt')
 
@@ -218,7 +217,7 @@ class BaseHeliographic(SunPyBaseCoordinateFrame):
                                 RepresentationMapping('d_distance', 'd_radius', u.km/u.s)],
     }
 
-    rsun = QuantityAttribute(default=_RSUN, unit=u.km)
+    rsun = SolarRadiusAttribute()
 
     def make_3d(self):
         """
@@ -531,7 +530,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
                                       RepresentationMapping('lat', 'Ty', u.arcsec)],
     }
 
-    rsun = QuantityAttribute(default=_RSUN, unit=u.km)
+    rsun = SolarRadiusAttribute()
     observer = ObserverCoordinateAttribute(HeliographicStonyhurst)
 
     @property


### PR DESCRIPTION
This PR adds a context manager as an option for dealing with the situation of inconsistent values for the solar radius.  This context manager makes it so that the `rsun` frame attribute for any relevant coordinate frame reports as the specified value, with 695.7 Mm as the default:

```python
>>> import astropy.units as u

>>> import sunpy.map
>>> from sunpy.coordinates import impose_solar_radius
>>> from sunpy.data.sample import AIA_171_IMAGE

>>> aiamap = sunpy.map.Map(AIA_171_IMAGE)
>>> print(aiamap.observer_coordinate)
<SkyCoord (HeliographicStonyhurst: obstime=2011-06-07T06:33:02.770, rsun=696000.0 km): (lon, lat, radius) in (deg, deg, m)
    (-0.00406308, 0.04787238, 1.51846026e+11)>

>>> with impose_solar_radius():  # defaults to the IAU value of 695.7 Mm
...    print(aiamap.observer_coordinate)
<SkyCoord (HeliographicStonyhurst: obstime=2011-06-07T06:33:02.770, rsun=695700.0 km): (lon, lat, radius) in (deg, deg, m)
    (-0.00406308, 0.04787238, 1.51846026e+11)>
```
If you perform a reprojection under this context manager, there will no longer be missing data due to a `rsun` mismatch.