### PR TITLE
Pin out pytest 8.1.1

### DIFF
--- a/.test_package_pins.txt
+++ b/.test_package_pins.txt
@@ -1,2 +1,5 @@
 # This file is used to pin test packages across sunpy coordinated packages
 # Do not remove, even if it's empty!
+
+# https://github.com/scientific-python/pytest-doctestplus/issues/243
+pytest<8.1.1

--- a/.test_package_pins.txt
+++ b/.test_package_pins.txt
@@ -2,4 +2,4 @@
 # Do not remove, even if it's empty!
 
 # https://github.com/scientific-python/pytest-doctestplus/issues/243
-pytest<8.1.1
+pytest<8.1


### PR DESCRIPTION
We also have to pin out the yanked 8.1.0 as pypicky doesn't filter yanked versions.