### PR TITLE
Fix missing attrs in import and added tests to ensure extent type wor…

### DIFF
--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -167,7 +167,7 @@ Additionally, there are several methods that provide basic summary statistics of
     >>> my_map.max()  # doctest: +REMOTE_DATA
     192130.17
     >>> my_map.mean()  # doctest: +REMOTE_DATA
-    427.02252
+    np.float32(427.02252)
 
 .. _sunpy-tutorial-map-coordinates-wcs:
 

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -144,7 +144,7 @@ For example, to get the 0th element in the array:
 .. code-block:: python
 
     >>> my_map.data[0, 0]  # doctest: +REMOTE_DATA
-    -95.92475
+    np.float32(-95.92475)
 
 The first index corresponds to the y direction and the second to the x direction in the two-dimensional pixel coordinate system.
 For more information about indexing, please refer to the `numpy documentation <https://numpy.org/doc/stable/user/basics.indexing.html#indexing-on-ndarrays>`__.
@@ -163,9 +163,9 @@ Additionally, there are several methods that provide basic summary statistics of
 .. code-block:: python
 
     >>> my_map.min()  # doctest: +REMOTE_DATA
-    -129.78036
+    np.float32(-129.78036)
     >>> my_map.max()  # doctest: +REMOTE_DATA
-    192130.17
+    np.float32(192130.17)
     >>> my_map.mean()  # doctest: +REMOTE_DATA
     np.float32(427.02252)
 
@@ -221,12 +221,12 @@ The WCS is accessible as an attribute:
     WCS Keywords
     <BLANKLINE>
     Number of WCS axes: 2
-    CTYPE : 'HPLN-TAN'  'HPLT-TAN'
-    CRVAL : 0.00089530541880571  0.00038493926472939
-    CRPIX : 512.5  512.5
-    PC1_1 PC1_2  : 0.99999706448085  0.0024230207763071
-    PC2_1 PC2_2  : -0.0024230207763071  0.99999706448085
-    CDELT : 0.00066744222222222  0.00066744222222222
+    CTYPE : 'HPLN-TAN' 'HPLT-TAN'
+    CRVAL : np.float64(0.00089530541880571) np.float64(0.00038493926472939)
+    CRPIX : np.float64(512.5) np.float64(512.5)
+    PC1_1 PC1_2  : np.float64(0.99999706448085) np.float64(0.0024230207763071)
+    PC2_1 PC2_2  : np.float64(-0.0024230207763071) np.float64(0.99999706448085)
+    CDELT : np.float64(0.00066744222222222) np.float64(0.00066744222222222)
     NAXIS : 1024  1024
 
 WCS is a fairly complex topic, but all we need to know for now is that the WCS provides the transformation between the pixel coordinates of the image and physical or "world" coordinates.
@@ -536,7 +536,7 @@ To test if all the maps in a `~sunpy.map.MapSequence` have the same shape:
 .. code-block:: python
 
     >>> map_seq.all_maps_same_shape()  # doctest: +REMOTE_DATA
-    True
+    np.True_
 
 It is often useful to return the image data in a `~sunpy.map.MapSequence` as a single three dimensional NumPy `~numpy.ndarray`:
 

--- a/sunpy/net/_attrs.py
+++ b/sunpy/net/_attrs.py
@@ -13,7 +13,7 @@ from sunpy.time.time import _variables_for_parse_time_docstring
 from sunpy.util.decorators import add_common_docstring
 from .attr import Range, SimpleAttr
 
