### PR TITLE
Pass in segments keyword to the DRMS to return the SUMS dirs

### DIFF
--- a/changelog/7469.feature.rst
+++ b/changelog/7469.feature.rst
@@ -1,1 +1,1 @@
-`sunpy.net.jsoc.JSOCCLient` queries now return the SUMS directory paths as the segment key value in the results table.
+`sunpy.net.jsoc.JSOCClient` queries now return the SUMS directory paths as the segment key value in the results table.

--- a/changelog/7469.feature.rst
+++ b/changelog/7469.feature.rst
@@ -1,0 +1,1 @@
+`sunpy.net.jsoc.JSOCCLient` queries now return the SUMS directory paths as the segment key value in the results table.

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import drms
 import numpy as np
+import pandas as pd
 import parfive
 from packaging.version import Version
 
@@ -745,11 +746,16 @@ class JSOCClient(BaseClient):
             key = keywords
         log.debug(f"Running following query: {ds}")
         log.debug(f"Requesting following keywords: {key}")
-        result = client.query(ds, key=key, rec_index=is_meta)
+        result = client.query(ds, key=key, seg=segments_passed, rec_index=is_meta)
         if result is None or result.empty:
             return astropy.table.Table()
+        if segments_passed :
+            # DRMS returns a tuple of length 2 if there is segment information
+            query_result, segment_result = result[0], result[1]
+            query_result = pd.concat([query_result, segment_result],axis=1)
         else:
-            return astropy.table.Table.from_pandas(result)
+            query_result = result
+        return astropy.table.Table.from_pandas(query_result)
 
     @classmethod
     def _can_handle_query(cls, *query):

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -753,7 +753,7 @@ class JSOCClient(BaseClient):
             query_result = pd.concat([query_result, segment_result],axis=1)
         else:
             query_result = result
-        if result is None or result.empty:
+        if result is None or query_result.empty:
             return astropy.table.Table()
         return astropy.table.Table.from_pandas(query_result)
 

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -747,14 +747,14 @@ class JSOCClient(BaseClient):
         log.debug(f"Running following query: {ds}")
         log.debug(f"Requesting following keywords: {key}")
         result = client.query(ds, key=key, seg=segments_passed, rec_index=is_meta)
-        if result is None or result.empty:
-            return astropy.table.Table()
-        if segments_passed :
+        if segments_passed:
             # DRMS returns a tuple of length 2 if there is segment information
             query_result, segment_result = result[0], result[1]
             query_result = pd.concat([query_result, segment_result],axis=1)
         else:
             query_result = result
+        if result is None or result.empty:
+            return astropy.table.Table()
         return astropy.table.Table.from_pandas(query_result)
 
     @classmethod

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -54,6 +54,8 @@ def test_return_query_args(client):
                         a.jsoc.Segment('Bp') & a.jsoc.Segment('magnetogram'))
     # Because res.query_args is list that contains dict
     assert 'primekey' in res.query_args[0]
+    assert "magnetogram" in res.keys()
+    assert res["magnetogram"][0].startswith("/SUM")
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
Supersedes https://github.com/sunpy/sunpy/pull/7236 

So the data on the JSOC is stored in SUM directories and they can return these locations to a user. To return this information, we just have to add a value for the `seg` key for the DRMS client.

The reason we will want to do this is that it allows a user (and in future the JSOCClient) to use these file locations to download the JSOC data without having to export. The JSOC has asked sunpy to stop doing exports and this is step 1 of that process. 