### PR TITLE
Do not optionally depend on truly optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ image = [
   # !=1.10.0 due to https://github.com/scipy/scipy/issues/17718
   "scipy>=1.8.0,!=1.10.0",
 ]
-jpeg2000 = ["glymur>=0.9.1,!=0.9.5", "lxml>=4.9.0,!=5.0.0"]
 map = [
   "matplotlib>=3.5.0",
   "mpl-animators>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ Changelog = "https://docs.sunpy.org/en/stable/whatsnew/changelog.html"
 [project.optional-dependencies]
 # The list of available extras is also in the installation docs, if you add or remove one please edit it there as well.
 asdf = ["asdf-astropy>=0.2.0", "asdf>=2.11.0"]
-dask = ["dask[array]>=2022.5.2"]
 image = [
   "scikit-image>=0.19.0",
   # !=1.10.0 due to https://github.com/scipy/scipy/issues/17718
@@ -67,7 +66,6 @@ map = [
   # !=1.10.0 due to https://github.com/scipy/scipy/issues/17718
   "scipy>=1.8.0,!=1.10.0",
 ]
-opencv = ["opencv-python>=4.6.0.66"]
 net = [
   "beautifulsoup4>=4.11.0",
   "drms>=0.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ Changelog = "https://docs.sunpy.org/en/stable/whatsnew/changelog.html"
 # The list of available extras is also in the installation docs, if you add or remove one please edit it there as well.
 asdf = ["asdf-astropy>=0.2.0", "asdf>=2.11.0"]
 image = [
-  "scikit-image>=0.19.0",
   # !=1.10.0 due to https://github.com/scipy/scipy/issues/17718
   "scipy>=1.8.0,!=1.10.0",
 ]


### PR DESCRIPTION
This has come out of #7369

I think one of the foundational issues exposed by #7369 is that our extras do not cleanly separate dependencies that are required to import a subpackage vs dependencies which are only triggered if you call a specific function (or sometimes even a specific function with a specific argument).

The (controversial) approach I have taken in this PR is that we shouldn't even list in our deps packages which fall into the latter category (we for instance do not do so for `jplephem` at the moment).

---

Note that I have exempted "spice" from this culling as it's really "sunpy.coordinates.spice" which is a required dep for a subsubmodule.