### PR TITLE
Remove skips for numpy 2

### DIFF
--- a/sunpy/image/tests/test_transform.py
+++ b/sunpy/image/tests/test_transform.py
@@ -7,7 +7,7 @@ from skimage import transform as tf
 from astropy.coordinates.matrix_utilities import rotation_matrix
 
 from sunpy.image.transform import _rotation_registry, affine_transform
-from sunpy.tests.helpers import figure_test, skip_numpy2
+from sunpy.tests.helpers import figure_test
 from sunpy.util import SunpyUserWarning
 
 # Tolerance for tests
@@ -265,7 +265,6 @@ def test_reproducible_matrix_multiplication():
 
 
 @figure_test
-@skip_numpy2
 def test_clipping(rot30):
     # Generates a plot to test the clipping the output image to the range of the input image
     image = np.ones((20, 20))
@@ -299,7 +298,6 @@ def test_clipping(rot30):
 
 @pytest.mark.filterwarnings("ignore:.*bug in the implementation of scikit-image")
 @figure_test
-@skip_numpy2
 def test_nans(rot30):
     # Generates a plot to test the preservation and expansions of NaNs by the rotation
     image_with_nans = np.ones((23, 23))
@@ -334,7 +332,6 @@ def test_nans(rot30):
 @pytest.mark.filterwarnings("ignore:.*bug in the implementation of scikit-image")
 @pytest.mark.parametrize('method', _rotation_registry.keys())
 @pytest.mark.parametrize('order', range(6))
-@skip_numpy2
 def test_endian(method, order, rot30):
     if order not in _rotation_registry[method].allowed_orders:
         return

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -30,7 +30,7 @@ from sunpy.data.test import get_dummy_map_from_header, get_test_filepath
 from sunpy.image.transform import _rotation_registry
 from sunpy.map.mapbase import GenericMap
 from sunpy.map.sources import AIAMap
-from sunpy.tests.helpers import figure_test, skip_numpy2
+from sunpy.tests.helpers import figure_test
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyMetadataWarning
@@ -1685,7 +1685,6 @@ def test_draw_contours_with_transform(sample_171, sample_hmi):
 
 @pytest.mark.parametrize('method', _rotation_registry.keys())
 @figure_test
-@skip_numpy2
 def test_derotating_nonpurerotation_pcij(aia171_test_map, method):
     # The following map has a a PCij matrix that is not a pure rotation
     weird_map = aia171_test_map.rotate(30*u.deg).superpixel([2, 1]*u.pix)

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
@@ -1,4 +1,6 @@
 {
+  "sunpy.image.tests.test_transform.test_clipping": "f36c82068789b048d5855315f295e2404c85b0a63ec77de0e294d58b43c9acaf",
+  "sunpy.image.tests.test_transform.test_nans": "776e5a2c12bbbff9f5f9de647052cd2ad1be03b39586b91502c8ebba08e87c1b",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map": "5776fedee0a8dd3f54d086af229a6af65f98c532e926315941ac82516654e6e5",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_contours": "594b502d051def47a174953cd784414788598264b1237d64998c111aaf8dc021",
   "sunpy.map.tests.test_compositemap.test_plot_composite_map_linewidths": "7df6e02d2517fcec2a283aef7ffdf401e8f6b87a0d4bf3aeae93552f9692b5b2",
@@ -9,6 +11,9 @@
   "sunpy.map.tests.test_map_factory.test_map_jp2_HMI": "a7098f65fd06e81723ab8310f8873d69bcc220100ceafa8edc24dfb07caa937c",
   "sunpy.map.tests.test_mapbase.test_rotation_rect_pixelated_data": "d722cee25ad829b78b9391b7f8f417c27e8e5f14c62b9882728590d2fce5fb11",
   "sunpy.map.tests.test_mapbase.test_draw_contours_with_transform": "cb1bfc0b30651b48df1430782ec43ebde5f2a785b892f99e4b9763abb4758221",
+  "sunpy.map.tests.test_mapbase.test_derotating_nonpurerotation_pcij[scipy]": "c15c6c707b3b0e707936988054aeb818eee7b39e2249db5309ca43585d325a51",
+  "sunpy.map.tests.test_mapbase.test_derotating_nonpurerotation_pcij[scikit-image]": "911a0442055922f0d31dd48d8f1ede3d1b8b4d11a55f00a3403e8124761c2346",
+  "sunpy.map.tests.test_mapbase.test_derotating_nonpurerotation_pcij[opencv]": "072505693731f65824dcaa7f0843087990f15f34b519285a2bc8965a1fa0ed37",
   "sunpy.map.tests.test_mapsequence.test_norm_animator": "2241b65ed7126250eb14ebbcd095ef4a1f696ad737a4e975ff8e66a007667487",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot": "86f2d19643fbeeaea8bd7097b9002a77da455eeeb46d4ac707bd3c55df15dc22",
   "sunpy.map.tests.test_mapsequence.test_map_sequence_plot_custom_cmap_norm": "129afdbcb3de6893187f3bbe20e9107316ae5d04ceecb8a1969befe3bb3ff540",

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -18,7 +18,6 @@ import sunpy.net.attrs as a
 import sunpy.timeseries
 from sunpy.data.test import get_test_data_filenames, get_test_filepath, rootdir
 from sunpy.net import Fido
-from sunpy.tests.helpers import skip_numpy2
 from sunpy.time import parse_time
 from sunpy.util import SunpyUserWarning
 from sunpy.util.datatype_factory_base import NoMatchError
@@ -98,7 +97,7 @@ def test_from_url():
     assert isinstance(ts[0], sunpy.timeseries.GenericTimeSeries)
     assert isinstance(ts[1], sunpy.timeseries.GenericTimeSeries)
 
-@skip_numpy2
+
 def test_read_cdf():
     ts_psp = sunpy.timeseries.TimeSeries(psp_filepath)
     assert len(ts_psp) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -85,9 +85,6 @@ deps =
     figure-!devdeps: astropy==6.0.0
     figure-!devdeps: matplotlib==3.8.2
     figure-!devdeps: mpl-animators==1.1.1
-    # Due to https://github.com/matplotlib/pytest-mpl/issues/216
-    # Needs a release of pytest-mpl with the fix
-    figure: pluggy<1.4
 extras =
     tests
 commands_pre =


### PR DESCRIPTION
Now that upstream should all be patched, we can unskip these tests. 