### PR TITLE
Add backwards compatibility for the scraper

### DIFF
--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -17,6 +17,21 @@ The main place this is done is when constructing a `~.UnifiedResponse` object, w
 
 .. _sunpy-topic-guide-new-source-for-fido-add-new-scraper-client:
 
+A migration guide for working with / adding new scraper clients:
+===============================================================
+The main change in 5.0 is the removal of the old regex-based pattern system in favor of a new parse-based pattern system.
+This change is to make the pattern system more flexible and easier to use. The new pattern system is based on the `parse <https://github.com/r1chardj0n3s/parse/>`__ format.
+Previously, when defining a new FIDO client or working with the Scraper, a regex-based ``baseurl`` and a parse-styled ``pattern`` attributes were required.
+Now only a single parse-based ``pattern`` is required when writing Fido clients.
+During the deprecation period for the old ``pattern``, the new one is to be passed as a ``format`` attribute to the Scraper.
+Instructions for writing the new pattern are:
+1. Much like the baseurl, the single pattern would cover the entire URL from the protocol, domain to the filename.
+2. Instead of conveying time or numerical information in the URL in a datetime or regex format, it is now done in the `parse <https://github.com/r1chardj0n3s/parse/>`__ format for eg. a ``"%Y"`` is now to be replaced with ``{{year:4d}}``. For a full list of the new keywords corresponding to datetime format, the supported time keys (to be used within ``{{}}``!) are: 'year:4d', 'year:2d', 'month:2d'. 'month_name:l', 'month_name_abbr:l', 'day:2d', 'day_of_year:3d', 'hour:2d', 'minute:2d', 'second:2d', 'microsecond:6d', 'millisecond:3d' and 'week_number:2d'.
+3. The metadata attributes for extraction are written within double curly-braces ``{{}}`` for eg. ``{{ADAPTRealizations:3d}}``.
+4. Single curly-braces ``{}`` are used in case of regular placeholders for Python format strings, each respective value being passed as ``kwargs`` to the Scraper.
+A more detailed explanation of the new pattern system is referred to in the topic-guide below.
+
+
 An explanation of how "scraper" clients work
 ============================================
 
@@ -29,7 +44,7 @@ A new "scraper" client inherits from `~sunpy.net.dataretriever.client.GenericCli
   Each `tuple` contains the "attr" value and its description.
 * A class attribute ``pattern``; this is a string used to match all URLs supported by the client and extract necessary metadata from the matched URLs.
   The time and other metadata attributes for extraction are written within double curly-braces ``{{}}`` in a `parse <https://github.com/r1chardj0n3s/parse/>`__ format.
-  Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``.
+  Single curly braces ``{}`` are only used for regular placeholders for Python format strings, each respective value passed as ``kwargs`` to the Scraper.
   An example of how such a pattern looks like is given in the algorithm explanation below.
 
 .. warning::
@@ -125,7 +140,7 @@ This client scrapes all the URLs available under the base url ``http://lasp.colo
 `~sunpy.net.scraper.Scraper` is primarily focused on URL parsing based on time ranges, so the rest of the ``pattern`` specifies where in the URL the time information is located, using `parse <https://github.com/r1chardj0n3s/parse/>`__ notation.
 The ``pattern`` attribute is first filled in with the calculated time-based values, and then used to populate the results table from the URLs matched with the ``pattern``.
 It includes some of the time definitions, as well as names of attrs (in this case "Level").
-The supported time keys are: '{year:4d}', '{year:2d}', '{month:2d}'. '{month_name:l}', '{month_name_abbr:l}', '{day:2d}', '{day_of_year:3d}', '{hour:2d}', '{minute:2d}', '{second:2d}', '{microsecond:6d}', '{millisecond:3d}' and '{week_number:2d}'.
+The supported time keys (to be used within ``{{}}``!) are: 'year:4d', 'year:2d', 'month:2d'. 'month_name:l', 'month_name_abbr:l', 'day:2d', 'day_of_year:3d', 'hour:2d', 'minute:2d', 'second:2d', 'microsecond:6d', 'millisecond:3d' and 'week_number:2d'.
 
 The attrs returned in the ``register_values()`` method are used to match your client to a search, as well as adding their values to the attr.
 This means that after this client has been imported, running ``print(a.Provider)`` will show that the ``EVEClient`` has registered a provider value of ``LASP``.

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -30,6 +30,8 @@ A new "scraper" client inherits from `~sunpy.net.dataretriever.client.GenericCli
 * A class attribute ``pattern``; this is a string used to match all URLs supported by the client and extract necessary metadata from the matched URLs.
   The time and other metadata attributes for extraction are written within double curly-braces ``{{}}`` in a `~sunpy.extern.parse.parse` format. Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``. An example of how such a pattern looks like is given in the algorithm explanation below.
 
+Note: The scraper has supported regex-based patterns for a long time, which is what it will still expect by default. However that is in the process of being replaced with parse-style patterns in the future versions of the package. To use the newer parse-style patterns, it's currently required to pass it as the ``format`` argument to the scraper.
+
 Each such client relies on the `~sunpy.net.scraper.Scraper` to be able to query for files using the :meth:`~sunpy.net.scraper.Scraper.filelist` method. The general algorithm to explain how the `~sunpy.net.scraper.Scraper` is able to do this is:
 
 A brief explanation of how the Scraper works is as follows:
@@ -48,7 +50,7 @@ For a more in-depth explanation on how this is accomplished internally, see the 
     >>> from sunpy.net import Scraper
     >>> pattern = ('http://proba2.oma.be/{instrument}/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/'
     ...            '{instrument}_lv1_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.fits')
-    >>> s = Scraper(pattern, instrument='swap')
+    >>> s = Scraper(format=pattern, instrument='swap')
     >>> s.dt_pattern
     'http://proba2.oma.be/swap/data/bsd/%Y/%m/%d/swap_lv1_%Y%m%d_%H%M%S.fits'
 

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -95,7 +95,7 @@ The files that satisfy these conditions are then added to the output.
     ['http://proba2.oma.be/swap/data/bsd/2015/01/01/swap_lv1_20150101_000857.fits',
     'http://proba2.oma.be/swap/data/bsd/2015/01/01/swap_lv1_20150101_001027.fits',
     '...',
-    'http://proba2.oma.be/swap/data/bsd/2015/01/01/swap_lv1_20150101_235947.fits']
+    'http://proba2.oma.be/swap/data/bsd/2015/01/02/swap_lv1_20150102_233313.fits']
 
 Writing a new "scraper" client
 ==============================

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -32,9 +32,16 @@ A new "scraper" client inherits from `~sunpy.net.dataretriever.client.GenericCli
   Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``.
   An example of how such a pattern looks like is given in the algorithm explanation below.
 
-Note: The scraper has supported regex-based patterns for a long time, which is what it will still expect by default. However that is in the process of being replaced with parse-style patterns in the future versions of the package. To use the newer parse-style patterns, it's currently required to pass it as the ``format`` argument to the scraper.
+.. warning::
 
-Each such client relies on the `~sunpy.net.scraper.Scraper` to be able to query for files using the :meth:`~sunpy.net.scraper.Scraper.filelist` method. The general algorithm to explain how the `~sunpy.net.scraper.Scraper` is able to do this is:
+    The scraper class has supported regex-based patterns for a long time
+    However, that is in the process of being replaced with parse-style patterns.
+    This is supported by the ``format`` keyword argument to the scraper.
+    The regex-style patterns have be deprecated and will be removed in the future.
+
+Each such client relies on the `~sunpy.net.scraper.Scraper` to be able to query for files using the :meth:`~sunpy.net.scraper.Scraper.filelist` method.
+
+The general algorithm to explain how the `~sunpy.net.scraper.Scraper` is able to do this is:
 A brief explanation of how the Scraper works is as follows:
 
 1. Drop the filename from the pattern and generate a list of directories to search for files.
@@ -44,8 +51,8 @@ A brief explanation of how the Scraper works is as follows:
 
 For a more verbose in-depth explanation on how this is accomplished internally:
 
-The Scraper takes as input the generalised ``pattern`` of how a desired file path looks like, in the ``parse`` format.
-Upon initialisation, a version of the pattern following the datetime format is also internally generated, called the ``datetime_pattern``.
+The scraper takes as input the generalized ``pattern`` of how a desired file path looks like, in the ``parse`` format.
+Upon initialization, a version of the pattern following the datetime format is also internally generated, called the ``datetime_pattern``.
 
 .. code-block:: python
 
@@ -79,7 +86,8 @@ The location given by the filled pattern is visited and a list of files at the l
 This is handled differently depending on whether the pattern is a web URL or a ``file://`` or an ``ftp://`` path in the :meth:`~sunpy.net.scraper.Scraper.filelist` method.
 
 Each filename is then parsed against the remaining portion of the pattern to determine if it matches.
-Each such file is then checked for lying in the intended timerange using the :meth:`~sunpy.net.scraper._check_timerange` method which in turn uses :meth:`sunpy.net.scraper_utils.get_timerange_from_exdict` to get the covered timerange for each file. The files that satisfy these conditions are then added to the output.
+Each such file is then checked for lying in the intended timerange using the :meth:`~sunpy.net.scraper._check_timerange` method which in turn uses :meth:`sunpy.net.scraper_utils.get_timerange_from_exdict` to get the covered timerange for each file.
+The files that satisfy these conditions are then added to the output.
 
 .. code-block:: python
 
@@ -91,7 +99,9 @@ Each such file is then checked for lying in the intended timerange using the :me
 
 Writing a new "scraper" client
 ==============================
-The `~sunpy.net.scraper` thus allows us to write Fido clients for a variety of sources. For a simple example of a scraper client, we can look at the implementation of `sunpy.net.dataretriever.sources.eve.EVEClient` in sunpy.
+
+The `~sunpy.net.scraper` thus allows us to write Fido clients for a variety of sources.
+For a simple example of a scraper client, we can look at the implementation of `sunpy.net.dataretriever.sources.eve.EVEClient` in sunpy.
 
 A version without documentation strings is reproduced below:
 
@@ -162,13 +172,14 @@ Examples
 
 Suppose any file of a data archive can be described by this URL ``https://some-domain.com/%Y/%m/%d/satname_{SatelliteNumber}_{Level}_%y%m%d%H%M%S_{any-2-digit-number}.fits``:
 
-The new format ``pattern`` becomes ``r'https://some-domain.com{{year:4d}}/{{month:2d}}{{day:2d}}/satname_{SatelliteNumber:2d}_{Level:1d}_{{year:2d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}{{second:2d}}_{{:2d}}.fits'``.
+The ``format`` pattern becomes ``r'https://some-domain.com{{year:4d}}/{{month:2d}}{{day:2d}}/satname_{SatelliteNumber:2d}_{Level:1d}_{{year:2d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}{{second:2d}}_{{:2d}}.fits'``.
 The datetime values and any other metadata attributes that we wish to extract are written within double curly-braces ``{{}}``.
 These metadata attributes are the desired keys for the returned dictionary and they should match with the ``attr.__name__``.
 Note that parts of such attributes can accordingly be omitted to match parts of the filename which are dynamic but not needed to be extracted.
 For example, ``{{:2d}}`` is used in the above example to match any 2-digit number in the filename.
 Similarly ``{{}}`` can be used to match a string of any length starting from its position in the filename.
-Now, ``register_values()`` can be written as:
+
+Finally, ``register_values()`` can be written as:
 
 .. code-block:: python
 

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -44,7 +44,8 @@ A brief explanation of how the Scraper works is as follows:
 
 For a more verbose in-depth explanation on how this is accomplished internally:
 
-1. A Scraper object takes as input the generalised ``pattern`` of how a desired filepath looks like, in the ``parse`` format. Upon initialisation, a version of the pattern following the datetime format is also internally generated, called the ``dt_pattern``.
+The Scraper takes as input the generalised ``pattern`` of how a desired file path looks like, in the ``parse`` format.
+Upon initialisation, a version of the pattern following the datetime format is also internally generated, called the ``datetime_pattern``.
 
 .. code-block:: python
 
@@ -52,15 +53,15 @@ For a more verbose in-depth explanation on how this is accomplished internally:
     >>> pattern = ('http://proba2.oma.be/{instrument}/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/'
     ...            '{instrument}_lv1_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.fits')
     >>> s = Scraper(format=pattern, instrument='swap')
-    >>> s.dt_pattern
+    >>> s.datetime_pattern
     'http://proba2.oma.be/swap/data/bsd/%Y/%m/%d/swap_lv1_%Y%m%d_%H%M%S.fits'
 
-The smallest unit of time / time-step for that directory-pattern (the full ``dt_pattern`` except the filename at the end) is then internally detected from ``dt_pattern`` by using the :meth:`~sunpy.net.scraper_utils.extract_timestep` util.
+The smallest unit of time / time-step for that directory-pattern (the full ``datetime_pattern`` except the filename at the end) is then internally detected from ``datetime_pattern`` by using :meth:`~sunpy.net.scraper_utils.extract_timestep`.
 
 .. code-block:: python
 
     >>> from sunpy.net.scraper_utils import extract_timestep
-    >>> extract_timestep(s.dt_pattern)
+    >>> extract_timestep(s.datetime_pattern)
     relativedelta(seconds=+1)
 
 After that `~sunpy.net.scraper.Scraper.range` is called on the pattern where for each time between start and stop, in increments of timestep, the time is first "floored" according to the pattern via :meth:`~sunpy.net.scraper_utils.date_floor` and a corresponding directory-pattern is generated.
@@ -74,9 +75,11 @@ After that `~sunpy.net.scraper.Scraper.range` is called on the pattern where for
     'http://proba2.oma.be/swap/data/bsd/2015/01/02/',
     'http://proba2.oma.be/swap/data/bsd/2015/01/03/']
 
-2. The location given by the filled pattern is visited and a list of files at the location is obtained. This is handled differently depending on whether the pattern is a web URL or a ``file://`` or an ``ftp://`` path in the :meth:`~sunpy.net.scraper.Scraper.filelist` method.
-3. Each filename is then parsed against the remaining portion of the pattern to determine if it matches.
-4. Each such file is then checked for lying in the intended timerange using the :meth:`~sunpy.net.scraper._check_timerange` method which in turn uses :meth:`sunpy.net.scraper_utils.get_timerange_from_exdict` to get the covered timerange for each file. The files that satisfy these conditions are then added to the output.
+The location given by the filled pattern is visited and a list of files at the location is obtained.
+This is handled differently depending on whether the pattern is a web URL or a ``file://`` or an ``ftp://`` path in the :meth:`~sunpy.net.scraper.Scraper.filelist` method.
+
+Each filename is then parsed against the remaining portion of the pattern to determine if it matches.
+Each such file is then checked for lying in the intended timerange using the :meth:`~sunpy.net.scraper._check_timerange` method which in turn uses :meth:`sunpy.net.scraper_utils.get_timerange_from_exdict` to get the covered timerange for each file. The files that satisfy these conditions are then added to the output.
 
 .. code-block:: python
 
@@ -160,9 +163,11 @@ Examples
 Suppose any file of a data archive can be described by this URL ``https://some-domain.com/%Y/%m/%d/satname_{SatelliteNumber}_{Level}_%y%m%d%H%M%S_{any-2-digit-number}.fits``:
 
 The new format ``pattern`` becomes ``r'https://some-domain.com{{year:4d}}/{{month:2d}}{{day:2d}}/satname_{SatelliteNumber:2d}_{Level:1d}_{{year:2d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}{{second:2d}}_{{:2d}}.fits'``.
-The date-time values and any other metadata attributes that we wish to extract are written within double curly-braces ``{{}}``. These metadata attributes are the desired keys for the returned dictionary and they should match with the ``attr.__name__``.
-Note that parts of such attributes can accordingly be omitted to match parts of the filename which are dynamic but not needed to be extracted. For example, ``{{:2d}}`` is used in the above example to match any 2-digit number in the filename. Similarly ``{{}}`` can be used to match a string of any length starting from its position in the filename.
-
+The datetime values and any other metadata attributes that we wish to extract are written within double curly-braces ``{{}}``.
+These metadata attributes are the desired keys for the returned dictionary and they should match with the ``attr.__name__``.
+Note that parts of such attributes can accordingly be omitted to match parts of the filename which are dynamic but not needed to be extracted.
+For example, ``{{:2d}}`` is used in the above example to match any 2-digit number in the filename.
+Similarly ``{{}}`` can be used to match a string of any length starting from its position in the filename.
 Now, ``register_values()`` can be written as:
 
 .. code-block:: python
@@ -181,7 +186,6 @@ Now, ``register_values()`` can be written as:
         }
 
         return adict
-
 
 .. _sunpy-topic-guide-new-source-for-fido-add-new-full-client:
 

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -17,27 +17,6 @@ The main place this is done is when constructing a `~.UnifiedResponse` object, w
 
 .. _sunpy-topic-guide-new-source-for-fido-add-new-scraper-client:
 
-A migration guide for working with / adding new scraper clients
-===============================================================
-
-The main change in 6.0 is the removal of the old regex-based pattern system in favor of a new parse-based pattern system.
-
-This change is to make the pattern system more flexible and easier to use.
-The new pattern system is based on the `parse <https://github.com/r1chardj0n3s/parse/>`__ format.
-
-Previously, when defining a new FIDO client or working with the Scraper, a regex-based ``baseurl`` and a parse-styled ``pattern`` attributes were required.
-Now only a single parse-based ``pattern`` is required when writing Fido clients.
-During the deprecation period for the old ``pattern``, the new one is to be passed as a ``format`` attribute to the Scraper.
-
-Instructions for writing the new pattern are:
-1. Much like the baseurl, the single pattern would cover the entire URL from the protocol, domain to the filename.
-2. Instead of conveying time or numerical information in the URL in a datetime or regex format, it is now done in the `parse <https://github.com/r1chardj0n3s/parse/>`__ format for eg. a ``"%Y"`` is now to be replaced with ``{{year:4d}}``. For a full list of the new keywords corresponding to datetime format, the supported time keys (to be used within ``{{}}``!) are: 'year:4d', 'year:2d', 'month:2d'. 'month_name:l', 'month_name_abbr:l', 'day:2d', 'day_of_year:3d', 'hour:2d', 'minute:2d', 'second:2d', 'microsecond:6d', 'millisecond:3d' and 'week_number:2d'.
-3. The metadata attributes for extraction are written within double curly-braces ``{{}}`` for eg. ``{{ADAPTRealizations:3d}}``.
-4. Single curly-braces ``{}`` are used in case of regular placeholders for Python format strings, each respective value being passed as ``kwargs`` to the Scraper.
-
-A more detailed explanation of the new pattern system is referred to in this topic-guide below.
-
-
 An explanation of how "scraper" clients work
 ============================================
 

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -17,19 +17,25 @@ The main place this is done is when constructing a `~.UnifiedResponse` object, w
 
 .. _sunpy-topic-guide-new-source-for-fido-add-new-scraper-client:
 
-A migration guide for working with / adding new scraper clients:
+A migration guide for working with / adding new scraper clients
 ===============================================================
-The main change in 5.0 is the removal of the old regex-based pattern system in favor of a new parse-based pattern system.
-This change is to make the pattern system more flexible and easier to use. The new pattern system is based on the `parse <https://github.com/r1chardj0n3s/parse/>`__ format.
+
+The main change in 6.0 is the removal of the old regex-based pattern system in favor of a new parse-based pattern system.
+
+This change is to make the pattern system more flexible and easier to use.
+The new pattern system is based on the `parse <https://github.com/r1chardj0n3s/parse/>`__ format.
+
 Previously, when defining a new FIDO client or working with the Scraper, a regex-based ``baseurl`` and a parse-styled ``pattern`` attributes were required.
 Now only a single parse-based ``pattern`` is required when writing Fido clients.
 During the deprecation period for the old ``pattern``, the new one is to be passed as a ``format`` attribute to the Scraper.
+
 Instructions for writing the new pattern are:
 1. Much like the baseurl, the single pattern would cover the entire URL from the protocol, domain to the filename.
 2. Instead of conveying time or numerical information in the URL in a datetime or regex format, it is now done in the `parse <https://github.com/r1chardj0n3s/parse/>`__ format for eg. a ``"%Y"`` is now to be replaced with ``{{year:4d}}``. For a full list of the new keywords corresponding to datetime format, the supported time keys (to be used within ``{{}}``!) are: 'year:4d', 'year:2d', 'month:2d'. 'month_name:l', 'month_name_abbr:l', 'day:2d', 'day_of_year:3d', 'hour:2d', 'minute:2d', 'second:2d', 'microsecond:6d', 'millisecond:3d' and 'week_number:2d'.
 3. The metadata attributes for extraction are written within double curly-braces ``{{}}`` for eg. ``{{ADAPTRealizations:3d}}``.
 4. Single curly-braces ``{}`` are used in case of regular placeholders for Python format strings, each respective value being passed as ``kwargs`` to the Scraper.
