### PR TITLE
Bugfix GONG Ha run_obs property

### DIFF
--- a/changelog/7652.bugfix.rst
+++ b/changelog/7652.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the :property:`~sunpy.map.sources.gong.GONGHalphaMap.rsun_obs` to use correct header information ``solar-r`` keyword.

--- a/changelog/7652.bugfix.rst
+++ b/changelog/7652.bugfix.rst
@@ -1,1 +1,1 @@
-Fix the :property:`~sunpy.map.sources.gong.GONGHalphaMap.rsun_obs` to use correct header information ``solar-r`` keyword.
+Fix the :attr:`~sunpy.map.sources.gong.GONGHalphaMap.rsun_obs` to use correct header information ``solar-r`` keyword.

--- a/changelog/7652.bugfix.rst
+++ b/changelog/7652.bugfix.rst
@@ -1,1 +1,1 @@
-Fix the :attr:`~sunpy.map.sources.gong.GONGHalphaMap.rsun_obs` to use correct header information ``solar-r`` keyword.
+Fix the `~sunpy.map.sources.gong.GONGHalphaMap.rsun_obs` to use correct header information ``solar-r`` keyword.

--- a/sunpy/map/sources/gong.py
+++ b/sunpy/map/sources/gong.py
@@ -93,12 +93,16 @@ class GONGHalphaMap(GenericMap):
         return (str(header.get('TELESCOP', '')).endswith('GONG') and
                 str(header.get('IMTYPE', '')).startswith('H-ALPHA'))
 
-
     @property
     def scale(self):
         solar_r = self.meta['SOLAR-R'] * u.arcsec
         return SpatialPair(solar_r / (self.meta['FNDLMBMI'] * u.pixel),
                            solar_r/ (self.meta['FNDLMBMA'] * u.pixel))
+
+    @property
+    def rsun_obs(self):
+        # Header contains a radius keyword which seems to have a higher priority but for GONG Ha is in pixels
+        return self.meta['SOLAR-R'] * u.arcsec
 
     @property
     def coordinate_system(self):

--- a/sunpy/map/sources/tests/test_gong_halpha_source.py
+++ b/sunpy/map/sources/tests/test_gong_halpha_source.py
@@ -39,6 +39,10 @@ def test_scale(gong_halpha):
     assert_equal(gong_halpha.scale.axis2, 1.0794939681708389 * (u.arcsec / u.pix))
 
 
+def test_rsub_obs(gong_halpha):
+    assert gong_halpha.rsun_obs == 971.544571353755 * u.arcsec
+
+
 def test_nickname(gong_halpha):
     """Tests the nickname property of the GONGHalphaMap map."""
     assert gong_halpha.nickname == "NSO-GONG, Big Bear"

--- a/sunpy/map/sources/tests/test_gong_halpha_source.py
+++ b/sunpy/map/sources/tests/test_gong_halpha_source.py
@@ -39,7 +39,7 @@ def test_scale(gong_halpha):
     assert_equal(gong_halpha.scale.axis2, 1.0794939681708389 * (u.arcsec / u.pix))
 
 
-def test_rsub_obs(gong_halpha):
+def test_rsun_obs(gong_halpha):
     assert gong_halpha.rsun_obs == 971.544571353755 * u.arcsec
 
 


### PR DESCRIPTION
## PR Description

The GONG Ha meta has a 'radius' keyword containing the solar radius in pixels and this seems to have been being used over the 'solar-r' keyword which contain the solar radius in arcecs. This meant the limb and grid were incorrectly place on the map in plots and I'm sure other areas too.  This PR overrides the `rsun_obs` property on the Ha map to use 'solar-r'

Before
![gong-ha-before](https://github.com/sunpy/sunpy/assets/24570854/72c58820-cdc1-4212-9079-8c8783e6aaa3)

After
![gong-ha-after](https://github.com/sunpy/sunpy/assets/24570854/4f4a3a34-dc0a-47ce-80c5-88ca9c90fce0)


