### PR TITLE
Clean up util imports

### DIFF
--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -9,9 +9,6 @@ import functools
 from inspect import Parameter, signature
 from functools import wraps
 
-import astropy.units as u
-from astropy.nddata import NDData
-
 from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyPendingDeprecationWarning, warn_deprecated
 
 __all__ = ['deprecated']
@@ -388,6 +385,10 @@ def check_arithmetic_compatibility(func):
     A decorator to check if an arithmetic operation can
     be performed between a map instance and some other operation.
     """
+    # import here to reduce import complexity of `import sunpy`
+    import astropy.units as u
+    from astropy.nddata import NDData
+
     @wraps(func)
     def inner(instance, value):
         # This is explicit because it is expected that users will try to do this. This raises


### PR DESCRIPTION
This will address #7560 but isn't really a "fix".

We need to be very careful with what we import at the top level inside `util` as we import it from the top `sunpy` namespace, and large import paths will slow that down and also occasionally cause weird issues (apparently).

This is a quick fix, but I am unsure what we should do about this to make sure we keep the import hygiene in util?