### PR TITLE
Remove plot_date due to upstream dep warning

### DIFF
--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -86,7 +86,7 @@ class XRSTimeSeries(GenericTimeSeries):
         plot_settings = {"xrsa": ["blue", r"0.5--4.0 $\AA$"], "xrsb": ["red", r"1.0--8.0 $\AA$"]}
         data = self.to_dataframe()
         for channel in columns:
-            axes.plot_date(
+            axes.plot(
                 data.index, data[channel], "-", label=plot_settings[channel][1], color=plot_settings[channel][0], lw=2, **kwargs
             )
         axes.set_yscale("log")


### PR DESCRIPTION
Should fix figure-devdeps

- Minor Change
- Backport to 5.0 and 5.1
- No changelog

See https://matplotlib.org/3.8.3/api/prev_api_changes/api_changes_3.5.0.html#discouraged-plot-date