### PR TITLE
Allow setting spherical screen radius

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -21,4 +21,5 @@ default.extend-ignore-identifiers-re = [
     "ot",
     # Coords,
     "pn",
+    "lightyear",
 ]

--- a/changelog/7115.deprecation.rst
+++ b/changelog/7115.deprecation.rst
@@ -1,1 +1,1 @@
-`~sunpy.coordinates.Helioprojective.assume_spherical_screen` has been deprecated in favor of `~sunpy.coordinates.SphericalScreen`.
+:meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` has been deprecated in favor of `~sunpy.coordinates.SphericalScreen`.

--- a/changelog/7115.feature.rst
+++ b/changelog/7115.feature.rst
@@ -1,1 +1,1 @@
-Added `~sunpy.coordinates.PlanarScreen` for realizing 3D versions of coordinates in a Helioprojective frame.
+Added `~sunpy.coordinates.PlanarScreen` for interpreting 2D `~sunpy.coordinates.Helioprojective` coordinates as being on the inside of a planar screen.

--- a/changelog/7532.feature.rst
+++ b/changelog/7532.feature.rst
@@ -1,1 +1,1 @@
-Allow the screen radius to be set when using `~sunpy.coordinates.Helioprojective.SphericalScreen`.
+Allow the screen radius to be set when using `~sunpy.coordinates.SphericalScreen`.

--- a/changelog/7532.feature.rst
+++ b/changelog/7532.feature.rst
@@ -1,0 +1,1 @@
+Allow the screen radius to be set when using :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen`.

--- a/changelog/7532.feature.rst
+++ b/changelog/7532.feature.rst
@@ -1,1 +1,1 @@
-Allow the screen radius to be set when using :meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen`.
+Allow the screen radius to be set when using `~sunpy.coordinates.Helioprojective.SphericalScreen`.

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -22,6 +22,7 @@ py:class Unit('deg')
 py:class Unit('pix')
 py:class Unit('s')
 py:class Unit('W / m2')
+py:class Unit('m')
 py:obj function
 py:obj iterable
 py:obj parfive

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -126,5 +126,5 @@ This replaces the default assumption where 2D coordinates are mapped onto the su
 Deprecate `~sunpy.coordinates.Helioprojective.assume_spherical_screen`
 ======================================================================
 
-:func:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` is now deprecated.
+:meth:`~sunpy.coordinates.Helioprojective.assume_spherical_screen` is now deprecated.
 Equivalent functionality is now provided by :class:`~sunpy.coordinates.SphericalScreen`.

--- a/examples/map_transformations/autoalign_aia_hmi.py
+++ b/examples/map_transformations/autoalign_aia_hmi.py
@@ -52,9 +52,8 @@ map_hmi.plot(axes=ax2)
 #
 # Note that off-disk HMI data are not retained by default because an
 # additional assumption is required to define the location of the HMI
-# emission in 3D space. We can use
-# :meth:`~sunpy.coordinates.SphericalScreen` to
-# retain the off-disk HMI data. See
+# emission in 3D space. We can use `~sunpy.coordinates.SphericalScreen`
+# to retain the off-disk HMI data. See
 # :ref:`sphx_glr_generated_gallery_map_transformations_reprojection_spherical_screen.py`
 # for more reference.
 

--- a/examples/map_transformations/reprojection_align_aia_hmi.py
+++ b/examples/map_transformations/reprojection_align_aia_hmi.py
@@ -58,9 +58,8 @@ out_hmi = map_hmi.reproject_to(map_aia.wcs)
 #
 # Note that off-disk HMI data are not retained by default because an
 # additional assumption is required to define the location of the HMI
-# emission in 3D space. We can use
-# :meth:`~sunpy.coordinates.SphericalScreen` to
-# retain the off-disk HMI data. See
+# emission in 3D space. We can use `~sunpy.coordinates.SphericalScreen`
+# to retain the off-disk HMI data. See
 # :ref:`sphx_glr_generated_gallery_map_transformations_reprojection_spherical_screen.py`
 # for more reference.
 

