### PR TITLE
Reduce the tox env_list to the common combinations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
 min_version = 4.0
 envlist =
-    py{310,311,312}{,-oldestdeps,-devdeps,-online,-figure,-conda}
+    py{310,311,312}{,-online}
+    py310-oldestdeps
+    py312-devdeps
+    py312-figure{,-devdeps}
     build_docs{,-gallery}
     codestyle
     base_deps


### PR DESCRIPTION
Other combinations are possible, but not run by default with a plain `tox run`.
