### PR TITLE
Fix the docstrings for Map cached properties

### DIFF
--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -159,7 +159,7 @@ def cached_property_based_on(attr_name):
         """
         prop: the property method being decorated
         """
-        @wraps(outer)
+        @wraps(prop)
         def inner(instance):
             """
             Parameters


### PR DESCRIPTION
We cache a few of the properties of Map (since #4467), but apparently no one in the subsequent four years has noticed or pointed out that the docstrings were not showing up.  This was due to a bug in the call to `functools.wraps()`.