### PR TITLE
The 'delim_whitespace' keyword in pd.read_csv is deprecated

### DIFF
--- a/changelog/7350.trivial.rst
+++ b/changelog/7350.trivial.rst
@@ -1,0 +1,2 @@
+The ``delim_whitespace`` keyword in `pandas.read_csv` is deprecated and was updated with ``sep='\s+'``.
+This should have no affect on the output of the code.

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -322,8 +322,7 @@ class EVESpWxTimeSeries(GenericTimeSeries):
         month = int(date_parts[2])
         day = int(date_parts[3])
 
-        data = read_csv(filepath, delim_whitespace=True, names=fields, comment=';',
-                        dtype={'HHMM': int})
+        data = read_csv(filepath, sep=r'\s+', names=fields, comment=';', dtype={'HHMM': int})
         # First line is YYYY DOY MM DD
         data = data.iloc[1:, :]
         data['Hour'] = data['HHMM'] // 100


### PR DESCRIPTION
Should fix the devdeps build but I will find out. 