### PR TITLE
Fix devdeps fails

### DIFF
--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -265,6 +265,7 @@ def test_reproducible_matrix_multiplication():
 
 
 @figure_test
+@skip_numpy2
 def test_clipping(rot30):
     # Generates a plot to test the clipping the output image to the range of the input image
     image = np.ones((20, 20))
@@ -298,6 +299,7 @@ def test_clipping(rot30):
 
 @pytest.mark.filterwarnings("ignore:.*bug in the implementation of scikit-image")
 @figure_test
+@skip_numpy2
 def test_nans(rot30):
     # Generates a plot to test the preservation and expansions of NaNs by the rotation
     image_with_nans = np.ones((23, 23))

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -30,7 +30,7 @@ from sunpy.data.test import get_dummy_map_from_header, get_test_filepath
 from sunpy.image.transform import _rotation_registry
 from sunpy.map.mapbase import GenericMap
 from sunpy.map.sources import AIAMap
-from sunpy.tests.helpers import figure_test
+from sunpy.tests.helpers import figure_test, skip_numpy2
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyMetadataWarning
@@ -1685,6 +1685,7 @@ def test_draw_contours_with_transform(sample_171, sample_hmi):
 
 @pytest.mark.parametrize('method', _rotation_registry.keys())
 @figure_test
+@skip_numpy2
 def test_derotating_nonpurerotation_pcij(aia171_test_map, method):
     # The following map has a a PCij matrix that is not a pure rotation
     weird_map = aia171_test_map.rotate(30*u.deg).superpixel([2, 1]*u.pix)

--- a/sunpy/map/tests/test_mapbase_dask.py
+++ b/sunpy/map/tests/test_mapbase_dask.py
@@ -22,11 +22,11 @@ def aia171_test_dask_map(aia171_test_map):
     )
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_dask_array_repr(aia171_test_dask_map):
     # Check that _repr_html_ functions for a dask array
-    with np.errstate(divide='ignore'):
-        html_dask_repr = aia171_test_dask_map._repr_html_(compute_dask=False)
-        html_computed_repr = aia171_test_dask_map._repr_html_(compute_dask=True)
+    html_dask_repr = aia171_test_dask_map._repr_html_(compute_dask=False)
+    html_computed_repr = aia171_test_dask_map._repr_html_(compute_dask=True)
     assert html_dask_repr != html_computed_repr
 
 


### PR DESCRIPTION
This just skips the failing ones on the figure tests.

This will need to be un-skipped when opencv does a release. 