### PR TITLE
Remove tox-conda from conda dev env

### DIFF
--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -50,7 +50,6 @@ dependencies:
   - pytest-timeout
   - pytest-xdist
   - tox
-  - tox-conda
 
   # Documentation
   - astroquery


### PR DESCRIPTION
tox-conda seems to not support modern tox. 

```
(sunpy-dev) sirjanh@DESKTOP-USD7Q1F:~/sunpy-main$ tox -v -l
Traceback (most recent call last):
File "/home/sirjanh/miniforge3/envs/sunpy-dev/bin/tox", line 10, in <module>
sys.exit(run())
^^^^^
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox/[run.py](http://run.py/)", line 20, in run
result = main(sys.argv[1:] if args is None else args)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox/[run.py](http://run.py/)", line 39, in main
state = setup_state(args)
^^^^^^^^^^^^^^^^^
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox/[run.py](http://run.py/)", line 53, in setup_state
options = get_options(*args)
^^^^^^^^^^^^^^^^^^
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox/config/cli/[parse.py](http://parse.py/)", line 37, in get_options
guess_verbosity, log_handler, source = _get_base(args)
^^^^^^^^^^^^^^^
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox/config/cli/[parse.py](http://parse.py/)", line 59, in _get_base
MANAGER.load_plugins(source.path)
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox/plugin/[manager.py](http://manager.py/)", line 103, in load_plugins
self._register_plugins(inline)
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox/plugin/[manager.py](http://manager.py/)", line 51, in _register_plugins
self.manager.load_setuptools_entrypoints(NAME)
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/pluggy/_[manager.py](http://manager.py/)", line 414, in load_setuptools_entrypoints
plugin = ep.load()
^^^^^^^^^
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/importlib/metadata/init.py", line 205, in load
module = import_module([match.group](http://match.group/)('module'))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/importlib/init.py", line 90, in import_module
return _bootstrap._gcd_import(name[level:], package, level)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
File "<frozen importlib._bootstrap_external>", line 994, in exec_module
File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
File "/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox_conda/[plugin.py](http://plugin.py/)", line 12, in <module>
from tox.config import DepConfig, DepOption, TestenvConfig
ImportError: cannot import name 'DepConfig' from 'tox.config' (/home/sirjanh/miniforge3/envs/sunpy-dev/lib/python3.12/site-packages/tox/config/init.py)".
```