-A more detailed explanation of the new pattern system is referred to in the topic-guide below.
+
+A more detailed explanation of the new pattern system is referred to in this topic-guide below.
 
 
 An explanation of how "scraper" clients work

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -28,12 +28,13 @@ A new "scraper" client inherits from `~sunpy.net.dataretriever.client.GenericCli
   It returns a dictionary where keys are the supported attrs and values are lists of tuples.
   Each `tuple` contains the "attr" value and its description.
 * A class attribute ``pattern``; this is a string used to match all URLs supported by the client and extract necessary metadata from the matched URLs.
-  The time and other metadata attributes for extraction are written within double curly-braces ``{{}}`` in a `parse <https://github.com/r1chardj0n3s/parse/>`__ format. Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``. An example of how such a pattern looks like is given in the algorithm explanation below.
+  The time and other metadata attributes for extraction are written within double curly-braces ``{{}}`` in a `parse <https://github.com/r1chardj0n3s/parse/>`__ format.
+  Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``.
+  An example of how such a pattern looks like is given in the algorithm explanation below.
 
 Note: The scraper has supported regex-based patterns for a long time, which is what it will still expect by default. However that is in the process of being replaced with parse-style patterns in the future versions of the package. To use the newer parse-style patterns, it's currently required to pass it as the ``format`` argument to the scraper.
 
 Each such client relies on the `~sunpy.net.scraper.Scraper` to be able to query for files using the :meth:`~sunpy.net.scraper.Scraper.filelist` method. The general algorithm to explain how the `~sunpy.net.scraper.Scraper` is able to do this is:
-
 A brief explanation of how the Scraper works is as follows:
 
 1. Drop the filename from the pattern and generate a list of directories to search for files.

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -28,7 +28,7 @@ A new "scraper" client inherits from `~sunpy.net.dataretriever.client.GenericCli
   It returns a dictionary where keys are the supported attrs and values are lists of tuples.
   Each `tuple` contains the "attr" value and its description.
 * A class attribute ``pattern``; this is a string used to match all URLs supported by the client and extract necessary metadata from the matched URLs.
-  The time and other metadata attributes for extraction are written within double curly-braces ``{{}}`` in a `parse` format. Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``. An example of how such a pattern looks like is given in the algorithm explanation below.
+  The time and other metadata attributes for extraction are written within double curly-braces ``{{}}`` in a `parse <https://github.com/r1chardj0n3s/parse/>`__ format. Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``. An example of how such a pattern looks like is given in the algorithm explanation below.
 
 Note: The scraper has supported regex-based patterns for a long time, which is what it will still expect by default. However that is in the process of being replaced with parse-style patterns in the future versions of the package. To use the newer parse-style patterns, it's currently required to pass it as the ``format`` argument to the scraper.
 
@@ -37,7 +37,7 @@ Each such client relies on the `~sunpy.net.scraper.Scraper` to be able to query 
 A brief explanation of how the Scraper works is as follows:
 
 1. Drop the filename from the pattern and generate a list of directories to search for files.
-2. For each directory, get a list of files.
+2. For each directory, get a list of files present in it.
 3. For each file, check if it matches the pattern.
 4. For each file that matches the pattern, check if it is in the timerange. If it is, add it to the output.
 
@@ -158,18 +158,11 @@ Examples
 
 Suppose any file of a data archive can be described by this URL ``https://some-domain.com/%Y/%m/%d/satname_{SatelliteNumber}_{Level}_%y%m%d%H%M%S_{any-2-digit-number}.fits``:
 
-``baseurl`` becomes ``r'https://some-domain.com/%Y/%m/%d/satname_(\d){2}_(\d){1}_(\d){12}_(\d){2}\.fits'``.
+The new format ``pattern`` becomes ``r'https://some-domain.com{{year:4d}}/{{month:2d}}{{day:2d}}/satname_{SatelliteNumber:2d}_{Level:1d}_{{year:2d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}{{second:2d}}_{{:2d}}.fits'``.
+The date-time values and any other metadata attributes that we wish to extract are written within double curly-braces ``{{}}``. These metadata attributes are the desired keys for the returned dictionary and they should match with the ``attr.__name__``.
+Note that parts of such attributes can accordingly be omitted to match parts of the filename which are dynamic but not needed to be extracted. For example, ``{{:2d}}`` is used in the above example to match any 2-digit number in the filename. Similarly ``{{}}`` can be used to match a string of any length starting from its position in the filename.
 
-Note all variables in the filename are converted to regex that will match any possible value for it.
-A character enclosed within ``()`` followed by a number enclosed within ``{}`` is used to match the specified number of occurrences of that special sequence.
-For example, ``%y%m%d%H%M%S`` is a twelve digit variable (with 2 digits for each item) and thus represented by ``r'(\d){12}'``.
-Note that ``\`` is used to escape the special character ``.``.
-
-``pattern`` becomes ``'{}/{year:4d}/{month:2d}{day:2d}/satname_{SatelliteNumber:2d}_{Level:1d}_{:6d}{hour:2d}{minute:2d}{second:2d}_{:2d}.fits'``.
-Note the sole purpose of ``pattern`` is to extract the information from matched URL, using `~sunpy.extern.parse.parse`.
-So the desired key names for returned dictionary should be written in the ``pattern`` within ``{}``, and they should match with the ``attr.__name__``.
-
-``register_values()`` can be written as:
+Now, ``register_values()`` can be written as:
 
 .. code-block:: python
 
@@ -187,6 +180,7 @@ So the desired key names for returned dictionary should be written in the ``patt
         }
 
         return adict
+
 
 .. _sunpy-topic-guide-new-source-for-fido-add-new-full-client:
 

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -28,7 +28,7 @@ A new "scraper" client inherits from `~sunpy.net.dataretriever.client.GenericCli
   It returns a dictionary where keys are the supported attrs and values are lists of tuples.
   Each `tuple` contains the "attr" value and its description.
 * A class attribute ``pattern``; this is a string used to match all URLs supported by the client and extract necessary metadata from the matched URLs.
-  The time and other metadata attributes for extraction are written within double curly-braces ``{{}}`` in a `~sunpy.extern.parse.parse` format. Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``. An example of how such a pattern looks like is given in the algorithm explanation below.
+  The time and other metadata attributes for extraction are written within double curly-braces ``{{}}`` in a `parse` format. Regular placeholders for Python format strings can still be included via single curly braces ``{}`` with their respective parameters passed as the ``kwargs``. An example of how such a pattern looks like is given in the algorithm explanation below.
 
 Note: The scraper has supported regex-based patterns for a long time, which is what it will still expect by default. However that is in the process of being replaced with parse-style patterns in the future versions of the package. To use the newer parse-style patterns, it's currently required to pass it as the ``format`` argument to the scraper.
 
@@ -75,7 +75,7 @@ After that `~sunpy.net.scraper.Scraper.range` is called on the pattern where for
 
 2. The location given by the filled pattern is visited and a list of files at the location is obtained. This is handled differently depending on whether the pattern is a web URL or a ``file://`` or an ``ftp://`` path in the :meth:`~sunpy.net.scraper.Scraper.filelist` method.
 3. Each filename is then examined to determine if it matches the remaining portion of the pattern using :meth:`~sunpy.extern.parse.parse`.
-4. Each such file is then checked for lying in the intended timerange using the :meth:`~sunpy.net.scraper_utils.check_timerange` method which in turn uses :meth:`sunpy.net.scraper_utils.get_timerange_from_exdict` to get the covered timerange for each file. The files that satisfy these conditions are then added to the output.
+4. Each such file is then checked for lying in the intended timerange using the :meth:`~sunpy.net.scraper._check_timerange` method which in turn uses :meth:`sunpy.net.scraper_utils.get_timerange_from_exdict` to get the covered timerange for each file. The files that satisfy these conditions are then added to the output.
 
 .. code-block:: python
 

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -41,7 +41,7 @@ A brief explanation of how the Scraper works is as follows:
 3. For each file, check if it matches the pattern.
 4. For each file that matches the pattern, check if it is in the timerange. If it is, add it to the output.
 
-For a more in-depth explanation on how this is accomplished internally, see the following explanation:
+For a more verbose in-depth explanation on how this is accomplished internally:
 
 1. A Scraper object takes as input the generalised ``pattern`` of how a desired filepath looks like, in the ``parse`` format. Upon initialisation, a version of the pattern following the datetime format is also internally generated, called the ``dt_pattern``.
 
@@ -74,7 +74,7 @@ After that `~sunpy.net.scraper.Scraper.range` is called on the pattern where for
     'http://proba2.oma.be/swap/data/bsd/2015/01/03/']
 
 2. The location given by the filled pattern is visited and a list of files at the location is obtained. This is handled differently depending on whether the pattern is a web URL or a ``file://`` or an ``ftp://`` path in the :meth:`~sunpy.net.scraper.Scraper.filelist` method.
-3. Each filename is then examined to determine if it matches the remaining portion of the pattern using :meth:`~sunpy.extern.parse.parse`.
+3. Each filename is then parsed against the remaining portion of the pattern to determine if it matches.
 4. Each such file is then checked for lying in the intended timerange using the :meth:`~sunpy.net.scraper._check_timerange` method which in turn uses :meth:`sunpy.net.scraper_utils.get_timerange_from_exdict` to get the covered timerange for each file. The files that satisfy these conditions are then added to the output.
 
 .. code-block:: python

--- a/docs/topic_guide/extending_fido.rst
+++ b/docs/topic_guide/extending_fido.rst
@@ -172,7 +172,7 @@ Examples
 
 Suppose any file of a data archive can be described by this URL ``https://some-domain.com/%Y/%m/%d/satname_{SatelliteNumber}_{Level}_%y%m%d%H%M%S_{any-2-digit-number}.fits``:
 
-The ``format`` pattern becomes ``r'https://some-domain.com{{year:4d}}/{{month:2d}}{{day:2d}}/satname_{SatelliteNumber:2d}_{Level:1d}_{{year:2d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}{{second:2d}}_{{:2d}}.fits'``.
+The ``format`` pattern becomes ``r'https://some-domain.com/{{year:4d}}/{{month:2d}}{{day:2d}}/satname_{SatelliteNumber:2d}_{Level:1d}_{{year:2d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}{{second:2d}}_{{:2d}}.fits'``.
 The datetime values and any other metadata attributes that we wish to extract are written within double curly-braces ``{{}}``.
 These metadata attributes are the desired keys for the returned dictionary and they should match with the ``attr.__name__``.
 Note that parts of such attributes can accordingly be omitted to match parts of the filename which are dynamic but not needed to be extracted.

--- a/docs/topic_guide/index.rst
+++ b/docs/topic_guide/index.rst
@@ -18,6 +18,7 @@ Although there are code snippets in various parts of each topic guide, these are
    coordinates/index
    custom_map_rotate
    extending_fido
+   scraper_migration
    history_comments
    installation
    logger

--- a/docs/topic_guide/scraper_migration.rst
+++ b/docs/topic_guide/scraper_migration.rst
@@ -4,7 +4,7 @@
 Migrating to the new Scraper pattern system in ``sunpy`` 6.0
 ************************************************************
 
-The `~sunpy.net.scarper.Scraper` has undergone a major change in the sunpy 6.0 release.
+The `~sunpy.net.scraper.Scraper` has undergone a major change in the sunpy 6.0 release.
 
 The old pattern system was regex-based, while the new pattern system is based on the `parse <https://github.com/r1chardj0n3s/parse/>`__
 We hope that the new pattern system is more flexible and easier to use.
@@ -13,9 +13,9 @@ We hope that the new pattern system is more flexible and easier to use.
 How to migrate
 ==============
 
-Previously, when defining a new Fido client or working with the `~sunpy.net.scarper.Scraper`, a regex-based ``baseurl`` and a parse-styled ``pattern`` attributes were required.
+Previously, when defining a new Fido client or working with the `~sunpy.net.scraper.Scraper`, a regex-based ``baseurl`` and a parse-styled ``pattern`` attributes were required.
 The new pattern system requires a single pattern string that covers the entire URL, a combination of the ``baseurl`` and ``pattern`` attributes from before.
-This pattern string has to be passed as a ``format`` keyword to the `~sunpy.net.scarper.Scraper`.
+This pattern string has to be passed as a ``format`` keyword to the `~sunpy.net.scraper.Scraper`.
 During the deprecation period, the old ``pattern`` argument will still be accepted, but it is recommended to switch to the new pattern system.
 
 Writing the new pattern
@@ -23,24 +23,25 @@ Writing the new pattern
 
 1. The new pattern covers the entire URL from the protocol, domain to the filename.
 2. Instead of conveying time or numerical information in the URL in a datetime or regex format, it is now done in the `parse <https://github.com/r1chardj0n3s/parse/#format-syntax>`__ format.
- E.g., a ``"%Y"`` is now to be replaced with ``{{year:4d}}``.
- For a full list of the new keywords corresponding to datetime format, the supported time keys (to be used within ``{{}}``) are:
-    * 'year:4d'
-    * 'year:2d'
-    * 'month:2d'
-    * 'month_name:l'
-    * 'month_name_abbr:l'
-    * 'day:2d'
-    * 'day_of_year:3d'
-    * 'hour:2d'
-    * 'minute:2d'
-    * 'second:2d'
-    * 'microsecond:6d'
-    * 'millisecond:3d'
-    * 'week_number:2d'
+   E.g., a ``"%Y"`` is now to be replaced with ``{{year:4d}}``.
+   For a full list of the new keywords corresponding to datetime format, the supported time keys (to be used within ``{{}}``) are:
+
+   * 'year:4d'
+   * 'year:2d'
+   * 'month:2d'
+   * 'month_name:l'
+   * 'month_name_abbr:l'
+   * 'day:2d'
+   * 'day_of_year:3d'
+   * 'hour:2d'
+   * 'minute:2d'
+   * 'second:2d'
+   * 'microsecond:6d'
+   * 'millisecond:3d'
+   * 'week_number:2d'
 
 3. The metadata attributes for extraction are written within double curly-braces ``{{}}`` for eg. ``{{ADAPTRealizations:3d}}``.
-4. Single curly-braces ``{}`` are used in case of regular placeholders for Python format strings, each respective value being passed as ``kwargs`` to the `~sunpy.net.scarper.Scraper`.
+4. Single curly-braces ``{}`` are used in case of regular placeholders for Python format strings, each respective value being passed as ``kwargs`` to the `~sunpy.net.scraper.Scraper`.
 
 Example
 -------

--- a/docs/topic_guide/scraper_migration.rst
+++ b/docs/topic_guide/scraper_migration.rst
@@ -1,0 +1,63 @@
+.. _sunpy-topic-guide-scraper-migration:
+
+************************************************************
+Migrating to the new Scraper pattern system in ``sunpy`` 6.0
+************************************************************
+
+The `~sunpy.net.scarper.Scraper` has undergone a major change in the sunpy 6.0 release.
+
+The old pattern system was regex-based, while the new pattern system is based on the `parse <https://github.com/r1chardj0n3s/parse/>`__
+We hope that the new pattern system is more flexible and easier to use.
+`The readme of parse library provides a good overview of the syntax. <https://github.com/r1chardj0n3s/parse/#format-syntax>`__
+
+How to migrate
+==============
+
+Previously, when defining a new Fido client or working with the `~sunpy.net.scarper.Scraper`, a regex-based ``baseurl`` and a parse-styled ``pattern`` attributes were required.
+The new pattern system requires a single pattern string that covers the entire URL, a combination of the ``baseurl`` and ``pattern`` attributes from before.
+This pattern string has to be passed as a ``format`` keyword to the `~sunpy.net.scarper.Scraper`.
+During the deprecation period, the old ``pattern`` argument will still be accepted, but it is recommended to switch to the new pattern system.
+
+Writing the new pattern
+-----------------------
+
+1. The new pattern covers the entire URL from the protocol, domain to the filename.
+2. Instead of conveying time or numerical information in the URL in a datetime or regex format, it is now done in the `parse <https://github.com/r1chardj0n3s/parse/#format-syntax>`__ format.
+ E.g., a ``"%Y"`` is now to be replaced with ``{{year:4d}}``.
+ For a full list of the new keywords corresponding to datetime format, the supported time keys (to be used within ``{{}}``) are:
+    * 'year:4d'
+    * 'year:2d'
+    * 'month:2d'
+    * 'month_name:l'
+    * 'month_name_abbr:l'
+    * 'day:2d'
+    * 'day_of_year:3d'
+    * 'hour:2d'
+    * 'minute:2d'
+    * 'second:2d'
+    * 'microsecond:6d'
+    * 'millisecond:3d'
+    * 'week_number:2d'
+
+3. The metadata attributes for extraction are written within double curly-braces ``{{}}`` for eg. ``{{ADAPTRealizations:3d}}``.
+4. Single curly-braces ``{}`` are used in case of regular placeholders for Python format strings, each respective value being passed as ``kwargs`` to the `~sunpy.net.scarper.Scraper`.
+
+Example
+-------
+
+Before migration:
+
+.. code-block:: python
+
+    baseurl = r'https://gong.nso.edu/adapt/maps/gong/%Y/adapt(\d){5}_(\d){2}(\w){1}(\d){3}_(\d){12}_(\w){1}(\d){8}(\w){1}(\d){1}\.fts\.gz'
+    pattern = '{}adapt{ADAPTFileType:1d}{ADAPTLonType:1d}{ADAPTInputSource:1d}{ADAPTDataAssimilation:1d}{ADAPTResolution:1d}' + \
+    '_{ADAPTVersionYear:2d}{ADAPTVersionMonth:1l}{ADAPTRealizations:3d}_{year:4d}{month:2d}{day:2d}{hour:2d}{minute:2d}' + \
+    '_{ADAPTEvolutionMode:1l}{days_since_last_obs:2d}{hours_since_last_obs:2d}{minutes_since_last_obs:2d}{seconds_since_last_obs:2d}{ADAPTHelioData:1l}{ADAPTMagData:1d}.fts.gz'
+
+After migration:
+
+.. code-block:: python
+
+    pattern = r'https://gong.nso.edu/adapt/maps/gong/{{year:4d}}/adapt{{ADAPTFileType:1d}}{{ADAPTLonType:1d}}{{ADAPTInputSource:1d}}{{ADAPTDataAssimilation:1d}}{{ADAPTResolution:1d}}' + \
+    '_{{ADAPTVersionYear:2d}}{{ADAPTVersionMonth:1l}}{{ADAPTRealizations:3d}}_{{year:4d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}' + \
+    '_{{ADAPTEvolutionMode:1l}}{{days_since_last_obs:2d}}{{hours_since_last_obs:2d}}{{minutes_since_last_obs:2d}}{{seconds_since_last_obs:2d}}{{ADAPTHelioData:1l}}{{ADAPTMagData:1d}}.fts.gz'

--- a/docs/whatsnew/5.0.rst
+++ b/docs/whatsnew/5.0.rst
@@ -131,12 +131,12 @@ In the past, ``sunpy`` only provided a search over the high-cadence data.
     8-15: https://www.ncei.noaa.gov/data/goes-space-environment-monitor/access/science/
     16-17: https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/
     <BLANKLINE>
-           Start Time               End Time        ... Provider Resolution
-    ----------------------- ----------------------- ... -------- ----------
-    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999 ...     NOAA      flx1s
-    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999 ...     NOAA      avg1m
-    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999 ...     NOAA      flx1s
-    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999 ...     NOAA      avg1m
+           Start Time               End Time        Instrument  Physobs   Source Provider Resolution SatelliteNumber
+    ----------------------- ----------------------- ---------- ---------- ------ -------- ---------- ---------------
+    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999        XRS irradiance   GOES     NOAA      flx1s              16
+    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999        XRS irradiance   GOES     NOAA      avg1m              16
+    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999        XRS irradiance   GOES     NOAA      flx1s              17
+    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999        XRS irradiance   GOES     NOAA      avg1m              17
     <BLANKLINE>
     <BLANKLINE>
 
