### PR TITLE
Fix bug which causes Fido.search to crash if SSL verification fails for HelioClient

### DIFF
--- a/changelog/7446.bugfix.rst
+++ b/changelog/7446.bugfix.rst
@@ -1,1 +1,1 @@
-Fix a bug which caused :meth:`~sunpy.net.Fido.search` to crash due to SSL certificate verification error for the `~sunpy.net.helio.HECClient` now returns no results and logs a warning in this case.
+Fix a bug which caused ``Fido.search`` to crash due to SSL certificate verification error for the `~sunpy.net.helio.HECClient` now returns no results and logs a warning in this case.

--- a/changelog/7446.bugfix.rst
+++ b/changelog/7446.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug which caused :meth:`~sunpy.net.Fido.search` to crash due to SSL certificate verification error for the `~sunpy.net.helio.HECClient` now returns no results and logs a warning in this case.

--- a/sunpy/net/helio/hec.py
+++ b/sunpy/net/helio/hec.py
@@ -6,11 +6,13 @@ import os
 
 from lxml import etree
 from requests import Session
+from requests.exceptions import SSLError
 from zeep import Client
 from zeep.transports import Transport
 
 from astropy.io.votable.table import parse_single_table
 
+from sunpy import log
 from sunpy.net import attrs as a
 from sunpy.net.base_client import BaseClient, QueryResponseTable
 from sunpy.net.helio import attrs as ha
@@ -87,7 +89,12 @@ class HECClient(BaseClient):
         # This is for use in our test suite.
         session.verify = not (bool(os.environ.get("NO_VERIFY_HELIO_SSL", 0)))
         transport = Transport(session=session)
-        self.hec_client = Client(link, transport=transport)
+        try:
+            self.hec_client = Client(link, transport=transport)
+        except SSLError:
+            log.warning('SSL verification error for HEC client.\n'
+                     'Set the \'NO_VERIFY_HELIO_SSL\' environment variable disable SSL verification for Helio.')
+            self.hec_client = None
 
     @classmethod
     def _can_handle_query(cls, *query):
@@ -137,6 +144,9 @@ class HECClient(BaseClient):
         <BLANKLINE>
         <BLANKLINE>
         """
+        if self.hec_client is None:
+            table = HECResponse([], client=self)
+            return table
         qrdict = {}
         for elem in args:
             if isinstance(elem, a.Time):


### PR DESCRIPTION
## PR Description

Fixes #7445 adds a try except for SSL error on client initiation and then if the client (zeep) is not defined just return an empty result.
