### PR TITLE
Bugfix _file_tools._read

### DIFF
--- a/changelog/7788.bugfix.rst
+++ b/changelog/7788.bugfix.rst
@@ -1,0 +1,1 @@
+Fix filetype detection to use the detected filetype if a known reader is registered.

--- a/sunpy/io/_file_tools.py
+++ b/sunpy/io/_file_tools.py
@@ -86,7 +86,6 @@ def _read(filepath, function_name, filetype=None, **kwargs):
         readername = detect_filetype(filepath)
         if readername in _READERS.keys():
             return getattr(_READERS[readername], function_name)(filepath, **kwargs)
-        
         readername = None
     except UnrecognizedFileTypeError:
         readername = None

--- a/sunpy/io/_file_tools.py
+++ b/sunpy/io/_file_tools.py
@@ -86,6 +86,8 @@ def _read(filepath, function_name, filetype=None, **kwargs):
         readername = detect_filetype(filepath)
         if readername not in _READERS.keys():
             readername = None
+        else:
+            return getattr(_READERS[readername], function_name)(filepath, **kwargs)
     except UnrecognizedFileTypeError:
         readername = None
     for extension, name in _KNOWN_EXTENSIONS.items():

--- a/sunpy/io/_file_tools.py
+++ b/sunpy/io/_file_tools.py
@@ -84,10 +84,10 @@ def _read(filepath, function_name, filetype=None, **kwargs):
         return getattr(_READERS[filetype], function_name)(filepath, **kwargs)
     try:
         readername = detect_filetype(filepath)
-        if readername not in _READERS.keys():
-            readername = None
-        else:
+        if readername in _READERS.keys():
             return getattr(_READERS[readername], function_name)(filepath, **kwargs)
+        
+        readername = None            
     except UnrecognizedFileTypeError:
         readername = None
     for extension, name in _KNOWN_EXTENSIONS.items():

--- a/sunpy/io/_file_tools.py
+++ b/sunpy/io/_file_tools.py
@@ -87,7 +87,7 @@ def _read(filepath, function_name, filetype=None, **kwargs):
         if readername in _READERS.keys():
             return getattr(_READERS[readername], function_name)(filepath, **kwargs)
         
-        readername = None            
+        readername = None
     except UnrecognizedFileTypeError:
         readername = None
     for extension, name in _KNOWN_EXTENSIONS.items():

--- a/sunpy/io/tests/test_filetools.py
+++ b/sunpy/io/tests/test_filetools.py
@@ -61,6 +61,16 @@ def test_read_file_fits_gzip(fname):
     assert np.all(hdulist[0][0] == np.tile(np.arange(32), (32, 1)).transpose())
 
 
+def test_read_file_fits_fz_ext(tmp_path):
+    test_fits = tmp_path / 'test.fits.fz'
+    with open(TEST_AIA_IMAGE, 'rb') as orig:
+        with (test_fits).open('wb') as test:
+            test.write(orig.read())
+
+    aia_header, aia_data = read_file(str(test_fits))[0]
+    assert isinstance(aia_header, np.ndarray)
+    assert isinstance(aia_data, FileHeader)
+
 @skip_glymur
 def test_read_file_jp2():
     # Aim is to verify that we can read a JP2 file


### PR DESCRIPTION
## PR Description

Currently `_read` defaults to use know extensions (`_KNOWN_EXTENSIONS`) even if `detect_filetype` worked.

This PR changes the control flow in `_read` to use the filetype `detect_filetype` returns if there is  a known reader for it.
