### PR TITLE
[map_branch] Moved data methods on mapbase to deprecated mixins

### DIFF
--- a/changelog/7592.removal.rst
+++ b/changelog/7592.removal.rst
@@ -1,0 +1,1 @@
+Deprecates several data methods on map in favour of `sunpy.map.GenericMap.data.method()`.

--- a/changelog/7592.removal.rst
+++ b/changelog/7592.removal.rst
@@ -1,1 +1,1 @@
-Deprecates several data methods on map in favour of `sunpy.map.GenericMap.data.method()`.
+Deprecated several data methods on map in favour of ``sunpy.map.GenericMap.data.<method_name>``.

--- a/docs/how_to/create_custom_map.rst
+++ b/docs/how_to/create_custom_map.rst
@@ -157,18 +157,18 @@ From these header MetaDict's that are generated, we can now create a custom map:
     <sunpy.map.mapbase.GenericMap object at ...>
     SunPy Map
     ---------
-    Observatory:                 Test case
-    Instrument:          UV detector
+    Observatory:		 Test case
+    Instrument:		 UV detector
     Detector:
-    Measurement:                 1000.0 Angstrom
-    Wavelength:          1000.0 Angstrom
-    Observation Date:    2013-10-28 00:00:00
-    Exposure Time:               Unknown
-    Dimension:           [10. 10.] pix
-    Coordinate System:   helioprojective
-    Scale:                       [2. 2.] arcsec / pix
-    Reference Pixel:     [5. 5.] pix
-    Reference Coord:     [0. 0.] arcsec
+    Measurement:		 1000.0 Angstrom
+    Wavelength:		 1000.0 Angstrom
+    Observation Date:	 2013-10-28 00:00:00
+    Exposure Time:		 Unknown
+    Pixel Dimensions:		 [10. 10.]
+    Coordinate System:	 helioprojective
+    Scale:			 [2. 2.] arcsec / pix
+    Reference Pixel:	 [5. 5.] pix
+    Reference Coord:	 [0. 0.] arcsec
     array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
            [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
            [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -285,7 +285,7 @@ class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
                    Wavelength:\t\t {wave}
                    Observation Date:\t {date}
                    Exposure Time:\t\t {dt}
-                   Dimension:\t\t {dim}
+                   Pixel Dimensions:\t\t {dim}
                    Coordinate System:\t {coord}
                    Scale:\t\t\t {scale}
                    Reference Pixel:\t {refpix}
@@ -294,7 +294,7 @@ class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
                                meas=measurement, wave=wave,
                                date=self.date.strftime(TIME_FORMAT),
                                dt=dt,
-                               dim=u.Quantity(self.shape),
+                               dim=u.Quantity(self.shape[::-1]),
                                scale=u.Quantity(self.scale),
                                coord=self._coordinate_frame_name,
                                refpix=u.Quantity(self.reference_pixel),
@@ -874,8 +874,8 @@ class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
         inv_rmatrix = np.linalg.inv(rmatrix)
 
         # Calculate the shape in pixels to contain all of the image data
-        corners = itertools.product([-0.5, self.shape[1]-0.5],
-                                    [-0.5, self.shape[0]-0.5])
+        corners = itertools.product([-0.5, self.data.shape[1]-0.5],
+                                    [-0.5, self.data.shape[0]-0.5])
         rot_corners = np.vstack([rmatrix @ c for c in corners]) * scale
         extent = np.max(rot_corners, axis=0) - np.min(rot_corners, axis=0)
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -750,8 +750,8 @@ class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
                                         method, center=True)
         new_data = new_data.T
 
-        scale_factor_x = float(self.dimensions[0] / dimensions[0])
-        scale_factor_y = float(self.dimensions[1] / dimensions[1])
+        scale_factor_x = float(self.shape[0] / dimensions[0])
+        scale_factor_y = float(self.shape[1] / dimensions[1])
 
         # Update image scale and number of pixels
         new_meta = self.meta.copy()

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -47,8 +47,10 @@ from sunpy.util.decorators import add_common_docstring, cached_property_based_on
 from sunpy.util.exceptions import warn_user
 from sunpy.util.functools import seconddispatch
 from sunpy.util.util import _figure_to_base64, fix_duplicate_notes
-from sunpy.visualization.plotter.mpl_plotter import MapPlotter
-from .mixins.mapmeta import MapDeprecateMixin, MapMetaMixin, PixelPair
+from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
+from sunpy.visualization.colormaps import cm as sunpy_cm
+from .mixins.mapdeprecate import MapDeprecateMixin
+from .mixins.mapmeta import MapMetaMixin, MapMetaValidationError, PixelPair
 
 TIME_FORMAT = config.get("general", "time_format")
 _NUMPY_COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -29,7 +29,7 @@ import astropy.units as u
 import astropy.wcs
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord, UnitSphericalRepresentation
 from astropy.utils.metadata import MetaData
-from astropy.visualization import AsymmetricPercentileInterval, HistEqStretch, ImageNormalize
+from astropy.visualization import HistEqStretch, ImageNormalize
 from astropy.visualization.wcsaxes import WCSAxes
 
 import sunpy
@@ -46,15 +46,10 @@ from sunpy.map.mixins.mapdeprecate import MapDeprecateMixin
 from sunpy.map.mixins.mapmeta import MapMetaMixin
 from sunpy.util import MetaDict
 from sunpy.util.decorators import add_common_docstring, cached_property_based_on
-from sunpy.util.decorators import (
-    add_common_docstring,
-    cached_property_based_on,
-    check_arithmetic_compatibility,
-)
 from sunpy.util.exceptions import warn_user
 from sunpy.util.functools import seconddispatch
 from sunpy.util.util import _figure_to_base64, fix_duplicate_notes
-from sunpy.visualization.plotter import MapPlotter
+from sunpy.visualization.plotter.mpl_plotter import MapPlotter
 
 TIME_FORMAT = config.get("general", "time_format")
 _NUMPY_COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -29,7 +29,7 @@ import astropy.units as u
 import astropy.wcs
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord, UnitSphericalRepresentation
 from astropy.utils.metadata import MetaData
-from astropy.visualization import HistEqStretch, ImageNormalize
+from astropy.visualization import AsymmetricPercentileInterval, HistEqStretch, ImageNormalize
 from astropy.visualization.wcsaxes import WCSAxes
 
 import sunpy
@@ -46,6 +46,11 @@ from sunpy.map.mixins.mapdeprecate import MapDeprecateMixin
 from sunpy.map.mixins.mapmeta import MapMetaMixin
 from sunpy.util import MetaDict
 from sunpy.util.decorators import add_common_docstring, cached_property_based_on
+from sunpy.util.decorators import (
+    add_common_docstring,
+    cached_property_based_on,
+    check_arithmetic_compatibility,
+)
 from sunpy.util.exceptions import warn_user
 from sunpy.util.functools import seconddispatch
 from sunpy.util.util import _figure_to_base64, fix_duplicate_notes
@@ -218,14 +223,9 @@ class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
 
         params = list(inspect.signature(NDCube).parameters)
         ndcube_kwargs = {x: kwargs.pop(x) for x in params & kwargs.keys()}
-        super().__init__(data, wcs=None, uncertainty=uncertainty, mask=mask,
+        super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,
                          meta=MetaDict(meta), unit=unit, copy=copy,
                          **ndcube_kwargs)
-        # NDData.__init__ sets self.wcs before it sets self.meta as our wcs
-        # setter needs self.meta to exist we call the parent __init__ with
-        # wcs=None and then set self.wcs so that meta is already set before the
-        # wcs setter is run with the "real" wcs.
-        self.wcs = wcs
 
         # Validate header
         # TODO: This should be a function of the header, not of the map

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -750,8 +750,8 @@ class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
                                         method, center=True)
         new_data = new_data.T
 
