### PR TITLE
fix the failing build-docs test 

### DIFF
--- a/docs/reference/net.rst
+++ b/docs/reference/net.rst
@@ -90,3 +90,5 @@ for `sunpy.net.Fido`.
 .. automodapi:: sunpy.net.attr
 
 .. automodapi:: sunpy.net.scraper
+
+.. automodapi:: sunpy.net.scraper_utils


### PR DESCRIPTION
hadn't added the new scraper_utils module to automodapi before