### PR TITLE
Allow units to be passed as strings to header helper

### DIFF
--- a/changelog/7454.feature.rst
+++ b/changelog/7454.feature.rst
@@ -1,0 +1,1 @@
+Allow units to be passed to `~sunpy.map.make_fitswcs_header` as strings.

--- a/changelog/7454.feature.rst
+++ b/changelog/7454.feature.rst
@@ -1,1 +1,1 @@
-Allow units to be passed to `~sunpy.map.make_fitswcs_header` as strings.
+Allow units to be passed to `~sunpy.map.header_helper.make_fitswcs_header` as strings.

--- a/sunpy/map/header_helper.py
+++ b/sunpy/map/header_helper.py
@@ -280,7 +280,7 @@ def _set_instrument_meta(meta_wcs, instrument, telescope, observatory, detector,
     if exposure is not None:
         meta_wcs['exptime'] = exposure.to_value(u.s)
     if unit is not None:
-        meta_wcs['bunit'] = unit.to_string("fits")
+        meta_wcs['bunit'] = u.Unit(unit).to_string("fits")
 
     return meta_wcs
 

--- a/sunpy/map/tests/test_header_helper.py
+++ b/sunpy/map/tests/test_header_helper.py
@@ -211,6 +211,13 @@ def test_quantity_input(map_data, hpc_coord):
     assert header['bunit'] == override_unit.to_string('fits')
 
 
+def test_unit_as_string(map_data, hpc_coord):
+    # Test that unit can be passed in as a string
+    map_unit = u.Unit('ct / (pix s)')
+    header = make_fitswcs_header(map_data, hpc_coord, unit=map_unit.to_string())
+    assert header['bunit'] == map_unit.to_string('fits')
+
+
 def test_invalid_inputs(map_data, hcc_coord, hpc_coord_notime, hpc_coord):
     # Raise the HCC error
     with pytest.raises(ValueError):


### PR DESCRIPTION
With this PR, the following now works,

```python
earth_observer = get_earth('2020-01-01')
celestial_header = sunpy.map.make_fitswcs_header(
    (2,2),
    SkyCoord(0,0,unit='arcsec',frame=Helioprojective(observer=earth_observer)),
    unit='ph / (Angstrom second steradian cm2)',
)
```

whereas before the unit had to be explicitly passed as a `astropy.units.Unit` object.