-        scale_factor_x = float(self.shape[0] / dimensions[0])
-        scale_factor_y = float(self.shape[1] / dimensions[1])
+        scale_factor_x = float(self.shape[1] / dimensions[0].value)
+        scale_factor_y = float(self.shape[0] / dimensions[1].value)
 
         # Update image scale and number of pixels
         new_meta = self.meta.copy()

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -48,7 +48,7 @@ from sunpy.util.exceptions import warn_user
 from sunpy.util.functools import seconddispatch
 from sunpy.util.util import _figure_to_base64, fix_duplicate_notes
 from sunpy.visualization.plotter.mpl_plotter import MapPlotter
-from .mixins.mapmeta import MapMetaMixin, PixelPair
+from .mixins.mapmeta import MapDeprecateMixin, MapMetaMixin, PixelPair
 
 TIME_FORMAT = config.get("general", "time_format")
 _NUMPY_COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None
@@ -96,7 +96,7 @@ to the standard PC_ij described in section 6.1 of .
 __all__ = ['GenericMap']
 
 
-class GenericMap(MapMetaMixin, NDCube):
+class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
     """
     A Generic spatially-aware 2D data array
 
@@ -555,51 +555,6 @@ class GenericMap(MapMetaMixin, NDCube):
         # This code is reused from Astropy
         return WCSAxes, {'wcs': self.wcs}
 
-    # Some numpy extraction
-    @property
-    def dimensions(self):
-        """
-        The dimensions of the array (x axis first, y axis second).
-        """
-        return PixelPair(*u.Quantity(np.flipud(self.data.shape), 'pixel'))
-
-    @property
-    def dtype(self):
-        """
-        The `numpy.dtype` of the array of the map.
-        """
-        return self.data.dtype
-
-    @property
-    def ndim(self):
-        """
-        The value of `numpy.ndarray.ndim` of the data array of the map.
-        """
-        return self.data.ndim
-
-    def std(self, *args, **kwargs):
-        """
-        Calculate the standard deviation of the data array, ignoring NaNs.
-        """
-        return np.nanstd(self.data, *args, **kwargs)
-
-    def mean(self, *args, **kwargs):
-        """
-        Calculate the mean of the data array, ignoring NaNs.
-        """
-        return np.nanmean(self.data, *args, **kwargs)
-
-    def min(self, *args, **kwargs):
-        """
-        Calculate the minimum value of the data array, ignoring NaNs.
-        """
-        return np.nanmin(self.data, *args, **kwargs)
-
-    def max(self, *args, **kwargs):
-        """
-        Calculate the maximum value of the data array, ignoring NaNs.
-        """
-        return np.nanmax(self.data, *args, **kwargs)
 
     @u.quantity_input
     def shift_reference_coord(self, axis1: u.deg, axis2: u.deg):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -874,8 +874,8 @@ class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
         inv_rmatrix = np.linalg.inv(rmatrix)
 
         # Calculate the shape in pixels to contain all of the image data
-        corners = itertools.product([-0.5, self.data.shape[1]-0.5],
-                                    [-0.5, self.data.shape[0]-0.5])
+        corners = itertools.product([-0.5, self.shape[1]-0.5],
+                                    [-0.5, self.shape[0]-0.5])
         rot_corners = np.vstack([rmatrix @ c for c in corners]) * scale
         extent = np.max(rot_corners, axis=0) - np.min(rot_corners, axis=0)
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -42,15 +42,14 @@ from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.image.resample import resample as sunpy_image_resample
 from sunpy.image.resample import reshape_image_to_4d_superpixel
 from sunpy.image.transform import _get_transform_method, _rotation_function_names, affine_transform
+from sunpy.map.mixins.mapdeprecate import MapDeprecateMixin
+from sunpy.map.mixins.mapmeta import MapMetaMixin
 from sunpy.util import MetaDict
 from sunpy.util.decorators import add_common_docstring, cached_property_based_on
 from sunpy.util.exceptions import warn_user
 from sunpy.util.functools import seconddispatch
 from sunpy.util.util import _figure_to_base64, fix_duplicate_notes
-from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
-from sunpy.visualization.colormaps import cm as sunpy_cm
-from .mixins.mapdeprecate import MapDeprecateMixin
-from .mixins.mapmeta import MapMetaMixin, MapMetaValidationError, PixelPair
+from sunpy.visualization.plotter import MapPlotter
 
 TIME_FORMAT = config.get("general", "time_format")
 _NUMPY_COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None
@@ -295,7 +294,7 @@ class GenericMap(MapDeprecateMixin, MapMetaMixin, NDCube):
                                meas=measurement, wave=wave,
                                date=self.date.strftime(TIME_FORMAT),
                                dt=dt,
-                               dim=u.Quantity(self.dimensions),
+                               dim=u.Quantity(self.shape),
                                scale=u.Quantity(self.scale),
                                coord=self._coordinate_frame_name,
                                refpix=u.Quantity(self.reference_pixel),

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -347,7 +347,7 @@ class MapSequence:
 
         if resample:
             if self.all_maps_same_shape():
-                resample = u.Quantity(self.maps[0].dimensions) * np.array(resample)
+                resample = u.Quantity(self.maps[0].shape) * np.array(resample)
                 ani_data = [amap.resample(resample) for amap in self.maps]
             else:
                 raise ValueError('Maps in mapsequence do not all have the same shape.')
@@ -465,7 +465,7 @@ class MapSequence:
         if resample:
             if self.all_maps_same_shape():
                 plot_sequence = MapSequence()
-                resample = u.Quantity(self.maps[0].dimensions) * np.array(resample)
+                resample = u.Quantity(self.maps[0].shape) * np.array(resample)
                 for amap in self.maps:
                     plot_sequence.maps.append(amap.resample(resample))
             else:

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -117,7 +117,7 @@ def map_edges(smap):
         hand side pixel locations respectively of the input map.
     """
     # Calculate all the edge pixels
