### PR TITLE
Fixed an inaccuracy in the HME<->HEE transformation

### DIFF
--- a/changelog/7530.bugfix.rst
+++ b/changelog/7530.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an inaccuracy in the implementation of `~sunpy.coordinates.HeliocentricEarthEcliptic` and `~sunpy.coordinates.GeocentricSolarEcliptic` such that the Earth was not exactly in the XY plane, but rather had an error of up ~10 meters.

--- a/sunpy/coordinates/_transformations.py
+++ b/sunpy/coordinates/_transformations.py
@@ -589,7 +589,8 @@ def _rotation_matrix_reprs_to_reprs(start_representation, end_representation):
     A = start_representation.to_cartesian()
     B = end_representation.to_cartesian()
     rotation_axis = A.cross(B)
-    rotation_angle = -np.arccos(A.dot(B) / (A.norm() * B.norm()))  # negation is required
+    # Calculate the angle using both cross and dot products to minimize numerical-precision issues
+    rotation_angle = -np.arctan2(rotation_axis.norm(), A.dot(B))  # negation is required
 
     if rotation_angle.isscalar:
         # This line works around some input/output quirks of Astropy's rotation_matrix()

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -695,6 +695,13 @@ def test_hme_hee_sunspice():
     assert_quantity_allclose(new.distance, old.distance)
 
 
+def test_hee_earth():
+    # The Earth in HEE should have negligible Z component
+    times = parse_time('2013-08-10 12:00') + np.arange(10) * u.s
+    earth_hee = get_earth(times).heliocentricearthecliptic
+    assert_quantity_allclose(0*u.m, earth_hee.cartesian.z, atol=1e-4*u.m)
+
+
 def test_hee_hee():
     # Test HEE loopback transformation
     obstime = Time('2001-01-01')


### PR DESCRIPTION
Thanks to Bob Weigel for discovering an inaccuracy in a coordinate transformation!  The Earth is supposed to be in the XY-plane of `HeliocentricEarthEcliptic` (and `GeocentricSolarEcliptic`), but our framework would gave the Earth a Z component of up to ~12 meters.
```python
>>> from sunpy.coordinates import get_earth
>>>
>>> get_earth('2013-08-10 12:00').heliocentricearthecliptic.cartesian.z.to('m')  # should be very close to zero!
<Quantity 11.24899785 m>
```
The reason turned out to be that there can be an extremely tiny tilt between `HeliocentricMeanEcliptic` (HME) and `HeliocentricEarthEcliptic` (HEE) – sub-arcsecond, because the Earth is extremely close to lying on the mean ecliptic plane – but the current approach for calculating the tilt angle amplifies any numerical-precision error for extremely small angles.

This PR fixes the calculation of the tilt angle to be numerically well-behaved.  The same calculation as above now gives a Z component of 17 microns rather than 11 meters.
```python
>>> get_earth('2013-08-10 12:00').heliocentricearthecliptic.cartesian.z.to('m')  # should be very close to zero!
<Quantity 1.66088901e-05 m>
```
Technically, since this internal function is used by many of the coordinate transformations, other transformations are in principle more accurate now, but the improvement in accuracy would be impossible to detect except in the rare cases of working with extremely small rotations.
