### PR TITLE
Update base URL for EVEClient to new LASP URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
-      posargs: -n auto
+      posargs: -n auto --color=yes
       envs: |
         - linux: py312
     secrets:
@@ -39,7 +39,7 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
-      posargs: -n auto
+      posargs: -n auto --color=yes
       envs: |
         - windows: py311
         - macos: py310
@@ -75,10 +75,8 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
-      posargs: -n auto --dist loadgroup
       envs: |
         - linux: build_docs-gallery
-          posargs: ''
           pytest: false
           cache-path: |
             docs/_build/
@@ -90,6 +88,7 @@ jobs:
               - libopenjp2-7
               - graphviz
         - linux: py312-online
+          posargs: -n auto --dist loadgroup --color=yes
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -105,7 +104,7 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
-      posargs: -n auto
+      posargs: -n auto --color=yes
       envs: |
         - linux: base_deps
         - linux: py311-devdeps

--- a/changelog/7483.bugfix.rst
+++ b/changelog/7483.bugfix.rst
@@ -1,0 +1,1 @@
+The EVE L0CS client now uses the new URLs for the data from LASP.

--- a/changelog/7483.doc.rst
+++ b/changelog/7483.doc.rst
@@ -1,0 +1,1 @@
+Fix a VSO doctest due to VSO now returning level one EIT data.

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,3 +60,4 @@ filterwarnings =
     ignore:ERFA function *
     # This seems to randomly crop up but I don't know why
     ignore:unclosed event loop:ResourceWarning
+    ignore:unclosed transport:ResourceWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -58,3 +58,5 @@ filterwarnings =
     # The following are raised by the py310-oldestdeps job
     ignore:distutils Version classes are deprecated
     ignore:ERFA function *
+    # This seems to randomly crop up but I don't know why
+    ignore:unclosed event loop:ResourceWarning

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -12,7 +12,7 @@ class EVEClient(GenericClient):
     Provides access to Level 0CS Extreme ultraviolet Variability Experiment (EVE) data.
 
     To use this client you must request Level 0 data.
-    It is hosted by `LASP <http://lasp.colorado.edu/home/eve/data/data-access/>`__.
+    It is hosted by `LASP <https://lasp.colorado.edu/eve/data_access/eve-space-weather/>`__.
 
     Examples
     --------
@@ -25,7 +25,7 @@ class EVEClient(GenericClient):
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the EVEClient:
-    Source: https://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/
+    Source: https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/L0CS/SpWx/
     <BLANKLINE>
            Start Time               End Time        Instrument ... Provider Level
     ----------------------- ----------------------- ---------- ... -------- -----
@@ -41,7 +41,7 @@ class EVEClient(GenericClient):
 
     @property
     def info_url(self):
-        return 'https://lasp.colorado.edu/eve/data_access/eve-space-weather/index.html'
+        return 'https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/L0CS/SpWx/'
 
     @classmethod
     def register_values(cls):

