### PR TITLE
add gitignore for sphinx build times page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+# sphinx gallery execution times
+docs/sg_execution_times.rst
 
 # PyBuilder
 target/


### PR DESCRIPTION
If you build sphinx locally you get this junk in your git changes.