### PR TITLE
Move private api page to main section of our docs

### DIFF
--- a/docs/dev_guide/index.rst
+++ b/docs/dev_guide/index.rst
@@ -71,7 +71,6 @@ This section contains the various guidelines to be followed by anyone working on
             contents/public_api
             contents/logger
             contents/remote_data_manager
-            contents/internal_api
 
 {%else%}
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -23,3 +23,4 @@ Reference
    customization
    troubleshooting
    ssw
+   internal_api

--- a/docs/reference/internal_api.rst
+++ b/docs/reference/internal_api.rst
@@ -1,10 +1,11 @@
-.. _sunpy-dev-guide-internal-api:
+.. _sunpy-reference-internal-api:
 
 **************************
 Internal API Documentation
 **************************
 
 This page contains the documentation for the internal API of `sunpy`.
+This is not intended for general use and is subject to change without notice.
 
 .. automodapi:: sunpy.io._file_tools
 


### PR DESCRIPTION
This broke on the actual tag release.

This will prevent that again.