### PR TITLE
Save a repeat access by using the walrus operator

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2530,8 +2530,7 @@ class GenericMap(NDData):
         msg = ('Cannot manually specify {0}, as the norm '
                'already has {0} set. To prevent this error set {0} on '
                '`m.plot_settings["norm"]` or the norm passed to `m.plot`.')
-        if imshow_args.get('norm', None) is not None:
-            norm = imshow_args['norm']
+        if (norm := imshow_args.get('norm', None)) is not None:
             if 'vmin' in imshow_args:
                 if norm.vmin is not None:
                     raise ValueError(msg.format('vmin'))


### PR DESCRIPTION
Correcting the oversight that #7261 should have made use of the walrus operator