@@ -156,10 +156,10 @@ If you want the 1s resolution data, you would instead pass ``a.Resolution("flx1s
     8-15: https://www.ncei.noaa.gov/data/goes-space-environment-monitor/access/science/
     16-17: https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/
     <BLANKLINE>
-           Start Time               End Time        ... Provider Resolution
-    ----------------------- ----------------------- ... -------- ----------
-    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999 ...     NOAA      avg1m
-    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999 ...     NOAA      avg1m
+           Start Time               End Time        Instrument  Physobs   Source Provider Resolution SatelliteNumber
+    ----------------------- ----------------------- ---------- ---------- ------ -------- ---------- ---------------
+    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999        XRS irradiance   GOES     NOAA      avg1m              16
+    2022-02-15 00:00:00.000 2022-02-15 23:59:59.999        XRS irradiance   GOES     NOAA      avg1m              17
     <BLANKLINE>
     <BLANKLINE>
 

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -60,6 +60,7 @@ class GenericClient(BaseClient):
     """
     # A string which is used to match all files and extract the desired metadata from urls correctly,
     # using ``sunpy.extern.parse.parse``.
+    baseurl = None
     pattern = None
     # Set of required 'attrs' for client to handle the query.
     required = {a.Time, a.Instrument}
@@ -119,7 +120,7 @@ class GenericClient(BaseClient):
         before using the scraper.
         """
         matchdict = cls._get_match_dict(*args, **kwargs)
-        return cls.pattern, matchdict
+        return cls.baseurl, cls.pattern, matchdict
 
     @classmethod
     def _can_handle_query(cls, *query):
@@ -232,10 +233,11 @@ class GenericClient(BaseClient):
         -------
         A `QueryResponse` instance containing the query result.
         """
-        pattern, matchdict = self.pre_search_hook(*args, **kwargs)
-        scraper = Scraper(format=pattern)
+        # baseurl added for backwards compatibility purposes only
+        baseurl, pattern, matchdict = self.pre_search_hook(*args, **kwargs)
+        scraper = Scraper(pattern=baseurl) if baseurl else Scraper(format=pattern)
         tr = TimeRange(matchdict['Start Time'], matchdict['End Time'])
-        filesmeta = scraper._extract_files_meta(tr, matcher=matchdict)
+        filesmeta = scraper._extract_files_meta(tr, extractor=pattern) if baseurl else scraper._extract_files_meta(tr, matcher=matchdict)
         filesmeta = sorted(filesmeta, key=lambda k: k['url'])
         metalist = []
         for i in filesmeta:

--- a/sunpy/net/dataretriever/client.py
+++ b/sunpy/net/dataretriever/client.py
@@ -233,7 +233,7 @@ class GenericClient(BaseClient):
         A `QueryResponse` instance containing the query result.
         """
         pattern, matchdict = self.pre_search_hook(*args, **kwargs)
-        scraper = Scraper(pattern)
+        scraper = Scraper(format=pattern)
         tr = TimeRange(matchdict['Start Time'], matchdict['End Time'])
         filesmeta = scraper._extract_files_meta(tr, matcher=matchdict)
         filesmeta = sorted(filesmeta, key=lambda k: k['url'])

--- a/sunpy/net/dataretriever/sources/adapt.py
+++ b/sunpy/net/dataretriever/sources/adapt.py
@@ -63,9 +63,9 @@ class ADAPTClient(GenericClient):
     ----------
     `Names and possible attrs values are available <https://gong.nso.edu/adapt/maps/adapt_filename_notes.txt>`__.
     """
-    pattern = r'https://gong.nso.edu/adapt/maps/gong/%Y/adapt{ADAPTFileType:1d}{ADAPTLonType:1d}{ADAPTInputSource:1d}{ADAPTDataAssimilation:1d}{ADAPTResolution:1d}' + \
-    '_{ADAPTVersionYear:2d}{ADAPTVersionMonth:1l}{ADAPTRealizations:3d}_{year:4d}{month:2d}{day:2d}{hour:2d}{minute:2d}' + \
-    '_{ADAPTEvolutionMode:1l}{days_since_last_obs:2d}{hours_since_last_obs:2d}{minutes_since_last_obs:2d}{seconds_since_last_obs:2d}{ADAPTHelioData:1l}{ADAPTMagData:1d}.fts.gz'
+    pattern = r'https://gong.nso.edu/adapt/maps/gong/{{year:4d}}/adapt{{ADAPTFileType:1d}}{{ADAPTLonType:1d}}{{ADAPTInputSource:1d}}{{ADAPTDataAssimilation:1d}}{{ADAPTResolution:1d}}' + \
+    '_{{ADAPTVersionYear:2d}}{{ADAPTVersionMonth:1l}}{{ADAPTRealizations:3d}}_{{year:4d}}{{month:2d}}{{day:2d}}{{hour:2d}}{{minute:2d}}' + \
+    '_{{ADAPTEvolutionMode:1l}}{{days_since_last_obs:2d}}{{hours_since_last_obs:2d}}{{minutes_since_last_obs:2d}}{{seconds_since_last_obs:2d}}{{ADAPTHelioData:1l}}{{ADAPTMagData:1d}}.fts.gz'
 
     @classmethod
     def _attrs_module(cls):

--- a/sunpy/net/dataretriever/sources/adapt.py
+++ b/sunpy/net/dataretriever/sources/adapt.py
@@ -63,8 +63,7 @@ class ADAPTClient(GenericClient):
     ----------
     `Names and possible attrs values are available <https://gong.nso.edu/adapt/maps/adapt_filename_notes.txt>`__.
     """
-    baseurl = r'https://gong.nso.edu/adapt/maps/gong/%Y/adapt(\d){5}_(\d){2}(\w){1}(\d){3}_(\d){12}_(\w){1}(\d){8}(\w){1}(\d){1}\.fts\.gz'
-    pattern = '{}adapt{ADAPTFileType:1d}{ADAPTLonType:1d}{ADAPTInputSource:1d}{ADAPTDataAssimilation:1d}{ADAPTResolution:1d}' + \
+    pattern = r'https://gong.nso.edu/adapt/maps/gong/%Y/adapt{ADAPTFileType:1d}{ADAPTLonType:1d}{ADAPTInputSource:1d}{ADAPTDataAssimilation:1d}{ADAPTResolution:1d}' + \
     '_{ADAPTVersionYear:2d}{ADAPTVersionMonth:1l}{ADAPTRealizations:3d}_{year:4d}{month:2d}{day:2d}{hour:2d}{minute:2d}' + \
     '_{ADAPTEvolutionMode:1l}{days_since_last_obs:2d}{hours_since_last_obs:2d}{minutes_since_last_obs:2d}{seconds_since_last_obs:2d}{ADAPTHelioData:1l}{ADAPTMagData:1d}.fts.gz'
 

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -58,16 +58,16 @@ class XRSClient(GenericClient):
     8-15: https://www.ncei.noaa.gov/data/goes-space-environment-monitor/access/science/
     16-17: https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/
     <BLANKLINE>
-           Start Time               End Time        ... Provider Resolution
-    ----------------------- ----------------------- ... -------- ----------
-    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999 ...     NOAA      flx1s
-    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999 ...     NOAA      flx1s
-    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999 ...     NOAA      avg1m
-    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999 ...     NOAA      avg1m
-    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999 ...     NOAA      flx1s
-    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999 ...     NOAA      flx1s
-    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999 ...     NOAA      avg1m
-    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999 ...     NOAA      avg1m
+           Start Time               End Time        Instrument  Physobs   Source Provider Resolution SatelliteNumber filename_res
+    ----------------------- ----------------------- ---------- ---------- ------ -------- ---------- --------------- ------------
+    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999        XRS irradiance   GOES     NOAA      irrad              13         gxrs
+    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999        XRS irradiance   GOES     NOAA      irrad              13         gxrs
+    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999        XRS irradiance   GOES     NOAA      avg1m              13         xrsf
+    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999        XRS irradiance   GOES     NOAA      avg1m              13         xrsf
+    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999        XRS irradiance   GOES     NOAA      irrad              15         gxrs
+    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999        XRS irradiance   GOES     NOAA      irrad              15         gxrs
+    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999        XRS irradiance   GOES     NOAA      avg1m              15         xrsf
+    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999        XRS irradiance   GOES     NOAA      avg1m              15         xrsf
     <BLANKLINE>
     <BLANKLINE>
     """

--- a/sunpy/net/dataretriever/sources/goes.py
+++ b/sunpy/net/dataretriever/sources/goes.py
@@ -128,7 +128,7 @@ class XRSClient(GenericClient):
         Function to help get list of OrderedDicts.
         """
         metalist = []
-        scraper = Scraper(pattern, **kwargs)
+        scraper = Scraper(format=pattern, **kwargs)
         tr = TimeRange(matchdict["Start Time"], matchdict["End Time"])
         filemeta = scraper._extract_files_meta(tr, matcher=matchdict)
         for i in filemeta:
@@ -298,7 +298,7 @@ class SUVIClient(GenericClient):
                     # formatting pattern using Level, SatelliteNumber and Wavelength
                     urlpattern = pattern.format(**formdict)
                     urlpattern = urlpattern.replace('{', '{{').replace('}', '}}')
-                    scraper = Scraper(urlpattern)
+                    scraper = Scraper(format=urlpattern)
                     tr = TimeRange(matchdict['Start Time'], matchdict['End Time'])
                     filesmeta = scraper._extract_files_meta(tr)
                     for i in filesmeta:

--- a/sunpy/net/dataretriever/sources/norh.py
+++ b/sunpy/net/dataretriever/sources/norh.py
@@ -70,7 +70,7 @@ class NoRHClient(GenericClient):
             d['Wavelength'].append('tca')
         if 34*u.GHz in req_wave:
             d['Wavelength'].append('tcz')
-        return cls.pattern, d
+        return cls.baseurl, cls.pattern, d
 
     def post_search_hook(self, exdict, matchdict):
         """

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -217,7 +217,7 @@ class RHESSIClient(GenericClient):
         return urlretrieve(url)
 
     def search(self, *args, **kwargs):
-        pattern, matchdict = self.pre_search_hook(*args, **kwargs)
+        baseurl, pattern, matchdict = self.pre_search_hook(*args, **kwargs)
         timerange = TimeRange(matchdict['Start Time'], matchdict['End Time'])
         metalist = []
         for url in self.get_observing_summary_filename(timerange):

--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -217,7 +217,7 @@ class RHESSIClient(GenericClient):
         return urlretrieve(url)
 
     def search(self, *args, **kwargs):
-        baseurl, pattern, matchdict = self.pre_search_hook(*args, **kwargs)
+        _, pattern, matchdict = self.pre_search_hook(*args, **kwargs)
         timerange = TimeRange(matchdict['Start Time'], matchdict['End Time'])
         metalist = []
         for url in self.get_observing_summary_filename(timerange):

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -74,7 +74,7 @@ class Scraper:
     >>> from sunpy.net import Scraper
     >>> pattern = ('http://proba2.oma.be/{instrument}/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/'
     ...            '{instrument}_lv1_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{month:2d}}{{second:2d}}.fits')
-    >>> swap = Scraper(pattern, instrument='swap')
+    >>> swap = Scraper(format=pattern, instrument='swap')
     >>> print(swap.pattern)
     http://proba2.oma.be/swap/data/bsd/{year:4d}/{month:2d}/{day:2d}/swap_lv1_{year:4d}{month:2d}{day:2d}_{hour:2d}{month:2d}{second:2d}.fits
     >>> print(swap.now)  # doctest: +SKIP
@@ -212,7 +212,7 @@ class Scraper:
         >>> from sunpy.net import Scraper
         >>> pattern = ('http://proba2.oma.be/{instrument}/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/'
         ...            '{instrument}_lv1_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.fits')
-        >>> swap = Scraper(pattern, instrument='swap')
+        >>> swap = Scraper(format=pattern, instrument='swap')
         >>> from sunpy.time import TimeRange
         >>> timerange = TimeRange('2015-01-01T00:08:00','2015-01-01T00:12:00')
         >>> print(swap.filelist(timerange))  # doctest: +REMOTE_DATA
@@ -224,7 +224,7 @@ class Scraper:
         >>> from sunpy.net import Scraper
         >>> from sunpy.time import TimeRange
         >>> pattern = 'http://proba2.oma.be/lyra/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/{{}}_lev{{Level:1d}}_std.fits'
-        >>> lyra = Scraper(pattern)
+        >>> lyra = Scraper(format=pattern)
         >>> timerange = TimeRange('2023-03-06T00:08:00','2023-03-12T00:12:00')
         >>> print(swap.filelist(timerange)) # doctest: +REMOTE_DATA
         ['http://proba2.oma.be/lyra/data/bsd/2023/03/06/lyra_20230306-000000_lev2_std.fits',

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -23,30 +23,7 @@ from sunpy.util.exceptions import warn_user
 
 __all__ = ['Scraper']
 
-# regular expressions to convert datetime format
-# added `%e` as for milliseconds `%f/1000`
-TIME_CONVERSIONS = {'%Y': r'\d{4}', '%y': r'\d{2}',
-                    '%b': '[A-Z][a-z]{2}', '%B': r'\W', '%m': r'\d{2}',
-                    '%d': r'\d{2}', '%j': r'\d{3}',
-                    '%H': r'\d{2}', '%I': r'\d{2}',
-                    '%M': r'\d{2}',
-                    '%S': r'\d{2}', '%e': r'\d{3}', '%f': r'\d{6}'}
 
-# `parse` expressions to convert into datetime format
-PARSE_TIME_CONVERSIONS = {"{year:4d}": "%Y", "{year:2d}": "%y",
-            "{month:2d}": "%m",
-            "{month_name:l}": "%B",
-            "{month_name_abbr:l}": "%b",
-            "{day:2d}": "%d", "{day_of_year:3d}": "%j",
-            "{hour:2d}": "%H",
-            "{minute:2d}": "%M",
-            "{second:2d}": "%S",
-            "{microsecond:6d}": "%f",
-            "{millisecond:3d}": "%e", # added `%e` as for milliseconds `%f/1000`
-            "{week_number:2d}": "%W",
-        }
-
-@deprecated_renamed_argument("pattern", None, since="5.1", message="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions.")
 # Regular expressions to convert datetime format
 TIME_CONVERSIONS = {
     '%Y': r'\d{4}', '%y': r'\d{2}',
@@ -75,6 +52,7 @@ DEPRECATED_MESSAGE = (
     "This comes with a new syntax and there is a migration guide available at "
     "<ADD URL>."
 )
+
 class Scraper:
     """
     A scraper to scrap web data archives based on dates.

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -422,9 +422,9 @@ class Scraper:
                 return tr.intersects(timerange)
             else:
                 datehref = self._extract_date(url).to_datetime()
-                smaller_pattern = extract_timestep(self.pattern)
-                file_timerange = TimeRange(datehref, datehref + smaller_pattern)
-                return file_timerange.intersects(timerange)
+                timestep = extract_timestep(self.pattern)
+                tr = TimeRange(datehref, datehref + timestep)
+                return tr.intersects(timerange)
         else:
             exdict = parse(self.pattern, url).named
             if exdict['year'] < 100:

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -53,26 +53,23 @@ class Scraper:
 
     Parameters
     ----------
+    format : `str`
+        A string containing the url with the date and other information to be
+        extracted encoded as ``parse`` formats, and any other ``kwargs`` parameters
+        as a string format, the former represented using double curly-brackets
+        to differentiate from the latter.
+        The accepted parse representations for datetime values are as given in ``PARSE_TIME_CONVERSIONS``.
+        This can also be a uri to a local file patterns. Default is `None`.
     pattern : `str`
         A string containing the url with the date encoded as datetime formats,
         and any other parameter as ``kwargs`` as a string format.
         This can also be a uri to a local file patterns. Deprecated in favor of `format`. Default is `None`.
-
     regex : `bool`
         Set to `True` if parts of the pattern uses regexp symbols.
         This only works for the filename part of the pattern rather than the full url.
         Be careful that periods ``.`` matches any character and therefore it's better to escape them.
         If regexp is used, other ``kwargs`` are ignored and string replacement is
         not possible. Default is `False`.
-
-    format : `str`
-        The new version for pattern, a string containing the url with the date and other information to be
-        extracted encoded as ``parse`` formats, and any other ``kwargs`` parameters
-        as a string format, the former represented using double curly-brackets
-        to differentiate from the latter.
-        The accepted parse representations for datetime values are as given in ``PARSE_TIME_CONVERSIONS``.
-        This can also be a uri to a local file patterns. Default is `None`.
-
 
     Attributes
     ----------
@@ -102,7 +99,7 @@ class Scraper:
     pattern looks with the actual time.
     """
 
-    def __init__(self, pattern=None, regex=False, format=None, **kwargs):
+    def __init__(self, format=None, pattern=None, regex=False, **kwargs):
         if pattern is not None and format is None:
             warnings.warn(
                 "Using 'pattern' for the URL format is deprecated. "

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -50,7 +50,7 @@ PARSE_TIME_CONVERSIONS = {
 DEPRECATED_MESSAGE = (
     "pattern has been replaced with the format keyword. "
     "This comes with a new syntax and there is a migration guide available at "
-    "<ADD URL>."
+    "https://docs.sunpy.org/en/stable/how_to/scraper_migration.html."
 )
 
 class Scraper:

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -54,18 +54,32 @@ class Scraper:
     Parameters
     ----------
     pattern : `str`
-        A string containing the url with the date and other information to be
+        A string containing the url with the date encoded as datetime formats,
+        and any other parameter as ``kwargs`` as a string format.
+        This can also be a uri to a local file patterns. Deprecated in favor of `format`. Default is `None`.
+
+    regex : `bool`
+        Set to `True` if parts of the pattern uses regexp symbols.
+        This only works for the filename part of the pattern rather than the full url.
+        Be careful that periods ``.`` matches any character and therefore it's better to escape them.
+        If regexp is used, other ``kwargs`` are ignored and string replacement is
+        not possible. Default is `False`.
+
+    format : `str`
+        The new version for pattern, a string containing the url with the date and other information to be
         extracted encoded as ``parse`` formats, and any other ``kwargs`` parameters
         as a string format, the former represented using double curly-brackets
         to differentiate from the latter.
         The accepted parse representations for datetime values are as given in ``PARSE_TIME_CONVERSIONS``.
-        This can also be a uri to a local file patterns.
+        This can also be a uri to a local file patterns. Default is `None`.
 
 
     Attributes
     ----------
     pattern : `str`
-        A converted string with the kwargs.
+        The pattern with the parse format.
+    dt_pattern : `str`
+        The parse pattern in the datetime format.
     now : `datetime.datetime`
         The pattern with the actual date.
 
@@ -77,6 +91,8 @@ class Scraper:
     >>> swap = Scraper(format=pattern, instrument='swap')
     >>> print(swap.pattern)
     http://proba2.oma.be/swap/data/bsd/{year:4d}/{month:2d}/{day:2d}/swap_lv1_{year:4d}{month:2d}{day:2d}_{hour:2d}{month:2d}{second:2d}.fits
+    >>> print(swap.dt_pattern)
+    http://proba2.oma.be/swap/data/bsd/%Y/%m/%d/swap_lv1_%Y%m%d_%H%m%S.fits
     >>> print(swap.now)  # doctest: +SKIP
     http://proba2.oma.be/swap/data/bsd/2022/12/21/swap_lv1_20221221_112433.fits
 
@@ -504,6 +520,8 @@ class Scraper:
         ----------
         timerange : `~sunpy.time.TimeRange`
             Time interval where to find the directories for a given pattern.
+        extractor : `str`
+            Extractor to extract metadata from URLs if the old format for pattern is used.
         matcher : `dict`
             Dictionary to check if extracted metadata is valid.
 

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -140,12 +140,9 @@ class Scraper:
         else:
             raise ValueError("Either 'pattern' or 'format' must be provided.")
         if self.use_old_format:
-            if regex:
-                self.pattern = pattern
-                if kwargs:
-                    warn_user('regex is being used, the extra arguments passed are being ignored')
-            else:
-                self.pattern = pattern.format(**kwargs)
+            if regex and kwargs:
+                warn_user('regexp being used, the extra arguments passed are being ignored')
+            self.pattern = pattern.format(**kwargs) if kwargs and not regex else self.pattern
             self.domain = f"{urlsplit(self.pattern).scheme}://{urlsplit(self.pattern).netloc}/"
             milliseconds = re.search(r'\%e', self.pattern)
             if not milliseconds:

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -234,16 +234,18 @@ class Scraper:
          'http://proba2.oma.be/swap/data/bsd/2015/01/01/swap_lv1_20150101_001157.fits']
 
         While writing the pattern, we can also leverage parse capabilities by using the ``{{}}`` notation to match parts of the filename that cannot be known beforehand:
+
         >>> from sunpy.net import Scraper
         >>> from sunpy.time import TimeRange
         >>> pattern = 'http://proba2.oma.be/lyra/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/{{}}_lev{{Level:1d}}_std.fits'
         >>> lyra = Scraper(format=pattern)
-        >>> timerange = TimeRange('2023-03-06T00:08:00','2023-03-12T00:12:00')
+        >>> timerange = TimeRange('2023-03-06T00:00:00','2023-03-06T00:10:00')
         >>> print(swap.filelist(timerange)) # doctest: +REMOTE_DATA
-        ['http://proba2.oma.be/lyra/data/bsd/2023/03/06/lyra_20230306-000000_lev2_std.fits',
-        'http://proba2.oma.be/lyra/data/bsd/2023/03/06/lyra_20230306-000000_lev3_std.fits',
-        '...',
-        'http://proba2.oma.be/lyra/data/bsd/2023/03/12/lyra_20230312-000000_lev3_std.fits']
+        ['http://proba2.oma.be/swap/data/bsd/2023/03/06/swap_lv1_20230306_000128.fits',
+        'http://proba2.oma.be/swap/data/bsd/2023/03/06/swap_lv1_20230306_000318.fits',
+        'http://proba2.oma.be/swap/data/bsd/2023/03/06/swap_lv1_20230306_000508.fits',
+        'http://proba2.oma.be/swap/data/bsd/2023/03/06/swap_lv1_20230306_000658.fits',
+        'http://proba2.oma.be/swap/data/bsd/2023/03/06/swap_lv1_20230306_000848.fits']
 
         Notes
         -----

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -404,7 +404,7 @@ class Scraper:
                 tr = get_timerange_from_exdict(exdict)
                 return tr.intersects(timerange)
             else:
-                datehref = self._extractDateURL(url).to_datetime()
+                datehref = self._extract_date(url).to_datetime()
                 smaller_pattern = extract_timestep(self.pattern)
                 file_timerange = TimeRange(datehref, datehref + smaller_pattern)
                 return file_timerange.intersects(timerange)
@@ -436,7 +436,7 @@ class Scraper:
             return parse(self.pattern, url)
 
 
-    def _extractDateURL(self, url):
+    def _extract_date(self, url):
         """
         Extracts the date from a particular url following the pattern.
         """

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -69,6 +69,7 @@ class Scraper:
         Be careful that periods ``.`` matches any character and therefore it's better to escape them.
         If regexp is used, other ``kwargs`` are ignored and string replacement is
         not possible. Default is `False`.
+        Deprecated in favor of `format`. Default is `False`.
     format : `str`
         A string containing the url with the date and other information to be
         extracted encoded as ``parse`` formats, and any other ``kwargs`` parameters
@@ -108,6 +109,7 @@ class Scraper:
     http://proba2.oma.be/swap/data/bsd/2022/12/21/swap_lv1_20221221_112433.fits
     """
     @deprecated_renamed_argument("pattern", None, since="6.0", message=DEPRECATED_MESSAGE)
+    @deprecated_renamed_argument("regex", None, since="6.0", message=DEPRECATED_MESSAGE)
     def __init__(self, pattern=None, regex=False, *, format=None, **kwargs):
         if pattern is not None and format is None:
             self.use_old_format = True

--- a/sunpy/net/scraper_utils.py
+++ b/sunpy/net/scraper_utils.py
@@ -1,10 +1,7 @@
-import re
 import calendar
 from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
-
-from astropy.time import Time
 
 from sunpy.time import TimeRange
 
@@ -85,67 +82,6 @@ def date_floor(date, timestep):
         time_tup[-5:] = [1, 1, 0, 0, 0]
 
     return datetime(*time_tup)
-
-def extractDateURL(self, url):
-    """
-    Extracts the date from a particular url following the pattern.
-    """
-    # remove the user and passwd from files if there:
-    url = url.replace("anonymous:data@sunpy.org@", "")
-
-    def url_to_list(txt):
-        # Substitutes '.' and '_' for '/'.
-        return re.sub(r'\.|_', '/', txt).split('/')
-
-    # create a list of all the blocks in times - assuming they are all
-    # separated with either '.', '_' or '/'.
-    pattern_list = url_to_list(self.pattern)
-    url_list = url_to_list(url)
-    time_order = ['%Y', '%y', '%b', '%B', '%m', '%d', '%j',
-                    '%H', '%I', '%M', '%S', '%e', '%f']
-    final_date = []
-    final_pattern = []
-    # Find in directory and filename
-    for pattern_elem, url_elem in zip(pattern_list, url_list):
-        time_formats = [x for x in time_order if x in pattern_elem]
-        if len(time_formats) > 0:
-            # Find whether there's text that should not be here
-            toremove = re.split('%.', pattern_elem)
-            if len(toremove) > 0:
-                for bit in toremove:
-                    if bit != '':
-                        url_elem = url_elem.replace(bit, '', 1)
-                        pattern_elem = pattern_elem.replace(bit, '', 1)
-            final_date.append(url_elem)
-            final_pattern.append(pattern_elem)
-            for time_bit in time_formats:
-                time_order.remove(time_bit)
-    # Find and remove repeated elements eg: %Y in ['%Y', '%Y%m%d']
-    # Make all as single strings
-    date_together = ''.join(final_date)
-    pattern_together = ''.join(final_pattern)
-    re_together = pattern_together
-    for k, v in TIME_CONVERSIONS.items():
-        re_together = re_together.replace(k, v)
-
-    # Lists to contain the unique elements of the date and the pattern
-    final_date = list()
-    final_pattern = list()
-    re_together = re_together.replace('[A-Z]', '\\[A-Z]')
-    for p, r in zip(pattern_together.split('%')[1:], re_together.split('\\')[1:]):
-        if p == 'e':
-            continue
-        regexp = fr'\{r}' if not r.startswith('[') else r
-        pattern = f'%{p}'
-        date_part = re.search(regexp, date_together)
-        date_together = date_together[:date_part.start()] \
-            + date_together[date_part.end():]
-        if pattern not in final_pattern:
-            final_pattern.append(f'%{p}')
-            final_date.append(date_part.group())
-    return Time.strptime(' '.join(final_date),
-                            ' '.join(final_pattern))
-
 
 def get_timerange_from_exdict(exdict):
     """

--- a/sunpy/net/scraper_utils.py
+++ b/sunpy/net/scraper_utils.py
@@ -5,20 +5,16 @@ from dateutil.relativedelta import relativedelta
 
 from sunpy.time import TimeRange
 
-TIME_CONVERSIONS = {'%Y': r'\d{4}', '%y': r'\d{2}',
-                    '%b': '[A-Z][a-z]{2}', '%B': r'\W', '%m': r'\d{2}',
-                    '%d': r'\d{2}', '%j': r'\d{3}',
-                    '%H': r'\d{2}', '%I': r'\d{2}',
-                    '%M': r'\d{2}',
-                    '%S': r'\d{2}', '%e': r'\d{3}', '%f': r'\d{6}'}
-
-TIME_QUANTITIES = {'day': timedelta(days=1),
-                   'hour': timedelta(hours=1),
-                   'minute': timedelta(minutes=1),
-                   'second': timedelta(seconds=1),
-                   'millisecond': timedelta(milliseconds=1)}
-
 __all__ = ["extract_timestep", "date_floor", "get_timerange_from_exdict"]
+
+TIME_QUANTITIES = {
+    'day': timedelta(days=1),
+    'hour': timedelta(hours=1),
+    'minute': timedelta(minutes=1),
+    'second': timedelta(seconds=1),
+    'millisecond': timedelta(milliseconds=1)
+}
+
 
 def extract_timestep(directoryPattern):
     """

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -10,55 +10,56 @@ from sunpy.extern import parse
 from sunpy.net.scraper import Scraper
 from sunpy.net.scraper_utils import get_timerange_from_exdict
 from sunpy.time import TimeRange, parse_time
+from sunpy.util.exceptions import SunpyDeprecationWarning
 
 
-def testDirectoryDatePattern():
-    with pytest.deprecated_call():
+def test_directory_date_pattern():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
         testpath = '2014/03/05/20140305_013000_59.fit.gz'
         d = parse_time((2014, 3, 5, 1, 30))
         assert s.matches(testpath, d)
 
 
-def testDirectoryDatePattern_new_format():
+def test_directory_date_pattern_new_format():
     s = Scraper(format='{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_59.fit.gz')
     testpath = '2014/03/05/20140305_013000_59.fit.gz'
     d = parse_time((2014, 3, 5, 1, 30))
     assert s.matches(testpath, d)
 
 
-def testDirectoryDatePatternFalse():
-    with pytest.deprecated_call():
+def test_directory_date_pattern_false():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
         testpath = '2013/03/05/20140305_013000_59.fit.gz'
         d = parse_time((2014, 3, 5, 1, 30))
         assert not s.matches(testpath, d)
 
 
-def testDirectoryDatePatternFalse_new_format():
+def test_directory_date_patternFalse_new_format():
     s = Scraper(format='{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_59.fit.gz')
     testpath = '2013/03/05/20140305_013000_59.fit.gz'
     d = parse_time((2014, 3, 5, 1, 30))
     assert not s.matches(testpath, d)
 
 
-def testDirectoryObsPattern():
-    with pytest.deprecated_call():
+def test_directory_obs_pattern():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%y%m%d/{observatory}_%Y%m%d.fits', observatory='SDO')
         testpath = '140305/SDO_20140305.fits'
         d = parse_time((2014, 3, 5))
         assert s.matches(testpath, d)
 
 
-def testDirectoryObsPattern_new_format():
+def test_directory_obs_pattern_new_format():
     s = Scraper(format='{{year:2d}}{{month:2d}}{{day:2d}}/{observatory}_{{year:4d}}{{month:2d}}{{day:2d}}.fits', observatory='SDO')
     testpath = '140305/SDO_20140305.fits'
     d = parse_time((2014, 3, 5))
     assert s.matches(testpath, d)
 
 
-def testDirectoryRange():
-    with pytest.deprecated_call():
+def test_directory_range():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H.fit.gz')
         directory_list = ['2009/12/30/', '2009/12/31/', '2010/01/01/',
                         '2010/01/02/', '2010/01/03/']
@@ -66,7 +67,7 @@ def testDirectoryRange():
         assert s.range(timerange) == directory_list
 
 
-def testDirectoryRange_new_format():
+def test_directory_range_new_format():
     s = Scraper(format='{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}.fit.gz')
     directory_list = ['2009/12/30/', '2009/12/31/', '2010/01/01/',
                       '2010/01/02/', '2010/01/03/']
@@ -74,8 +75,8 @@ def testDirectoryRange_new_format():
     assert s.range(timerange) == directory_list
 
 
-def testDirectoryRegex():
-    with pytest.deprecated_call():
+def test_directory_regex():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         # Test for Windows where '\' is a path separator and not part of the regex
         s = Scraper(pattern='scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext', regex=True)
         timerange = TimeRange('2019-02-01', '2019-02-03')
@@ -83,7 +84,7 @@ def testDirectoryRegex():
         assert directory == ['scheme://a.url.with/a/few/forward/slashes/']
 
 
-def testDirectoryRegex_new_format():
+def test_directory_regex_new_format():
     # Test for Windows where '\' is a path separator and not part of the regex
     s = Scraper(format='scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext')
     timerange = TimeRange('2019-02-01', '2019-02-03')
@@ -91,8 +92,8 @@ def testDirectoryRegex_new_format():
     assert directory == ['scheme://a.url.with/a/few/forward/slashes/']
 
 
-def testDirectoryRangeFalse():
-    with pytest.deprecated_call():
+def test_directory_rangeFalse():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%Y%m%d/%Y%m%d_%H.fit.gz')
         directory_list = ['20091230/', '20091231/', '20100101/',
                         '20090102/', '20090103/']
@@ -100,7 +101,7 @@ def testDirectoryRangeFalse():
         assert s.range(timerange) != directory_list
 
 
-def testDirectoryRangeFalse_new_format():
+def test_directory_range_false_new_format():
     s = Scraper(format='{{year:4d}}{{month:2d}}{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}.fit.gz')
     directory_list = ['20091230/', '20091231/', '20100101/',
                       '20090102/', '20090103/']
@@ -108,8 +109,8 @@ def testDirectoryRangeFalse_new_format():
     assert s.range(timerange) != directory_list
 
 
-def testNoDateDirectory():
-    with pytest.deprecated_call():
+def test_no_date_directory():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='mySpacecraft/myInstrument/xMinutes/aaa%y%b.ext')
         directory_list = ['mySpacecraft/myInstrument/xMinutes/']
         timerange = TimeRange('2009/11/20', '2010/01/03')
