### PR TITLE
Remove packages that are already pre-installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       posargs: -n auto
-      libraries: |
-        apt:
-          - libopenjp2-7
       envs: |
         - linux: py312
     secrets:
@@ -43,9 +40,6 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       posargs: -n auto
-      libraries: |
-        brew:
-          - openjpeg
       envs: |
         - windows: py311
         - macos: py310
@@ -68,7 +62,6 @@ jobs:
       cache-key: docs-${{ github.run_id }}
       libraries: |
         apt:
-          - libopenjp2-7
           - graphviz
       envs: |
         - linux: build_docs
@@ -83,9 +76,6 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       posargs: -n auto --dist loadgroup
-      libraries: |
-        apt:
-          - libopenjp2-7
       envs: |
         - linux: build_docs-gallery
           posargs: ''
@@ -116,9 +106,6 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       posargs: -n auto
-      libraries: |
-        apt:
-          - libopenjp2-7
       envs: |
         - linux: base_deps
         - linux: py311-devdeps


### PR DESCRIPTION
These are already pre-installed on each image.

The brew on mac is forcing an upgrade which is breaking the CI. 