### PR TITLE
Handle FITS io differently for time series vs Map

### DIFF
--- a/sunpy/io/_fits.py
+++ b/sunpy/io/_fits.py
@@ -38,8 +38,9 @@ from sunpy.util.io import HDPair
 
 __all__ = ['header_to_fits', 'read', 'get_header', 'write', 'extract_waveunit', 'format_comments_and_history']
 
+SUPPORTED_FITS_IMAGES_TYPES = (fits.CompImageHDU, fits.PrimaryHDU, fits.ImageHDU)
 
-def read(filepath, hdus=None, memmap=None, **kwargs):
+def read(filepath, hdus=None, memmap=None, timeseries=False, **kwargs):
     """
     Read a fits file.
 
@@ -80,6 +81,8 @@ def read(filepath, hdus=None, memmap=None, **kwargs):
         pairs = []
 
         for i, (hdu, header) in enumerate(zip(hdulist, headers)):
+            if not timeseries and not isinstance(hdu, SUPPORTED_FITS_IMAGES_TYPES):
+                continue
             try:
                 pairs.append(HDPair(hdu.data, header))
             except (KeyError, ValueError) as e:

--- a/sunpy/io/tests/test_filetools.py
+++ b/sunpy/io/tests/test_filetools.py
@@ -41,7 +41,7 @@ def test_read_file_fits_multiple_hdu():
     # Aim is to verify that we can read a FITS file with multiple HDUs
     hdulist = read_file(TEST_RHESSI_IMAGE)
     assert isinstance(hdulist, list)
-    assert len(hdulist) == 4
+    assert len(hdulist) == 1
     assert all(len(hdupair) == 2 for hdupair in hdulist)
     assert all(isinstance(hdupair[0], np.ndarray) for hdupair in hdulist)
     assert all(isinstance(hdupair[1], FileHeader) for hdupair in hdulist)

--- a/sunpy/io/tests/test_fits.py
+++ b/sunpy/io/tests/test_fits.py
@@ -23,18 +23,6 @@ pytestmark = pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in heade
 
 
 @pytest.mark.parametrize(
-    ('fname', 'hdus', 'length'),
-    [(TEST_RHESSI_IMAGE, None, 4),
-     (TEST_RHESSI_IMAGE, 1, 1),
-     (TEST_RHESSI_IMAGE, [1, 2], 2),
-     (TEST_RHESSI_IMAGE, range(0, 2), 2)]
-)
-def test_read_hdus(fname, hdus, length):
-    pairs = _fits.read(fname, hdus=hdus)
-    assert len(pairs) == length
-
-
-@pytest.mark.parametrize(
     ('fname', 'waveunit'),
     [(TEST_RHESSI_IMAGE, None),
      (TEST_EIT_HEADER, None),

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -18,6 +18,7 @@ from astropy.time import Time
 from astropy.utils.decorators import deprecated_renamed_argument
 
 import sunpy
+from sunpy import log
 from sunpy.io._file_tools import UnrecognizedFileTypeError, detect_filetype, read_file
 from sunpy.io._header import FileHeader
 from sunpy.timeseries.sources import source_names
@@ -147,11 +148,10 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                     from sunpy.io._cdf import read_cdf
                     return read_cdf(os.fspath(fname), **kwargs)
             except UnrecognizedFileTypeError:
-                pass
+                log.debug(f"Unrecognized file type: {fname}")
 
             try:
-                pairs = read_file(os.fspath(fname), **kwargs)
-
+                pairs = read_file(os.fspath(fname), timeseries=True, **kwargs)
                 new_pairs = []
                 for pair in pairs:
                     filedata, filemeta = pair
@@ -161,6 +161,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
                         new_pairs.append(HDPair(data, meta))
                 return [new_pairs]
             except UnrecognizedFileTypeError:
+                log.debug(f"Unrecognized file type: {fname}")
                 return [fname]
         else:
             return [fname]


### PR DESCRIPTION
So for a long time, we have been just loading all the hdu's of a FITS file even if we don't support them or can even load them into a map or time series.

This PR tackles that by explicitly opting for Images only for Map and adding a hack workaround for time series. 

The goal is which we can load ADAPT FITS files which are strange.
Our other choice is to just say that to load a adapt fits, you have to manually pass in the primary header and data pair yourself. 