@@ -123,21 +124,21 @@ def testNoDateDirectory_new_format():
     assert s.range(timerange) == directory_list
 
 
-def testDirectoryRangeHours():
-    with pytest.deprecated_call():
+def test_directory_range_hours():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%Y%m%d_%H/%H%M.csv')
         timerange = TimeRange('2009-12-31T23:40:00', '2010-01-01T01:15:00')
         assert len(s.range(timerange)) == 3  # 3 directories (1 per hour)
 
 
-def testDirectoryRangeHours_new_format():
+def test_directory_range_hours_new_format():
     s = Scraper(format='{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}/{{hour:2d}}{{minute:2d}}.csv')
     timerange = TimeRange('2009-12-31T23:40:00', '2010-01-01T01:15:00')
     assert len(s.range(timerange)) == 3  # 3 directories (1 per hour)
 
 
-def testDirectoryRange_single():
-    with pytest.deprecated_call():
+def test_directory_range_single():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%Y%m%d/%H_%M.csv')
         startdate = parse_time((2010, 10, 10, 5, 0))
         enddate = parse_time((2010, 10, 10, 7, 0))
@@ -145,7 +146,7 @@ def testDirectoryRange_single():
         assert len(s.range(timerange)) == 1
 
 
-def testDirectoryRange_single_new_format():
+def test_directory_range_single_new_format():
     s = Scraper(format='{{year:4d}}{{month:2d}}{{day:2d}}/{{hour:2d}}_{{minute:2d}}.csv')
     startdate = parse_time((2010, 10, 10, 5, 0))
     enddate = parse_time((2010, 10, 10, 7, 0))
@@ -153,8 +154,8 @@ def testDirectoryRange_single_new_format():
     assert len(s.range(timerange)) == 1
 
 
-def testDirectoryRange_Month():
-    with pytest.deprecated_call():
+def test_directory_range_month():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%Y%m/%d/%j_%H.txt')
         startdate = parse_time((2008, 2, 20, 10))
         enddate = parse_time((2008, 3, 2, 5))
@@ -166,7 +167,7 @@ def testDirectoryRange_Month():
         assert len(s.range(timerange)) == 11
 
 
-def testDirectoryRange_Month_new_format():
+def test_directory_range_month_new_format():
     s = Scraper(format='{{year:4d}}{{month:2d}}/{{day:2d}}/{{day_of_year:3d}}_{{hour:2d}}.txt')
     startdate = parse_time((2008, 2, 20, 10))
     enddate = parse_time((2008, 3, 2, 5))
@@ -178,58 +179,58 @@ def testDirectoryRange_Month_new_format():
     assert len(s.range(timerange)) == 11
 
 
-def testExtractDates_usingPattern():
-    with pytest.deprecated_call():
+def test_extract_dates_using_pattern():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         # Standard pattern
         s = Scraper(pattern='data/%Y/%m/%d/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
-        testURL = 'data/2014/05/14/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
+        test_url = 'data/2014/05/14/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
-        assert s._extract_date(testURL) == timeURL
+        assert s._extract_date(test_url) == timeURL
         # Not-full repeated pattern
         s = Scraper(pattern='data/%Y/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
-        testURL = 'data/2014/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
+        test_url = 'data/2014/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
-        assert s._extract_date(testURL) == timeURL
+        assert s._extract_date(test_url) == timeURL
 
 
-def testExtractDates_notSeparators():
-    with pytest.deprecated_call():
+def test_extract_dates_not_separators():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='data/%Y/%m/swap%m%d_%H%M%S')
-        testURL = 'data/2014/05/swap0514_200135'
+        test_url = 'data/2014/05/swap0514_200135'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
-        assert s._extract_date(testURL) == timeURL
+        assert s._extract_date(test_url) == timeURL
 
 
-def testExtractDates_notSeparators_andSimilar():
-    with pytest.deprecated_call():
+def test_extract_dates_not_separators_and_similar():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='data/%Y/Jun%b%d_%H%M%S')
-        testURL = 'data/2014/JunJun14_200135'
+        test_url = 'data/2014/JunJun14_200135'
         timeURL = parse_time((2014, 6, 14, 20, 1, 35))
-        assert s._extract_date(testURL) == timeURL
-        testURL = 'data/2014/JunMay14_200135'
+        assert s._extract_date(test_url) == timeURL
+        test_url = 'data/2014/Jun_may14_200135'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
-        assert s._extract_date(testURL) == timeURL
+        assert s._extract_date(test_url) == timeURL
         # and testing with the month afterwards
         s = Scraper(pattern='data/%Y/%dJun%b_%H%M%S')
-        testURL = 'data/2014/14JunJun_200135'
+        test_url = 'data/2014/14JunJun_200135'
         timeURL = parse_time((2014, 6, 14, 20, 1, 35))
-        assert s._extract_date(testURL) == timeURL
+        assert s._extract_date(test_url) == timeURL
 
 
-def testURL():
-    with pytest.deprecated_call():
+def test_url():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='fd_%Y%m%d_%H%M%S.fts')
-        assert s._URL_followsPattern('fd_20130410_231211.fts')
-        assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
-        assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
+        assert s._url_follows_pattern('fd_20130410_231211.fts')
+        assert not s._url_follows_pattern('fd_20130410_231211.fts.gz')
+        assert not s._url_follows_pattern('fd_20130410_ar_231211.fts.gz')
 
 
-def testURL_pattern():
-    with pytest.deprecated_call():
+def test_url_pattern():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='fd_%Y%m%d_%H%M%S.fts')
-        assert s._URL_followsPattern('fd_20130410_231211.fts')
-        assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
-        assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
+        assert s._url_follows_pattern('fd_20130410_231211.fts')
+        assert not s._url_follows_pattern('fd_20130410_231211.fts.gz')
+        assert not s._url_follows_pattern('fd_20130410_ar_231211.fts.gz')
 
 
 @pytest.mark.parametrize(('pattern', 'filename', 'metadict'), [
@@ -238,20 +239,20 @@ def testURL_pattern():
     ('fd_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_{{millisecond:3d}}.fts', 'fd_20130410_231211_119.fts',
      {'year': 2013, 'month': 4, 'day': 10, 'hour': 23, 'minute': 12, 'second': 11, 'millisecond': 119})
 ])
-def testURL_pattern_new_format(pattern, filename, metadict):
+def test_url_pattern_new_format(pattern, filename, metadict):
     assert parse(pattern.format(None), filename).named == metadict
 
 
-def testURL_patternMillisecondsGeneric():
-    with pytest.deprecated_call():
+def test_url_pattern_milliseconds_generic():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='fd_%Y%m%d_%H%M%S_%e.fts')
-        assert s._URL_followsPattern('fd_20130410_231211_119.fts')
-        assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
-        assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
+        assert s._url_follows_pattern('fd_20130410_231211_119.fts')
+        assert not s._url_follows_pattern('fd_20130410_231211.fts.gz')
+        assert not s._url_follows_pattern('fd_20130410_ar_231211.fts.gz')
 
 
-def testURL_patternMillisecondsZeroPadded():
-    with pytest.deprecated_call():
+def test_url_pattern_milliseconds_zero_padded():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         # Asserts solution to ticket #1954.
         # Milliseconds must be zero-padded in order to match URL lengths.
         now_mock = Mock(return_value=datetime.datetime(2019, 4, 19, 0, 0, 0, 4009))
@@ -261,7 +262,7 @@ def testURL_patternMillisecondsZeroPadded():
         assert s.now == 'fd_20190419_000000_004.fts'
 
 
-def testURL_patternMillisecondsZeroPadded_new_format():
+def test_url_pattern_milliseconds_zero_padded_new_format():
     # Asserts solution to ticket #1954.
     # Milliseconds must be zero-padded in order to match URL lengths.
     now_mock = Mock(return_value=datetime.datetime(2019, 4, 19, 0, 0, 0, 4009))
@@ -271,8 +272,8 @@ def testURL_patternMillisecondsZeroPadded_new_format():
     assert s.now == 'fd_20190419_000000_004.fts'
 
 
-def testFilesRange_sameDirectory_local():
-    with pytest.deprecated_call():
+def test_files_range_same_directory_local():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='/'.join(['file:/', str(rootdir),
                             'EIT_header', 'efz%Y%m%d.%H%M%S_s.header']))
         startdate = parse_time((2004, 3, 1, 4, 0))
@@ -283,7 +284,7 @@ def testFilesRange_sameDirectory_local():
         assert len(s.filelist(TimeRange(startdate, enddate))) == 0
 
 
-def testFilesRange_sameDirectory_local_new_format():
+def test_files_range_same_directory_local_new_format():
     s = Scraper(format='/'.join(['file:/', str(rootdir),
                           'EIT_header', 'efz{{year:4d}}{{month:2d}}{{day:2d}}.{{hour:2d}}{{minute:2d}}{{second:2d}}_s.header']))
     startdate = parse_time((2004, 3, 1, 4, 0))
@@ -295,8 +296,8 @@ def testFilesRange_sameDirectory_local_new_format():
 
 
 @pytest.mark.remote_data
-def testFilesRange_sameDirectory_remote():
-    with pytest.deprecated_call():
+def test_files_range_same_directory_remote():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         pattern = ('http://proba2.oma.be/{instrument}/data/bsd/%Y/%m/%d/'
                 '{instrument}_lv1_%Y%m%d_%H%M%S.fits')
         s = Scraper(pattern, instrument='swap')
