### PR TITLE
0 results due to server error 

### DIFF
--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -90,7 +90,7 @@ class UnifiedResponse(Sequence):
         The first index is to the client and the second index is the records
         returned from those clients.
         """
-        if isinstance(aslice, int | slice):
+        if isinstance(aslice, (int | slice)):
             ret = self._list[aslice]
 
         # using the client's name for indexing the responses.
@@ -119,7 +119,7 @@ class UnifiedResponse(Sequence):
         else:
             raise IndexError("UnifiedResponse objects must be sliced with integers or strings.")
 
-        if isinstance(ret, QueryResponseTable | QueryResponseColumn | QueryResponseRow):
+        if isinstance(ret, (QueryResponseTable | QueryResponseColumn | QueryResponseRow)):
             return ret
 
         return UnifiedResponse(*ret)
@@ -318,8 +318,10 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         # This is because the VSO _can_handle_query is very broad because we
         # don't know the full list of supported values we can search for (yet).
         results = [r for r in results if not isinstance(r, vso.VSOQueryResponseTable) or len(r) > 0]
-
-        return UnifiedResponse(*results)
+        results = UnifiedResponse(*results)
+        if results._numfile == 0:
+            return " WARNING : No data found for query"
+        return results
 
     def fetch(self, *query_results, path=None, max_conn=5, progress=True,
               overwrite=False, downloader=None, **kwargs):

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -90,7 +90,7 @@ class UnifiedResponse(Sequence):
         The first index is to the client and the second index is the records
         returned from those clients.
         """
-        if isinstance(aslice, (int | slice)):
+        if isinstance(aslice, int | slice):
             ret = self._list[aslice]
 
         # using the client's name for indexing the responses.
@@ -119,7 +119,7 @@ class UnifiedResponse(Sequence):
         else:
             raise IndexError("UnifiedResponse objects must be sliced with integers or strings.")
 
-        if isinstance(ret, (QueryResponseTable | QueryResponseColumn | QueryResponseRow)):
+        if isinstance(ret, QueryResponseTable | QueryResponseColumn | QueryResponseRow):
             return ret
 
         return UnifiedResponse(*ret)

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -283,8 +283,10 @@ class Scraper:
             return self._ftpfileslist(timerange)
         if urlsplit(directories[0]).scheme == "file":
             return self._localfilelist(timerange)
+        directory_tries_count = { directory : 0 for directory in directories}
         while directories:
             directory = directories.pop(0)
+            directory_tries_count[directory] += 1
             try:
                 opn = urlopen(directory)
                 try:
@@ -321,6 +323,9 @@ class Scraper:
                     # Put this dir back on the queue
                     directories.insert(0, directory)
                     continue
+                if directory_tries_count[directory] == 5:
+                    # Retry the directory
+                    return "Failed to scrape directory {} after 5 tries.".format(directory)
                 raise
             except Exception:
                 raise


### PR DESCRIPTION

## PR Description
Solving (#5661 )
This PR tries to resolve the ambiguity caused by 0 results caused by ```no matching response from server``` vs ```server error``` resulting in no response. The main motive is to return the error code from the scraper to get the context that there has been a server error which is difficult to reproduce it manually. 
<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->
