### PR TITLE
Saw these links error on the release branches

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -398,7 +398,7 @@ Documentation
 - Improved the plotting guide. (`#6430 <https://github.com/sunpy/sunpy/pull/6430>`__)
 - Slight improvements to the downloading data with Fido part of the guide. (`#6444 <https://github.com/sunpy/sunpy/pull/6444>`__)
 - Split the units and coordinate guides on to separate pages, and made minor improvements to them. (`#6462 <https://github.com/sunpy/sunpy/pull/6462>`__)
-- Added a how-to guide (:ref:`conda_for_dependencies`) for using ``conda`` to set up an environment with the complete set of dependencies to use all optional features, build the documentation, and/or run the full test suite.
+- Added a how-to guide ``conda_for_dependencies`` for using ``conda`` to set up an environment with the complete set of dependencies to use all optional features, build the documentation, and/or run the full test suite.
   The guide also describes how best to have an editable installation of ``sunpy`` in this environment. (`#6524 <https://github.com/sunpy/sunpy/pull/6524>`__)
 
 

--- a/docs/topic_guide/new_map_class.rst
+++ b/docs/topic_guide/new_map_class.rst
@@ -14,7 +14,7 @@ Any subclass of `~sunpy.map.GenericMap` which defines a method named ``is_dataso
 The ``is_datasource_for()`` method is used by the `~sunpy.map.Map` factory to check if a file should use a particular instrument Map class.
 This function can run any test it needs to determine this.
 For example, it might check the value of the "INSTRUMENT" key in the metadata dictionary.
-The following example shows how this works and includes a sample doc string that is compatible with the :ref:`Docs Guidelines for Data Sources`:
+The following example shows how this works and includes a sample doc string that is aligned with `the documentation guidelines <https://docs.sunpy.org/en/latest/dev_guide/contents/documentation.html#docs-guidelines-for-data-sources>`__:
 
 .. code-block:: python
 


### PR DESCRIPTION
We do not compile the dev guide on the release branches to ensure we do not need to backport that part of our docs.

But we now link to it in some of our release docs. So for now I commented out the links or added direct urls but it is not the best solution.