### PR TITLE
Handle norm for mapsequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       posargs: -n auto --color=yes
       envs: |
         - linux: py312
+          libraries:
+            apt:
+              - libopenjp2-7
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -43,7 +46,13 @@ jobs:
       envs: |
         - windows: py311
         - macos: py310
+          libraries:
+            brew:
+              - openjpeg
         - linux: py310-oldestdeps
+          libraries:
+            apt:
+              - libopenjp2-7
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -60,11 +69,11 @@ jobs:
         docs/generated/
         .tox/sample_data/
       cache-key: docs-${{ github.run_id }}
-      libraries: |
-        apt:
-          - graphviz
       envs: |
         - linux: build_docs
+          libraries:
+            apt:
+              - libopenjp2-7
 
   online:
     if: "!startsWith(github.event.ref, 'refs/tags/v')"
@@ -90,6 +99,9 @@ jobs:
               - graphviz
         - linux: py312-online
           posargs: -n auto --dist loadgroup --color=yes
+          libraries:
+            apt:
+              - libopenjp2-7
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -106,6 +118,9 @@ jobs:
       toxdeps: tox-pypi-filter
       envs: |
         - linux: py312-devdeps
+          libraries:
+            apt:
+              - libopenjp2-7
         - linux: core_deps
         - linux: linkcheck
           pytest: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           libraries:
             apt:
               - libopenjp2-7
+              - graphviz
 
   online:
     if: "!startsWith(github.event.ref, 'refs/tags/v')"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -585,7 +585,7 @@ Bug Fixes
   now automatically scales with the left-hand y-axis. (`#6486 <https://github.com/sunpy/sunpy/pull/6486>`__)
 - Add support for Python 3.11.
 
-  The deprecated `cgi.parse_header` is now available as
+  The deprecated "cgi.parse_header" is now available as
   `sunpy.util.net.parse_header`. (`#6512 <https://github.com/sunpy/sunpy/pull/6512>`__)
 - Fixed the metadata handling of :meth:`~sunpy.map.GenericMap.resample` and :meth:`~sunpy.map.GenericMap.superpixel` so that the CDELTi values are scaled and the PCi_j matrix (if used) is modified in the correct manner for asymmetric scaling.
   The previous approach of having the PCi_j matrix store all of the scaling resulted in non-intuitive behaviors when accessing the `~sunpy.map.GenericMap.scale` and `~sunpy.map.GenericMap.rotation_matrix` properties, and when de-rotating a map via :meth:`~sunpy.map.GenericMap.rotate`. (`#6571 <https://github.com/sunpy/sunpy/pull/6571>`__)

--- a/changelog/7674.bugfix.rst
+++ b/changelog/7674.bugfix.rst
@@ -1,0 +1,1 @@
+`sunpy.map.MapSequence` unable to set the normalization for data that was UNIT8 (JPEG2000) causing the animations to break.

--- a/changelog/7674.bugfix.rst
+++ b/changelog/7674.bugfix.rst
@@ -1,1 +1,1 @@
-`sunpy.map.MapSequence` unable to set the normalization for data that was UNIT8 (JPEG2000) causing the animations to break.
+`sunpy.map.MapSequence` unable to set the normalization for data that was UINT8 (JPEG2000) causing the animations to break.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -239,7 +239,6 @@ class GenericMap(NDData):
         # Validate header
         # TODO: This should be a function of the header, not of the map
         self._validate_meta()
