### PR TITLE
Double check a non-empty but not None value was provided to jsoc notify

### DIFF
--- a/changelog/7342.trivial.rst
+++ b/changelog/7342.trivial.rst
@@ -1,1 +1,1 @@
-`~sunpy.net.jsoc.attrs.Notify` checks for a valid input value.
+`~sunpy.net.jsoc.attrs.Notify` checks that a valid email address has been given as a value.

--- a/changelog/7342.trivial.rst
+++ b/changelog/7342.trivial.rst
@@ -1,0 +1,1 @@
+`~sunpy.net.jsoc.attrs.Notify` checks for a valid input value.

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -110,11 +110,11 @@ class Notify(SimpleAttr):
 
     def __init__(self, value):
         super().__init__(value)
-        if value is None:
+        if not value:
             raise ValueError("Notify attribute must contain an email address")
         if value.find('@') == -1:
             raise ValueError("Notify attribute must contain an '@' symbol "
-                             "to be a valid email address")
+                             "to be a valid email address: {value}")
         self.value = value
 
 

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -110,11 +110,11 @@ class Notify(SimpleAttr):
 
     def __init__(self, value):
         super().__init__(value)
-        if not value:
+        if value is None:
             raise ValueError("Notify attribute must contain an email address")
         if value.find('@') == -1:
             raise ValueError("Notify attribute must contain an '@' symbol "
-                             "to be a valid email address: {value}")
+                             "to be a valid email address")
         self.value = value
 
 

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -110,6 +110,8 @@ class Notify(SimpleAttr):
 
     def __init__(self, value):
         super().__init__(value)
+        if value is None:
+            raise ValueError("Notify attribute must contain an email address")
         if value.find('@') == -1:
             raise ValueError("Notify attribute must contain an '@' symbol "
                              "to be a valid email address")

--- a/sunpy/net/jsoc/tests/test_attr.py
+++ b/sunpy/net/jsoc/tests/test_attr.py
@@ -75,7 +75,7 @@ def test_random():
 
 def test_empty_notify():
     with pytest.raises(ValueError, match="Notify attribute must contain an email address"):
-        attrs.Notify("")
+        attrs.Notify(None)
 
 
 def test_not_email_notify():

--- a/sunpy/net/jsoc/tests/test_attr.py
+++ b/sunpy/net/jsoc/tests/test_attr.py
@@ -14,7 +14,8 @@ from sunpy.net.attr import AttrAnd, AttrOr
                           (attrs.Notify('email@somemail.com'),
                            attrs.Notify('someemail@somemail.com'))])
 def test_and(attr1, attr2):
-    pytest.raises(TypeError, lambda: attr1 & attr2)
+    with pytest.raises(TypeError, match=r"unsupported operand type\(s\) for \&"):
+        attr1 & attr2
 
 
 def test_basicquery():
@@ -70,3 +71,13 @@ def test_random():
     w1 = attrs.Wavelength(193*u.AA)
     w2 = attrs.Series('spam')
     assert jsoc.jsoc.and_(w1 | w2) == AttrOr([w1, w2])
+
+
+def test_empty_notify():
+    with pytest.raises(ValueError, match="Notify attribute must contain an email address"):
+        attrs.Notify("")
+
+
+def test_not_email_notify():
+    with pytest.raises(ValueError, match="Notify attribute must contain an '@' symbol to be a valid email address"):
+        attrs.Notify("someemailthatisntone")


### PR DESCRIPTION
This catches me out when running examples sometimes, as if you do not index the os.environ dict but use .get, you get a default value. I guess the answer is to fix the example but either way, we should catch this.