-    nx, ny = smap.dimensions.x.value, smap.dimensions.y.value
+    ny, nx = smap.shape
     top = list(product(np.arange(nx), [ny - 1])) * u.pix
     bottom = list(product(np.arange(nx), [0])) * u.pix
     left_hand_side = list(product([0], np.arange(ny))) * u.pix

--- a/sunpy/map/mixins/__init__.py
+++ b/sunpy/map/mixins/__init__.py
@@ -1,3 +1,4 @@
+from .mapdeprecate import MapDeprecateMixin
 from .mapmeta import MapMetaMixin, MapMetaValidationError
 
-__all__ = ['MapMetaValidationError', 'MapMetaMixin']
+__all__ = ['MapMetaValidationError', 'MapMetaMixin', 'MapDeprecateMixin']

--- a/sunpy/map/mixins/mapdeprecate.py
+++ b/sunpy/map/mixins/mapdeprecate.py
@@ -15,7 +15,7 @@ class MapDeprecateMixin:
     # Some numpy extraction
 
     @property
-    @deprecated(since="6.1", message=".dimension will be removed in 6.1. Use sunpy.map.GenericMap.shape instead")
+    @deprecated(since="6.1", message=".dimensions will be removed in 6.1. Use sunpy.map.GenericMap.shape instead")
     def dimensions(self):
         """
         The dimensions of the array (x axis first, y axis second).

--- a/sunpy/map/mixins/mapdeprecate.py
+++ b/sunpy/map/mixins/mapdeprecate.py
@@ -1,7 +1,9 @@
 import numpy as np
-from mapmeta import PixelPair
 
 from astropy import units as u
+
+from sunpy.util.decorators import deprecated
+from .mapmeta import PixelPair
 
 __all__ = ['MapDeprecateMixin']
 
@@ -11,6 +13,7 @@ class MapDeprecateMixin:
     """
 
     # Some numpy extraction
