### PR TITLE
[map branch] Remove arithmetic methods

### DIFF
--- a/changelog/7582.removal.rst
+++ b/changelog/7582.removal.rst
@@ -1,0 +1,1 @@
+Remove the arithmetic operators on `~sunpy.map.GenericMap` in favor of using those on `~ndcube.NDCube`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -523,7 +523,9 @@ class GenericMap(MapMetaMixin, NDCube):
             meta = copy.deepcopy(getattr(self, 'meta'))
         if new_unit := kwargs.get('unit', None):
             meta['bunit'] = new_unit.to_string('fits')
-        new_map = super()._new_instance(data=data, meta=meta, **kwargs)
+        # NOTE: wcs=None is explicitly passed here because the wcs of a map is
+        # derived from the information in the metadata.
+        new_map = super()._new_instance(data=data, meta=meta, wcs=None, **kwargs)
         # plot_settings are set explicitly here as some map sources
         # explicitly set some of the plot_settings in the constructor
         # and we want to preserve the plot_settings of the previous

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -515,25 +515,22 @@ class GenericMap(MapMetaMixin, NDCube):
                 </html>"""))
         webbrowser.open_new_tab(url)
 
-    @classmethod
-    def _new_instance(cls, data, meta, plot_settings=None, **kwargs):
+    def _new_instance(self, data=None, meta=None, plot_settings=None, **kwargs):
         """
         Instantiate a new instance of this class using given data.
         This is a shortcut for ``type(self)(data, meta, plot_settings)``.
         """
-        new_map = cls(data, meta=meta, **kwargs)
+        if meta is None:
+            meta = copy.deepcopy(getattr(self, 'meta'))
+        if new_unit := kwargs.get('unit', None):
+            meta['bunit'] = new_unit.to_string('fits')
+        new_map = super()._new_instance(data=data, meta=meta, **kwargs)
         # plot_settings are set explicitly here as some map sources
         # explicitly set some of the plot_settings in the constructor
         # and we want to preserve the plot_settings of the previous
         # instance.
         if plot_settings is not None:
             new_map.plot_settings.update(plot_settings)
-        return new_map
-
-    def _new_instance_from_op(self, new_data, new_unit, new_uncertainty):
-        new_map = super()._new_instance_from_op(new_data, new_unit, new_uncertainty)
-        new_map.meta['bunit'] = new_unit.to_string('fits')
-        new_map.plot_settings = copy.deepcopy(self.plot_settings)
         return new_map
 
     def _get_lon_lat(self, frame):
@@ -653,7 +650,7 @@ class GenericMap(MapMetaMixin, NDCube):
         new_meta['crval2'] = ((self._reference_latitude + axis2).to(self.spatial_units[1])).value
 
         # Create new map with the modification
-        new_map = self._new_instance(self.data, new_meta, self.plot_settings)
+        new_map = self._new_instance(data=self.data, meta=new_meta, plot_settings=self.plot_settings)
 
         return new_map
 
@@ -851,7 +848,7 @@ class GenericMap(MapMetaMixin, NDCube):
         new_meta['naxis2'] = new_data.shape[0]
 
         # Create new map instance
-        new_map = self._new_instance(new_data, new_meta, self.plot_settings)
+        new_map = self._new_instance(data=new_data, meta=new_meta, plot_settings=self.plot_settings)
         return new_map
 
     @add_common_docstring(rotation_function_names=_rotation_function_names)
@@ -1044,7 +1041,7 @@ class GenericMap(MapMetaMixin, NDCube):
         new_meta.pop('CD2_2', None)
 
         # Create new map with the modification
-        new_map = self._new_instance(new_data, new_meta, self.plot_settings)
+        new_map = self._new_instance(data=new_data, meta=new_meta, plot_settings=self.plot_settings)
 
         return new_map
 
@@ -1218,10 +1215,10 @@ class GenericMap(MapMetaMixin, NDCube):
         if self.mask is not None:
             new_mask = self.mask[arr_slice].copy()
             # Create new map with the modification
-            new_map = self._new_instance(new_data, new_meta, self.plot_settings, mask=new_mask)
+            new_map = self._new_instance(data=new_data, meta=new_meta, plot_settings=self.plot_settings, mask=new_mask)
             return new_map
         # Create new map with the modification
-        new_map = self._new_instance(new_data, new_meta, self.plot_settings)
+        new_map = self._new_instance(data=new_data, meta=new_meta, plot_settings=self.plot_settings)
         return new_map
 
     @seconddispatch
@@ -1371,7 +1368,7 @@ class GenericMap(MapMetaMixin, NDCube):
             new_mask = None
 
         # Create new map with the modified data
-        new_map = self._new_instance(new_data, new_meta, self.plot_settings, mask=new_mask)
+        new_map = self._new_instance(data=new_data, meta=new_meta, plot_settings=self.plot_settings, mask=new_mask)
         return new_map
 
 # #### Visualization #### #

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -47,7 +47,6 @@ from sunpy.util import MetaDict
 from sunpy.util.decorators import (
     add_common_docstring,
     cached_property_based_on,
-    check_arithmetic_compatibility,
     deprecate_positional_args_since,
 )
 from sunpy.util.exceptions import warn_user

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -543,54 +543,6 @@ class GenericMap(MapMetaMixin, NDCube):
         """Unitful representation of the map data."""
         return u.Quantity(self.data, self.unit, copy=_NUMPY_COPY_IF_NEEDED)
 
-    def _new_instance_from_op(self, new_data):
-        """
-        Helper function for creating new map instances after arithmetic
-        operations.
-        """
-        new_meta = copy.deepcopy(self.meta)
-        new_meta['bunit'] = new_data.unit.to_string('fits')
-        return self._new_instance(new_data.value, new_meta, plot_settings=self.plot_settings)
-
-    def __neg__(self):
-        return self._new_instance(-self.data, self.meta, plot_settings=self.plot_settings)
-
-    @check_arithmetic_compatibility
-    def __pow__(self, value):
-        new_data = self.quantity ** value
-        return self._new_instance_from_op(new_data)
-
-    @check_arithmetic_compatibility
-    def __add__(self, value):
-        new_data = self.quantity + value
-        return self._new_instance_from_op(new_data)
-
-    def __radd__(self, value):
-        return self.__add__(value)
-
-    def __sub__(self, value):
-        return self.__add__(-value)
-
-    def __rsub__(self, value):
-        return self.__neg__().__add__(value)
-
-    @check_arithmetic_compatibility
-    def __mul__(self, value):
-        new_data = self.quantity * value
-        return self._new_instance_from_op(new_data)
-
-    def __rmul__(self, value):
-        return self.__mul__(value)
-
-    @check_arithmetic_compatibility
-    def __truediv__(self, value):
-        return self.__mul__(1/value)
-
-    @check_arithmetic_compatibility
-    def __rtruediv__(self, value):
-        new_data = value / self.quantity
-        return self._new_instance_from_op(new_data)
-
     def _set_symmetric_vmin_vmax(self):
         """
         Set symmetric vmin and vmax about zero

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -533,6 +533,7 @@ class GenericMap(MapMetaMixin, NDCube):
     def _new_instance_from_op(self, new_data, new_unit, new_uncertainty):
         new_map = super()._new_instance_from_op(new_data, new_unit, new_uncertainty)
         new_map.meta['bunit'] = new_unit.to_string('fits')
