### PR TITLE
Add try except around client queries

### DIFF
--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -477,9 +477,11 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         candidate_widget_types = self._check_registered_widgets(*query)
         results = []
         for client in candidate_widget_types:
-            tmpclient = client()
-            results.append(tmpclient.search(*query))
-
+            try:
+                tmpclient = client()
+                results.append(tmpclient.search(*query))
+            except Exception:
+                pass
         # This method is called by `search` and the results are fed into a
         # UnifiedResponse object.
         return results

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -18,7 +18,7 @@ from packaging.version import Version
 
 from astropy.table import Table
 
-from sunpy import config
+from sunpy import config, log
 from sunpy.net import attr, vso
 from sunpy.net.base_client import BaseClient, QueryResponseColumn, QueryResponseRow, QueryResponseTable
 from sunpy.util.datatype_factory_base import BasicRegistrationFactory, NoMatchError
@@ -481,7 +481,8 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
                 tmpclient = client()
                 results.append(tmpclient.search(*query))
             except Exception:
-                pass
+                log.exception(f"Error while searching for {client}", stack_info=True)
+
         # This method is called by `search` and the results are fed into a
         # UnifiedResponse object.
         return results

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -79,6 +79,14 @@ def test_online_fido(query):
     check_response(query, unifiedresp)
 
 
+@pytest.mark.remote_data
+@mock.patch("sunpy.net.vso.vso.VSOClient.search", side_effect=ConnectionError('VSO is down'))
+def test_fido_client_error(vso_search):
+    with pytest.raises(ConnectionError):
+        q = Fido.search(a.Time('2012/01/01', '2012/01/01'), a.Instrument.soon)  # noqa: F841
+
+
+
 def check_response(query, unifiedresp):
     """
     Common test for online or offline query


### PR DESCRIPTION
## PR Description
Make `Fido.search` more robust by wrapping the `client.search` calls in a try except. Current code works but introduces silent fails I will add some logging. Need a way to surface the errors to the user in the search results maybe add a `ClientError` that could be include in the result or add and `.error` similarly to the `Fido.fetch`

- [ ] Add `.errors` to the `UnifiedResponse`
- [ ] Reduce log clutter

Closes #7625