### PR TITLE
Revert "Backport PR #7369 on branch 5.0 (Warn user when importing submodule without the submodules dependencies)"

### DIFF
--- a/changelog/7369.feature.rst
+++ b/changelog/7369.feature.rst
@@ -1,1 +1,0 @@
-Added warning when importing a submodule without installing that submodules extra dependencies.

--- a/sunpy/image/__init__.py
+++ b/sunpy/image/__init__.py
@@ -1,4 +1,0 @@
-# Check if user has installed the image extras
-from sunpy.util.sysinfo import _warn_missing_deps
-
-_warn_missing_deps('image')

--- a/sunpy/map/__init__.py
+++ b/sunpy/map/__init__.py
@@ -12,7 +12,3 @@ from sunpy.map.map_factory import Map
 from sunpy.map.maputils import *
 from .compositemap import CompositeMap
 from .mapsequence import MapSequence
-
-# Check if user has installed the map extras
-from sunpy.util.sysinfo import _warn_missing_deps
-_warn_missing_deps('map')

--- a/sunpy/net/__init__.py
+++ b/sunpy/net/__init__.py
@@ -1,7 +1,3 @@
-# Check if user has installed the net extras
-from sunpy.util.sysinfo import _warn_missing_deps
-
-_warn_missing_deps('net')
 
 # Import and register the clients but we do not want them in the namespace, we import them as _
 from sunpy.net import base_client as _

--- a/sunpy/timeseries/__init__.py
+++ b/sunpy/timeseries/__init__.py
@@ -1,8 +1,3 @@
-# Check if user has installed the timeseries extras
-from sunpy.util.sysinfo import _warn_missing_deps
-
-_warn_missing_deps('timeseries')
-
 from sunpy.timeseries.metadata import TimeSeriesMetaData
 from sunpy.timeseries.sources import *
 from sunpy.timeseries.timeseries_factory import TimeSeries

--- a/sunpy/util/sysinfo.py
+++ b/sunpy/util/sysinfo.py
@@ -9,7 +9,6 @@ from packaging.markers import Marker
 from packaging.requirements import Requirement
 
 import sunpy.extern.distro as distro
-from sunpy.util import warn_user
 
 __all__ = ['system_info', 'find_dependencies', 'missing_dependencies_by_extra']
 
@@ -99,22 +98,6 @@ def find_dependencies(package="sunpy", extras=None):
         missing_requirements[package] = format_requirement_string(
             resolve_requirement_versions(package_versions))
     return missing_requirements, installed_requirements
-
-
-def _warn_missing_deps(extras):
-    """
-    Warn a user if they are missing dependencies defined in a given extras.
-    """
-    if (deps := find_dependencies(package="sunpy", extras=extras)):
-        missing_deps = [deps[0][key].split(";")[0].strip("Missing ") for key in deps[0].keys()]
-        if missing_deps:
-            warn_user(f"Importing sunpy.{extras} without its extra dependencies may result in errors.\n"
-                      f"The following packages are not installed:\n{missing_deps}\n"
-                      f"To install sunpy with these dependencies use `pip install sunpy[{extras}]` "
-                      f"or `pip install sunpy[all]` for all extras. \n"
-                      "If you installed sunpy via conda, please report this "
-                      "to the community channel: https://matrix.to/#/#sunpy:openastronomy.org"
-                      )
 
 
 def missing_dependencies_by_extra(package="sunpy", exclude_extras=None):

--- a/sunpy/visualization/__init__.py
+++ b/sunpy/visualization/__init__.py
@@ -1,6 +1,2 @@
-# Check if user has installed the visualisation extras
-from sunpy.util.sysinfo import _warn_missing_deps
 from sunpy.visualization.limb import *
 from sunpy.visualization.visualization import *
-
-_warn_missing_deps('visualization')


### PR DESCRIPTION
Reverts sunpy/sunpy#7506

I don't believe this PR should have been backported, because it's not a bug fix and clearly can trigger downstream issues on packages which don't depend on all the extras because it did with DKIST.