--- a/examples/plotting/lasco_overlay.py
+++ b/examples/plotting/lasco_overlay.py
@@ -35,8 +35,7 @@ aia_map = Map(sunpy.data.sample.AIA_171_IMAGE)
 #
 # Note that off-disk AIA data are not retained by default because an
 # additional assumption is required to define the location of the AIA
-# emission in 3D space. We can use
-# :meth:`~sunpy.coordinates.SphericalScreen` to
+# emission in 3D space. We can use `~sunpy.coordinates.SphericalScreen` to
 # retain the off-disk AIA data. See
 # :ref:`sphx_glr_generated_gallery_map_transformations_reprojection_spherical_screen.py`
 # for more reference.
@@ -51,8 +50,8 @@ projected_header = sunpy.map.make_fitswcs_header(aia_map.data.shape,
                                                  scale=u.Quantity(aia_map.scale),
                                                  instrument=aia_map.instrument,
                                                  wavelength=aia_map.wavelength)
-# We use `SphericalScreen` to ensure that the off limb AIA pixels are reprojected
-# otherwise it will only be the on disk pixels that are reprojected.
+# We use `~sunpy.coordinates.SphericalScreen` to ensure that the off limb AIA pixels
+# are reprojected. Otherwise it will only be the on disk pixels that are reprojected.
 with SphericalScreen(aia_map.observer_coordinate):
     aia_reprojected = aia_map.reproject_to(projected_header)
 

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -570,7 +570,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
             d = ((-1*b) - np.sqrt(b**2 - 4*c)) / 2  # use the "near" solution
 
         if self._assumed_screen:
-            d_screen = self._assumed_screen._calculate_distance(self)
+            d_screen = self._assumed_screen.calculate_distance(self)
             d = np.fmin(d, d_screen) if self._assumed_screen.only_off_disk else d_screen
 
         # This warning can be triggered in specific draw calls when plt.show() is called

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -570,7 +570,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
             d = ((-1*b) - np.sqrt(b**2 - 4*c)) / 2  # use the "near" solution
 
         if self._assumed_screen:
-            d_screen = self._assumed_screen.calculate_distance(self)
+            d_screen = self._assumed_screen._calculate_distance(self)
             d = np.fmin(d, d_screen) if self._assumed_screen.only_off_disk else d_screen
 
         # This warning can be triggered in specific draw calls when plt.show() is called

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -673,7 +673,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     @classmethod
     @sunpycontextmanager
     @deprecated('6.0', alternative='sunpy.coordinates.screens.SphericalScreen')
-    def assume_spherical_screen(cls, center, radius=None, only_off_disk=False):
+    def assume_spherical_screen(cls, center, *, radius=None, only_off_disk=False):
         try:
             old_assumed_screen = cls._assumed_screen  # nominally None
             from sunpy.coordinates import SphericalScreen

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -673,11 +673,11 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     @classmethod
     @sunpycontextmanager
     @deprecated('6.0', alternative='sunpy.coordinates.screens.SphericalScreen')
-    def assume_spherical_screen(cls, center, only_off_disk=False):
+    def assume_spherical_screen(cls, center, radius=None, only_off_disk=False):
         try:
             old_assumed_screen = cls._assumed_screen  # nominally None
             from sunpy.coordinates import SphericalScreen
-            sph_screen = SphericalScreen(center, only_off_disk=only_off_disk)
+            sph_screen = SphericalScreen(center, radius=radius, only_off_disk=only_off_disk)
             cls._assumed_screen = sph_screen
             yield
         finally:

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -673,7 +673,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     @classmethod
     @sunpycontextmanager
     @deprecated('6.0', alternative='sunpy.coordinates.screens.SphericalScreen')
