### PR TITLE
Added an example of plotting a rectangle on a map with a rotation angle relative to the axes

### DIFF
--- a/changelog/7348.feature.rst
+++ b/changelog/7348.feature.rst
@@ -1,1 +1,1 @@
-Add an example of plotting a rectangle on a map with a rotation angle relative to the axes.
+Add an example of plotting a rectangle on a map with a rotation angle relative to the axes :ref:`sphx_glr_generated_gallery_plotting_plot_rotated_rectangle.py`

--- a/changelog/7348.feature.rst
+++ b/changelog/7348.feature.rst
@@ -1,1 +1,1 @@
-Add an example of plotting a rectangle on a map with a rotation angle relative to the axes :ref:`sphx_glr_generated_gallery_plotting_plot_rotated_rectangle.py`
+Add an example of plotting a rectangle on a map with a rotation angle relative to the axes (:ref:`sphx_glr_generated_gallery_plotting_plot_rotated_rectangle.py).`

--- a/changelog/7348.feature.rst
+++ b/changelog/7348.feature.rst
@@ -1,1 +1,1 @@
-Added an example of plotting a rectangle on a map with a rotation angle relative to the axes using :meth:`~sunpy.map.GenericMap.draw_quadrangle` using ``SkyOffsetFrame``
+Add an example of plotting a rectangle on a map with a rotation angle relative to the axes.

--- a/changelog/7348.feature.rst
+++ b/changelog/7348.feature.rst
@@ -1,1 +1,1 @@
-Add an example of plotting a rectangle on a map with a rotation angle relative to the axes (:ref:`sphx_glr_generated_gallery_plotting_plot_rotated_rectangle.py).`
+Add an example of plotting a rectangle on a map with a rotation angle relative to the axes (:ref:`sphx_glr_generated_gallery_plotting_plot_rotated_rectangle.py`).

--- a/changelog/7348.feature.rst
+++ b/changelog/7348.feature.rst
@@ -1,0 +1,1 @@
+Added an example of plotting a rectangle on a map with a rotation angle relative to the axes using :meth:`~sunpy.map.GenericMap.draw_quadrangle` using ``SkyOffsetFrame``

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -3,7 +3,7 @@
 Drawing a rotated rectangle on a map
 ====================================
 
-This example will demonstrate how to draw a rectangle that can be rotated relative
+This example will demonstrate how to draw a rectangle that is rotated relative
 to the axes on a map using :meth:`~sunpy.map.GenericMap.draw_quadrangle`.
 """
 import matplotlib.pyplot as plt
@@ -32,14 +32,14 @@ aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
 # sphinx_gallery_defer_figures
 
 rotation_angle = 90 * u.deg
-center_coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, frame=aia_map.coordinate_frame)
+center_coord = SkyCoord(-300 * u.arcsec, -300 * u.arcsec, frame=aia_map.coordinate_frame)
 width = 400 * u.arcsec
 height = 300 * u.arcsec
 
 ################################################################################
-# To specify the rotation and center, we will use `~astropy.coordinates.SkyOffsetFrame`.
-# Define the corner coordinates in the `~astropy.coordinates.SkyCoord` frame
-# Transform corner coordinates to the original map's coordinate frame
+# Now to specify the rotation and center for the rectangle, we will use `~astropy.coordinates.SkyOffsetFrame`.
+# First we will define the bottom left and top right within the rotated frame
+# and then transform these into the AIA 171 coordinate frame.
 
 # sphinx_gallery_defer_figures
 
@@ -59,7 +59,6 @@ aia_map.draw_quadrangle(
     edgecolor="purple",
     linestyle="--",
     linewidth=2,
-    label='Rotated Rectangle'
 )
 
 plt.show()

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -19,6 +19,8 @@ import sunpy.map
 
 aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 
+# sphinx_gallery_defer_figures
+
 fig = plt.figure(figsize=(5, 5))
 ax = fig.add_subplot(projection=aia_map)
 aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
@@ -26,6 +28,9 @@ aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
 ################################################################################
 # Define the rotation angle and center coordinate of the rectangle
 # Width and height of the rectangle
+
+# sphinx_gallery_defer_figures
+
 rotation_angle = 90 * u.deg
 center_coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, frame=aia_map.coordinate_frame)
 width = 400 * u.arcsec

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -17,19 +17,11 @@ import sunpy.map
 ################################################################################
 # Let's start with a sample image of AIA 171.
 
-# sphinx_gallery_defer_figures
-
 aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-
-fig = plt.figure()
-ax = fig.add_subplot(projection=aia_map)
-aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
 
 ################################################################################
 # Define the rotation angle and center coordinate of the rectangle,
 # as well as the width and height in physical units.
-
-# sphinx_gallery_defer_figures
 
 rotation_angle = 30 * u.deg
 center_coord = SkyCoord(-100 * u.arcsec, -300 * u.arcsec, frame=aia_map.coordinate_frame)
@@ -43,15 +35,17 @@ height = 300 * u.arcsec
 # `~astropy.coordinates.SkyCoord` in that custom coordinate frame for the
 # bottom-left and top-right corners of the rectangle.
 
-# sphinx_gallery_defer_figures
-
 offset_frame = SkyOffsetFrame(origin=center_coord, rotation=rotation_angle)
 rectangle = SkyCoord(lon=[-1/2, 1/2] * width, lat=[-1/2, 1/2] * height, frame=offset_frame)
 
 ################################################################################
 # Finally, we will draw the rotated rectangle and its center.
 
+fig = plt.figure()
+ax = fig.add_subplot(projection=aia_map)
+aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
 ax.plot_coord(center_coord, "o", color="red")
+
 aia_map.draw_quadrangle(
     rectangle,
     axes=ax,

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -31,32 +31,31 @@ aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
 
 # sphinx_gallery_defer_figures
 
-rotation_angle = 90 * u.deg
-center_coord = SkyCoord(-300 * u.arcsec, -300 * u.arcsec, frame=aia_map.coordinate_frame)
-width = 400 * u.arcsec
+rotation_angle = 30 * u.deg
+center_coord = SkyCoord(-100 * u.arcsec, -300 * u.arcsec, frame=aia_map.coordinate_frame)
+width = 1000 * u.arcsec
 height = 300 * u.arcsec
 
 ################################################################################
-# Now to specify the rotation and center for the rectangle, we will use `~astropy.coordinates.SkyOffsetFrame`.
-# First we will define the bottom left and top right within the rotated frame
-# and then transform these into the AIA 171 coordinate frame.
+# We define a custom coordinate frame for the rotated rectangle by providing
+# the center in the AIA 171 coordinate frame and rotation angle to
+# `~astropy.coordinates.SkyOffsetFrame`.  We then define a 2-element
+# `~astropy.coordinates.SkyCoord` in that custom coordinate frame for the
+# bottom-left and top-right corners of the rectangle.
 
 # sphinx_gallery_defer_figures
 
 offset_frame = SkyOffsetFrame(origin=center_coord, rotation=rotation_angle)
-corner_bottom_left = SkyCoord(lon=-width / 2, lat=-height / 2, frame=offset_frame)
-corner_top_right = SkyCoord(lon=width / 2, lat=height / 2, frame=offset_frame)
-corner_bottom_left = corner_bottom_left.transform_to(aia_map.coordinate_frame)
-corner_top_right = corner_top_right.transform_to(aia_map.coordinate_frame)
+rectangle = SkyCoord(lon=[-1/2, 1/2] * width, lat=[-1/2, 1/2] * height, frame=offset_frame)
 
 ################################################################################
-# Finally, we will draw the rotated rectangle.
+# Finally, we will draw the rotated rectangle and its center.
 
+ax.plot_coord(center_coord, "o", color="red")
 aia_map.draw_quadrangle(
-    bottom_left=corner_bottom_left,
-    top_right=corner_top_right,
+    rectangle,
     axes=ax,
-    edgecolor="purple",
+    edgecolor="red",
     linestyle="--",
     linewidth=2,
 )

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -37,8 +37,8 @@ width = 400 * u.arcsec
 height = 300 * u.arcsec
 
 ################################################################################
-# To specify the rotation and center, we will use `SkyOffsetFrame`.
-# Define the corner coordinates in the SkyCoord frame
+# To specify the rotation and center, we will use `~astropy.coordinates.SkyOffsetFrame`.
+# Define the corner coordinates in the `~astropy.coordinates.SkyCoord` frame
 # Transform corner coordinates to the original map's coordinate frame
 
 # sphinx_gallery_defer_figures
@@ -61,6 +61,5 @@ aia_map.draw_quadrangle(
     linewidth=2,
     label='Rotated Rectangle'
 )
-ax.legend()
 
 plt.show()

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -1,7 +1,7 @@
 """
-============================
+====================================
 Drawing a rotated rectangle on a map
-============================
+====================================
 
 This example will demonstrate how to draw a rectangle that can be rotated relative
 to the axes on a map using :meth:`~sunpy.map.GenericMap.draw_quadrangle`.
@@ -15,19 +15,19 @@ import sunpy.data.sample
 import sunpy.map
 
 ################################################################################
-# Let's start with a sample AIA image.
-
-aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
+# Let's start with a sample image of AIA 171.
 
 # sphinx_gallery_defer_figures
+
+aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 
 fig = plt.figure(figsize=(5, 5))
 ax = fig.add_subplot(projection=aia_map)
 aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
 
 ################################################################################
-# Define the rotation angle and center coordinate of the rectangle
-# Width and height of the rectangle
+# Define the rotation angle and center coordinate of the rectangle,
+# as well as the width and height in physical units.
 
 # sphinx_gallery_defer_figures
 
@@ -37,9 +37,12 @@ width = 400 * u.arcsec
 height = 300 * u.arcsec
 
 ################################################################################
-# Create a SkyOffsetFrame with the specified rotation and center
+# To specify the rotation and center, we will use `SkyOffsetFrame`.
 # Define the corner coordinates in the SkyCoord frame
 # Transform corner coordinates to the original map's coordinate frame
+
+# sphinx_gallery_defer_figures
+
 offset_frame = SkyOffsetFrame(origin=center_coord, rotation=rotation_angle)
 corner_bottom_left = SkyCoord(lon=-width / 2, lat=-height / 2, frame=offset_frame)
 corner_top_right = SkyCoord(lon=width / 2, lat=height / 2, frame=offset_frame)
@@ -47,7 +50,8 @@ corner_bottom_left = corner_bottom_left.transform_to(aia_map.coordinate_frame)
 corner_top_right = corner_top_right.transform_to(aia_map.coordinate_frame)
 
 ################################################################################
-# Draw the rotated rectangle
+# Finally, we will draw the rotated rectangle.
+
 aia_map.draw_quadrangle(
     bottom_left=corner_bottom_left,
     top_right=corner_top_right,

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -1,0 +1,38 @@
+import matplotlib.pyplot as plt
+import astropy.units as u
+from astropy.coordinates import SkyCoord, SkyOffsetFrame
+import sunpy.data.sample
+import sunpy.map
+
+aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
+
+rotation_angle = 90 * u.deg
+center_coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, frame=aia_map.coordinate_frame)
+
+width = 400 * u.arcsec
+height = 300 * u.arcsec
+
+offset_frame = SkyOffsetFrame(origin=center_coord, rotation=rotation_angle)
+
+corner_bottom_left = SkyCoord(lon=-width / 2, lat=-height / 2, frame=offset_frame)
+corner_top_right = SkyCoord(lon=width / 2, lat=height / 2, frame=offset_frame)
+
+corner_bottom_left = corner_bottom_left.transform_to(aia_map.coordinate_frame)
+corner_top_right = corner_top_right.transform_to(aia_map.coordinate_frame)
+
+fig = plt.figure(figsize=(5, 5))
+ax = fig.add_subplot(projection=aia_map)
+aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
+
+aia_map.draw_quadrangle(
+    bottom_left=corner_bottom_left,
+    top_right=corner_top_right,
+    axes=ax,
+    edgecolor="purple",
+    linestyle="--",
+    linewidth=2,
+    label='Rotated Rectangle'
+)
+
+ax.legend()
+plt.show()

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -1,29 +1,48 @@
+"""
+============================
+Drawing a rotated rectangle on a map
+============================
+
+This example will demonstrate how to draw a rectangle that can be rotated relative
+to the axes on a map using :meth:`~sunpy.map.GenericMap.draw_quadrangle`.
+"""
 import matplotlib.pyplot as plt
+
 import astropy.units as u
 from astropy.coordinates import SkyCoord, SkyOffsetFrame
+
 import sunpy.data.sample
 import sunpy.map
 
+################################################################################
+# Let's start with a sample AIA image.
+
 aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
-
-rotation_angle = 90 * u.deg
-center_coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, frame=aia_map.coordinate_frame)
-
-width = 400 * u.arcsec
-height = 300 * u.arcsec
-
-offset_frame = SkyOffsetFrame(origin=center_coord, rotation=rotation_angle)
-
-corner_bottom_left = SkyCoord(lon=-width / 2, lat=-height / 2, frame=offset_frame)
-corner_top_right = SkyCoord(lon=width / 2, lat=height / 2, frame=offset_frame)
-
-corner_bottom_left = corner_bottom_left.transform_to(aia_map.coordinate_frame)
-corner_top_right = corner_top_right.transform_to(aia_map.coordinate_frame)
 
 fig = plt.figure(figsize=(5, 5))
 ax = fig.add_subplot(projection=aia_map)
 aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
 
+################################################################################
+# Define the rotation angle and center coordinate of the rectangle
+# Width and height of the rectangle
+rotation_angle = 90 * u.deg
+center_coord = SkyCoord(0 * u.arcsec, 0 * u.arcsec, frame=aia_map.coordinate_frame)
+width = 400 * u.arcsec
+height = 300 * u.arcsec
+
+################################################################################
+# Create a SkyOffsetFrame with the specified rotation and center
+# Define the corner coordinates in the SkyCoord frame
+# Transform corner coordinates to the original map's coordinate frame
+offset_frame = SkyOffsetFrame(origin=center_coord, rotation=rotation_angle)
+corner_bottom_left = SkyCoord(lon=-width / 2, lat=-height / 2, frame=offset_frame)
+corner_top_right = SkyCoord(lon=width / 2, lat=height / 2, frame=offset_frame)
+corner_bottom_left = corner_bottom_left.transform_to(aia_map.coordinate_frame)
+corner_top_right = corner_top_right.transform_to(aia_map.coordinate_frame)
+
+################################################################################
+# Draw the rotated rectangle
 aia_map.draw_quadrangle(
     bottom_left=corner_bottom_left,
     top_right=corner_top_right,
@@ -33,6 +52,6 @@ aia_map.draw_quadrangle(
     linewidth=2,
     label='Rotated Rectangle'
 )
-
 ax.legend()
+
 plt.show()

--- a/examples/plotting/plot_rotated_rectangle.py
+++ b/examples/plotting/plot_rotated_rectangle.py
@@ -21,7 +21,7 @@ import sunpy.map
 
 aia_map = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 
-fig = plt.figure(figsize=(5, 5))
+fig = plt.figure()
 ax = fig.add_subplot(projection=aia_map)
 aia_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
 


### PR DESCRIPTION

 dealing with issue #7303, added a new file plot_rotated_rectangle.py that contains a rectangle on a map with a rotation angle relative to the axes.