+    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.shape")
     @property
     def dimensions(self):
         """
@@ -18,6 +21,8 @@ class MapDeprecateMixin:
         """
         return PixelPair(*u.Quantity(np.flipud(self.data.shape), 'pixel'))
 
+
+    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.dtype")
     @property
     def dtype(self):
         """
@@ -25,6 +30,7 @@ class MapDeprecateMixin:
         """
         return self.data.dtype
 
+    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.ndim()")
     @property
     def ndim(self):
         """
@@ -32,24 +38,28 @@ class MapDeprecateMixin:
         """
         return self.data.ndim
 
+    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.std()")
     def std(self, *args, **kwargs):
         """
         Calculate the standard deviation of the data array, ignoring NaNs.
         """
         return np.nanstd(self.data, *args, **kwargs)
 
+    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.mean()")
     def mean(self, *args, **kwargs):
         """
         Calculate the mean of the data array, ignoring NaNs.
         """
         return np.nanmean(self.data, *args, **kwargs)
 
+    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.min()")
     def min(self, *args, **kwargs):
         """
         Calculate the minimum value of the data array, ignoring NaNs.
         """
         return np.nanmin(self.data, *args, **kwargs)
 
+    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.max()")
     def max(self, *args, **kwargs):
         """
         Calculate the maximum value of the data array, ignoring NaNs.

--- a/sunpy/map/mixins/mapdeprecate.py
+++ b/sunpy/map/mixins/mapdeprecate.py
@@ -1,0 +1,57 @@
+import numpy as np
+from mapmeta import PixelPair
+
+from astropy import units as u
+
+__all__ = ['MapDeprecateMixin']
+
+class MapDeprecateMixin:
+    """
+    This class contains the deprecated attributes on map
+    """
+
+    # Some numpy extraction
+    @property
+    def dimensions(self):
+        """
+        The dimensions of the array (x axis first, y axis second).
+        """
+        return PixelPair(*u.Quantity(np.flipud(self.data.shape), 'pixel'))
+
+    @property
+    def dtype(self):
+        """
+        The `numpy.dtype` of the array of the map.
+        """
+        return self.data.dtype
+
+    @property
+    def ndim(self):
+        """
+        The value of `numpy.ndarray.ndim` of the data array of the map.
+        """
+        return self.data.ndim
+
+    def std(self, *args, **kwargs):
+        """
+        Calculate the standard deviation of the data array, ignoring NaNs.
+        """
+        return np.nanstd(self.data, *args, **kwargs)
+
+    def mean(self, *args, **kwargs):
+        """
+        Calculate the mean of the data array, ignoring NaNs.
+        """
+        return np.nanmean(self.data, *args, **kwargs)
+
+    def min(self, *args, **kwargs):
+        """
+        Calculate the minimum value of the data array, ignoring NaNs.
+        """
+        return np.nanmin(self.data, *args, **kwargs)
+
+    def max(self, *args, **kwargs):
+        """
+        Calculate the maximum value of the data array, ignoring NaNs.
+        """
+        return np.nanmax(self.data, *args, **kwargs)

--- a/sunpy/map/mixins/mapdeprecate.py
+++ b/sunpy/map/mixins/mapdeprecate.py
@@ -13,8 +13,9 @@ class MapDeprecateMixin:
     """
 
     # Some numpy extraction
