### PR TITLE
Enable use of  SunPyBaseCoordinateFrame outside sunpy

### DIFF
--- a/changelog/7594.bugfix.rst
+++ b/changelog/7594.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that interfered with :func:`astropy.wcs.utils.celestial_frame_to_wcs` when working with a custom subclass of :class:`~sunpy.coordinates.frames.SunPyBaseCoordinateFrame`.

--- a/sunpy/coordinates/tests/test_wcs_utils.py
+++ b/sunpy/coordinates/tests/test_wcs_utils.py
@@ -15,6 +15,7 @@ from sunpy.coordinates.frames import (
     HeliographicCarrington,
     HeliographicStonyhurst,
     Helioprojective,
+    SunPyBaseCoordinateFrame,
 )
 from sunpy.coordinates.wcs_utils import (
     _set_wcs_aux_obs_coord,
@@ -379,3 +380,11 @@ def test_observer_hgln_crln_priority():
     # Note: don't test whether crlt or hglt is used---according to
     # _set_wcs_aux_obs_coord, those are expected to always be the same and so
     # the same one is always used
+
+
+def test_sunpybaseframe_external():
+    class MyFrame(SunPyBaseCoordinateFrame):
+        pass
+
+    out = solar_frame_to_wcs_mapping(MyFrame())
+    assert out is None

--- a/sunpy/coordinates/wcs_utils.py
+++ b/sunpy/coordinates/wcs_utils.py
@@ -191,6 +191,9 @@ def solar_frame_to_wcs_mapping(frame, projection='TAN'):
             xcoord = 'HGLN' + '-' + projection
             ycoord = 'HGLT' + '-' + projection
             wcs.wcs.cunit = ['deg', 'deg']
+        else:
+            # A subclass not supported by the core library
+            return None
 
     else:
         return None


### PR DESCRIPTION
Closes #7593 by enabling use of `SunPyBaseCoordinateFrame` outside of sunpy by returning None if not a sunpy Frame instead of raising an error. 