### PR TITLE
Remove extra tox settings for online test suite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,10 +66,6 @@ deps =
     oldestdeps: scipy<1.8.0
     oldestdeps: tqdm<4.33.0
     oldestdeps: zeep<3.5.0
-    # These are specific extras we use to run in specific factors
-    online: pytest-rerunfailures
-    online: pytest-timeout
-    online: matplotlib>=3.8
     # Figure tests need a tightly controlled environment
     # These are pinned to the minimum version that we support
     figure-!devdeps: astropy==5.1.1
@@ -83,7 +79,7 @@ commands =
     pip freeze --all --no-input
     oldestdeps: python -c "import astropy.time; astropy.time.update_leap_seconds()"
     !online-!figure: {env:PYTEST_COMMAND} {posargs}
-    online: {env:PYTEST_COMMAND} --hypothesis-show-statistics --reruns 2 --reruns-delay 15 --timeout=30 --remote-data=any {posargs}
+    online: {env:PYTEST_COMMAND} --hypothesis-show-statistics --remote-data=any {posargs}
     figure: /bin/bash -c "mkdir -p ./figure_test_images; python -c 'import matplotlib as mpl; print(mpl.ft2font.__file__, mpl.ft2font.__freetype_version__, mpl.ft2font.__freetype_build_type__)' > ./figure_test_images/figure_version_info.txt"
     figure: /bin/bash -c "pip freeze >> ./figure_test_images/figure_version_info.txt"
     figure: /bin/bash -c "cat ./figure_test_images/figure_version_info.txt"


### PR DESCRIPTION
My reasoning for this is the following:

1. Back in the travis days, we used to have network problems that were outside of the server 404 or erroring.
2. We had a much flakier test suite back then.
3. These days, if a online test fails its due to a server error and that will not be fixed by rerunning the test again. So we just delay the return for no reason.

E.g.,
```
E       drms.exceptions.DrmsExportError: User jsoc@sunpy.org has 1 pending export requests (JSOC_20240124_611); please wait until at least one request has completed before submitting a new one. [status=7]
```
Will not be fixed by a re-run 15 seconds later and we know that since it still fails with the current settings.

Or in fact the following error that happened on this PR:
```
Expected:
    <parfive.results.Results object at ...>
    ['.../aia_lev1_335a_2020_01_01t00_00_00_64z_image_lev1.fits']
Got:
    <parfive.results.Results object at 0x7f65c4113970>
    []
    Errors:
    (<parfive.results.Error object at 0x7f65c41e8ef0>
    https://sdo7.nascom.nasa.gov/cgi-bin/drms_export.cgi?series=aia__lev1;compress=rice;record=335_1356912039-1356912039,
    Timeout on reading data from socket)
```