-    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.shape")
+
     @property
+    @deprecated(since="6.1", message=".dimension will be removed in 6.1. Use sunpy.map.GenericMap.shape instead")
     def dimensions(self):
         """
         The dimensions of the array (x axis first, y axis second).
@@ -22,44 +23,45 @@ class MapDeprecateMixin:
         return PixelPair(*u.Quantity(np.flipud(self.data.shape), 'pixel'))
 
 
-    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.dtype")
     @property
+    @deprecated(since="6.1", message="sunpy.map.GenericMap.dtype will be removed in 6.1, use sunpy.map.GenericMap.data.dtype instead")
     def dtype(self):
         """
         The `numpy.dtype` of the array of the map.
         """
         return self.data.dtype
 
-    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.ndim()")
     @property
+    @deprecated(since="6.1", message="sunpy.map.GenericMap.ndim will be removed in 6.1, use sunpy.map.GenericMap.data.ndim() instead")
     def ndim(self):
         """
         The value of `numpy.ndarray.ndim` of the data array of the map.
         """
         return self.data.ndim
 
-    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.std()")
+
+    @deprecated(since="6.1", message="sunpy.map.GenericMap.std() will be removed in 6.1, use sunpy.map.GenericMap.data.std() instead")
     def std(self, *args, **kwargs):
         """
         Calculate the standard deviation of the data array, ignoring NaNs.
         """
         return np.nanstd(self.data, *args, **kwargs)
 
-    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.mean()")
+    @deprecated(since="6.1", message="sunpy.map.GenericMap.mean() will be removed in 6.1, use sunpy.map.GenericMap.data.mean() instead")
     def mean(self, *args, **kwargs):
         """
         Calculate the mean of the data array, ignoring NaNs.
         """
         return np.nanmean(self.data, *args, **kwargs)
 
-    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.min()")
+    @deprecated(since="6.1", message="sunpy.map.GenericMap.min() will be removed in 6.1, use sunpy.map.GenericMap.data.min() instead")
     def min(self, *args, **kwargs):
         """
         Calculate the minimum value of the data array, ignoring NaNs.
         """
         return np.nanmin(self.data, *args, **kwargs)
 
-    @deprecated(since="6.1", message="this will be removed.", alternative="sunpy.map.GenericMap.data.max()")
+    @deprecated(since="6.1", message="sunpy.map.GenericMap.max() will be removed in 6.1, use sunpy.map.GenericMap.data.max() instead")
     def max(self, *args, **kwargs):
         """
         Calculate the maximum value of the data array, ignoring NaNs.

--- a/sunpy/map/mixins/mapdeprecate.py
+++ b/sunpy/map/mixins/mapdeprecate.py
@@ -9,10 +9,8 @@ __all__ = ['MapDeprecateMixin']
 
 class MapDeprecateMixin:
     """
-    This class contains the deprecated attributes on map
+    This class contains the deprecated attributes on map.
     """
-
-    # Some numpy extraction
 
     @property
     @deprecated(since="6.1", message=".dimensions will be removed in 6.1. Use sunpy.map.GenericMap.shape instead")

--- a/sunpy/map/mixins/mapmeta.py
+++ b/sunpy/map/mixins/mapmeta.py
@@ -301,7 +301,7 @@ class MapMetaMixin:
         """
         The physical coordinate at the center of the the top right ([-1, -1]) pixel.
         """
-        top_right = np.array([self.shape.x.value, self.shape.y.value]) - 1
+        top_right = np.array([self.shape[1], self.shape[0]]) - 1
         return self.wcs.pixel_to_world(*top_right)
 
     @property
@@ -312,7 +312,7 @@ class MapMetaMixin:
         If the array has an even number of pixels in a given dimension,
         the coordinate returned lies on the edge between the two central pixels.
         """
-        center = (np.array([self.shape.x.value, self.shape.y.value]) - 1) / 2.
+        center = (np.array([self.shape[1], self.shape[0]]) - 1) / 2.
         return self.wcs.pixel_to_world(*center)
 
     def _rsun_meters(self, dsun=None):

--- a/sunpy/map/mixins/mapmeta.py
+++ b/sunpy/map/mixins/mapmeta.py
@@ -301,7 +301,7 @@ class MapMetaMixin:
         """
         The physical coordinate at the center of the the top right ([-1, -1]) pixel.
         """
-        top_right = np.array([self.dimensions.x.value, self.dimensions.y.value]) - 1
+        top_right = np.array([self.shape.x.value, self.shape.y.value]) - 1
         return self.wcs.pixel_to_world(*top_right)
 
     @property
@@ -312,7 +312,7 @@ class MapMetaMixin:
         If the array has an even number of pixels in a given dimension,
         the coordinate returned lies on the edge between the two central pixels.
         """
