### PR TITLE
Fix the way we set date on WCS

### DIFF
--- a/changelog/7606.bugfix.rst
+++ b/changelog/7606.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug in `~.GenericMap.wcs` where the ``.dateobs`` property of the `~astropy.wcs.WCS` object was being set from the `~.GenericMap.date` property which preferrs the ``DATE-OBS`` header key over the more correct ``DATE-AVG`` if both exist.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -608,13 +608,23 @@ class GenericMap(NDData):
         w2.wcs.crval = u.Quantity([self._reference_longitude, self._reference_latitude])
         w2.wcs.ctype = self.coordinate_system
         w2.wcs.pc = self.rotation_matrix
-        w2.wcs.set_pv(self._pv_values)
         # FITS standard doesn't allow both PC_ij *and* CROTA keywords
         w2.wcs.crota = (0, 0)
         w2.wcs.cunit = self.spatial_units
-        w2.wcs.dateobs = self.date.isot
-        w2.wcs.aux.rsun_ref = self.rsun_meters.to_value(u.m)
+        w2.wcs.set_pv(self._pv_values)
 
+        # If date average exists we should use it.  If it doesn't then we
+        # fallback to dateobs because it can come from many places
+        if self.date_average is not None:
+            w2.wcs.dateavg = self.date_average.isot
+        else:
+            w2.wcs.dateobs = self.date.isot
+        if self.date_start is not None:
+            w2.wcs.datebeg = self.date_start.isot
+        if self.date_end is not None:
+            w2.wcs.dateend = self.date_end.isot
+
+        w2.wcs.aux.rsun_ref = self.rsun_meters.to_value(u.m)
         # Set observer coordinate information except when we know it is not appropriate (e.g., HGS)
         sunpy_frame = sunpy.coordinates.wcs_utils._sunpy_frame_class_from_ctypes(w2.wcs.ctype)
         if sunpy_frame is None or hasattr(sunpy_frame, 'observer'):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -280,6 +280,21 @@ def test_date(generic_map, keys, expected_date):
     else:
         assert generic_map.date == expected_date
 
+    # Validate that the WCS date properties reflect the same information as the
+    # map properties
+    if "DATE-AVG" in keys or ("DATE-BEG" in keys and "DATE-END" in keys):
+        assert parse_time(generic_map.wcs.wcs.dateavg) - expected_date < 1*u.s
+        assert not generic_map.wcs.wcs.dateobs
+    else:
+        assert parse_time(generic_map.wcs.wcs.dateobs) - expected_date < 1*u.s
+
+    if "DATE-BEG" in keys:
+        assert generic_map.wcs.wcs.datebeg
+
+    if "DATE-END" in keys:
+        assert generic_map.wcs.wcs.dateend
+
+
 
 def test_date_scale(generic_map):
     # Check that default time scale is UTC


### PR DESCRIPTION
We got an in-person bug report from someone trying to reproject EUI/FSI to a SPICE map. SPICE headers (apparently all SolO data) have date-beg, date-avg and date-end in their header but to "support [...] older software" they also specify date-obs with the same value as date-beg.

All this is to setup the fact that we only set `dateobs` on the WCS we build in map from our date property which (in order) pulls from these sources:

1. The DATE-OBS FITS keyword
2. `.date_average`
3. `.date_start`
4. `.date_end`
5. The current time

This means that the WCS object we build for SPICE (which is a GenericMap) uses `DATE-OBS` which isn't the time corresponding to the observer location, and can in fact be out by hours.

This fix priorities setting `wcs.dateavg` which is more correct and should fix the specific SPICE issue.
