### PR TITLE
Made GenericMap.plot() arguments keyword only #7166

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2421,7 +2421,7 @@ class GenericMap(NDData):
         return figure
 
     @u.quantity_input
-    def plot(self, annotate=True, axes=None, title=True, autoalign=False,
+    def plot(self,*, annotate=True, axes=None, title=True, autoalign=False,
              clip_interval: u.percent = None, **imshow_kwargs):
         """
         Plots the map object using matplotlib, in a method equivalent


### PR DESCRIPTION
## PR Description
Made the GenericMap.plot() accept keywords only as arguments, As discussed in #7166 and #7163.