-        center = (np.array([self.dimensions.x.value, self.dimensions.y.value]) - 1) / 2.
+        center = (np.array([self.shape.x.value, self.shape.y.value]) - 1) / 2.
         return self.wcs.pixel_to_world(*center)
 
     def _rsun_meters(self, dsun=None):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1103,8 +1103,8 @@ def test_rotate(aia171_test_map):
     assert rotated_map_2.data.shape > rotated_map_1.data.shape > aia171_test_map.data.shape
     assert np.isnan(rotated_map_1.data[0, 0])
     assert np.isnan(rotated_map_2.data[0, 0])
-    np.testing.assert_allclose(aia171_test_map.data.mean(), rotated_map_1.data.mean(), rtol=5e-3)
-    np.testing.assert_allclose(aia171_test_map.data.mean(), rotated_map_2.data.mean(), rtol=5e-3)
+    np.testing.assert_allclose(aia171_test_map.data.mean(), np.nanmean(rotated_map_1.data), rtol=5e-3)
+    np.testing.assert_allclose(aia171_test_map.data.mean(), np.nanmean(rotated_map_2.data), rtol=5e-3)
 
     # A scaled-up map should have the same mean because the output map should be expanded
     rotated_map_3 = aia171_test_map.rotate(0 * u.deg, order=0, scale=2)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -990,25 +990,25 @@ def test_superpixel_metadata(generic_map, f, dimensions):
 
 
 def test_superpixel_masked(aia171_test_map_with_mask):
-    input_dims = u.Quantity(aia171_test_map_with_mask.dimensions)
+    input_dims = aia171_test_map_with_mask.shape
     dimensions = (2, 2) * u.pix
     # Test that the mask is respected
     superpix_map = aia171_test_map_with_mask.superpixel(dimensions)
     assert superpix_map.mask is not None
     # Check the shape of the mask
     expected_shape = input_dims * (1 * u.pix / dimensions)
-    assert np.all(superpix_map.mask.shape * u.pix == expected_shape)
+    assert np.all(superpix_map.mask.shape == expected_shape)
 
     # Test that the offset is respected
     superpix_map = aia171_test_map_with_mask.superpixel(dimensions, offset=(1, 1) * u.pix)
-    assert superpix_map.shape[0] == expected_shape[0] - 1 * u.pix
-    assert superpix_map.shape[1] == expected_shape[1] - 1 * u.pix
+    assert superpix_map.shape[0] == expected_shape[1] - 1 #* u.pix
+    assert superpix_map.shape[1] == expected_shape[0] - 1 #* u.pix
 
     dimensions = (7, 9) * u.pix
     superpix_map = aia171_test_map_with_mask.superpixel(dimensions, offset=(4, 4) * u.pix)
     expected_shape = np.round(input_dims * (1 * u.pix / dimensions))
-    assert superpix_map.shape[0] == expected_shape[0] - 1 * u.pix
-    assert superpix_map.shape[1] == expected_shape[1] - 1 * u.pix
+    assert superpix_map.shape[0] == expected_shape[1] - 1 #* u.pix
+    assert superpix_map.shape[1] == expected_shape[0] - 1 #* u.pix
 
 
 def test_superpixel_units(generic_map):
@@ -1329,7 +1329,7 @@ def test_more_than_two_dimensions():
                 bad_map = sunpy.map.Map(bad_data, hdr)
     # Test fails if map.ndim > 2 and if the dimensions of the array are wrong.
     assert bad_map.data.ndim == 2
-    assert_quantity_allclose(bad_map.shape, (5, 3))
+    assert_quantity_allclose(bad_map.shape, (3, 5))
 
 
 def test_missing_metadata_warnings():

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1103,18 +1103,18 @@ def test_rotate(aia171_test_map):
     assert rotated_map_2.data.shape > rotated_map_1.data.shape > aia171_test_map.data.shape
     assert np.isnan(rotated_map_1.data[0, 0])
     assert np.isnan(rotated_map_2.data[0, 0])
-    np.testing.assert_allclose(aia171_test_map.data.mean(), np.nanmean(rotated_map_1.data), rtol=5e-3)
-    np.testing.assert_allclose(aia171_test_map.data.mean(), np.nanmean(rotated_map_2.data), rtol=5e-3)
+    np.testing.assert_allclose(np.nanmean(aia171_test_map.data), np.nanmean(rotated_map_1.data), rtol=5e-3)
+    np.testing.assert_allclose(np.nanmean(aia171_test_map.data), np.nanmean(rotated_map_2.data), rtol=5e-3)
 
     # A scaled-up map should have the same mean because the output map should be expanded
     rotated_map_3 = aia171_test_map.rotate(0 * u.deg, order=0, scale=2)