-    def assume_spherical_screen(cls, center, *, radius=None, only_off_disk=False):
+    def assume_spherical_screen(cls, center, only_off_disk=False, *, radius=None):
         try:
             old_assumed_screen = cls._assumed_screen  # nominally None
             from sunpy.coordinates import SphericalScreen

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -133,7 +133,7 @@ class PlanarScreen(BaseScreen):
     ----------
     vantage_point : `~astropy.coordinates.SkyCoord`
         The vantage point that defines the orientation of the plane.
-    distance_from_center : `~astropy.units.Quantity`
+    distance_from_center : `~astropy.units.Quantity`, optional
         Distance from Sun center of the planar screen. Defaults to 0 such
         that the plane goes through Sun center
     only_off_disk : `bool`, optional

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -173,7 +173,7 @@ class PlanarScreen(BaseScreen):
     screen_type = 'planar'
 
     @u.quantity_input
-     def __init__(self, vantage_point, *, distance_from_center: u.m=0*u.m, **kwargs):
+    def __init__(self, vantage_point, *, distance_from_center: u.m=0*u.m, **kwargs):
         self._vantage_point = vantage_point
         self._distance_from_center = distance_from_center
         super().__init__(**kwargs)

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -26,7 +26,7 @@ class BaseScreen(abc.ABC):
 
     @abc.abstractmethod
     @u.quantity_input
-    def _calculate_distance(self) -> u.cm:
+    def calculate_distance(self) -> u.cm:
         ...
 
     def __enter__(self):
@@ -111,7 +111,7 @@ class SphericalScreen(BaseScreen):
             self._radius = center_hgs.radius
         super().__init__(**kwargs)
 
-    def _calculate_distance(self, frame):
+    def calculate_distance(self, frame):
         sphere_center = self._center.transform_to(frame).cartesian
         c = sphere_center.norm()**2 - self._radius**2
         rep = frame.represent_as(UnitSphericalRepresentation)
@@ -186,7 +186,7 @@ class PlanarScreen(BaseScreen):
         self._distance_from_center = distance_from_center
         super().__init__(**kwargs)
 
-    def _calculate_distance(self, frame):
+    def calculate_distance(self, frame):
         direction = self._vantage_point.transform_to(frame).cartesian
         direction = CartesianRepresentation(1, 0, 0) * frame.observer.radius - direction
         direction /= direction.norm()

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -63,6 +63,10 @@ class SphericalScreen(BaseScreen):
         If `True`, apply this assumption only to off-disk coordinates, with on-disk coordinates
         still mapped onto the surface of the Sun.  Defaults to `False`.
 
+    See Also
+    --------
+    sunpy.coordinates.PlanarScreen
+
     Examples
     --------
     .. minigallery:: sunpy.coordinates.SphericalScreen
@@ -139,6 +143,10 @@ class PlanarScreen(BaseScreen):
     only_off_disk : `bool`, optional
         If `True`, apply this assumption only to off-disk coordinates, with on-disk coordinates
         still mapped onto the surface of the Sun.  Defaults to `False`.
+
+    See Also
+    --------
+    sunpy.coordinates.SphericalScreen
 
     Examples
     --------

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -97,7 +97,7 @@ class SphericalScreen(BaseScreen):
     screen_type = 'spherical'
 
     @u.quantity_input
-    def __init__(self, center, radius: u.m=None, **kwargs):
+    def __init__(self, center, *, radius: u.m=None, **kwargs):
         self._center = center
         if radius is not None:
             self._radius = radius

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -173,7 +173,7 @@ class PlanarScreen(BaseScreen):
     screen_type = 'planar'
 
     @u.quantity_input
-    def __init__(self, vantage_point, distance_from_center: u.m=0*u.m, **kwargs):
+     def __init__(self, vantage_point, *, distance_from_center: u.m=0*u.m, **kwargs):
         self._vantage_point = vantage_point
         self._distance_from_center = distance_from_center
         super().__init__(**kwargs)

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -26,7 +26,7 @@ class BaseScreen(abc.ABC):
 
     @abc.abstractmethod
     @u.quantity_input
-    def calculate_distance(self) -> u.cm:
+    def _calculate_distance(self) -> u.cm:
         ...
 
     def __enter__(self):
