### PR TITLE
replace usages of ``copy_arrays`` with ``memmap``

### DIFF
--- a/sunpy/io/special/asdf/tests/test_genericmap.py
+++ b/sunpy/io/special/asdf/tests/test_genericmap.py
@@ -48,7 +48,7 @@ def test_genericmap_mask(aia171_test_map, tmpdir):
 @asdf_entry_points
 def test_load_100_file_with_shift():
     fname = get_test_filepath("aiamap_shift_genericmap_1.0.0.asdf")
-    with asdf.open(fname, copy_arrays=True) as af:
+    with asdf.open(fname, memmap=False) as af:
         aiamap = af['object']
         assert isinstance(aiamap, sunpy.map.sources.AIAMap)
         assert "crval1" in aiamap.meta.modified_items
@@ -59,7 +59,7 @@ def test_load_100_file_with_shift():
 @asdf_entry_points
 def test_load_100_file_with_no_shift():
     fname = get_test_filepath("aiamap_genericmap_1.0.0.asdf")
-    with asdf.open(fname, copy_arrays=True) as af:
+    with asdf.open(fname, memmap=False) as af:
         aiamap = af['object']
         assert isinstance(aiamap, sunpy.map.sources.AIAMap)
         assert "crval1" not in aiamap.meta.modified_items


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

follow-on to https://github.com/asdf-format/asdf/pull/1797