-    np.testing.assert_allclose(aia171_test_map.data.mean(), rotated_map_3.data.mean(), rtol=1e-4)
+    np.testing.assert_allclose(np.nanmean(aia171_test_map.data), np.nanmean(rotated_map_3.data), rtol=1e-4)
 
     # Mean and std should be equal for a 90 degree rotation as long as 1 pixel is cropped out on
     # all sides
     rotated_map_4 = aia171_test_map.rotate(90 * u.deg, order=0)
-    np.testing.assert_allclose(aia171_test_map.data[1:-1, 1:-1].mean(),
-                               rotated_map_4.data[1:-1, 1:-1].mean(), rtol=1e-10)
+    np.testing.assert_allclose(np.nanmean(aia171_test_map.data[1:-1, 1:-1]),
+                               np.nanmean(rotated_map_4.data[1:-1, 1:-1]), rtol=1e-10)
     np.testing.assert_allclose(aia171_test_map.data[1:-1, 1:-1].std(),
                                rotated_map_4.data[1:-1, 1:-1].std(), rtol=1e-10)
 

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1113,10 +1113,10 @@ def test_rotate(aia171_test_map):
     # Mean and std should be equal for a 90 degree rotation as long as 1 pixel is cropped out on
     # all sides
     rotated_map_4 = aia171_test_map.rotate(90 * u.deg, order=0)