-__all__ = ['Physobs', 'Resolution', 'Detector', 'Sample',
+__all__ = ['Physobs', 'Resolution', 'Detector', 'Sample', 'ExtentType', 'Physobs',
            'Level', 'Instrument', 'Wavelength', 'Time', 'Source', 'Provider']
 
 

--- a/sunpy/net/base_client.py
+++ b/sunpy/net/base_client.py
@@ -484,14 +484,13 @@ class BaseClient(ABC):
     @staticmethod
     def check_attr_types_in_query(query, required_attrs={}, optional_attrs={}):
         """
-        Check a query againsted required and optional attributes.
+        Check a query against required and optional attributes.
 
         Returns `True` if *query* contains all the attrs in *required_attrs*,
         and if *query* contains only attrs in both *required_attrs* and *optional_attrs*.
         """
         query_attrs = {type(x) for x in query}
         all_attrs = required_attrs.union(optional_attrs)
-
         return required_attrs.issubset(query_attrs) and query_attrs.issubset(all_attrs)
 
     @classmethod

--- a/sunpy/net/cdaweb/helpers.py
+++ b/sunpy/net/cdaweb/helpers.py
@@ -88,7 +88,7 @@ def get_datasets(observatory):
       STB_L2_SWEA_PAD
      STB_L1_SWEA_SPEC
     >>> datasets.loc['STB_L1_SWEA_SPEC']['Label'] # doctest: +REMOTE_DATA
-    'STEREO Behind IMPACT/SWEA Spectra - J. Luhmann (UCB/SSL)'
+    np.str_('STEREO Behind IMPACT/SWEA Spectra - J. Luhmann (UCB/SSL)')
     >>> datasets.loc['STB_L1_SWEA_SPEC'][['Start', 'End']] # doctest: +REMOTE_DATA
     <Row index=4>
              Start                     End

--- a/sunpy/net/hek/tests/test_hek.py
+++ b/sunpy/net/hek/tests/test_hek.py
@@ -180,7 +180,7 @@ def test_mixed_results_get():
                            attrs.hek.FRM.Name == 'SPoCA')
     assert isinstance(result, hek.hek.HEKTable)
     assert len(result) == 89
-    assert result[0]["SOL_standard"] == 'SOL2013-01-31T20:13:31L010C158'
+    assert result[0]["SOL_standard"] == 'SOL2013-01-31T20:13:31L253C063'
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -495,3 +495,10 @@ def test_path_format_keys():
     assert t2.path_format_keys() == {'_excite_', 'end_time'}
     unif = UnifiedResponse(t1, t2)
     assert unif.path_format_keys() == {'_excite_'}
+
+
+@pytest.mark.remote_data
+def test_fido_stereo_extent_type():
+    res = Fido.search(a.Time('2008/01/14', '2008/01/14 01:00:00'), a.Instrument.secchi, a.Source('STEREO_A'), a.ExtentType('CORONA'))
+    assert len(res[0]) == 123
+    assert not all(res[0].columns["Extent Type"] == "CORONA")

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -45,7 +45,6 @@ class Extent(_attr.DataAttr):
     """
     Specify the spatial field-of-view of the query. Due to a bug in the VSO,
     the Extent attribute is not used.
-
     """
 
     def __init__(self, x, y, width, length, atype):

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -474,3 +474,17 @@ def test_fetch_lyra(client, tmp_path):
     res = client.search(a.Time('2020/02/15 00:00:00', '2020/02/17 20:00:00'), a.Instrument('lyra'), a.Provider('ESA'), a.Source('PROBA2'))
     files = client.fetch(res[0:1], path=tmp_path)
     assert len(files) == 1
+
+
+@pytest.mark.remote_data
+def test_client_stereo_extent(client):
+    res = client.search(a.Time('2008/01/14', '2008/01/14 01:00:00'), a.Instrument.secchi, a.Source('STEREO_A'), a.ExtentType('CORONA'))
+    assert len(res) == 123
+    assert all(res.columns["Extent Type"] == "CORONA")
+
+
+@pytest.mark.remote_data
+def test_fido_stereo_extent_type(client):
+    res = client.search(a.Time('2008/01/14', '2008/01/14 01:00:00'), a.Instrument.secchi, a.Source('STEREO_A'), a.ExtentType('CORONA'))
+    assert len(res) == 123
+    assert not all(res.columns["Extent Type"] == "CORONA")

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -479,12 +479,14 @@ def test_fetch_lyra(client, tmp_path):
 @pytest.mark.remote_data
 def test_client_stereo_extent(client):
     res = client.search(a.Time('2008/01/14', '2008/01/14 01:00:00'), a.Instrument.secchi, a.Source('STEREO_A'), a.ExtentType('CORONA'))
+    # TODO: Update when VSo Extent filtering works
     assert len(res) == 123
-    assert all(res.columns["Extent Type"] == "CORONA")
+    assert not all(res.columns["Extent Type"] == "CORONA")
 
 
 @pytest.mark.remote_data
 def test_fido_stereo_extent_type(client):
     res = client.search(a.Time('2008/01/14', '2008/01/14 01:00:00'), a.Instrument.secchi, a.Source('STEREO_A'), a.ExtentType('CORONA'))
+    # TODO: Update when VSo Extent filtering works
     assert len(res) == 123
     assert not all(res.columns["Extent Type"] == "CORONA")


### PR DESCRIPTION
Reference to https://github.com/sunpy/sunpy/issues/7690

We were missing two imports here which is how our internal code is checking for optional attrs.

Filtering by extent type doesn't do anything on the VSO Client and I am unsure if that's an us problem or an upstream one. 