### PR TITLE
Fix crash by checking FILLVAL attribute for floating-point data types

### DIFF
--- a/sunpy/io/_cdf.py
+++ b/sunpy/io/_cdf.py
@@ -83,7 +83,7 @@ def read_cdf(fname):
             # Set fillval values to NaN
             # It would be nice to properley mask these values to work with
             # non-floating point (ie. int) dtypes, but this is not possible with pandas
-            if np.issubdtype(data.dtype, np.floating):
+            if np.issubdtype(data.dtype, np.floating) and 'FILLVAL' in attrs:
                 data[data == attrs['FILLVAL']] = np.nan
 
             # Get units


### PR DESCRIPTION


## PR Description

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

Fix crash by checking FILLVAL attribute for floating-point data types

Fixes #7565