+        new_map.plot_settings = copy.deepcopy(self.plot_settings)
         return new_map
 
     def _get_lon_lat(self, frame):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -530,6 +530,11 @@ class GenericMap(MapMetaMixin, NDCube):
             new_map.plot_settings.update(plot_settings)
         return new_map
 
+    def _new_instance_from_op(self, new_data, new_unit, new_uncertainty):
+        new_map = super()._new_instance_from_op(new_data, new_unit, new_uncertainty)
+        new_map.meta['bunit'] = new_unit.to_string('fits')
+        return new_map
+
     def _get_lon_lat(self, frame):
         """
         Given a coordinate frame, extract the lon and lat by casting to

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1783,8 +1783,9 @@ def test_map_arithmetic_operations_raise_exceptions(aia171_test_map, value):
         _ = aia171_test_map + value
     with pytest.raises(TypeError):
         _ = aia171_test_map * value
-    with pytest.raises(TypeError):
-        _ = value / aia171_test_map
+    with pytest.warns(RuntimeWarning):
+        with pytest.raises(TypeError):
+            _ = value / aia171_test_map
 
 
 def test_parse_fits_units():

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1738,7 +1738,7 @@ def test_map_arithmetic_addition_subtraction(aia171_test_map, value):
 
 
 @pytest.mark.parametrize('value', [
-    10 * u.ct,
+    10 * u.s,
     u.Quantity([10], u.ct),
     u.Quantity(np.random.rand(128), u.ct),
     u.Quantity(np.random.rand(128, 128), u.ct),


### PR DESCRIPTION
This PR removes the arithmetic methods on map in favor of using those provided by `NDCube`

This needs sunpy/ndcube#692