--- a/sunpy/net/dataretriever/sources/eve.py
+++ b/sunpy/net/dataretriever/sources/eve.py
@@ -35,13 +35,13 @@ class EVEClient(GenericClient):
     <BLANKLINE>
 
     """
-    baseurl = (r'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/'
+    baseurl = (r'https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/'
                r'L0CS/SpWx/%Y/%Y%m%d_EVE_L0CS_DIODES_1m.txt')
     pattern = '{}/SpWx/{:4d}/{year:4d}{month:2d}{day:2d}_EVE_L{Level:1d}{}'
 
     @property
     def info_url(self):
-        return 'https://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/'
+        return 'https://lasp.colorado.edu/eve/data_access/eve-space-weather/index.html'
 
     @classmethod
     def register_values(cls):

--- a/sunpy/net/dataretriever/sources/tests/test_eve.py
+++ b/sunpy/net/dataretriever/sources/tests/test_eve.py
@@ -18,16 +18,16 @@ def LCClient():
 @pytest.mark.remote_data
 @pytest.mark.parametrize(("timerange", "url_start", "url_end"), [
     (Time('2012/4/21', '2012/4/21'),
-     'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120421_EVE_L0CS_DIODES_1m.txt',
-     'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120421_EVE_L0CS_DIODES_1m.txt'
+     'https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/L0CS/SpWx/2012/20120421_EVE_L0CS_DIODES_1m.txt',
+     'https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/L0CS/SpWx/2012/20120421_EVE_L0CS_DIODES_1m.txt'
      ),
     (Time('2012/5/5', '2012/5/6'),
-     'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120505_EVE_L0CS_DIODES_1m.txt',
-     'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120506_EVE_L0CS_DIODES_1m.txt',
+     'https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/L0CS/SpWx/2012/20120505_EVE_L0CS_DIODES_1m.txt',
+     'https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/L0CS/SpWx/2012/20120506_EVE_L0CS_DIODES_1m.txt',
      ),
     (Time('2012/7/7', '2012/7/14'),
-     'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120707_EVE_L0CS_DIODES_1m.txt',
-     'http://lasp.colorado.edu/eve/data_access/evewebdata/quicklook/L0CS/SpWx/2012/20120714_EVE_L0CS_DIODES_1m.txt',
+     'https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/L0CS/SpWx/2012/20120707_EVE_L0CS_DIODES_1m.txt',
+     'https://lasp.colorado.edu/eve/data_access/eve_data/quicklook/L0CS/SpWx/2012/20120714_EVE_L0CS_DIODES_1m.txt',
      )
 ])
 def test_get_url_for_time_range(LCClient, timerange, url_start, url_end):

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -195,25 +195,27 @@ class VSOClient(BaseClient):
 
         Examples
         --------
-        Query all data from eit or aia between 2010-01-01T00:00 and
+        Query all data from the EIT instrument 2010-01-01T00:00 and
         2010-01-01T01:00.
 
-        >>> from datetime import datetime
         >>> from sunpy.net import vso, attrs as a
         >>> client = vso.VSOClient()  # doctest: +REMOTE_DATA
-        >>> client.search(
-        ...    a.Time(datetime(2010, 1, 1), datetime(2010, 1, 1, 1)),
-        ...    a.Instrument.eit | a.Instrument.aia,
-        ...    response_format="table")   # doctest:  +REMOTE_DATA
+        >>> client.search(a.Time("2010/01/01", "2010/01/01 01:00"),
+        ...               a.Instrument.eit)   # doctest:  +REMOTE_DATA
         <sunpy.net.vso.table_response.VSOQueryResponseTable object at ...>
             Start Time               End Time        Source ... Extent Type   Size
                                                             ...              Mibyte
         ----------------------- ----------------------- ------ ... ----------- -------
         2010-01-01 00:00:08.000 2010-01-01 00:00:20.000   SOHO ...    FULLDISK 2.01074
+        2010-01-01 00:10:55.000 2010-01-01 00:11:07.000   SOHO ...    FULLDISK  4.2002
         2010-01-01 00:12:08.000 2010-01-01 00:12:20.000   SOHO ...    FULLDISK 2.01074
+        2010-01-01 00:22:57.000 2010-01-01 00:23:09.000   SOHO ...    FULLDISK  4.2002
         2010-01-01 00:24:10.000 2010-01-01 00:24:22.000   SOHO ...    FULLDISK 2.01074
+        2010-01-01 00:34:55.000 2010-01-01 00:35:07.000   SOHO ...    FULLDISK  4.2002
         2010-01-01 00:36:08.000 2010-01-01 00:36:20.000   SOHO ...    FULLDISK 2.01074
+        2010-01-01 00:46:56.000 2010-01-01 00:47:08.000   SOHO ...    FULLDISK  4.2002
         2010-01-01 00:48:09.000 2010-01-01 00:48:21.000   SOHO ...    FULLDISK 2.01074
+        2010-01-01 00:58:58.000 2010-01-01 00:59:11.000   SOHO ...    FULLDISK  4.2002
 
         Returns
         -------


### PR DESCRIPTION
This fixes the online tests by changing the EVE L0CS client to use the new URLs for the data from LASP and account for the fact that the VSO new returns L1 SOHO EIT data.