-
         self.plot_settings = {'cmap': 'gray',
                             'interpolation': 'nearest',
                             'origin': 'lower'

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -3,7 +3,6 @@
 import html
 import textwrap
 import webbrowser
-from copy import deepcopy
 from tempfile import NamedTemporaryFile
 
 import matplotlib.animation
@@ -362,18 +361,15 @@ class MapSequence:
 
             im.set_array(ani_data[i].data)
             im.set_cmap(kwargs.get('cmap', ani_data[i].plot_settings['cmap']))
-            norm = deepcopy(kwargs.get('norm', ani_data[i].plot_settings['norm']))
+            norm = kwargs.get('norm') or ani_data[i].plot_settings["norm"] if "norm" in ani_data[i].plot_settings else None
 
             if clip_interval is not None:
                 vmin, vmax = _clip_interval(ani_data[i].data, clip_interval)
                 norm.vmin=vmin
                 norm.vmax=vmax
-            _handle_norm(norm, kwargs)
-
-            # The following explicit call is for bugged versions of Astropy's ImageNormalize
-            norm.autoscale_None(ani_data[i].data)
-            im.set_norm(norm)
-
+            if norm:
+                _handle_norm(norm, kwargs)
+                im.set_norm(norm)
             if wcsaxes_compat.is_wcsaxes(axes):
                 im.axes.reset_wcs(ani_data[i].wcs)
                 wcsaxes_compat.default_wcs_grid(axes)

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -11,6 +11,7 @@ import numpy as np
 import numpy.ma as ma
 
 import astropy.units as u
+from astropy.visualization import ImageNormalize
 
 from sunpy.map import GenericMap
 from sunpy.map.maputils import _clip_interval, _handle_norm
@@ -359,13 +360,13 @@ class MapSequence:
         def updatefig(i, im, annotate, ani_data, removes):
             while removes:
                 removes.pop(0).remove()
-
             im.set_array(ani_data[i].data)
-            im.set_cmap(kwargs.get('cmap', ani_data[i].plot_settings['cmap']))
-            norm = deepcopy(kwargs.get('norm')) or deepcopy(ani_data[i].plot_settings["norm"]) if "norm" in ani_data[i].plot_settings else None
-
+            im.set_cmap(kwargs.get('cmap', ani_data[i].plot_settings.get('cmap')) or "grey")
+            norm = deepcopy(kwargs.get('norm', ani_data[i].plot_settings.get('norm')))
             if clip_interval is not None:
                 vmin, vmax = _clip_interval(ani_data[i].data, clip_interval)
+                if norm is None:
+                    norm = ImageNormalize()
                 norm.vmin=vmin
                 norm.vmax=vmax
             if norm:

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -3,6 +3,7 @@
 import html
 import textwrap
 import webbrowser
+from copy import deepcopy
 from tempfile import NamedTemporaryFile
 
 import matplotlib.animation
@@ -361,7 +362,7 @@ class MapSequence:
 
             im.set_array(ani_data[i].data)
             im.set_cmap(kwargs.get('cmap', ani_data[i].plot_settings['cmap']))
-            norm = kwargs.get('norm') or ani_data[i].plot_settings["norm"] if "norm" in ani_data[i].plot_settings else None
+            norm = deepcopy(kwargs.get('norm')) or deepcopy(ani_data[i].plot_settings["norm"]) if "norm" in ani_data[i].plot_settings else None
 
             if clip_interval is not None:
                 vmin, vmax = _clip_interval(ani_data[i].data, clip_interval)

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -46,7 +46,6 @@ class AIAMap(GenericMap):
 
     def __init__(self, data, header, **kwargs):
         super().__init__(data, header, **kwargs)
-
         # Fill in some missing info
         self._nickname = self.detector
         self.plot_settings['cmap'] = self._get_cmap_name()

--- a/sunpy/map/tests/conftest.py
+++ b/sunpy/map/tests/conftest.py
@@ -1,8 +1,12 @@
+import warnings
+
 import numpy as np
 import pytest
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.io.fits.verify import VerifyWarning
 from astropy.time import Time
 
 import sunpy.coordinates
@@ -143,7 +147,13 @@ def eit_test_map():
 def sample_171():
     from sunpy.data.sample import AIA_171_IMAGE
 
-    return sunpy.map.Map(AIA_171_IMAGE)
+    # Need to bypass
+    # VerifyWarning: Invalid 'BLANK' keyword in header.
+    # The 'BLANK' keyword is only applicable to integer data, and will be ignored in this HDU.
+    with fits.open(AIA_171_IMAGE) as hdu:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=VerifyWarning)
+            return sunpy.map.Map(hdu[1].data, hdu[1].header)
 
 
 @pytest.fixture

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -13,7 +13,7 @@ import sunpy
 import sunpy.data.test
 import sunpy.map
 from sunpy.data.test import get_test_filepath
