### PR TITLE
Use headless opencv in conda devenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           conda list
           cd /tmp
-          pytest -vvv -r a --pyargs sunpy --cov-report=xml --cov=sunpy --cov-config=$GITHUB_WORKSPACE/pyproject.toml $GITHUB_WORKSPACE/docs -n auto
+          pytest -vvv -r a --pyargs sunpy --cov-report=xml --cov=sunpy --cov-config=$GITHUB_WORKSPACE/pyproject.toml $GITHUB_WORKSPACE/docs -n auto --color=yes
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -34,6 +34,7 @@ dependencies:
   - jplephem
   - lxml
   - opencv
+  - libopencv *=headless*
   - spiceypy
 
   # Testing


### PR DESCRIPTION
https://github.com/conda-forge/opencv-feedstock/issues/401

This is an attempt to fix the conda build, I don't think having headless opencv is a problem for our use of it @ayshih?