### PR TITLE
Fix a unit test for our `observer` frame attribute

### DIFF
--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -130,8 +130,8 @@ def test_observer_not_default_representation(oca):
 
 def test_coord_get():
 
-    # Test default (instance=None)
-    obs = Helioprojective.observer
+    # Test default observer is None
+    obs = Helioprojective().observer
     assert obs is None
 
     # Test get


### PR DESCRIPTION
One of our unit tests checked the default value of an `observer` frame attribute by retrieving it from the class (`Helioprojective`) rather than retrieving it from an instance of the class (`Helioprojective()`).  The test should really have been doing the latter.  As of astropy/astropy#15259, retrieving the frame attribute from the class returns the attribute instance instead of the default value, so the test now fails.  Thus, this PR fixes the unit test so that it properly checks the frame attribute on an instance.