### PR TITLE
Enhance flexibility of get_dummy_map_from_header for cross-package use

### DIFF
--- a/sunpy/data/test/__init__.py
+++ b/sunpy/data/test/__init__.py
@@ -29,7 +29,7 @@ rootdir = Path(os.path.dirname(sunpy.__file__)) / "data" / "test"
 file_list = glob.glob(os.path.join(rootdir, '*.[!p]*'))
 
 
-def get_test_filepath(filename, **kwargs):
+def get_test_filepath(filename, package="sunpy.data.test", **kwargs):
     """
     Return the full path to a test file in the ``data/test`` directory.
 
@@ -37,6 +37,8 @@ def get_test_filepath(filename, **kwargs):
     ----------
     filename : `str`
         The name of the file inside the ``data/test`` directory.
+    package : `str`, optional
+        The package in which to look for the file. Defaults to "sunpy.data.test".
 
     Returns
     -------
@@ -51,7 +53,7 @@ def get_test_filepath(filename, **kwargs):
     if isinstance(filename, Path):
         # NOTE: get_pkg_data_filename does not accept Path objects
         filename = filename.as_posix()
-    return get_pkg_data_filename(filename, package="sunpy.data.test", **kwargs)
+    return get_pkg_data_filename(filename, package=package, **kwargs)
 
 
 def get_test_data_filenames():
@@ -103,14 +105,14 @@ def write_image_file_from_header_file(header_file, fits_directory):
     return fits_file
 
 
-def get_dummy_map_from_header(filename):
+def get_dummy_map_from_header(filename, package="sunpy.data.test"):
     """
     Generate a dummy `~sunpy.map.Map` from header-only test data.
 
     The "image" will be random numbers with the correct shape
     as specified by the header.
     """
-    filepath = get_test_filepath(filename)
+    filepath = get_test_filepath(filename, package=package)
     header = _fits.format_comments_and_history(astropy.io.fits.Header.fromtextfile(filepath))
     data = np.random.rand(header['NAXIS2'], header['NAXIS1'])
     if 'BITPIX' in header:


### PR DESCRIPTION

## PR Description

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

Enhance flexibility of get_dummy_map_from_header for cross-package use

- Modified get_test_filepath to accept an optional 'package' argument, allowing specification of the package directory.
- Updated get_dummy_map_from_header to pass the 'package' argument to get_test_filepath, enabling its use outside of 'sunpy.data.test'.


Fixes #7608