### PR TITLE
Removes internal coordinate-frame docstring code

### DIFF
--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -178,29 +178,29 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
         return (self._data is not None and self._data.norm().unit is u.one
                 and u.allclose(self._data.norm(), 1*u.one))
 
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
+#     def __init_subclass__(cls, **kwargs):
+#         super().__init_subclass__(**kwargs)
 
-        # TODO: Remove this after the minimum Astropy dependency includes astropy/astropy#12005
-        cls._fix_property_docstrings()
+#         # TODO: Remove this after the minimum Astropy dependency includes astropy/astropy#12005
+#         cls._fix_property_docstrings()
 
-    @classmethod
-    def _fix_property_docstrings(cls):
-        # This class method adds docstrings to properties dynamically created by
-        # BaseCoordinateFrame.__init_subclass__().  Accordingly, this method needs to itself be
-        # called from SunPyBaseCoordinateFrame.__init_subclass__() to work for our subclasses.
-        property_docstrings = {
-            'default_representation': "Default representation for position data",
-            'default_differential': "Default representation for differential data",
-            'frame_specific_representation_info': "Mapping for frame-specific component names",
-        }
-        for prop, docstring in property_docstrings.items():
-            if getattr(cls, prop).__doc__ is None:
-                setattr(getattr(cls, prop), '__doc__', docstring)
+#     @classmethod
+#     def _fix_property_docstrings(cls):
+#         # This class method adds docstrings to properties dynamically created by
+#         # BaseCoordinateFrame.__init_subclass__().  Accordingly, this method needs to itself be
+#         # called from SunPyBaseCoordinateFrame.__init_subclass__() to work for our subclasses.
+#         property_docstrings = {
+#             'default_representation': "Default representation for position data",
+#             'default_differential': "Default representation for differential data",
+#             'frame_specific_representation_info': "Mapping for frame-specific component names",
+#         }
+#         for prop, docstring in property_docstrings.items():
+#             if getattr(cls, prop).__doc__ is None:
+#                 setattr(getattr(cls, prop), '__doc__', docstring)
 
 
-# TODO: Remove this after the minimum Astropy dependency includes astropy/astropy#12005
-SunPyBaseCoordinateFrame._fix_property_docstrings()
+# # TODO: Remove this after the minimum Astropy dependency includes astropy/astropy#12005
+# SunPyBaseCoordinateFrame._fix_property_docstrings()
 
 
 class BaseHeliographic(SunPyBaseCoordinateFrame):

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -178,30 +178,6 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
         return (self._data is not None and self._data.norm().unit is u.one
                 and u.allclose(self._data.norm(), 1*u.one))
 
-#     def __init_subclass__(cls, **kwargs):
-#         super().__init_subclass__(**kwargs)
-
-#         # TODO: Remove this after the minimum Astropy dependency includes astropy/astropy#12005
-#         cls._fix_property_docstrings()
-
-#     @classmethod
-#     def _fix_property_docstrings(cls):
-#         # This class method adds docstrings to properties dynamically created by
-#         # BaseCoordinateFrame.__init_subclass__().  Accordingly, this method needs to itself be
-#         # called from SunPyBaseCoordinateFrame.__init_subclass__() to work for our subclasses.
-#         property_docstrings = {
-#             'default_representation': "Default representation for position data",
-#             'default_differential': "Default representation for differential data",
-#             'frame_specific_representation_info': "Mapping for frame-specific component names",
-#         }
-#         for prop, docstring in property_docstrings.items():
-#             if getattr(cls, prop).__doc__ is None:
-#                 setattr(getattr(cls, prop), '__doc__', docstring)
-
-
-# # TODO: Remove this after the minimum Astropy dependency includes astropy/astropy#12005
-# SunPyBaseCoordinateFrame._fix_property_docstrings()
-
 
 class BaseHeliographic(SunPyBaseCoordinateFrame):
     """


### PR DESCRIPTION
## PR Description
This PR completes the TODO mentioned in the #7179. I have checked that the docs build correctly and the necessary changes are in place. This doesn't require a changelog since its an internal change.