### PR TITLE
Build aarch64 wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
       anaconda_package: sunpy
       anaconda_keep_n_latest: 1
       sdist: false
-      test_extras: 'tests'
+      test_extras: 'all,tests-only'
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
       targets: |
@@ -215,7 +215,7 @@ jobs:
       anaconda_package: sunpy
       anaconda_keep_n_latest: 1
       sdist: false
-      test_extras: 'tests_only'
+      test_extras: 'tests-only'
       # only test ana here to save time as it's the only compiled code
       test_command: 'pytest -p no:warnings --doctest-rst --pyargs sunpy.io.tests.test_ana'
       submodules: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,15 +187,48 @@ jobs:
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
       targets: |
-        - cp3{10,11,12}-manylinux*_x86_64
+        - cp3{10,11,12}-manylinux_x86_64
         - cp3{10,11,12}-macosx_x86_64
         - cp3{10,11,12}-macosx_arm64
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
       anaconda_token: ${{ secrets.anaconda_org_upload_token }}
 
+  publish_exotic:
+    # Build wheels when pushing to any branch except main
+    # publish.yml will only publish if tagged ^v.*
+    if: |
+      (
+        github.event_name != 'pull_request' && (
+          github.ref_name != 'main' ||
+          github.event_name == 'workflow_dispatch'
+        )
+      ) || (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'Run publish')
+      )
+    needs: [test, docs]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@main
+    with:
+      upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      anaconda_user: scientific-python-nightly-wheels
+      anaconda_package: sunpy
+      anaconda_keep_n_latest: 1
+      sdist: false
+      test_extras: 'tests_only'
+      # only test ana here to save time as it's the only compiled code
+      test_command: 'pytest -p no:warnings --doctest-rst --pyargs sunpy.io.tests.test_ana'
+      submodules: false
+      targets: |
+        - cp310-manylinux_aarch64
+        - cp311-manylinux_aarch64
+        - cp312-manylinux_aarch64
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}
+      anaconda_token: ${{ secrets.anaconda_org_upload_token }}
+
   publish_pure:
-    needs: [publish]
+    needs: [publish, publish_exotic]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@main
     with:
       python-version: "3.12"

--- a/changelog/7679.feature.rst
+++ b/changelog/7679.feature.rst
@@ -1,0 +1,1 @@
+Added build support for aarch64 wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,14 +94,16 @@ timeseries = [
 visualization = ["matplotlib>=3.5.0", "mpl-animators>=1.0.0"]
 core = ["sunpy[image,map,net,timeseries,visualization]"]
 all = ["sunpy[core,asdf,jpeg2000,opencv,spice,scikit-image]"]
-tests = [
-  "sunpy[all]",
+tests_only = [
   "hvpy>=1.1.0",
   "jplephem>=2.14",
   "pytest-astropy>=0.11.0",
   "pytest-mpl>=0.16",
   "pytest-xdist>=3.0.2",
   "pytest>=7.1.0",
+]
+tests = [
+  "sunpy[all,tests_only]",
 ]
 docs = [
   "sunpy[all]",
@@ -158,10 +160,6 @@ py-limited-api = "cp310"
 
 [tool.extension-helpers]
 use_extension_helpers = "true"
-
-[tool.cibuildwheel]
-test-command = "pytest -p no:warnings --doctest-rst -m 'not mpl_image_compare' --pyargs sunpy"
-test-extras = ["tests"]
 
 [tool.gilesbot]
   [tool.gilesbot.circleci_artifacts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ timeseries = [
 visualization = ["matplotlib>=3.5.0", "mpl-animators>=1.0.0"]
 core = ["sunpy[image,map,net,timeseries,visualization]"]
 all = ["sunpy[core,asdf,jpeg2000,opencv,spice,scikit-image]"]
-tests_only = [
+tests-only = [
   "hvpy>=1.1.0",
   "jplephem>=2.14",
   "pytest-astropy>=0.11.0",
@@ -103,7 +103,7 @@ tests_only = [
   "pytest>=7.1.0",
 ]
 tests = [
-  "sunpy[all,tests_only]",
+  "sunpy[all,tests-only]",
 ]
 docs = [
   "sunpy[all]",

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -12,7 +12,6 @@ import astropy.io.fits
 from astropy.utils import iers
 
 from sunpy.data.test import get_test_data_filenames, get_test_filepath, write_image_file_from_header_file
-from sunpy.map import Map
 from sunpy.util import SunpyUserWarning
 
 # Force MPL to use non-gui backends for testing.
@@ -191,6 +190,7 @@ def pytest_runtest_teardown(item):
 
 @pytest.fixture(scope="session")
 def aia171_test_map():
+    from sunpy.map import Map
     return Map(get_test_filepath('aia_171_level1.fits'))
 
 

--- a/sunpy/data/test/__init__.py
+++ b/sunpy/data/test/__init__.py
@@ -14,7 +14,6 @@ from astropy.utils.data import get_pkg_data_filename
 
 import sunpy
 import sunpy.io._fits as _fits
-import sunpy.map
 
 __all__ = [
     'rootdir',
@@ -110,6 +109,8 @@ def get_dummy_map_from_header(filename):
     The "image" will be random numbers with the correct shape
     as specified by the header.
     """
+    import sunpy.map
+
     filepath = get_test_filepath(filename)
     header = _fits.format_comments_and_history(astropy.io.fits.Header.fromtextfile(filepath))
     data = np.random.rand(header['NAXIS2'], header['NAXIS1'])

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
     oldestdeps: glymur<0.9.2
     oldestdeps: h5netcdf<1.1.0
     oldestdeps: matplotlib<3.6.0
-    oldestdeps: numpy<1.23.0
+    oldestdeps: numpy<1.24.0
     oldestdeps: opencv-python<4.7.0.68
     oldestdeps: pandas<1.5.0
     oldestdeps: parfive<2.1.0


### PR DESCRIPTION
This enables aarch64 wheels.

Due to the fact we are currently emulating aarch64 to build and test these (hopefully soon we will have native aarch64 runners) I have setup the tests to only run the `sunpy/io/tests/test_ana.py` file as a way of checking the compiled code works and saving a signifiant amount of build time (this turned out to be harder than it should have been).

When we have native runners for aarch64 we should be able to row this back to be trivial.