### PR TITLE
Bail out of a unit test for `Helioprojective.is_visible()` if it won't be a meaningful test of tolerance

### DIFF
--- a/changelog/7356.trivial.rst
+++ b/changelog/7356.trivial.rst
@@ -1,0 +1,1 @@
+Fixed an environment-specific failure of a unit test for :meth:`sunpy.coordinates.Helioprojective.is_visible`.

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -259,9 +259,10 @@ def test_hpc_is_visible_tolerance():
     hpc = Helioprojective(200*u.arcsec, 0*u.arcsec,
                           observer='earth', obstime='2023-08-03').make_3d()
 
-    # Due to the limitations of numerical precision, the coordinate will be computed to be slightly
-    # below the solar surface, and thus invisible when the tolerance is set to zero
-    assert not hpc.is_visible(tolerance=0*u.m)
+    # Due to the limitations of numerical precision, the coordinate may be computed to be slightly
+    # below the solar surface, and thus may be invisible when the tolerance is set to zero
+    if hpc.is_visible(tolerance=0*u.m):
+        pytest.skip("Test already passes prior to increasing the tolerance.")
 
     assert hpc.is_visible(tolerance=1*u.m)
 


### PR DESCRIPTION
The unit test for the tolerance option of `Helioprojective.is_visible()` required that one gets the wrong answer if the tolerance is set to zero, but in some environments it is possible to get the correct answer (see #7349).  This PR adjusts the unit test so that it first checks whether the answer is in fact wrong at zero tolerance, otherwise it bails out on the test.

Fixes #7349