### PR TITLE
ignore all socket resouce warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -58,8 +58,10 @@ filterwarnings =
     # The following are raised by the py310-oldestdeps job
     ignore:distutils Version classes are deprecated
     ignore:ERFA function *
-    # This seems to randomly crop up but I don't know why
+    # This seems to randomly crop up due to our network stack
+    # One day we need to track down the root cause
     ignore:unclosed event loop:ResourceWarning
     ignore:unclosed transport:ResourceWarning
+    ignore:unclosed \<socket:ResourceWarning
     # Pending removal from sunpy 7.0
     ignore:The QueryResponse class is deprecated


### PR DESCRIPTION
Sometimes see:

```
    @pytest.fixture
    def noaa_pre_json_test_ts():
        # NOAA pre data contains years long into the future, which ERFA complains about
>       with pytest.warns(ErfaWarning, match=r'.*dubious year'):
E       ResourceWarning: unclosed <socket.socket fd=18, family=2, type=1, proto=6, laddr=('10.1.0.54', 34270), raddr=('169.154.154.65', 443)>

/home/runner/work/sunpy/sunpy/.tox/py312-online/lib/python3.12/site-packages/sunpy/timeseries/conftest.py:80: ResourceWarning
```

Hopefully this will stop them failing our CI. 