### PR TITLE
Flip jp2 data vertically before saving

### DIFF
--- a/changelog/7486.bugfix.rst
+++ b/changelog/7486.bugfix.rst
@@ -1,0 +1,1 @@
+JPEG2000 files are now saved with the correct orientation. Previously they would be vertically flipped when saved.

--- a/sunpy/io/_jp2.py
+++ b/sunpy/io/_jp2.py
@@ -176,7 +176,7 @@ def write(fname, data, header, **kwargs):
 
     tmpname = fname + "tmp.jp2"
     jp2_data = np.uint8(data)
-    jp2 = Jp2k(tmpname, jp2_data, **kwargs)
+    jp2 = Jp2k(tmpname, np.flip(jp2_data, 0), **kwargs)
 
     # Append the XML data to the header information stored in jp2.box
     meta_boxes = jp2.box

--- a/sunpy/io/_jp2.py
+++ b/sunpy/io/_jp2.py
@@ -176,7 +176,11 @@ def write(fname, data, header, **kwargs):
 
     tmpname = fname + "tmp.jp2"
     jp2_data = np.uint8(data)
-    jp2 = Jp2k(tmpname, np.flip(jp2_data, 0), **kwargs)
+
+    # The jp2 data is flipped when read in, so we have to flip it back before
+    # saving.
+    flipped = np.flip(jp2_data, 0)
+    jp2 = Jp2k(tmpname, flipped, **kwargs)
 
     # Append the XML data to the header information stored in jp2.box
     meta_boxes = jp2.box

--- a/sunpy/io/_jp2.py
+++ b/sunpy/io/_jp2.py
@@ -178,7 +178,7 @@ def write(fname, data, header, **kwargs):
     jp2_data = np.uint8(data)
 
     # The jp2 data is flipped when read in, so we have to flip it back before
-    # saving.
+    # saving. See https://github.com/sunpy/sunpy/pull/768 for context.
     flipped = np.flip(jp2_data, 0)
     jp2 = Jp2k(tmpname, flipped, **kwargs)
 

--- a/sunpy/io/tests/test_jp2.py
+++ b/sunpy/io/tests/test_jp2.py
@@ -44,3 +44,8 @@ def test_simple_write(tmpdir):
     # Sanity check that reading back the jp2 returns coherent data
     jp2_readback = _jp2.read(outfile)
     assert header['DATE'] == jp2_readback[0].header['DATE']
+
+    # jp2 requires the data array to have type uint8, so cast the original
+    # data array to uint8 to compare it with the generated jp2 file.
+    original_data = np.uint8(data)
+    assert np.array_equal(original_data, jp2_readback[0].data)


### PR DESCRIPTION
## PR Description

Fixes #7485 

Flipping the data array when saving as jp2 fixes this problem.
