### PR TITLE
Fixed an unnecessary division computation for an unsupported division by a Map

### DIFF
--- a/changelog/7551.trivial.rst
+++ b/changelog/7551.trivial.rst
@@ -1,0 +1,1 @@
+Fixed an unnecessary division computation when performing a unsupported division operation using a `~sunpy.map.Map`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -570,6 +570,7 @@ class GenericMap(NDData):
     def __rmul__(self, value):
         return self.__mul__(value)
 
+    @check_arithmetic_compatibility
     def __truediv__(self, value):
         return self.__mul__(1/value)
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -3,7 +3,6 @@ Test Generic Map
 """
 import re
 import tempfile
-import contextlib
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -1732,23 +1731,15 @@ def test_map_arithmetic_neg(aia171_test_map):
     check_arithmetic_value_and_units(new_map, -aia171_test_map.quantity)
 
 
-@pytest.mark.parametrize(("value", "warn_context"), [
-    ('map', pytest.warns(RuntimeWarning)),
-    ('foobar', contextlib.nullcontext()),
-    (None, contextlib.nullcontext()),
-    (['foo', 'bar'], contextlib.nullcontext()),
-])
-def test_map_arithmetic_operations_raise_exceptions(aia171_test_map, value, warn_context):
+@pytest.mark.parametrize("value", ['map', 'foobar', None, ['foo', 'bar']])
+def test_map_arithmetic_operations_raise_exceptions(aia171_test_map, value):
     value = aia171_test_map if value == 'map' else value
     with pytest.raises(TypeError):
         _ = aia171_test_map + value
     with pytest.raises(TypeError):
         _ = aia171_test_map * value
-    with pytest.raises(TypeError):  # NOQA: PT012
-        # A runtime warning is thrown when dividing by zero in the case of
-        # the map test
-        with warn_context:
-            _ = value / aia171_test_map
+    with pytest.raises(TypeError):
+        _ = value / aia171_test_map
 
 
 def test_parse_fits_units():


### PR DESCRIPTION
Dividing a map by something is implemented as multiplying the map by the inverse of that something.  When that something is also a map, the operation is not supported.  We weren't checking whether the division is supported, and instead relying on checking whether the latter multiplication is supported, but that means that the inverse is computed even when the overall operation is not supported.  This PR simply makes us check the division upfront.

This PR also happens to fix part of #7550