@@ -311,7 +312,7 @@ def testFilesRange_sameDirectory_remote():
 
 
 @pytest.mark.remote_data
-def testFilesRange_sameDirectory_remote_new_format():
+def test_files_range_same_directory_remote_new_format():
     pattern = ('http://proba2.oma.be/{instrument}/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/'
                '{instrument}_lv1_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.fits')
     s = Scraper(format=pattern, instrument='swap')
@@ -326,8 +327,8 @@ def testFilesRange_sameDirectory_remote_new_format():
 
 
 @pytest.mark.remote_data
-def testFilesRange_sameDirectory_months_remote():
-    with pytest.deprecated_call():
+def test_files_range_same_directory_months_remote():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         pattern = ('http://www.srl.caltech.edu/{spacecraft}/DATA/{instrument}/'
                 'Ahead/1minute/AeH%y%b.1m')
         s = Scraper(pattern, spacecraft='STEREO', instrument='HET')
@@ -341,7 +342,7 @@ def testFilesRange_sameDirectory_months_remote():
 
 
 @pytest.mark.remote_data
-def testFilesRange_sameDirectory_months_remote_new_format():
+def test_files_range_same_directory_months_remote_new_format():
     pattern = ('http://www.srl.caltech.edu/{spacecraft}/DATA/{instrument}/'
                'Ahead/1minute/AeH{{year:2d}}{{month_name_abbr:w}}.1m')
     s = Scraper(format=pattern, spacecraft='STEREO', instrument='HET')
@@ -355,7 +356,7 @@ def testFilesRange_sameDirectory_months_remote_new_format():
 
 @pytest.mark.remote_data
 def test_ftp():
-    with pytest.deprecated_call():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         pattern = 'ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/%Y/%m/%Y%m%dSRS.txt'
         s = Scraper(pattern)
         timerange = TimeRange('2024/5/18', '2024/5/20')
@@ -386,7 +387,7 @@ def test_filelist_url_missing_directory_new_format():
 
 @pytest.mark.remote_data
 def test_filelist_url_missing_directory():
-    with pytest.deprecated_call():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         # Asserts solution to ticket #2684.
         # Attempting to access data for the year 1960 results in a 404, so no files are returned.
         pattern = 'http://lasp.colorado.edu/eve/data_access/evewebdataproducts/level2/%Y/%j/'
@@ -397,7 +398,7 @@ def test_filelist_url_missing_directory():
 
 @pytest.mark.remote_data
 def test_filelist_relative_hrefs():
-    with pytest.deprecated_call():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         # the url opened by the scraper from below pattern contains some links which don't have hrefs
         pattern = 'http://www.bbso.njit.edu/pub/archive/%Y/%m/%d/bbso_halph_fr_%Y%m%d_%H%M%S.fts'
         s = Scraper(pattern)
@@ -427,25 +428,25 @@ def test_filelist_relative_hrefs_new_format():
     (r'(\d){5}_(\d){2}\.fts', '01122_25.fts'),
     (r'_%Y%m%d__%ec(\d){5}_(\d){2}\s.fts', '_20201535__012c12345_33 .fts')])
 def test_regex(pattern, check_file):
-    with pytest.deprecated_call():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern, regex=True)
-        assert s._URL_followsPattern(check_file)
+        assert s._url_follows_pattern(check_file)
 
 
 @pytest.mark.remote_data
 def test_regex_data():
-    with pytest.deprecated_call():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         prefix = r'https://gong2.nso.edu/oQR/zqs/'
         pattern = prefix + r'%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
         s = Scraper(pattern, regex=True)
         timerange = TimeRange('2020-01-05', '2020-01-06T16:00:00')
-        assert s._URL_followsPattern(prefix + '202001/mrzqs200106/mrzqs200106t1514c2226_297.fits.gz')
+        assert s._url_follows_pattern(prefix + '202001/mrzqs200106/mrzqs200106t1514c2226_297.fits.gz')
         assert len(s.filelist(timerange)) == 37
 
 
 @pytest.mark.remote_data
 def test_extract_files_meta():
-    with pytest.deprecated_call():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         prefix = r'https://gong2.nso.edu/oQR/zqs/'
         baseurl1 = prefix + r'%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
         extractpattern1 = ('{}/zqs/{year:4d}{month:2d}/mrzqs{:4d}{day:2d}/mrzqs{:6d}t'
@@ -479,15 +480,15 @@ def test_extract_files_meta_new_format():
     assert metalist1[-1]['url'] == urls[-1]
 
 
-def testNoDirectory():
-    with pytest.deprecated_call():
+def test_no_directory():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='files/%Y%m%d_%H%M.dat')
         startdate = parse_time((2010, 1, 10, 20, 30))
         enddate = parse_time((2010, 1, 20, 20, 30))
         timerange = TimeRange(startdate, enddate)
         assert len(s.range(timerange)) == 1
 
-def testNoDirectory_new_format():
+def test_no_directory_new_format():
     s = Scraper(format='files/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{month:2d}}.dat')
     startdate = parse_time((2010, 1, 10, 20, 30))
     enddate = parse_time((2010, 1, 20, 20, 30))
@@ -517,7 +518,7 @@ def test_parse_pattern_data_new_format():
 
 @pytest.mark.remote_data
 def test_yearly_overlap():
-    with pytest.deprecated_call():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         # Check that a time range that falls within the interval that a file represents
         # returns a single result.
         pattern = "https://www.ngdc.noaa.gov/stp/space-weather/solar-data/solar-features/solar-flares/x-rays/goes/xrs/goes-xrs-report_%Y.txt"
@@ -588,7 +589,7 @@ def test_http_404_error_debug_message_new_format(caplog):
 
 
 def test_check_timerange():
-    with pytest.deprecated_call():
+    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
         s = Scraper(pattern='%Y.fits')
         # Valid time range for 2014.fits is the whole of 2014
         # Test different cases to make sure check_timerange is working as expected

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -184,12 +184,12 @@ def testExtractDates_usingPattern():
         s = Scraper('data/%Y/%m/%d/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
         testURL = 'data/2014/05/14/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
-        assert s._extractDateURL(testURL) == timeURL
+        assert s._extract_date(testURL) == timeURL
         # Not-full repeated pattern
         s = Scraper('data/%Y/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
         testURL = 'data/2014/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
-        assert s._extractDateURL(testURL) == timeURL
+        assert s._extract_date(testURL) == timeURL
 
 
 def testExtractDates_notSeparators():
@@ -197,7 +197,7 @@ def testExtractDates_notSeparators():
         s = Scraper('data/%Y/%m/swap%m%d_%H%M%S')
         testURL = 'data/2014/05/swap0514_200135'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
-        assert s._extractDateURL(testURL) == timeURL
+        assert s._extract_date(testURL) == timeURL
 
 
 def testExtractDates_notSeparators_andSimilar():
@@ -205,15 +205,15 @@ def testExtractDates_notSeparators_andSimilar():
         s = Scraper('data/%Y/Jun%b%d_%H%M%S')
         testURL = 'data/2014/JunJun14_200135'
         timeURL = parse_time((2014, 6, 14, 20, 1, 35))
-        assert s._extractDateURL(testURL) == timeURL
+        assert s._extract_date(testURL) == timeURL
         testURL = 'data/2014/JunMay14_200135'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
-        assert s._extractDateURL(testURL) == timeURL
+        assert s._extract_date(testURL) == timeURL
         # and testing with the month afterwards
         s = Scraper('data/%Y/%dJun%b_%H%M%S')
         testURL = 'data/2014/14JunJun_200135'
         timeURL = parse_time((2014, 6, 14, 20, 1, 35))
-        assert s._extractDateURL(testURL) == timeURL
+        assert s._extract_date(testURL) == timeURL
 
 
 def testURL():

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -294,7 +294,6 @@ def test_files_range_same_directory_local_new_format():
     enddate = parse_time((2010, 1, 20, 20, 30))
     assert len(s.filelist(TimeRange(startdate, enddate))) == 0
 
-
 @pytest.mark.remote_data
 def test_files_range_same_directory_remote():
     with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -14,8 +14,8 @@ from sunpy.util.exceptions import SunpyDeprecationWarning
 
 
 def test_directory_date_pattern():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
         testpath = '2014/03/05/20140305_013000_59.fit.gz'
         d = parse_time((2014, 3, 5, 1, 30))
         assert s.matches(testpath, d)
@@ -29,8 +29,8 @@ def test_directory_date_pattern_new_format():
 
 
 def test_directory_date_pattern_false():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
         testpath = '2013/03/05/20140305_013000_59.fit.gz'
         d = parse_time((2014, 3, 5, 1, 30))
         assert not s.matches(testpath, d)
@@ -44,8 +44,8 @@ def test_directory_date_patternFalse_new_format():
 
 
 def test_directory_obs_pattern():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%y%m%d/{observatory}_%Y%m%d.fits', observatory='SDO')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%y%m%d/{observatory}_%Y%m%d.fits', observatory='SDO')
         testpath = '140305/SDO_20140305.fits'
         d = parse_time((2014, 3, 5))
         assert s.matches(testpath, d)
@@ -59,8 +59,8 @@ def test_directory_obs_pattern_new_format():
 
 
 def test_directory_range():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H.fit.gz')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%Y/%m/%d/%Y%m%d_%H.fit.gz')
         directory_list = ['2009/12/30/', '2009/12/31/', '2010/01/01/',
                         '2010/01/02/', '2010/01/03/']
         timerange = TimeRange('2009-12-30', '2010-01-03')
@@ -76,9 +76,9 @@ def test_directory_range_new_format():
 
 
 def test_directory_regex():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         # Test for Windows where '\' is a path separator and not part of the regex
-        s = Scraper(pattern='scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext', regex=True)
+        s = Scraper('scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext', regex=True)
         timerange = TimeRange('2019-02-01', '2019-02-03')
         directory = s.range(timerange)
         assert directory == ['scheme://a.url.with/a/few/forward/slashes/']
@@ -93,8 +93,8 @@ def test_directory_regex_new_format():
 
 
 def test_directory_rangeFalse():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%Y%m%d/%Y%m%d_%H.fit.gz')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%Y%m%d/%Y%m%d_%H.fit.gz')
         directory_list = ['20091230/', '20091231/', '20100101/',
                         '20090102/', '20090103/']
         timerange = TimeRange('2009/12/30', '2010/01/03')
@@ -110,8 +110,8 @@ def test_directory_range_false_new_format():
 
 
 def test_no_date_directory():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='mySpacecraft/myInstrument/xMinutes/aaa%y%b.ext')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('mySpacecraft/myInstrument/xMinutes/aaa%y%b.ext')
         directory_list = ['mySpacecraft/myInstrument/xMinutes/']
         timerange = TimeRange('2009/11/20', '2010/01/03')
         assert s.range(timerange) == directory_list
@@ -125,8 +125,8 @@ def testNoDateDirectory_new_format():
 
 
 def test_directory_range_hours():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%Y%m%d_%H/%H%M.csv')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%Y%m%d_%H/%H%M.csv')
         timerange = TimeRange('2009-12-31T23:40:00', '2010-01-01T01:15:00')
         assert len(s.range(timerange)) == 3  # 3 directories (1 per hour)
 
@@ -138,8 +138,8 @@ def test_directory_range_hours_new_format():
 
 
 def test_directory_range_single():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%Y%m%d/%H_%M.csv')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%Y%m%d/%H_%M.csv')
         startdate = parse_time((2010, 10, 10, 5, 0))
         enddate = parse_time((2010, 10, 10, 7, 0))
         timerange = TimeRange(startdate, enddate)
@@ -155,8 +155,8 @@ def test_directory_range_single_new_format():
 
 
 def test_directory_range_month():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%Y%m/%d/%j_%H.txt')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%Y%m/%d/%j_%H.txt')
         startdate = parse_time((2008, 2, 20, 10))
         enddate = parse_time((2008, 3, 2, 5))
         timerange = TimeRange(startdate, enddate)
@@ -180,54 +180,54 @@ def test_directory_range_month_new_format():
 
 
 def test_extract_dates_using_pattern():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         # Standard pattern
-        s = Scraper(pattern='data/%Y/%m/%d/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
+        s = Scraper('data/%Y/%m/%d/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
         test_url = 'data/2014/05/14/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
         assert s._extract_date(test_url) == timeURL
         # Not-full repeated pattern
-        s = Scraper(pattern='data/%Y/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
+        s = Scraper('data/%Y/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
         test_url = 'data/2014/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
         assert s._extract_date(test_url) == timeURL
 
 
 def test_extract_dates_not_separators():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='data/%Y/%m/swap%m%d_%H%M%S')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('data/%Y/%m/swap%m%d_%H%M%S')
         test_url = 'data/2014/05/swap0514_200135'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
         assert s._extract_date(test_url) == timeURL
 
 
 def test_extract_dates_not_separators_and_similar():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='data/%Y/Jun%b%d_%H%M%S')
-        test_url = 'data/2014/JunJun14_200135'
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('data/%Y/Jun%b%d_%H%M%S')
+        test_url = 'data/2014/JunJune14_200135'
         timeURL = parse_time((2014, 6, 14, 20, 1, 35))
         assert s._extract_date(test_url) == timeURL
-        test_url = 'data/2014/Jun_may14_200135'
+        test_url = 'data/2014/JunMay14_200135'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
         assert s._extract_date(test_url) == timeURL
         # and testing with the month afterwards
-        s = Scraper(pattern='data/%Y/%dJun%b_%H%M%S')
-        test_url = 'data/2014/14JunJun_200135'
+        s = Scraper('data/%Y/%dJun%b_%H%M%S')
+        test_url = 'data/2014/14JunJune_200135'
         timeURL = parse_time((2014, 6, 14, 20, 1, 35))
         assert s._extract_date(test_url) == timeURL
 
 
 def test_url():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='fd_%Y%m%d_%H%M%S.fts')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('fd_%Y%m%d_%H%M%S.fts')
         assert s._url_follows_pattern('fd_20130410_231211.fts')
         assert not s._url_follows_pattern('fd_20130410_231211.fts.gz')
         assert not s._url_follows_pattern('fd_20130410_ar_231211.fts.gz')
 
 
 def test_url_pattern():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='fd_%Y%m%d_%H%M%S.fts')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('fd_%Y%m%d_%H%M%S.fts')
         assert s._url_follows_pattern('fd_20130410_231211.fts')
         assert not s._url_follows_pattern('fd_20130410_231211.fts.gz')
         assert not s._url_follows_pattern('fd_20130410_ar_231211.fts.gz')
@@ -244,20 +244,20 @@ def test_url_pattern_new_format(pattern, filename, metadict):
 
 
 def test_url_pattern_milliseconds_generic():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='fd_%Y%m%d_%H%M%S_%e.fts')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
         assert s._url_follows_pattern('fd_20130410_231211_119.fts')
         assert not s._url_follows_pattern('fd_20130410_231211.fts.gz')
         assert not s._url_follows_pattern('fd_20130410_ar_231211.fts.gz')
 
 
 def test_url_pattern_milliseconds_zero_padded():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         # Asserts solution to ticket #1954.
         # Milliseconds must be zero-padded in order to match URL lengths.
         now_mock = Mock(return_value=datetime.datetime(2019, 4, 19, 0, 0, 0, 4009))
         with patch('sunpy.net.scraper.datetime', now=now_mock):
-            s = Scraper(pattern='fd_%Y%m%d_%H%M%S_%e.fts')
+            s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
         now_mock.assert_called_once()
         assert s.now == 'fd_20190419_000000_004.fts'
 
@@ -273,8 +273,8 @@ def test_url_pattern_milliseconds_zero_padded_new_format():
 
 
 def test_files_range_same_directory_local():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='/'.join(['file:/', str(rootdir),
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('/'.join(['file:/', str(rootdir),
                             'EIT_header', 'efz%Y%m%d.%H%M%S_s.header']))
         startdate = parse_time((2004, 3, 1, 4, 0))
         enddate = parse_time((2004, 3, 1, 6, 30))
@@ -296,7 +296,7 @@ def test_files_range_same_directory_local_new_format():
 
 @pytest.mark.remote_data
 def test_files_range_same_directory_remote():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         pattern = ('http://proba2.oma.be/{instrument}/data/bsd/%Y/%m/%d/'
                 '{instrument}_lv1_%Y%m%d_%H%M%S.fits')
         s = Scraper(pattern, instrument='swap')
@@ -327,7 +327,7 @@ def test_files_range_same_directory_remote_new_format():
 
 @pytest.mark.remote_data
 def test_files_range_same_directory_months_remote():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         pattern = ('http://www.srl.caltech.edu/{spacecraft}/DATA/{instrument}/'
                 'Ahead/1minute/AeH%y%b.1m')
         s = Scraper(pattern, spacecraft='STEREO', instrument='HET')
@@ -355,7 +355,7 @@ def test_files_range_same_directory_months_remote_new_format():
 
 @pytest.mark.remote_data
 def test_ftp():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         pattern = 'ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/%Y/%m/%Y%m%dSRS.txt'
         s = Scraper(pattern)
         timerange = TimeRange('2024/5/18', '2024/5/20')
@@ -386,7 +386,7 @@ def test_filelist_url_missing_directory_new_format():
 
 @pytest.mark.remote_data
 def test_filelist_url_missing_directory():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         # Asserts solution to ticket #2684.
         # Attempting to access data for the year 1960 results in a 404, so no files are returned.
         pattern = 'http://lasp.colorado.edu/eve/data_access/evewebdataproducts/level2/%Y/%j/'
@@ -397,7 +397,7 @@ def test_filelist_url_missing_directory():
 
 @pytest.mark.remote_data
 def test_filelist_relative_hrefs():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         # the url opened by the scraper from below pattern contains some links which don't have hrefs
         pattern = 'http://www.bbso.njit.edu/pub/archive/%Y/%m/%d/bbso_halph_fr_%Y%m%d_%H%M%S.fts'
         s = Scraper(pattern)
@@ -427,14 +427,14 @@ def test_filelist_relative_hrefs_new_format():
     (r'(\d){5}_(\d){2}\.fts', '01122_25.fts'),
     (r'_%Y%m%d__%ec(\d){5}_(\d){2}\s.fts', '_20201535__012c12345_33 .fts')])
 def test_regex(pattern, check_file):
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         s = Scraper(pattern, regex=True)
         assert s._url_follows_pattern(check_file)
 
 
 @pytest.mark.remote_data
 def test_regex_data():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         prefix = r'https://gong2.nso.edu/oQR/zqs/'
         pattern = prefix + r'%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
         s = Scraper(pattern, regex=True)
@@ -445,7 +445,7 @@ def test_regex_data():
 
 @pytest.mark.remote_data
 def test_extract_files_meta():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         prefix = r'https://gong2.nso.edu/oQR/zqs/'
         baseurl1 = prefix + r'%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
         extractpattern1 = ('{}/zqs/{year:4d}{month:2d}/mrzqs{:4d}{day:2d}/mrzqs{:6d}t'
@@ -480,8 +480,8 @@ def test_extract_files_meta_new_format():
 
 
 def test_no_directory():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='files/%Y%m%d_%H%M.dat')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('files/%Y%m%d_%H%M.dat')
         startdate = parse_time((2010, 1, 10, 20, 30))
         enddate = parse_time((2010, 1, 20, 20, 30))
         timerange = TimeRange(startdate, enddate)
@@ -517,7 +517,7 @@ def test_parse_pattern_data_new_format():
 
 @pytest.mark.remote_data
 def test_yearly_overlap():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         # Check that a time range that falls within the interval that a file represents
         # returns a single result.
         pattern = "https://www.ngdc.noaa.gov/stp/space-weather/solar-data/solar-features/solar-flares/x-rays/goes/xrs/goes-xrs-report_%Y.txt"
@@ -588,8 +588,8 @@ def test_http_404_error_debug_message_new_format(caplog):
 
 
 def test_check_timerange():
-    with pytest.warns(SunpyDeprecationWarning, match="Please use `format` to pass the new syntax. Current `pattern` format was deprecated in 5.1 and will be replaced in future versions."):
-        s = Scraper(pattern='%Y.fits')
+    with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
+        s = Scraper('%Y.fits')
         # Valid time range for 2014.fits is the whole of 2014
         # Test different cases to make sure check_timerange is working as expected
 

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -366,12 +366,12 @@ def test_ftp():
 
 @pytest.mark.remote_data
 def test_ftp_new_format():
-    pattern = 'ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/%Y/%m/%Y%m%dSRS.txt'
+    pattern = 'ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/{{year:4d}}/{{month:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}SRS.txt'
     s = Scraper(format=pattern)
-    timerange = TimeRange('2016/5/18 15:28:00', '2016/5/20 16:30:50')
+    timerange = TimeRange('2024/5/18 15:28:00', '2024/5/20 16:30:50')
     urls = s.filelist(timerange)