@@ -111,7 +111,7 @@ class SphericalScreen(BaseScreen):
             self._radius = center_hgs.radius
         super().__init__(**kwargs)
 
-    def calculate_distance(self, frame):
+    def _calculate_distance(self, frame):
         sphere_center = self._center.transform_to(frame).cartesian
         c = sphere_center.norm()**2 - self._radius**2
         rep = frame.represent_as(UnitSphericalRepresentation)
@@ -186,7 +186,7 @@ class PlanarScreen(BaseScreen):
         self._distance_from_center = distance_from_center
         super().__init__(**kwargs)
 
-    def calculate_distance(self, frame):
+    def _calculate_distance(self, frame):
         direction = self._vantage_point.transform_to(frame).cartesian
         direction = CartesianRepresentation(1, 0, 0) * frame.observer.radius - direction
         direction /= direction.norm()

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -34,6 +34,7 @@ from sunpy.coordinates import (
     HeliographicStonyhurst,
     Helioprojective,
     SolarMagnetic,
+    SphericalScreen,
     propagate_with_solar_surface,
     sun,
     transform_with_sun_center,
@@ -132,7 +133,7 @@ def test_hpc_hpc_spherical_screen():
     sc_in = SkyCoord(Tx0, 0*u.deg, observer=observer_in,
                      frame='helioprojective')
 
-    with Helioprojective.assume_spherical_screen(observer_in):
+    with SphericalScreen(observer_in):
         sc_3d = sc_in.make_3d()
         sc_out = sc_in.transform_to(Helioprojective(observer=observer_out))
 
@@ -148,7 +149,7 @@ def test_hpc_hpc_spherical_screen():
     # Now test with a very large screen, letting us approximate the two
     # observers as being the same (aside from a different zero point for Tx)
     r_s = 1e9 * u.lightyear
-    with Helioprojective.assume_spherical_screen(observer_in, radius=r_s):
+    with SphericalScreen(observer_in, radius=r_s):
         sc_3d = sc_in.make_3d()
         sc_out = sc_in.transform_to(Helioprojective(observer=observer_out))
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2505,7 +2505,7 @@ class GenericMap(NDData):
         beyond the solar disk may not appear, which may also inhibit Matplotlib's
         autoscaling of the plot limits.  The plot limits can be set manually.
         To preserve the off-disk parts of the map, using the
-        :meth:`~sunpy.coordinates.SphericalScreen` context
+        `~sunpy.coordinates.SphericalScreen` context
         manager may be appropriate.
         """
         # Todo: remove this when deprecate_positional_args_since is removed


### PR DESCRIPTION
With Helioprojective frames, you can use `assume_spherical_screen` to transform coordinates into another frame. The screen's center is configurable, but the radius is always such that the screen passes through the Sun. That's usually the right choice, but a user (i.e. me) might want to change the radius of the screen (with it then not passing through the Sun). This PR allows that. Delightfully, the spherical screen part of `Helioprojective.make_3d` is written in full generality, so all that's needed is an argument to `assume_spherical_screen` allowing a radius to be passed in.

It looks like there weren't any tests for `assume_spherical_screen` (though there was coverage through examples in the docs), so I added a one and exercise this option.

My use case here is making videos with WISPR on PSP, which involves compositing two images from the two imagers, which are taken at slightly different times and locations. It's a wide FOV that doesn't include the Sun, but the FOV is ~fixed in helioprojective coordinates. A spherical screen passing through the Sun starts to be uncomfortably close to PSP (perihelia near 10 R_sun, while traveling ~10 R_sun/day). Projecting the images onto that kinda-close screen to composite them adds a bit of jittery parallax for the stars, which makes videos look a bit jumpy. As an experiment, I'm instead projecting onto a screen at infinity, which has the stars move very smoothly and evenly through the FOV---in trade, the coronal structures should have a bit of parallax, but since they're large, diffuse, and evolving, it's less noticeable. (My only goal in this is pretty videos.)