### PR TITLE
Fixed the GEI->HME transformation to preserve the length unit of the coordinate

### DIFF
--- a/changelog/7545.bugfix.rst
+++ b/changelog/7545.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with any coordinate transformation starting in `~sunpy.coordinates.GeocentricEarthEquatorial` (GEI) returning output with AU as the length unit, rather than preserving the length unit of the initial coordinate.

--- a/sunpy/coordinates/_transformations.py
+++ b/sunpy/coordinates/_transformations.py
@@ -1071,7 +1071,7 @@ def gei_to_hme(geicoord, hmeframe):
     earth_object_int = geicoord.cartesian.transform(rot_matrix)
 
     # Find the Sun-object vector in the intermediate frame
-    sun_object_int = sun_earth_int + earth_object_int
+    sun_object_int = earth_object_int + sun_earth_int  # add in this order to preserve the original units
     int_coord = int_frame.realize_frame(sun_object_int)
 
     # Convert to the final frame through HCRS

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -1055,6 +1055,36 @@ def test_rsun_preservation():
             assert_quantity_allclose(out_coord.rsun, args_out['rsun'])
 
 
+_framepairs = [
+    ('hcrs', 'heliographic_stonyhurst'),
+    ('heliographic_stonyhurst', 'heliographic_carrington'),
+    ('heliographic_stonyhurst', 'heliocentricinertial'),
+    ('heliographic_stonyhurst', 'heliocentric'),
+    ('heliocentric', 'helioprojective'),
+    ('heliocentricmeanecliptic', 'heliocentricearthecliptic'),
+    ('heliocentricearthecliptic', 'geocentricsolarecliptic'),
+    ('heliocentricmeanecliptic', 'geocentricearthequatorial'),
+    ('itrs', 'geomagnetic'),
+    ('geomagnetic', 'solarmagnetic'),
+    ('solarmagnetic', 'geocentricsolarmagnetospheric'),
+]
+
+
+@pytest.mark.parametrize(("frame1", "frame2"), _framepairs)
+@pytest.mark.parametrize("unit", [u.m, u.AU])
+def test_unit_preservation(frame1, frame2, unit):
+    coord = SkyCoord(CartesianRepresentation(0, 0, 0) * unit,
+                     frame=frame1, obstime="2001-01-01", observer="earth")
+
+    # Transform one direction and verify the unit is preserved
+    result1 = coord.transform_to(frame2)
+    assert result1.cartesian.xyz.unit == unit
+
+    # Transform back and verify the unit is preserved
+    result2 = result1.transform_to(frame1)
+    assert result2.cartesian.xyz.unit == unit
+
+
 def test_propagate_with_solar_surface():
     # Test propagating the meridian by 6 days of solar rotation
     meridian = SkyCoord(0*u.deg, np.arange(0, 90, 10)*u.deg, 1*u.AU,


### PR DESCRIPTION
Thanks to Bob Weigel for reporting this bug!  It turns out that one of our transformation steps – `GeocentricEarthEquatorial` (GEI) to `HeliocentricMeanEcliptic` (HME or HAE) – inadvertently did not preserve the length unit of the coordinate, but instead always returned the coordinate in AU.  (I never noticed because I probably tested that transformation only with coordinates where AU was already the length unit.)  While changing the unit does not make the answer wrong, it can be inconvenient for the user.

This PR makes the amusingly silly-looking fix, and importantly adds a comprehensive unit test that covers each of our transformation steps.