-    assert urls[0] == ('ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/2024/05/20240517SRS.txt')
-    assert len(urls) == 4
+    assert urls[0] == ('ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/2024/05/20240518SRS.txt')
+    assert len(urls) == 3
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -8,32 +8,66 @@ import pytest
 from sunpy.data.test import rootdir
 from sunpy.extern import parse
 from sunpy.net.scraper import Scraper
+from sunpy.net.scraper_utils import get_timerange_from_exdict
 from sunpy.time import TimeRange, parse_time
 
 
 def testDirectoryDatePattern():
-    s = Scraper('{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_59.fit.gz')
+    with pytest.deprecated_call():
+        s = Scraper('%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
+        testpath = '2014/03/05/20140305_013000_59.fit.gz'
+        d = parse_time((2014, 3, 5, 1, 30))
+        assert s.matches(testpath, d)
+
+
+def testDirectoryDatePattern_new_format():
+    s = Scraper(format='{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_59.fit.gz')
     testpath = '2014/03/05/20140305_013000_59.fit.gz'
     d = parse_time((2014, 3, 5, 1, 30))
     assert s.matches(testpath, d)
 
 
 def testDirectoryDatePatternFalse():
-    s = Scraper('{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_59.fit.gz')
+    with pytest.deprecated_call():
+        s = Scraper('%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
+        testpath = '2013/03/05/20140305_013000_59.fit.gz'
+        d = parse_time((2014, 3, 5, 1, 30))
+        assert not s.matches(testpath, d)
+
+
+def testDirectoryDatePatternFalse_new_format():
+    s = Scraper(format='{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_59.fit.gz')
     testpath = '2013/03/05/20140305_013000_59.fit.gz'
     d = parse_time((2014, 3, 5, 1, 30))
     assert not s.matches(testpath, d)
 
 
 def testDirectoryObsPattern():
-    s = Scraper('{{year:2d}}{{month:2d}}{{day:2d}}/{observatory}_{{year:4d}}{{month:2d}}{{day:2d}}.fits', observatory='SDO')
+    with pytest.deprecated_call():
+        s = Scraper('%y%m%d/{observatory}_%Y%m%d.fits', observatory='SDO')
+        testpath = '140305/SDO_20140305.fits'
+        d = parse_time((2014, 3, 5))
+        assert s.matches(testpath, d)
+
+
+def testDirectoryObsPattern_new_format():
+    s = Scraper(format='{{year:2d}}{{month:2d}}{{day:2d}}/{observatory}_{{year:4d}}{{month:2d}}{{day:2d}}.fits', observatory='SDO')
     testpath = '140305/SDO_20140305.fits'
     d = parse_time((2014, 3, 5))
     assert s.matches(testpath, d)
 
 
 def testDirectoryRange():
-    s = Scraper('{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}.fit.gz')
+    with pytest.deprecated_call():
+        s = Scraper('%Y/%m/%d/%Y%m%d_%H.fit.gz')
+        directory_list = ['2009/12/30/', '2009/12/31/', '2010/01/01/',
+                        '2010/01/02/', '2010/01/03/']
+        timerange = TimeRange('2009-12-30', '2010-01-03')
+        assert s.range(timerange) == directory_list
+
+
+def testDirectoryRange_new_format():
+    s = Scraper(format='{{year:4d}}/{{month:2d}}/{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}.fit.gz')
     directory_list = ['2009/12/30/', '2009/12/31/', '2010/01/01/',
                       '2010/01/02/', '2010/01/03/']
     timerange = TimeRange('2009-12-30', '2010-01-03')
@@ -41,15 +75,33 @@ def testDirectoryRange():
 
 
 def testDirectoryRegex():
+    with pytest.deprecated_call():
+        # Test for Windows where '\' is a path separator and not part of the regex
+        s = Scraper('scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext', regex=True)
+        timerange = TimeRange('2019-02-01', '2019-02-03')
+        directory = s.range(timerange)
+        assert directory == ['scheme://a.url.with/a/few/forward/slashes/']
+
+
+def testDirectoryRegex_new_format():
     # Test for Windows where '\' is a path separator and not part of the regex
-    s = Scraper('scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext', regex=True)
+    s = Scraper(format='scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext')
     timerange = TimeRange('2019-02-01', '2019-02-03')
     directory = s.range(timerange)
     assert directory == ['scheme://a.url.with/a/few/forward/slashes/']
 
 
 def testDirectoryRangeFalse():
-    s = Scraper('{{year:4d}}{{month:2d}}{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}.fit.gz')
+    with pytest.deprecated_call():
+        s = Scraper('%Y%m%d/%Y%m%d_%H.fit.gz')
+        directory_list = ['20091230/', '20091231/', '20100101/',
+                        '20090102/', '20090103/']
+        timerange = TimeRange('2009/12/30', '2010/01/03')
+        assert s.range(timerange) != directory_list
+
+
+def testDirectoryRangeFalse_new_format():
+    s = Scraper(format='{{year:4d}}{{month:2d}}{{day:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}.fit.gz')
     directory_list = ['20091230/', '20091231/', '20100101/',
                       '20090102/', '20090103/']
     timerange = TimeRange('2009/12/30', '2010/01/03')
@@ -57,20 +109,44 @@ def testDirectoryRangeFalse():
 
 
 def testNoDateDirectory():
-    s = Scraper('mySpacecraft/myInstrument/xMinutes/aaa{{year:4d}}{{month_name_abbr:l}}.ext')
+    with pytest.deprecated_call():
+        s = Scraper('mySpacecraft/myInstrument/xMinutes/aaa%y%b.ext')
+        directory_list = ['mySpacecraft/myInstrument/xMinutes/']
+        timerange = TimeRange('2009/11/20', '2010/01/03')
+        assert s.range(timerange) == directory_list
+
+
+def testNoDateDirectory_new_format():
+    s = Scraper(format='mySpacecraft/myInstrument/xMinutes/aaa{{year:4d}}{{month_name_abbr:l}}.ext')
     directory_list = ['mySpacecraft/myInstrument/xMinutes/']
     timerange = TimeRange('2009/11/20', '2010/01/03')
     assert s.range(timerange) == directory_list
 
 
 def testDirectoryRangeHours():
-    s = Scraper('{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}/{{hour:2d}}{{minute:2d}}.csv')
+    with pytest.deprecated_call():
+        s = Scraper('%Y%m%d_%H/%H%M.csv')
+        timerange = TimeRange('2009-12-31T23:40:00', '2010-01-01T01:15:00')
+        assert len(s.range(timerange)) == 3  # 3 directories (1 per hour)
+
+
+def testDirectoryRangeHours_new_format():
+    s = Scraper(format='{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}/{{hour:2d}}{{minute:2d}}.csv')
     timerange = TimeRange('2009-12-31T23:40:00', '2010-01-01T01:15:00')
     assert len(s.range(timerange)) == 3  # 3 directories (1 per hour)
 
 
 def testDirectoryRange_single():
-    s = Scraper('{{year:4d}}{{month:2d}}{{day:2d}}/{{hour:2d}}_{{minute:2d}}.csv')
+    with pytest.deprecated_call():
+        s = Scraper('%Y%m%d/%H_%M.csv')
+        startdate = parse_time((2010, 10, 10, 5, 0))
+        enddate = parse_time((2010, 10, 10, 7, 0))
+        timerange = TimeRange(startdate, enddate)
+        assert len(s.range(timerange)) == 1
+
+
+def testDirectoryRange_single_new_format():
+    s = Scraper(format='{{year:4d}}{{month:2d}}{{day:2d}}/{{hour:2d}}_{{minute:2d}}.csv')
     startdate = parse_time((2010, 10, 10, 5, 0))
     enddate = parse_time((2010, 10, 10, 7, 0))
     timerange = TimeRange(startdate, enddate)
@@ -78,7 +154,20 @@ def testDirectoryRange_single():
 
 
 def testDirectoryRange_Month():
-    s = Scraper('{{year:4d}}{{month:2d}}/{{day:2d}}/{{day_of_year:3d}}_{{hour:2d}}.txt')
+    with pytest.deprecated_call():
+        s = Scraper('%Y%m/%d/%j_%H.txt')
+        startdate = parse_time((2008, 2, 20, 10))
+        enddate = parse_time((2008, 3, 2, 5))
+        timerange = TimeRange(startdate, enddate)
+        assert len(s.range(timerange)) == 12
+        startdate = parse_time((2009, 2, 20, 10))
+        enddate = parse_time((2009, 3, 2, 5))
+        timerange = TimeRange(startdate, enddate)
+        assert len(s.range(timerange)) == 11
+
+
+def testDirectoryRange_Month_new_format():
+    s = Scraper(format='{{year:4d}}{{month:2d}}/{{day:2d}}/{{day_of_year:3d}}_{{hour:2d}}.txt')
     startdate = parse_time((2008, 2, 20, 10))
     enddate = parse_time((2008, 3, 2, 5))
     timerange = TimeRange(startdate, enddate)
@@ -89,12 +178,58 @@ def testDirectoryRange_Month():
     assert len(s.range(timerange)) == 11
 
 
-def testNoDirectory():
-    s = Scraper('files/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{month:2d}}.dat')
-    startdate = parse_time((2010, 1, 10, 20, 30))
-    enddate = parse_time((2010, 1, 20, 20, 30))
-    timerange = TimeRange(startdate, enddate)
-    assert len(s.range(timerange)) == 1
+def testExtractDates_usingPattern():
+    with pytest.deprecated_call():
+        # Standard pattern
+        s = Scraper('data/%Y/%m/%d/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
+        testURL = 'data/2014/05/14/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
+        timeURL = parse_time((2014, 5, 14, 20, 1, 35))
+        assert s._extractDateURL(testURL) == timeURL
+        # Not-full repeated pattern
+        s = Scraper('data/%Y/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
+        testURL = 'data/2014/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
+        timeURL = parse_time((2014, 5, 14, 20, 1, 35))
+        assert s._extractDateURL(testURL) == timeURL
+
+
+def testExtractDates_notSeparators():
+    with pytest.deprecated_call():
+        s = Scraper('data/%Y/%m/swap%m%d_%H%M%S')
+        testURL = 'data/2014/05/swap0514_200135'
+        timeURL = parse_time((2014, 5, 14, 20, 1, 35))
+        assert s._extractDateURL(testURL) == timeURL
+
+
+def testExtractDates_notSeparators_andSimilar():
+    with pytest.deprecated_call():
+        s = Scraper('data/%Y/Jun%b%d_%H%M%S')
+        testURL = 'data/2014/JunJun14_200135'
+        timeURL = parse_time((2014, 6, 14, 20, 1, 35))
+        assert s._extractDateURL(testURL) == timeURL
+        testURL = 'data/2014/JunMay14_200135'
+        timeURL = parse_time((2014, 5, 14, 20, 1, 35))
+        assert s._extractDateURL(testURL) == timeURL
+        # and testing with the month afterwards
+        s = Scraper('data/%Y/%dJun%b_%H%M%S')
+        testURL = 'data/2014/14JunJun_200135'
+        timeURL = parse_time((2014, 6, 14, 20, 1, 35))
+        assert s._extractDateURL(testURL) == timeURL
+
+
+def testURL():
+    with pytest.deprecated_call():
+        s = Scraper(pattern='fd_%Y%m%d_%H%M%S.fts')
+        assert s._URL_followsPattern('fd_20130410_231211.fts')
+        assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
+        assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
+
+
+def testURL_pattern():
+    with pytest.deprecated_call():
+        s = Scraper('fd_%Y%m%d_%H%M%S.fts')
+        assert s._URL_followsPattern('fd_20130410_231211.fts')
+        assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
+        assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
 
 
 @pytest.mark.parametrize(('pattern', 'filename', 'metadict'), [
@@ -103,22 +238,53 @@ def testNoDirectory():
     ('fd_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_{{millisecond:3d}}.fts', 'fd_20130410_231211_119.fts',
      {'year': 2013, 'month': 4, 'day': 10, 'hour': 23, 'minute': 12, 'second': 11, 'millisecond': 119})
 ])
-def testURL_pattern(pattern, filename, metadict):
+def testURL_pattern_new_format(pattern, filename, metadict):
     assert parse(pattern.format(None), filename).named == metadict
 
 
+def testURL_patternMillisecondsGeneric():
+    with pytest.deprecated_call():
+        s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
+        assert s._URL_followsPattern('fd_20130410_231211_119.fts')
+        assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
+        assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
+
+
 def testURL_patternMillisecondsZeroPadded():
+    with pytest.deprecated_call():
+        # Asserts solution to ticket #1954.
+        # Milliseconds must be zero-padded in order to match URL lengths.
+        now_mock = Mock(return_value=datetime.datetime(2019, 4, 19, 0, 0, 0, 4009))
+        with patch('sunpy.net.scraper.datetime', now=now_mock):
+            s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
+        now_mock.assert_called_once()
+        assert s.now == 'fd_20190419_000000_004.fts'
+
+
+def testURL_patternMillisecondsZeroPadded_new_format():
     # Asserts solution to ticket #1954.
     # Milliseconds must be zero-padded in order to match URL lengths.
     now_mock = Mock(return_value=datetime.datetime(2019, 4, 19, 0, 0, 0, 4009))
     with patch('sunpy.net.scraper.datetime', now=now_mock):
-        s = Scraper('fd_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_{{millisecond:3d}}.fts')
+        s = Scraper(format='fd_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_{{millisecond:3d}}.fts')
     now_mock.assert_called_once()
     assert s.now == 'fd_20190419_000000_004.fts'
 
 
 def testFilesRange_sameDirectory_local():
-    s = Scraper('/'.join(['file:/', str(rootdir),
+    with pytest.deprecated_call():
+        s = Scraper('/'.join(['file:/', str(rootdir),
+                            'EIT_header', 'efz%Y%m%d.%H%M%S_s.header']))
+        startdate = parse_time((2004, 3, 1, 4, 0))
+        enddate = parse_time((2004, 3, 1, 6, 30))
+        assert len(s.filelist(TimeRange(startdate, enddate))) == 3
+        startdate = parse_time((2010, 1, 10, 20, 30))
+        enddate = parse_time((2010, 1, 20, 20, 30))
+        assert len(s.filelist(TimeRange(startdate, enddate))) == 0
+
+
+def testFilesRange_sameDirectory_local_new_format():
+    s = Scraper(format='/'.join(['file:/', str(rootdir),
                           'EIT_header', 'efz{{year:4d}}{{month:2d}}{{day:2d}}.{{hour:2d}}{{minute:2d}}{{second:2d}}_s.header']))
     startdate = parse_time((2004, 3, 1, 4, 0))
     enddate = parse_time((2004, 3, 1, 6, 30))
@@ -127,11 +293,28 @@ def testFilesRange_sameDirectory_local():
     enddate = parse_time((2010, 1, 20, 20, 30))
     assert len(s.filelist(TimeRange(startdate, enddate))) == 0
 
+
 @pytest.mark.remote_data
 def testFilesRange_sameDirectory_remote():
+    with pytest.deprecated_call():
+        pattern = ('http://proba2.oma.be/{instrument}/data/bsd/%Y/%m/%d/'
+                '{instrument}_lv1_%Y%m%d_%H%M%S.fits')
+        s = Scraper(pattern, instrument='swap')
+        startdate = parse_time((2014, 5, 14, 0, 0))
+        enddate = parse_time((2014, 5, 14, 0, 5))
+        timerange = TimeRange(startdate, enddate)
+        assert len(s.filelist(timerange)) == 2
+        startdate = parse_time((2014, 5, 14, 0, 6))
+        enddate = parse_time((2014, 5, 14, 0, 7))
+        timerange = TimeRange(startdate, enddate)
+        assert len(s.filelist(timerange)) == 0
+
+
+@pytest.mark.remote_data
+def testFilesRange_sameDirectory_remote_new_format():
     pattern = ('http://proba2.oma.be/{instrument}/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/'
                '{instrument}_lv1_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.fits')
-    s = Scraper(pattern, instrument='swap')
+    s = Scraper(format=pattern, instrument='swap')
     startdate = parse_time((2014, 5, 14, 0, 0))
     enddate = parse_time((2014, 5, 14, 0, 5))
     timerange = TimeRange(startdate, enddate)
@@ -144,9 +327,24 @@ def testFilesRange_sameDirectory_remote():
 
 @pytest.mark.remote_data
 def testFilesRange_sameDirectory_months_remote():
+    with pytest.deprecated_call():
+        pattern = ('http://www.srl.caltech.edu/{spacecraft}/DATA/{instrument}/'
+                'Ahead/1minute/AeH%y%b.1m')
+        s = Scraper(pattern, spacecraft='STEREO', instrument='HET')
+        startdate = parse_time((2007, 8, 1))
+        enddate = parse_time((2007, 9, 10))
+        timerange = TimeRange(startdate, enddate)
+        files = s.filelist(timerange)
+        assert files == ['http://www.srl.caltech.edu/STEREO/DATA/HET/Ahead/1minute/AeH07Aug.1m',
+                        'http://www.srl.caltech.edu/STEREO/DATA/HET/Ahead/1minute/AeH07Jul.1m',
+                        'http://www.srl.caltech.edu/STEREO/DATA/HET/Ahead/1minute/AeH07Sep.1m']
+
+
+@pytest.mark.remote_data
+def testFilesRange_sameDirectory_months_remote_new_format():
     pattern = ('http://www.srl.caltech.edu/{spacecraft}/DATA/{instrument}/'
                'Ahead/1minute/AeH{{year:2d}}{{month_name_abbr:w}}.1m')
-    s = Scraper(pattern, spacecraft='STEREO', instrument='HET')
+    s = Scraper(format=pattern, spacecraft='STEREO', instrument='HET')
     startdate = parse_time((2007, 8, 1))
     enddate = parse_time((2007, 9, 10))
     timerange = TimeRange(startdate, enddate)
@@ -157,29 +355,65 @@ def testFilesRange_sameDirectory_months_remote():
 
 @pytest.mark.remote_data
 def test_ftp():
+    with pytest.deprecated_call():
+        pattern = 'ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/%Y/%m/%Y%m%dSRS.txt'
+        s = Scraper(pattern)
+        timerange = TimeRange('2024/5/18', '2024/5/20')
+        urls = s.filelist(timerange)
+        assert urls[0] == ('ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/2024/05/20240517SRS.txt')
+        assert len(urls) == 4
+
+
+@pytest.mark.remote_data
+def test_ftp_new_format():
     pattern = 'ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/%Y/%m/%Y%m%dSRS.txt'
-    s = Scraper(pattern)
-    timerange = TimeRange('2024/5/18', '2024/5/20')
+    s = Scraper(format=pattern)
+    timerange = TimeRange('2016/5/18 15:28:00', '2016/5/20 16:30:50')
     urls = s.filelist(timerange)
     assert urls[0] == ('ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/2024/05/20240517SRS.txt')
     assert len(urls) == 4
 
 
 @pytest.mark.remote_data
-def test_filelist_url_missing_directory():
+def test_filelist_url_missing_directory_new_format():
     # Asserts solution to ticket #2684.
     # Attempting to access data for the year 1960 results in a 404, so no files are returned.
     pattern = 'http://lasp.colorado.edu/eve/data_access/evewebdataproducts/level2/{{year:4d}}/{{day_of_year:3d}}/'
-    s = Scraper(pattern)
+    s = Scraper(format=pattern)
     timerange = TimeRange('1960/01/01 00:00:00', '1960/01/02 00:00:00')
     assert len(s.filelist(timerange)) == 0
 
 
 @pytest.mark.remote_data
+def test_filelist_url_missing_directory():
+    with pytest.deprecated_call():
+        # Asserts solution to ticket #2684.
+        # Attempting to access data for the year 1960 results in a 404, so no files are returned.
+        pattern = 'http://lasp.colorado.edu/eve/data_access/evewebdataproducts/level2/%Y/%j/'
+        s = Scraper(pattern)
+        timerange = TimeRange('1960/01/01 00:00:00', '1960/01/02 00:00:00')
+        assert len(s.filelist(timerange)) == 0
+
+
+@pytest.mark.remote_data
 def test_filelist_relative_hrefs():
+    with pytest.deprecated_call():
+        # the url opened by the scraper from below pattern contains some links which don't have hrefs
+        pattern = 'http://www.bbso.njit.edu/pub/archive/%Y/%m/%d/bbso_halph_fr_%Y%m%d_%H%M%S.fts'
+        s = Scraper(pattern)
+        timerange = TimeRange('2016/5/18 15:28:00', '2016/5/18 16:30:00')
+        assert s.domain == 'http://www.bbso.njit.edu/'
+        # hrefs are relative to domain here, not to the directory they are present in
+        # this checks that `scraper.filelist` returns fileurls relative to the domain
+        fileurls = s.filelist(timerange)
+        assert fileurls[1] == s.domain + 'pub/archive/2016/05/18/bbso_halph_fr_20160518_160033.fts'
+
+
+@pytest.mark.remote_data
+def test_filelist_relative_hrefs_new_format():
     # the url opened by the scraper from below pattern contains some links which don't have hrefs
     pattern = 'http://www.bbso.njit.edu/pub/archive/{{year:4d}}/{{month:2d}}/{{day:2d}}/bbso_halph_fr_{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.fts'
-    s = Scraper(pattern)
+    s = Scraper(format=pattern)
     timerange = TimeRange('2016/5/18 15:28:00', '2016/5/18 16:30:00')
     assert s.domain == 'http://www.bbso.njit.edu/'
     # hrefs are relative to domain here, not to the directory they are present in
@@ -188,19 +422,46 @@ def test_filelist_relative_hrefs():
     assert fileurls[1] == s.domain + 'pub/archive/2016/05/18/bbso_halph_fr_20160518_160033.fts'
 
 
+@pytest.mark.parametrize(('pattern', 'check_file'), [
+    (r'MyFile_%Y_%M_%e\.(\D){2}\.fits', 'MyFile_2020_55_234.aa.fits'),
+    (r'(\d){5}_(\d){2}\.fts', '01122_25.fts'),
+    (r'_%Y%m%d__%ec(\d){5}_(\d){2}\s.fts', '_20201535__012c12345_33 .fts')])
+def test_regex(pattern, check_file):
+    with pytest.deprecated_call():
+        s = Scraper(pattern, regex=True)
+        assert s._URL_followsPattern(check_file)
+
+
 @pytest.mark.remote_data
-def test_parse_pattern_data():
-    prefix = 'https://gong2.nso.edu/oQR/zqs/'
-    pattern = prefix + '{{year:4d}}{{month:2d}}/mrzqs{{year:2d}}{{month:2d}}{{day:2d}}/mrzqs{{year:2d}}{{month:2d}}{{day:2d}}t{{hour:2d}}{{minute:2d}}c{{:4d}}_{{:3d}}.fits.gz'
-    s = Scraper(pattern)
-    timerange = TimeRange('2020-01-05', '2020-01-06T16:00:00')
-    assert len(s.filelist(timerange)) == 37
+def test_regex_data():
+    with pytest.deprecated_call():
+        prefix = r'https://gong2.nso.edu/oQR/zqs/'
+        pattern = prefix + r'%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
+        s = Scraper(pattern, regex=True)
+        timerange = TimeRange('2020-01-05', '2020-01-06T16:00:00')
+        assert s._URL_followsPattern(prefix + '202001/mrzqs200106/mrzqs200106t1514c2226_297.fits.gz')
+        assert len(s.filelist(timerange)) == 37
 
 
 @pytest.mark.remote_data
 def test_extract_files_meta():
+    with pytest.deprecated_call():
+        prefix = r'https://gong2.nso.edu/oQR/zqs/'
+        baseurl1 = prefix + r'%Y%m/mrzqs%y%m%d/mrzqs%y%m%dt%H%Mc(\d){4}_(\d){3}\.fits.gz'
+        extractpattern1 = ('{}/zqs/{year:4d}{month:2d}/mrzqs{:4d}{day:2d}/mrzqs{:6d}t'
+                        '{hour:2d}{minute:2d}c{CAR_ROT:4d}_{:3d}.fits.gz')
+        s1 = Scraper(baseurl1, regex=True)
+        timerange1 = TimeRange('2020-01-05', '2020-01-05T16:00:00')
+        metalist1 = s1._extract_files_meta(timerange1, extractpattern1)
+        urls = s1.filelist(timerange1)
+        assert metalist1[3]['CAR_ROT'] == 2226
+        assert metalist1[-1]['url'] == urls[-1]
+
+
+@pytest.mark.remote_data
+def test_extract_files_meta_new_format():
     pattern0 = 'https://solar.nro.nao.ac.jp/norh/data/tcx/{{year:4d}}/{{month:2d}}/{{wave}}{{year:2d}}{{month:2d}}{{day:2d}}'
-    s0 = Scraper(pattern0)
+    s0 = Scraper(format=pattern0)
     timerange0 = TimeRange('2020/1/1 4:00', '2020/1/2')
     matchdict = {'wave': ['tca', 'tcz']}
     metalist0 = s0._extract_files_meta(timerange0, matcher=matchdict)
@@ -210,7 +471,7 @@ def test_extract_files_meta():
 
     pattern1 = ('https://gong2.nso.edu/oQR/zqs/{{year:4d}}{{month:2d}}/mrzqs{{year:2d}}{{month:2d}}{{day:2d}}'
                 '/mrzqs{{year:2d}}{{month:2d}}{{day:2d}}t{{hour:2d}}{{minute:2d}}c{{CAR_ROT:4d}}_{{:3d}}.fits.gz')
-    s1 = Scraper(pattern1)
+    s1 = Scraper(format=pattern1)
     timerange1 = TimeRange('2020-01-05', '2020-01-05T16:00:00')
     metalist1 = s1._extract_files_meta(timerange1)
     urls = s1.filelist(timerange1)
@@ -218,12 +479,60 @@ def test_extract_files_meta():
     assert metalist1[-1]['url'] == urls[-1]
 
 
+def testNoDirectory():
+    with pytest.deprecated_call():
+        s = Scraper('files/%Y%m%d_%H%M.dat')
+        startdate = parse_time((2010, 1, 10, 20, 30))
+        enddate = parse_time((2010, 1, 20, 20, 30))
+        timerange = TimeRange(startdate, enddate)
+        assert len(s.range(timerange)) == 1
+
+def testNoDirectory_new_format():
+    s = Scraper(format='files/{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{month:2d}}.dat')
+    startdate = parse_time((2010, 1, 10, 20, 30))
+    enddate = parse_time((2010, 1, 20, 20, 30))
+    timerange = TimeRange(startdate, enddate)
+    assert len(s.range(timerange)) == 1
+
+@pytest.mark.parametrize(('exdict', 'start', 'end'), [
+    ({"year": 2000}, '2000-01-01 00:00:00', '2000-12-31 23:59:59.999000'),
+    ({"year": 2016, "month": 2}, '2016-02-01 00:00:00', '2016-02-29 23:59:59.999000'),
+    ({'year': 2019, 'month': 2, 'day': 28}, '2019-02-28 00:00:00', '2019-02-28 23:59:59.999000'),
+    ({'year': 2020, 'month': 7, 'day': 31, 'hour': 23, 'minute': 59, 'second': 59},
+     '2020-07-31 23:59:59', '2020-07-31 23:59:59.999000')])
+def test_get_timerange_with_extractor(exdict, start, end):
+    tr = TimeRange(start, end)
+    file_timerange = get_timerange_from_exdict(exdict)
+    assert file_timerange == tr
+
+
+@pytest.mark.remote_data
+def test_parse_pattern_data_new_format():
+    prefix = 'https://gong2.nso.edu/oQR/zqs/'
+    pattern = prefix + '{{year:4d}}{{month:2d}}/mrzqs{{year:2d}}{{month:2d}}{{day:2d}}/mrzqs{{year:2d}}{{month:2d}}{{day:2d}}t{{hour:2d}}{{minute:2d}}c{{:4d}}_{{:3d}}.fits.gz'
+    s = Scraper(format=pattern)
+    timerange = TimeRange('2020-01-05', '2020-01-06T16:00:00')
+    assert len(s.filelist(timerange)) == 37
+
+
 @pytest.mark.remote_data
 def test_yearly_overlap():
+    with pytest.deprecated_call():
+        # Check that a time range that falls within the interval that a file represents
+        # returns a single result.
+        pattern = "https://www.ngdc.noaa.gov/stp/space-weather/solar-data/solar-features/solar-flares/x-rays/goes/xrs/goes-xrs-report_%Y.txt"
+        scraper = Scraper(pattern)
+
+        # Should return a single file for 2013
+        trange = TimeRange("2013-01-02", "2013-01-03")
+        assert len(scraper.filelist(trange)) == 1
+
+@pytest.mark.remote_data
+def test_yearly_overlap_new_format():
     # Check that a time range that falls within the interval that a file represents
     # returns a single result.
     pattern = "https://www.ngdc.noaa.gov/stp/space-weather/solar-data/solar-features/solar-flares/x-rays/goes/xrs/goes-xrs-report_{{year:4d}}.txt"
-    scraper = Scraper(pattern)
+    scraper = Scraper(format=pattern)
 
     # Should return a single file for 2013
     trange = TimeRange("2013-01-02", "2013-01-03")
@@ -239,31 +548,31 @@ def test_yearly_overlap():
         (504, 6, "Gateway Timeout"),
     ],
 )
-def test_http_errors_with_enqueue_limit(error_code, expected_number_calls, error_message):
+def test_http_errors_with_enqueue_limit_new_format(error_code, expected_number_calls, error_message):
     with patch("sunpy.net.scraper.urlopen") as mocked_urlopen:
         mocked_urlopen.side_effect = HTTPError(
             "http://example.com", error_code, error_message, {}, None
         )
         time_range = TimeRange("2012/3/4", "2012/3/4 02:00")
         pattern = "http://proba2.oma.be/lyra/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/{{}}_lev{{Level:1d}}_std.fits"
-        scraper = Scraper(pattern)
+        scraper = Scraper(format=pattern)
         with pytest.raises(HTTPError, match=error_message) as excinfo:
             scraper._httpfilelist(time_range)
         assert excinfo.value.code == error_code
         assert mocked_urlopen.call_count == expected_number_calls
 
 
-def test_connection_error():
+def test_connection_error_new_format():
     with patch('sunpy.net.scraper.urlopen') as mocked_urlopen:
         mocked_urlopen.side_effect = URLError('connection error')
         time = TimeRange('2012/3/4', '2012/3/4 02:00')
         pattern = "http://proba2.oma.be/lyra/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/{{}}_lev{{Level:1d}}_std.fits"
-        scraper = Scraper(pattern)
+        scraper = Scraper(format=pattern)
         with pytest.raises(URLError, match='connection error'):
             scraper._httpfilelist(time)
 
 
-def test_http_404_error_debug_message(caplog):
+def test_http_404_error_debug_message_new_format(caplog):
     with caplog.at_level(logging.DEBUG, logger='sunpy'):
         def patch_range(self, range):
             return ['http://test.com/']
@@ -272,6 +581,58 @@ def test_http_404_error_debug_message(caplog):
                 mocked_urlopen.side_effect = HTTPError('http://example.com', 404, '', {}, None)
                 time = TimeRange('2012/3/4', '2012/3/4 02:00')
                 pattern = "http://proba2.oma.be/lyra/data/bsd/{{year:4d}}/{{month:2d}}/{{day:2d}}/{{}}_lev{{Level:1d}}_std.fits"
-                scraper = Scraper(pattern)
+                scraper = Scraper(format=pattern)
                 scraper._httpfilelist(time)
                 assert "Directory http://test.com/ not found." in caplog.text
+
+
+
+def test_check_timerange():
+    with pytest.deprecated_call():
+        s = Scraper('%Y.fits')
+        # Valid time range for 2014.fits is the whole of 2014
+        # Test different cases to make sure check_timerange is working as expected
+
+        # Interval exactly on lower boundary
+        assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2014-01-01"))
+        # Overlaps lower boundary
+        assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2014-01-02"))
+        # Overlaps upper and lower boundary
+        assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2015-01-02"))
+        # Entirely within both boundaries
+        assert s._check_timerange('2014.fits', TimeRange("2014-06-01", "2014-07-02"))
+        # Overlaps upper boundary
+        assert s._check_timerange('2014.fits', TimeRange("2014-06-01", "2015-01-02"))
+        # Interval exactly on upper boundary
+        assert s._check_timerange('2014.fits', TimeRange("2015-01-01", "2015-01-02"))
+
+        # Interval below both boundaries
+        assert not s._check_timerange('2014.fits', TimeRange("2002-01-01", "2013-01-02"))
+        # Interval above both boundaries
+        assert not s._check_timerange('2014.fits', TimeRange("2022-01-01", "2025-01-02"))
+
+def test_check_timerange_new_pattern():
+    s = Scraper(format='{{year:4d}}.fits')
+    # Valid time range for 2014.fits is the whole of 2014
+    # Test different cases to make sure check_timerange is working as expected
+
+    # Interval exactly on lower boundary
+    assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2014-01-01"))
+    # Overlaps lower boundary
+    assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2014-01-02"))
+    # Overlaps upper and lower boundary
+    assert s._check_timerange('2014.fits', TimeRange("2013-06-01", "2015-01-02"))
+    # Entirely within both boundaries
+    assert s._check_timerange('2014.fits', TimeRange("2014-06-01", "2014-07-02"))
+    # Overlaps upper boundary
+    assert s._check_timerange('2014.fits', TimeRange("2014-06-01", "2015-01-02"))
+    # Interval exactly on upper boundary
+    assert not s._check_timerange('2014.fits', TimeRange("2015-01-01", "2015-01-02"))
+
+    # Interval below both boundaries
+    assert not s._check_timerange('2014.fits', TimeRange("2002-01-01", "2013-01-02"))
+    # Interval above both boundaries
+    assert not s._check_timerange('2014.fits', TimeRange("2022-01-01", "2025-01-02"))
+
+    # Only 2-digit Year
+    assert s._check_timerange('14.fits', TimeRange("2013-06-01", "2014-01-01"))

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -14,7 +14,7 @@ from sunpy.time import TimeRange, parse_time
 
 def testDirectoryDatePattern():
     with pytest.deprecated_call():
-        s = Scraper('%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
+        s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
         testpath = '2014/03/05/20140305_013000_59.fit.gz'
         d = parse_time((2014, 3, 5, 1, 30))
         assert s.matches(testpath, d)
@@ -29,7 +29,7 @@ def testDirectoryDatePattern_new_format():
 
 def testDirectoryDatePatternFalse():
     with pytest.deprecated_call():
-        s = Scraper('%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
+        s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H%M%S_59.fit.gz')
         testpath = '2013/03/05/20140305_013000_59.fit.gz'
         d = parse_time((2014, 3, 5, 1, 30))
         assert not s.matches(testpath, d)
@@ -44,7 +44,7 @@ def testDirectoryDatePatternFalse_new_format():
 
 def testDirectoryObsPattern():
     with pytest.deprecated_call():
-        s = Scraper('%y%m%d/{observatory}_%Y%m%d.fits', observatory='SDO')
+        s = Scraper(pattern='%y%m%d/{observatory}_%Y%m%d.fits', observatory='SDO')
         testpath = '140305/SDO_20140305.fits'
         d = parse_time((2014, 3, 5))
         assert s.matches(testpath, d)
@@ -59,7 +59,7 @@ def testDirectoryObsPattern_new_format():
 
 def testDirectoryRange():
     with pytest.deprecated_call():
-        s = Scraper('%Y/%m/%d/%Y%m%d_%H.fit.gz')
+        s = Scraper(pattern='%Y/%m/%d/%Y%m%d_%H.fit.gz')
         directory_list = ['2009/12/30/', '2009/12/31/', '2010/01/01/',
                         '2010/01/02/', '2010/01/03/']
         timerange = TimeRange('2009-12-30', '2010-01-03')
@@ -77,7 +77,7 @@ def testDirectoryRange_new_format():
 def testDirectoryRegex():
     with pytest.deprecated_call():
         # Test for Windows where '\' is a path separator and not part of the regex
-        s = Scraper('scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext', regex=True)
+        s = Scraper(pattern='scheme://a.url.with/a/few/forward/slashes/andbacklash\\inthename.ext', regex=True)
         timerange = TimeRange('2019-02-01', '2019-02-03')
         directory = s.range(timerange)
         assert directory == ['scheme://a.url.with/a/few/forward/slashes/']
@@ -93,7 +93,7 @@ def testDirectoryRegex_new_format():
 
 def testDirectoryRangeFalse():
     with pytest.deprecated_call():
-        s = Scraper('%Y%m%d/%Y%m%d_%H.fit.gz')
+        s = Scraper(pattern='%Y%m%d/%Y%m%d_%H.fit.gz')
         directory_list = ['20091230/', '20091231/', '20100101/',
                         '20090102/', '20090103/']
         timerange = TimeRange('2009/12/30', '2010/01/03')
@@ -110,7 +110,7 @@ def testDirectoryRangeFalse_new_format():
 
 def testNoDateDirectory():
     with pytest.deprecated_call():
-        s = Scraper('mySpacecraft/myInstrument/xMinutes/aaa%y%b.ext')
+        s = Scraper(pattern='mySpacecraft/myInstrument/xMinutes/aaa%y%b.ext')
         directory_list = ['mySpacecraft/myInstrument/xMinutes/']
         timerange = TimeRange('2009/11/20', '2010/01/03')
         assert s.range(timerange) == directory_list
@@ -125,7 +125,7 @@ def testNoDateDirectory_new_format():
 
 def testDirectoryRangeHours():
     with pytest.deprecated_call():
-        s = Scraper('%Y%m%d_%H/%H%M.csv')
+        s = Scraper(pattern='%Y%m%d_%H/%H%M.csv')
         timerange = TimeRange('2009-12-31T23:40:00', '2010-01-01T01:15:00')
         assert len(s.range(timerange)) == 3  # 3 directories (1 per hour)
 
@@ -138,7 +138,7 @@ def testDirectoryRangeHours_new_format():
 
 def testDirectoryRange_single():
     with pytest.deprecated_call():
-        s = Scraper('%Y%m%d/%H_%M.csv')
+        s = Scraper(pattern='%Y%m%d/%H_%M.csv')
         startdate = parse_time((2010, 10, 10, 5, 0))
         enddate = parse_time((2010, 10, 10, 7, 0))
         timerange = TimeRange(startdate, enddate)
@@ -155,7 +155,7 @@ def testDirectoryRange_single_new_format():
 
 def testDirectoryRange_Month():
     with pytest.deprecated_call():
-        s = Scraper('%Y%m/%d/%j_%H.txt')
+        s = Scraper(pattern='%Y%m/%d/%j_%H.txt')
         startdate = parse_time((2008, 2, 20, 10))
         enddate = parse_time((2008, 3, 2, 5))
         timerange = TimeRange(startdate, enddate)
@@ -181,12 +181,12 @@ def testDirectoryRange_Month_new_format():
 def testExtractDates_usingPattern():
     with pytest.deprecated_call():
         # Standard pattern
-        s = Scraper('data/%Y/%m/%d/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
+        s = Scraper(pattern='data/%Y/%m/%d/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
         testURL = 'data/2014/05/14/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
         assert s._extract_date(testURL) == timeURL
         # Not-full repeated pattern
-        s = Scraper('data/%Y/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
+        s = Scraper(pattern='data/%Y/fits/swap/swap_00174_fd_%Y%m%d_%H%M%S.fts.gz')
         testURL = 'data/2014/fits/swap/swap_00174_fd_20140514_200135.fts.gz'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
         assert s._extract_date(testURL) == timeURL
@@ -194,7 +194,7 @@ def testExtractDates_usingPattern():
 
 def testExtractDates_notSeparators():
     with pytest.deprecated_call():
-        s = Scraper('data/%Y/%m/swap%m%d_%H%M%S')
+        s = Scraper(pattern='data/%Y/%m/swap%m%d_%H%M%S')
         testURL = 'data/2014/05/swap0514_200135'
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
         assert s._extract_date(testURL) == timeURL
@@ -202,7 +202,7 @@ def testExtractDates_notSeparators():
 
 def testExtractDates_notSeparators_andSimilar():
     with pytest.deprecated_call():
-        s = Scraper('data/%Y/Jun%b%d_%H%M%S')
+        s = Scraper(pattern='data/%Y/Jun%b%d_%H%M%S')
         testURL = 'data/2014/JunJun14_200135'
         timeURL = parse_time((2014, 6, 14, 20, 1, 35))
         assert s._extract_date(testURL) == timeURL
@@ -210,7 +210,7 @@ def testExtractDates_notSeparators_andSimilar():
         timeURL = parse_time((2014, 5, 14, 20, 1, 35))
         assert s._extract_date(testURL) == timeURL
         # and testing with the month afterwards
-        s = Scraper('data/%Y/%dJun%b_%H%M%S')
+        s = Scraper(pattern='data/%Y/%dJun%b_%H%M%S')
         testURL = 'data/2014/14JunJun_200135'
         timeURL = parse_time((2014, 6, 14, 20, 1, 35))
         assert s._extract_date(testURL) == timeURL
@@ -226,7 +226,7 @@ def testURL():
 
 def testURL_pattern():
     with pytest.deprecated_call():
-        s = Scraper('fd_%Y%m%d_%H%M%S.fts')
+        s = Scraper(pattern='fd_%Y%m%d_%H%M%S.fts')
         assert s._URL_followsPattern('fd_20130410_231211.fts')
         assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
         assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
@@ -244,7 +244,7 @@ def testURL_pattern_new_format(pattern, filename, metadict):
 
 def testURL_patternMillisecondsGeneric():
     with pytest.deprecated_call():
-        s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
+        s = Scraper(pattern='fd_%Y%m%d_%H%M%S_%e.fts')
         assert s._URL_followsPattern('fd_20130410_231211_119.fts')
         assert not s._URL_followsPattern('fd_20130410_231211.fts.gz')
         assert not s._URL_followsPattern('fd_20130410_ar_231211.fts.gz')
@@ -256,7 +256,7 @@ def testURL_patternMillisecondsZeroPadded():
         # Milliseconds must be zero-padded in order to match URL lengths.
         now_mock = Mock(return_value=datetime.datetime(2019, 4, 19, 0, 0, 0, 4009))
         with patch('sunpy.net.scraper.datetime', now=now_mock):
-            s = Scraper('fd_%Y%m%d_%H%M%S_%e.fts')
+            s = Scraper(pattern='fd_%Y%m%d_%H%M%S_%e.fts')
         now_mock.assert_called_once()
         assert s.now == 'fd_20190419_000000_004.fts'
 
@@ -273,7 +273,7 @@ def testURL_patternMillisecondsZeroPadded_new_format():
 
 def testFilesRange_sameDirectory_local():
     with pytest.deprecated_call():
-        s = Scraper('/'.join(['file:/', str(rootdir),
+        s = Scraper(pattern='/'.join(['file:/', str(rootdir),
                             'EIT_header', 'efz%Y%m%d.%H%M%S_s.header']))
         startdate = parse_time((2004, 3, 1, 4, 0))
         enddate = parse_time((2004, 3, 1, 6, 30))
@@ -481,7 +481,7 @@ def test_extract_files_meta_new_format():
 
 def testNoDirectory():
     with pytest.deprecated_call():
-        s = Scraper('files/%Y%m%d_%H%M.dat')
+        s = Scraper(pattern='files/%Y%m%d_%H%M.dat')
         startdate = parse_time((2010, 1, 10, 20, 30))
         enddate = parse_time((2010, 1, 20, 20, 30))
         timerange = TimeRange(startdate, enddate)
@@ -589,7 +589,7 @@ def test_http_404_error_debug_message_new_format(caplog):
 
 def test_check_timerange():
     with pytest.deprecated_call():
-        s = Scraper('%Y.fits')
+        s = Scraper(pattern='%Y.fits')
         # Valid time range for 2014.fits is the whole of 2014
         # Test different cases to make sure check_timerange is working as expected
 

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -368,7 +368,7 @@ def test_ftp():
 def test_ftp_new_format():
     pattern = 'ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/{{year:4d}}/{{month:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}SRS.txt'
     s = Scraper(format=pattern)
-    timerange = TimeRange('2024/5/18 15:28:00', '2024/5/20 16:30:50')
+    timerange = TimeRange('2024/5/18', '2024/5/20')
     urls = s.filelist(timerange)
     assert urls[0] == ('ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/2024/05/20240518SRS.txt')
     assert len(urls) == 3

--- a/sunpy/net/tests/test_scraper_utils.py
+++ b/sunpy/net/tests/test_scraper_utils.py
@@ -6,14 +6,14 @@ from dateutil.relativedelta import relativedelta
 from sunpy.net.scraper_utils import check_timerange, date_floor, extract_timestep, get_timerange_from_exdict
 from sunpy.time import TimeRange, parse_time
 
-TIMEPATTERN_EXAMPLES = [
+DT_PATTERN_EXAMPLES = [
     ('%b%y', relativedelta(months=1)),
     ('%m%y', relativedelta(months=1)),
     ('%H%d', relativedelta(hours=1)),
     ('%y%b', relativedelta(months=1)),
 ]
 
-@pytest.mark.parametrize(('pattern', 'mintime'), TIMEPATTERN_EXAMPLES)
+@pytest.mark.parametrize(('pattern', 'mintime'), DT_PATTERN_EXAMPLES)
 def test_extract_timestep(pattern, mintime):
     assert mintime == extract_timestep(pattern)
 

--- a/sunpy/net/tests/test_scraper_utils.py
+++ b/sunpy/net/tests/test_scraper_utils.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from dateutil.relativedelta import relativedelta
 
-from sunpy.net.scraper_utils import check_timerange, date_floor, extract_timestep, get_timerange_from_exdict
+from sunpy.net.scraper_utils import date_floor, extract_timestep, get_timerange_from_exdict
 from sunpy.time import TimeRange, parse_time
 
 DT_PATTERN_EXAMPLES = [
@@ -16,39 +16,6 @@ DT_PATTERN_EXAMPLES = [
 @pytest.mark.parametrize(('pattern', 'mintime'), DT_PATTERN_EXAMPLES)
 def test_extract_timestep(pattern, mintime):
     assert mintime == extract_timestep(pattern)
-
-
-def test_check_timerange():
-    pattern = '{{year:4d}}.fits'.format()
-    # Valid time range for 2014.fits is the whole of 2014
-    # Test different cases to make sure check_timerange is working as expected
-
-    # Interval exactly on lower boundary
-    assert check_timerange(pattern, '2014.fits', TimeRange("2013-06-01", "2014-01-01"))
-    # Overlaps lower boundary
-    assert check_timerange(pattern, '2014.fits', TimeRange("2013-06-01", "2014-01-02"))
-    # Overlaps upper and lower boundary
-    assert check_timerange(pattern, '2014.fits', TimeRange("2013-06-01", "2015-01-02"))
-    # Entirely within both boundaries
-    assert check_timerange(pattern, '2014.fits', TimeRange("2014-06-01", "2014-07-02"))
-    # Overlaps upper boundary
-    assert check_timerange(pattern, '2014.fits', TimeRange("2014-06-01", "2015-01-02"))
-    # Interval exactly on upper boundary
-    assert not check_timerange(pattern, '2014.fits', TimeRange("2015-01-01", "2015-01-02"))
-
-    # Interval below both boundaries
-    assert not check_timerange(pattern, '2014.fits', TimeRange("2002-01-01", "2013-01-02"))
-    # Interval above both boundaries
-    assert not check_timerange(pattern, '2014.fits', TimeRange("2022-01-01", "2025-01-02"))
-
-    # Only 2-digit Year
-    assert check_timerange(pattern, '14.fits', TimeRange("2013-06-01", "2014-01-01"))
-
-    pattern_month_name = '{{year:4d}}-{{month_name:l}}.fits'.format()
-    assert check_timerange(pattern_month_name, '2014-March.fits', TimeRange("2014-03-01", "2014-04-01"))
-
-    pattern_month_name_abbr = '{{year:4d}}-{{month_name_abbr:l}}-{{day:2d}}.fits'.format()
-    assert check_timerange(pattern_month_name_abbr, '2004-Mar-06.fits', TimeRange("2004-03-06", "2004-03-07"))
 
 @pytest.mark.parametrize(('exdict', 'start', 'end'), [
     ({"year": 2000}, '2000-01-01 00:00:00', '2000-12-31 23:59:59.999000'),

--- a/sunpy/net/tests/test_scraper_utils.py
+++ b/sunpy/net/tests/test_scraper_utils.py
@@ -6,14 +6,14 @@ from dateutil.relativedelta import relativedelta
 from sunpy.net.scraper_utils import date_floor, extract_timestep, get_timerange_from_exdict
 from sunpy.time import TimeRange, parse_time
 
-DT_PATTERN_EXAMPLES = [
+DATETIME_PATTERN_EXAMPLES = [
     ('%b%y', relativedelta(months=1)),
     ('%m%y', relativedelta(months=1)),
     ('%H%d', relativedelta(hours=1)),
     ('%y%b', relativedelta(months=1)),
 ]
 
-@pytest.mark.parametrize(('pattern', 'mintime'), DT_PATTERN_EXAMPLES)
+@pytest.mark.parametrize(('pattern', 'mintime'), DATETIME_PATTERN_EXAMPLES)
 def test_extract_timestep(pattern, mintime):
     assert mintime == extract_timestep(pattern)
 

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -1,5 +1,5 @@
 """
-This module provides SunPy specific decorators.
+This module provides sunpy specific decorators.
 """
 from inspect import Parameter, signature
 from functools import wraps
@@ -12,8 +12,16 @@ from astropy.utils.decorators import deprecated_renamed_argument as _deprecated_
 
 from sunpy.util.exceptions import SunpyDeprecationWarning, warn_deprecated
 
-__all__ = ['deprecated', 'sunpycontextmanager', 'ACTIVE_CONTEXTS']
-
+__all__ = [
+    'ACTIVE_CONTEXTS',
+    'deprecated',
+    'deprecated_renamed_argument',
+    'deprecate_positional_args_since',
+    'cached_property_based_on',
+    'check_arithmetic_compatibility',
+    'sunpycontextmanager',
+    'add_common_docstring'
+]
 _NUMPY_COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None
 _NOT_FOUND = object()
 # Public dictionary for context (de)activation tracking
@@ -72,6 +80,7 @@ def deprecated(
         obj_type=obj_type, warning_type=warning_type
     )
 
+
 def deprecated_renamed_argument(
     old_name,
     new_name,
@@ -83,7 +92,8 @@ def deprecated_renamed_argument(
     alternative="",
     message="",
 ):
-    """Deprecate a _renamed_ or _removed_ function argument.
+    """
+    Deprecate a _renamed_ or _removed_ function argument.
 
     The decorator assumes that the argument with the ``old_name`` was removed
     from the function signature and the ``new_name`` replaced it at the
@@ -95,14 +105,11 @@ def deprecated_renamed_argument(
     ----------
     old_name : str or sequence of str
         The old name of the argument.
-
     new_name : str or sequence of str or None
         The new name of the argument. Set this to `None` to remove the
         argument ``old_name`` instead of renaming it.
-
     since : str or number or sequence of str or number
         The release at which the old argument became deprecated.
-
     arg_in_kwargs : bool or sequence of bool, optional
         If the argument is not a named argument (for example it
         was meant to be consumed by ``**kwargs``) set this to
@@ -110,27 +117,22 @@ def deprecated_renamed_argument(
         if the ``new_name`` cannot be found in the signature of
         the decorated function.
         Default is ``False``.
-
     relax : bool or sequence of bool, optional
         If ``False`` a ``TypeError`` is raised if both ``new_name`` and
         ``old_name`` are given.  If ``True`` the value for ``new_name`` is used
         and a Warning is issued.
         Default is ``False``.
-
     pending : bool or sequence of bool, optional
         If ``True`` this will hide the deprecation warning and ignore the
         corresponding ``relax`` parameter value.
         Default is ``False``.
-
     warning_type : Warning
         Warning to be issued.
         Default is `~astropy.utils.exceptions.AstropyDeprecationWarning`.
-
     alternative : str, optional
         An alternative function or class name that the user may use in
         place of the deprecated object if ``new_name`` is None. The deprecation
         warning will tell the user about this alternative if provided.
-
     message : str, optional
         A custom warning message. If provided then ``since`` and
         ``alternative`` options will have no effect.
@@ -155,70 +157,13 @@ def deprecated_renamed_argument(
         also be a list or tuple with the same number of entries. ``relax`` and
         ``arg_in_kwarg`` can be a single bool (applied to all) or also a
         list/tuple with the same number of entries like ``new_name``, etc.
-
-    Examples
-    --------
-    The deprecation warnings are not shown in the following examples.
-
-    To deprecate a positional or keyword argument::
-
-        >>> from astropy.utils.decorators import deprecated_renamed_argument
-        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0')
-        ... def test(sigma):
-        ...     return sigma
-
-        >>> test(2)
-        2
-        >>> test(sigma=2)
-        2
-        >>> test(sig=2)  # doctest: +SKIP
-        2
-
-    To deprecate an argument caught inside the ``**kwargs`` the
-    ``arg_in_kwargs`` has to be set::
-
-        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0',
-        ...                             arg_in_kwargs=True)
-        ... def test(**kwargs):
-        ...     return kwargs['sigma']
-
-        >>> test(sigma=2)
-        2
-        >>> test(sig=2)  # doctest: +SKIP
-        2
-
-    By default providing the new and old keyword will lead to an Exception. If
-    a Warning is desired set the ``relax`` argument::
-
-        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0', relax=True)
-        ... def test(sigma):
-        ...     return sigma
-
-        >>> test(sig=2)  # doctest: +SKIP
-        2
-
-    It is also possible to replace multiple arguments. The ``old_name``,
-    ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
-    same number of entries::
-
-        >>> @deprecated_renamed_argument(['a', 'b'], ['alpha', 'beta'],
-        ...                              ['1.0', 1.2])
-        ... def test(alpha, beta):
-        ...     return alpha, beta
-
-        >>> test(a=2, b=3)  # doctest: +SKIP
-        (2, 3)
-
-    In this case ``arg_in_kwargs`` and ``relax`` can be a single value (which
-    is applied to all renamed arguments) or must also be a `tuple` or `list`
-    with values for each of the arguments.
-
     """
     return _deprecated_renamed_argument(
         old_name=old_name, new_name=new_name, since=since, arg_in_kwargs=arg_in_kwargs,
         relax=relax, pending=pending, warning_type=warning_type, alternative=alternative,
         message=message
     )
+
 
 def deprecate_positional_args_since(func=None, *, since):
     """
@@ -363,7 +308,6 @@ def check_arithmetic_compatibility(func):
             return NotImplemented
         return func(instance, value)
     return inner
-
 
 
 def sunpycontextmanager(func):

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 import numpy as np
 
 from astropy.utils.decorators import deprecated as _deprecated
+from astropy.utils.decorators import deprecated_renamed_argument as _deprecated_renamed_argument
 
 from sunpy.util.exceptions import SunpyDeprecationWarning, warn_deprecated
 
@@ -71,6 +72,153 @@ def deprecated(
         obj_type=obj_type, warning_type=warning_type
     )
 
+def deprecated_renamed_argument(
+    old_name,
+    new_name,
+    since,
+    arg_in_kwargs=False,
+    relax=False,
+    pending=False,
+    warning_type=SunpyDeprecationWarning,
+    alternative="",
+    message="",
+):
+    """Deprecate a _renamed_ or _removed_ function argument.
+
+    The decorator assumes that the argument with the ``old_name`` was removed
+    from the function signature and the ``new_name`` replaced it at the
+    **same position** in the signature.  If the ``old_name`` argument is
+    given when calling the decorated function the decorator will catch it and
+    issue a deprecation warning and pass it on as ``new_name`` argument.
+
+    Parameters
+    ----------
+    old_name : str or sequence of str
+        The old name of the argument.
+
+    new_name : str or sequence of str or None
+        The new name of the argument. Set this to `None` to remove the
+        argument ``old_name`` instead of renaming it.
+
+    since : str or number or sequence of str or number
+        The release at which the old argument became deprecated.
+
+    arg_in_kwargs : bool or sequence of bool, optional
+        If the argument is not a named argument (for example it
+        was meant to be consumed by ``**kwargs``) set this to
+        ``True``.  Otherwise the decorator will throw an Exception
+        if the ``new_name`` cannot be found in the signature of
+        the decorated function.
+        Default is ``False``.
+
+    relax : bool or sequence of bool, optional
+        If ``False`` a ``TypeError`` is raised if both ``new_name`` and
+        ``old_name`` are given.  If ``True`` the value for ``new_name`` is used
+        and a Warning is issued.
+        Default is ``False``.
+
+    pending : bool or sequence of bool, optional
+        If ``True`` this will hide the deprecation warning and ignore the
+        corresponding ``relax`` parameter value.
+        Default is ``False``.
+
+    warning_type : Warning
+        Warning to be issued.
+        Default is `~astropy.utils.exceptions.AstropyDeprecationWarning`.
+
+    alternative : str, optional
+        An alternative function or class name that the user may use in
+        place of the deprecated object if ``new_name`` is None. The deprecation
+        warning will tell the user about this alternative if provided.
+
+    message : str, optional
+        A custom warning message. If provided then ``since`` and
+        ``alternative`` options will have no effect.
+
+    Raises
+    ------
+    TypeError
+        If the new argument name cannot be found in the function
+        signature and arg_in_kwargs was False or if it is used to
+        deprecate the name of the ``*args``-, ``**kwargs``-like arguments.
+        At runtime such an Error is raised if both the new_name
+        and old_name were specified when calling the function and
+        "relax=False".
+
+    Notes
+    -----
+    The decorator should be applied to a function where the **name**
+    of an argument was changed but it applies the same logic.
+
+    .. warning::
+        If ``old_name`` is a list or tuple the ``new_name`` and ``since`` must
+        also be a list or tuple with the same number of entries. ``relax`` and
+        ``arg_in_kwarg`` can be a single bool (applied to all) or also a
+        list/tuple with the same number of entries like ``new_name``, etc.
+
+    Examples
+    --------
+    The deprecation warnings are not shown in the following examples.
+
+    To deprecate a positional or keyword argument::
+
+        >>> from astropy.utils.decorators import deprecated_renamed_argument
+        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0')
+        ... def test(sigma):
+        ...     return sigma
+
+        >>> test(2)
+        2
+        >>> test(sigma=2)
+        2
+        >>> test(sig=2)  # doctest: +SKIP
+        2
+
+    To deprecate an argument caught inside the ``**kwargs`` the
+    ``arg_in_kwargs`` has to be set::
+
+        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0',
+        ...                             arg_in_kwargs=True)
+        ... def test(**kwargs):
+        ...     return kwargs['sigma']
+
+        >>> test(sigma=2)
+        2
+        >>> test(sig=2)  # doctest: +SKIP
+        2
+
+    By default providing the new and old keyword will lead to an Exception. If
+    a Warning is desired set the ``relax`` argument::
+
+        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0', relax=True)
+        ... def test(sigma):
+        ...     return sigma
+
+        >>> test(sig=2)  # doctest: +SKIP
+        2
+
+    It is also possible to replace multiple arguments. The ``old_name``,
+    ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
+    same number of entries::
+
+        >>> @deprecated_renamed_argument(['a', 'b'], ['alpha', 'beta'],
+        ...                              ['1.0', 1.2])
+        ... def test(alpha, beta):
+        ...     return alpha, beta
+
+        >>> test(a=2, b=3)  # doctest: +SKIP
+        (2, 3)
+
+    In this case ``arg_in_kwargs`` and ``relax`` can be a single value (which
+    is applied to all renamed arguments) or must also be a `tuple` or `list`
+    with values for each of the arguments.
+
+    """
+    return _deprecated_renamed_argument(
+        old_name=old_name, new_name=new_name, since=since, arg_in_kwargs=arg_in_kwargs,
+        relax=relax, pending=pending, warning_type=warning_type, alternative=alternative,
+        message=message
+    )
 
 def deprecate_positional_args_since(func=None, *, since):
     """

--- a/tox.ini
+++ b/tox.ini
@@ -122,6 +122,7 @@ extras =
 commands =
     pip freeze --all --no-input
     sphinx-build \
+    -j auto \
     --color \
     -W \
     --keep-going \


### PR DESCRIPTION
Aims to add backwards compatibility for the base scraper post-rewrite from #7077 so that we can go through a deprecation period for the breaking changes.

Addressing @dstansby's [suggestions](https://github.com/sunpy/sunpy/pull/7227#pullrequestreview-1682939171) on how we can approach this, so far this PR pretty much addresses all the points in terms of the Scraper design, namely the PR:

  - Makes `pattern` optional (ie. , pattern=None)
  - Adds a new keyword-only argument, `format`, to take the new format
  - Raises an error if both pattern and format are provided
  - Uses old behaviour, and raises a deprecation warning saying to use new format=... instead if only `pattern` passed
  - Uses new behaviour if only `format` passed.

Outside of changing `sunpy.net.scraper` I've done the following:
- Added back the tests for the original scraper with the ones I wrote (distinguished by a `new_format` suffix) and they all should be passing now.
- During the rewrite, I had previously moved out `check_timerange` from `scraper` to `scraper_utils` but I moved it back in so long as the old scraper is still around since I felt it'd get a bit too complex otherwise (for example, it'd require internal scraper functions that were removed in the rewrite, etc).
- Updated hopefully all the relevant docstring examples and the base dataretriever clients' code. I am _not_ sure of all the tests passing, i'm curious of the CI's verdict on that rn :P
- I've also updated the `extending_fido.rst` doc about `pattern` vs `format` and have tried to improve some of the documentation I wrote previously explaining the Scraper algorithm.
- *also renamed `timepattern` to ~~`dt_pattern`~~ `datetime_pattern` since it's also appearing in docs rn, felt it more fitting.

The really long file for the scraper tests right now make me doubt a little if maybe I should've skimmed over some tests when adding backwards compatibility, I'd love to know if I've been on the right path with this so far :cowboy_hat_face:

TODO:
- [x] We need to add a test that creates an old style scraper client (basically use one of the old clients) and make sure that it raises the warning correctly and still works. (Added back nearly all the old teststhat expect and catch the warning  and renamed new ones to have a `new_format` suffix)
- [x] Write a migration guide in the developer docs and link to it in the message.