-from sunpy.tests.helpers import figure_test, skip_windows
+from sunpy.tests.helpers import figure_test, skip_glymur
 from sunpy.util.metadata import MetaDict
 
 
@@ -241,7 +241,7 @@ def test_map_sequence_plot_clip_interval(aia171_test_map):
     animation._step()
 
 
-@skip_windows
+@skip_glymur
 def test_mapsequence_plot_uint8_norm():
     # We want to check the case for images with no norms set
     # This code used to fail in this case.
@@ -251,10 +251,20 @@ def test_mapsequence_plot_uint8_norm():
     moving_coconut._step()
 
 
-@skip_windows
+@skip_glymur
 def test_mapsequence_plot_uint8_norm_clip_interval():
     # This code used to fail in this case.
     coconuts = sunpy.map.Map([get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")]*10,sequence=True)
     [coconut.plot_settings.pop("norm") for coconut in coconuts]
     moving_coconut = coconuts.plot(clip_interval=(1, 99.99)*u.percent)
+    moving_coconut._step()
+
+
+@skip_glymur
+def test_mapsequence_plot_set_norm_pass_vmin_vmax(aia171_test_map):
+    # CHecking that passing in interval values works if the map has a norm
+    coconuts = sunpy.map.Map([aia171_test_map]*10,sequence=True)
+    moving_coconut = coconuts.plot(clip_interval=(1, 99.99)*u.percent)
+    moving_coconut._step()
+    moving_coconut = coconuts.plot(vmin=100, vmax=1000)
     moving_coconut._step()

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -13,7 +13,7 @@ import sunpy
 import sunpy.data.test
 import sunpy.map
 from sunpy.data.test import get_test_filepath
-from sunpy.tests.helpers import figure_test
+from sunpy.tests.helpers import figure_test, skip_windows
 from sunpy.util.metadata import MetaDict
 
 
@@ -241,6 +241,7 @@ def test_map_sequence_plot_clip_interval(aia171_test_map):
     animation._step()
 
 
+@skip_windows
 def test_mapsequence_plot_unit8_norm():
     # We want to check the case for images with no norms set
     # This code used to fail in this case.
@@ -250,6 +251,7 @@ def test_mapsequence_plot_unit8_norm():
     moving_coconut._step()
 
 
+@skip_windows
 def test_mapsequence_plot_unit8_norm_clip_interval():
     # We want to check the case for images with no norms set
     # This code used to fail in this case.

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -242,7 +242,7 @@ def test_map_sequence_plot_clip_interval(aia171_test_map):
 
 
 @skip_windows
-def test_mapsequence_plot_unit8_norm():
+def test_mapsequence_plot_uint8_norm():
     # We want to check the case for images with no norms set
     # This code used to fail in this case.
     coconuts = sunpy.map.Map([get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")]*10,sequence=True)
@@ -252,8 +252,7 @@ def test_mapsequence_plot_unit8_norm():
 
 
 @skip_windows
-def test_mapsequence_plot_unit8_norm_clip_interval():
-    # We want to check the case for images with no norms set
+def test_mapsequence_plot_uint8_norm_clip_interval():
     # This code used to fail in this case.
     coconuts = sunpy.map.Map([get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")]*10,sequence=True)
     [coconut.plot_settings.pop("norm") for coconut in coconuts]

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -12,6 +12,7 @@ from astropy.visualization import ImageNormalize
 import sunpy
 import sunpy.data.test
 import sunpy.map
+from sunpy.data.test import get_test_filepath
 from sunpy.tests.helpers import figure_test
 from sunpy.util.metadata import MetaDict
 
@@ -238,3 +239,21 @@ def test_map_sequence_plot_clip_interval(aia171_test_map):
     # We want to blow the image out to make sure it is clipped on the test data
     animation = seq.plot(clip_interval=(5,75)*u.percent)
     animation._step()
+
+
+def test_mapsequence_plot_unit8_norm():
+    # We want to check the case for images with no norms set
+    # This code used to fail in this case.
+    coconuts = sunpy.map.Map([get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")]*10,sequence=True)
+    [coconut.plot_settings.pop("norm") for coconut in coconuts]
+    moving_coconut = coconuts.plot()
+    moving_coconut._step()
+
+
+def test_mapsequence_plot_unit8_norm_clip_interval():
+    # We want to check the case for images with no norms set
+    # This code used to fail in this case.
+    coconuts = sunpy.map.Map([get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")]*10,sequence=True)
+    [coconut.plot_settings.pop("norm") for coconut in coconuts]
+    moving_coconut = coconuts.plot(clip_interval=(1, 99.99)*u.percent)
+    moving_coconut._step()

--- a/sunpy/visualization/animator/mapsequenceanimator.py
+++ b/sunpy/visualization/animator/mapsequenceanimator.py
@@ -68,13 +68,11 @@ class MapSequenceAnimator(BaseFuncAnimator):
         # plot
         while self.remove_obj:
             self.remove_obj.pop(0).remove()
-
         i = int(val)
         im.set_array(self.data[i].data)
         im.set_cmap(self.mapsequence[i].plot_settings['cmap'])
-        norm = deepcopy(self.mapsequence[i].plot_settings['norm'])
-        im.set_norm(norm)
-
+        if "norm" in self.mapsequence[i].plot_settings:
+            im.set_norm(deepcopy(self.mapsequence[i].plot_settings['norm']))
         if wcsaxes_compat.is_wcsaxes(im.axes):
             im.axes.reset_wcs(self.mapsequence[i].wcs)
         # Having this line in means the plot will resize for non-homogeneous
@@ -83,7 +81,6 @@ class MapSequenceAnimator(BaseFuncAnimator):
         # im.set_extent(self.mapsequence[i].xrange + self.mapsequence[i].yrange)
         if self.annotate:
             self._annotate_plot(i)
-
         self.remove_obj += list(
             self.user_plot_function(self.fig, self.axes, self.mapsequence[i]))
 

--- a/sunpy/visualization/animator/mapsequenceanimator.py
+++ b/sunpy/visualization/animator/mapsequenceanimator.py
@@ -70,7 +70,7 @@ class MapSequenceAnimator(BaseFuncAnimator):
             self.remove_obj.pop(0).remove()
         i = int(val)
         im.set_array(self.data[i].data)
-        im.set_cmap(self.mapsequence[i].plot_settings.get('cmap',"grey"))
+        im.set_cmap(self.mapsequence[i].plot_settings.get('cmap', "grey"))
         if norm := self.mapsequence[i].plot_settings.get('norm'):
             im.set_norm(deepcopy(norm))
         if wcsaxes_compat.is_wcsaxes(im.axes):

--- a/sunpy/visualization/animator/mapsequenceanimator.py
+++ b/sunpy/visualization/animator/mapsequenceanimator.py
@@ -70,9 +70,9 @@ class MapSequenceAnimator(BaseFuncAnimator):
             self.remove_obj.pop(0).remove()
         i = int(val)
         im.set_array(self.data[i].data)
-        im.set_cmap(self.mapsequence[i].plot_settings['cmap'])
-        if "norm" in self.mapsequence[i].plot_settings:
-            im.set_norm(deepcopy(self.mapsequence[i].plot_settings['norm']))
+        im.set_cmap(self.mapsequence[i].plot_settings.get('cmap',"grey"))
+        if norm := self.mapsequence[i].plot_settings.get('norm'):
+            im.set_norm(deepcopy(norm))
         if wcsaxes_compat.is_wcsaxes(im.axes):
             im.axes.reset_wcs(self.mapsequence[i].wcs)
         # Having this line in means the plot will resize for non-homogeneous


### PR DESCRIPTION
For JPEG2000 files (UNIT8 data) we do not set a norm and the map sequence code assumed it was always there. So I just used get and it all works.
 
I can try to add a test?