-    np.testing.assert_allclose(aia171_test_map.data[1:-1, 1:-1].data.mean(),
-                               rotated_map_4.data[1:-1, 1:-1].data.mean(), rtol=1e-10)
-    np.testing.assert_allclose(aia171_test_map.data[1:-1, 1:-1].data.std(),
-                               rotated_map_4.data[1:-1, 1:-1].data.std(), rtol=1e-10)
+    np.testing.assert_allclose(aia171_test_map.data[1:-1, 1:-1].mean(),
+                               rotated_map_4.data[1:-1, 1:-1].mean(), rtol=1e-10)
+    np.testing.assert_allclose(aia171_test_map.data[1:-1, 1:-1].std(),
+                               rotated_map_4.data[1:-1, 1:-1].std(), rtol=1e-10)
 
     # Rotation of a rectangular map by a large enough angle will change which dimension is larger
     aia171_test_map_crop = aia171_test_map.submap(

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -868,9 +868,9 @@ def test_resample(simple_map, shape):
     assert u.allclose(resampled_upper_left.Ty, original_upper_left.Ty)
 
 
-resample_test_data = [('linear', (100, 200) * u.pix ),
-                      ('nearest', (512, 128) * u.pix ),
-                      ('spline', (200, 200) ) * u.pix]
+resample_test_data = [('linear', (100, 200) * u.pixel),
+                      ('nearest', (512, 128) * u.pixel),
+                      ('spline', (200, 200) * u.pixel)]
 
 
 @pytest.mark.parametrize(("sample_method", "new_dimensions"), resample_test_data)

--- a/sunpy/map/tests/test_mapbase_dask.py
+++ b/sunpy/map/tests/test_mapbase_dask.py
@@ -37,13 +37,9 @@ with pytest.warns(VerifyWarning, match="Invalid 'BLANK' keyword in header."):
 
 
 @pytest.mark.parametrize(("func", "args"), [
-    ("max", {}),
-    ("mean", {}),
-    ("min", {}),
     pytest.param("reproject_to", {"wcs": aia_wcs}, marks=pytest.mark.xfail(reason="reproject is not dask aware")),
     pytest.param("resample", {"dimensions": (100, 100)*u.pix}, marks=pytest.mark.xfail()),
-    pytest.param("rotate", {}, marks=pytest.mark.xfail(reason="nanmedian is not implemented in Dask")),
-    ("std", {}),
+    pytest.param("rotate", {}, marks=pytest.mark.xfail(reason="nanmedian in Dask doesn't support our use")),
     ("superpixel", {"dimensions": (10, 10)*u.pix}),
     ("submap", {"bottom_left": (100, 100)*u.pixel, "width": 10*u.pixel, "height": 10*u.pixel}),
 ])
@@ -53,8 +49,8 @@ def test_method_preserves_dask_array(aia171_test_map, aia171_test_dask_map, func
     operating on them and bringing them into memory.
     """
     # Check that result array is still a Dask array
-    res_dask = aia171_test_dask_map.__getattribute__(func)(**args)
-    res = aia171_test_map.__getattribute__(func)(**args)
+    res_dask = getattr(aia171_test_dask_map, func)(**args)
+    res = getattr(aia171_test_map, func)(**args)
     result_is_map = isinstance(res, sunpy.map.GenericMap)
     if result_is_map:
         assert isinstance(res_dask.data, type(aia171_test_dask_map.data))

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -100,8 +100,8 @@ def test_all_coordinates_from_map(sub_smap):
     assert_quantity_allclose(ypix*u.pix, 0*u.pix, atol=1e-7*u.pix)
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[-1, -1])
-    assert_quantity_allclose(xpix*u.pix, sub_smap.dimensions[0] - 1*u.pix)
-    assert_quantity_allclose(ypix*u.pix, sub_smap.dimensions[1] - 1*u.pix)
+    assert_quantity_allclose(xpix*u.pix, sub_smap.shape[0] - 1*u.pix)
+    assert_quantity_allclose(ypix*u.pix, sub_smap.shape[1] - 1*u.pix)
 
 
 def test_all_corner_coordinates_from_map(sub_smap):
@@ -117,8 +117,8 @@ def test_all_corner_coordinates_from_map(sub_smap):
     assert_quantity_allclose(ypix*u.pix, -0.5*u.pix)
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[-1, -1])
-    assert_quantity_allclose(xpix*u.pix, sub_smap.dimensions[0] - 0.5*u.pix)
-    assert_quantity_allclose(ypix*u.pix, sub_smap.dimensions[1] - 0.5*u.pix)
+    assert_quantity_allclose(xpix*u.pix, sub_smap.shape[0] - 0.5*u.pix)
+    assert_quantity_allclose(ypix*u.pix, sub_smap.shape[1] - 0.5*u.pix)
 
 
 def test_map_edges(all_off_disk_map):

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -96,12 +96,12 @@ def test_all_coordinates_from_map(sub_smap):
     assert coordinates.frame.name == sub_smap.coordinate_frame.name
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[0, 0])
-    assert_quantity_allclose(xpix*u.pix, 0*u.pix, atol=1e-7*u.pix)
-    assert_quantity_allclose(ypix*u.pix, 0*u.pix, atol=1e-7*u.pix)
+    assert_quantity_allclose(xpix, 0, atol=1e-7)
+    assert_quantity_allclose(ypix, 0, atol=1e-7)
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[-1, -1])
-    assert_quantity_allclose(xpix*u.pix, sub_smap.shape[0] - 1*u.pix)
-    assert_quantity_allclose(ypix*u.pix, sub_smap.shape[1] - 1*u.pix)
+    assert_quantity_allclose(xpix, sub_smap.shape[1] - 1)
+    assert_quantity_allclose(ypix, sub_smap.shape[0] - 1)
 
 
 def test_all_corner_coordinates_from_map(sub_smap):
@@ -113,12 +113,12 @@ def test_all_corner_coordinates_from_map(sub_smap):
     assert coordinates.frame.name == sub_smap.coordinate_frame.name
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[0, 0])
-    assert_quantity_allclose(xpix*u.pix, -0.5*u.pix)
-    assert_quantity_allclose(ypix*u.pix, -0.5*u.pix)
+    assert_quantity_allclose(xpix, -0.5)
+    assert_quantity_allclose(ypix, -0.5)
 
     xpix, ypix = sub_smap.wcs.world_to_pixel(coordinates[-1, -1])
-    assert_quantity_allclose(xpix*u.pix, sub_smap.shape[0] - 0.5*u.pix)
-    assert_quantity_allclose(ypix*u.pix, sub_smap.shape[1] - 0.5*u.pix)
+    assert_quantity_allclose(xpix, sub_smap.shape[1] - 0.5)
+    assert_quantity_allclose(ypix, sub_smap.shape[0] - 0.5)
 
 
 def test_map_edges(all_off_disk_map):

--- a/sunpy/visualization/plotter/mpl_plotter.py
+++ b/sunpy/visualization/plotter/mpl_plotter.py
@@ -49,7 +49,7 @@ class MapPlotter:
 
     @plot_settings.setter
     def plot_settings(self, value):
-        if self.smap.dtype == np.uint8:
+        if self.smap.data.dtype == np.uint8:
             norm = None
         else:
             # Put import here to reduce sunpy.map import time

--- a/sunpy/visualization/plotter/mpl_plotter.py
+++ b/sunpy/visualization/plotter/mpl_plotter.py
@@ -18,6 +18,7 @@ from sunpy.util.exceptions import warn_user
 from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
 from sunpy.visualization.colormaps import cm as sunpy_cm
 
+__all__ = ['MapPlotter']
 
 class MapPlotter:
 


### PR DESCRIPTION
Removed following data methods from mapbase and put it in deprecated mixins:
```
.ndim
.dtype
.std
.mean
.min
.max
.dimensions (encourage users to use .shape)
```