### PR TITLE
Make XRTMap have default units of DN

### DIFF
--- a/changelog/7744.bugfix.rst
+++ b/changelog/7744.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where `~sunpy.map.sources.XRTMap` was still defaulting to `~astropy.units.ct` rather than
+`~astropy.units.DN`.

--- a/changelog/7744.bugfix.rst
+++ b/changelog/7744.bugfix.rst
@@ -1,2 +1,1 @@
-Fixed a bug where `~sunpy.map.sources.XRTMap` was still defaulting to `~astropy.units.ct` rather than
-`~astropy.units.DN`.
+Fixed a bug where `~sunpy.map.sources.XRTMap` was still defaulting to counts rather than DN.

--- a/sunpy/map/sources/hinode.py
+++ b/sunpy/map/sources/hinode.py
@@ -105,10 +105,10 @@ class XRTMap(GenericMap):
         # See Table 1.1 and Section 2.11 of the XRT Analysis Guide.
         unit = super().unit
         if not unit:
-            unit = u.ct
+            unit = u.DN
             history = self.meta.get('HISTORY', '')
             if "xrt_renormalize" in history.lower():
-                unit = u.ct / u.second
+                unit = u.DN / u.second
         return unit
 
     @classmethod

--- a/sunpy/map/sources/tests/test_xrt_source.py
+++ b/sunpy/map/sources/tests/test_xrt_source.py
@@ -1,6 +1,8 @@
 """
 Test cases for HINODE XRTMap subclass.
 """
+import copy
+
 import pytest
 
 import astropy.units as u
@@ -40,8 +42,16 @@ def test_measurement(xrt_map):
 
 def test_unit(xrt_map):
     """Tests the unit property of the XRTMap object."""
-    assert xrt_map.unit == u.ct / u.second
+    assert xrt_map.unit == u.DN / u.second
 
+def test_unit_no_renormalize(xrt_map):
+    """
+    Tests that the unit defaults ot DN if the history key does not say it has
+    been normalized
+    """
+    new_xrt_map = copy.deepcopy(xrt_map)
+    new_xrt_map.meta.pop('history')
+    assert new_xrt_map.unit == u.DN
 
 def test_level_number(xrt_map):
     assert xrt_map.processing_level == 1


### PR DESCRIPTION
Fixes a bug where the XRT map source was still using default units of `u.ct` instead of `u.DN`