### PR TITLE
Adds a warn when using both assume_spherical_screen() and propagate_with_solar_surface() context managers with reproject_to()

### DIFF
--- a/changelog/7437.bugfix.rst
+++ b/changelog/7437.bugfix.rst
@@ -1,0 +1,1 @@
+When calling :meth:`~sunpy.map.GenericMap.reproject_to` along with both context managers :func:`~sunpy.coordinates.propagate_with_solar_surface` and :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` now raises a warning.

--- a/sunpy/coordinates/_transformations.py
+++ b/sunpy/coordinates/_transformations.py
@@ -15,7 +15,6 @@ This module contains the functions for converting one
 import logging
 from copy import deepcopy
 from functools import wraps
-from contextlib import contextmanager
 
 import erfa
 import numpy as np
@@ -45,6 +44,7 @@ from astropy.time import Time
 
 from sunpy import log
 from sunpy.sun import constants
+from sunpy.util.decorators import sunpycontextmanager
 from .frames import (
     _J2000,
     GeocentricEarthEquatorial,
@@ -74,7 +74,7 @@ _ignore_sun_motion = False
 _autoapply_diffrot = None
 
 
-@contextmanager
+@sunpycontextmanager
 def transform_with_sun_center():
     """
     Context manager for coordinate transformations to ignore the motion of the center of the Sun.
@@ -138,7 +138,7 @@ def transform_with_sun_center():
         _ignore_sun_motion = old_ignore_sun_motion
 
 
-@contextmanager
+@sunpycontextmanager
 def propagate_with_solar_surface(rotation_model='howard'):
     """
     Context manager for coordinate transformations to automatically apply solar

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -7,7 +7,6 @@ the `astropy.coordinates` module.
 import os
 import re
 import traceback
-from contextlib import contextmanager
 
 import numpy as np
 
@@ -29,7 +28,7 @@ from astropy.utils.data import download_file
 from sunpy import log
 from sunpy.sun.constants import radius as _RSUN
 from sunpy.time.time import _variables_for_parse_time_docstring
-from sunpy.util.decorators import add_common_docstring
+from sunpy.util.decorators import add_common_docstring, sunpycontextmanager
 from sunpy.util.exceptions import warn_user
 from .frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy
 
@@ -678,7 +677,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     _spherical_screen = None
 
     @classmethod
-    @contextmanager
+    @sunpycontextmanager
     def assume_spherical_screen(cls, center, only_off_disk=False):
         """
         Context manager to interpret 2D coordinates as being on the inside of a spherical screen.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -18,6 +18,8 @@ import numpy as np
 from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.figure import Figure
 
+from sunpy.util.decorators import active_contexts
+
 try:
     from dask.array import Array as DaskArray
     DASK_INSTALLED = True
@@ -2713,6 +2715,10 @@ class GenericMap(NDData):
 
         .. minigallery:: sunpy.map.GenericMap.reproject_to
         """
+        # Check if both context managers are active
+        if active_contexts.get('propagate_with_solar_surface', False) and active_contexts.get('assume_spherical_screen', False):
+            warn_user("Using propagate_with_solar_surface and assume_spherical_screen together result in loss of off-disk data.")
+
         try:
             import reproject
         except ImportError as exc:

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -12,6 +12,8 @@ from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
 import sunpy.map
+from sunpy.coordinates import frames
+from sunpy.coordinates._transformations import propagate_with_solar_surface
 from sunpy.tests.helpers import figure_test
 from sunpy.util.exceptions import SunpyUserWarning
 
@@ -129,3 +131,11 @@ def test_rsun_mismatch_warning(aia171_test_map, hpc_header):
 
         # Reproject with the mismatched rsun
         aia171_test_map.reproject_to(hpc_header)
+
+
+def test_reproject_to_warn_using_contexts(aia171_test_map, hpc_header):
+    with propagate_with_solar_surface():
+        with frames.Helioprojective.assume_spherical_screen(aia171_test_map.observer_coordinate):
+            # Check if a warning is raised if both context managers are used at the same time.
+            with pytest.warns(UserWarning, match="Using propagate_with_solar_surface and assume_spherical_screen together result in loss of off-disk data."):
+                aia171_test_map.reproject_to(hpc_header)

--- a/sunpy/util/tests/test_decorators.py
+++ b/sunpy/util/tests/test_decorators.py
@@ -4,7 +4,13 @@ import pytest
 
 import astropy.units as u
 
-from sunpy.util.decorators import deprecate_positional_args_since, deprecated, get_removal_version
+from sunpy.util.decorators import (
+    active_contexts,
+    deprecate_positional_args_since,
+    deprecated,
+    get_removal_version,
+    sunpycontextmanager,
+)
 from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyPendingDeprecationWarning
 
 
@@ -82,3 +88,22 @@ def test_deprecate_positional_args_warns_for_class():
 
     with pytest.warns(SunpyDeprecationWarning, match=r"Pass c=3, d=4 as keyword args"):
         A2(1, 2, 3, 4)
+
+
+@sunpycontextmanager
+def somefunc():
+    print("Entering")
+    yield
+    print("Exiting")
+
+
+def test_somefunc_context():
+    # Check that the context is not active before entering
+    assert not active_contexts.get('somefunc' , False)
+
+    with somefunc():
+        # Check that the context is active while inside
+        assert active_contexts.get('somefunc', False)
+
+    # Check that the context is not active after exiting
+    assert not active_contexts.get('somefunc' , False)


### PR DESCRIPTION
## PR Description
As mentioned in the #7172, this PR warns the user when both the context managers are active at the same time. 