### PR TITLE
TST: fix incorrect upper bound on numpy for oldestdeps tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
     oldestdeps: glymur<0.9.2
     oldestdeps: h5netcdf<1.1.0
     oldestdeps: matplotlib<3.6.0
-    oldestdeps: numpy<1.23.0
+    oldestdeps: numpy<1.24.0
     oldestdeps: opencv-python<4.7.0.68
     oldestdeps: pandas<1.5.0
     oldestdeps: parfive<2.1.0


### PR DESCRIPTION
## PR Description
I noticed that oldestdeps jobs were accidentally running numpy 2.0.0 (see [example logs](https://github.com/sunpy/sunpy/actions/runs/9577652835/job/26406459276))
This resolves it.