### PR TITLE
Added area-based contouring to `GenericMap.contour()`

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2870,7 +2870,6 @@ class GenericMap(NDData):
             cumulative_sum /= cumulative_sum.max()
             # Threshold values for the desired percentages and draw contours
             index = np.searchsorted(cumulative_sum, level)
-            # print(index)
             index = min(index, len(sorted_values) - 1)
             level = sorted_values[index]
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2733,12 +2733,6 @@ class GenericMap(NDData):
             Value along which to find contours in the array. If the map unit attribute
             is not `None`, this must be a `~astropy.units.Quantity` with units
             equivalent to the map data units.
-        area : bool, optional
-            If `True`, the contour level is interpreted as the fraction of
-            the total area of the map data. The contour is drawn at the value
-            that corresponds to the specified fraction of area. If `False`,
-            the contour is drawn at the specified level value.
-            Defaults to `False`.
         kwargs :
             Additional keyword arguments are passed to `skimage.measure.find_contours`.
 
@@ -2766,20 +2760,12 @@ class GenericMap(NDData):
          (719.58811599, -356.68119768), (721.29217122, -354.76448374),
          (719.59798458, -352.60839064)]>
 
-        >>> contours = aia.contour(0.99*u.DN, area=True)  # doctest: +REMOTE_DATA
-        >>> print(contours[0])  # doctest: +REMOTE_DATA
-        <SkyCoord (Helioprojective: obstime=2011-06-07T06:33:02.880, rsun=696000.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.880, rsun=696000.0 km): (lon, lat, radius) in (deg, deg, m)
-        (-0.00406429, 0.04787238, 1.51846026e+11)>): (Tx, Ty) in arcsec
-        [(100.16572879, -1143.25308903), ( 99.68139649, -1143.76979777),
-         (100.159315  , -1145.90002049), (100.68236775, -1143.77222046),
-         (100.16572879, -1143.25308903)]>
-    
         See Also
         --------
         skimage.measure.find_contours
         """
         from skimage import measure
-        
+
         level = self._process_levels_arg(level)
         if level.size != 1:
             raise ValueError("level must be a single scalar value")
@@ -2787,21 +2773,6 @@ class GenericMap(NDData):
             # _process_levels_arg converts level to a 1D array, but
             # find_contours expects a scalar below
             level = level[0]
-        if area:
-            if not 0 <= level <= 1:
-                # print(level)
-                raise ValueError('level must be between 0 and 1 when area is set to True.')
-            # Sort pixels by value, then find the value that corresponds to the
-            # specified area fraction.
-            flattened_data = self.data.flatten()
-            sorted_values = np.sort(flattened_data)[::-1]
-            cumulative_sum = np.cumsum(sorted_values)
-            cumulative_sum /= cumulative_sum.max()
-            # Threshold values for the desired percentages and draw contours
-            index = np.searchsorted(cumulative_sum, level)
-            # print(index)
-            index = min(index, len(sorted_values) - 1)
-            level = sorted_values[index]
 
         contours = measure.find_contours(self.data, level=level, **kwargs)
         contours = [self.wcs.array_index_to_world(c[:, 0], c[:, 1]) for c in contours]

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1483,6 +1483,11 @@ def test_get_contours_contourpy(simple_map):
     assert u.allclose(contour.Ty, [ 0, -0.5, 0, 0.5, 0] * u.arcsec, atol=1e-10 * u.arcsec)
     with pytest.raises(ValueError, match='level must be a single scalar value'):
         simple_map.get_contours([1.5, 2.5])
+    # Area
+    contours_area = simple_map.get_contours(0.5 * u.DN, method='contourpy', area=True)
+    assert len(contours_area) == 1
+    assert u.allclose(contours_area[0].Tx, [0.5, 7.5, 7.5, 0.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
+    assert u.allclose(contours_area[0].Ty, [0.5, 0.5, 7.5, 7.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
 
 
 def test_get_contours_skimage(simple_map):
@@ -1500,7 +1505,11 @@ def test_get_contours_skimage(simple_map):
     assert u.allclose(contour.Ty, [0.5, 0, -0.5, 0, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
     with pytest.raises(ValueError, match='level must be a single scalar value'):
         simple_map.get_contours([1.5, 2.5])
-
+    # Area
+    contours_area = simple_map.get_contours(0.5 * u.DN, method='skimage', area=True)
+    assert len(contours_area) == 1
+    assert u.allclose(contours_area[0].Tx, [0.5, 7.5, 7.5, 0.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
+    assert u.allclose(contours_area[0].Ty, [0.5, 0.5, 7.5, 7.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
 
 def test_get_contours_invalid_library(simple_map):
     with pytest.raises(ValueError, match="Unknown method 'invalid_method'. Use 'contourpy' or 'skimage'."):
@@ -1546,6 +1555,9 @@ def test_get_contours_inputs(simple_map):
         simple_map.draw_contours(1.5 * u.s)
     with pytest.raises(u.UnitsError, match=re.escape("'s' (time) and 'm' (length) are not convertible")):
         simple_map.get_contours(1.5 * u.s)
+
+    with pytest.raises(ValueError, match='level must be between 0 and 1'):
+        simple_map.get_contours(1.2 * u.DN, area=True)
 
     # With no units, check that dimensionless works
     simple_map.meta.pop('bunit')

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1501,6 +1501,12 @@ def test_get_contours_skimage(simple_map):
     with pytest.raises(ValueError, match='level must be a single scalar value'):
         simple_map.get_contours([1.5, 2.5])
 
+    # Area
+    contours_area = simple_map.contour(0.5 * u.DN, area=True)
+    assert len(contours_area) == 1
+    assert u.allclose(contours_area[0].Tx, [0.5, 7.5, 7.5, 0.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
+    assert u.allclose(contours_area[0].Ty, [0.5, 0.5, 7.5, 7.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
+
 
 def test_get_contours_invalid_library(simple_map):
     with pytest.raises(ValueError, match="Unknown method 'invalid_method'. Use 'contourpy' or 'skimage'."):
@@ -1546,6 +1552,9 @@ def test_get_contours_inputs(simple_map):
         simple_map.draw_contours(1.5 * u.s)
     with pytest.raises(u.UnitsError, match=re.escape("'s' (time) and 'm' (length) are not convertible")):
         simple_map.get_contours(1.5 * u.s)
+
+    with pytest.raises(ValueError, match='level must be between 0 and 1'):
+        simple_map.contour(1.2 * u.DN, area=True)
 
     # With no units, check that dimensionless works
     simple_map.meta.pop('bunit')

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1484,7 +1484,7 @@ def test_get_contours_contourpy(simple_map):
     with pytest.raises(ValueError, match='level must be a single scalar value'):
         simple_map.get_contours([1.5, 2.5])
     # Area
-    contours_area = simple_map.get_contours(0.5 * u.DN, method='contourpy', area=True)
+    contours_area = simple_map.get_contours(0.5, method='contourpy', area=True)
     assert len(contours_area) == 1
     assert u.allclose(contours_area[0].Tx, [0.5, 7.5, 7.5, 0.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
     assert u.allclose(contours_area[0].Ty, [0.5, 0.5, 7.5, 7.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
@@ -1506,7 +1506,7 @@ def test_get_contours_skimage(simple_map):
     with pytest.raises(ValueError, match='level must be a single scalar value'):
         simple_map.get_contours([1.5, 2.5])
     # Area
-    contours_area = simple_map.get_contours(0.5 * u.DN, method='skimage', area=True)
+    contours_area = simple_map.get_contours(0.5, method='skimage', area=True)
     assert len(contours_area) == 1
     assert u.allclose(contours_area[0].Tx, [0.5, 7.5, 7.5, 0.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
     assert u.allclose(contours_area[0].Ty, [0.5, 0.5, 7.5, 7.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
@@ -1557,7 +1557,7 @@ def test_get_contours_inputs(simple_map):
         simple_map.get_contours(1.5 * u.s)
 
     with pytest.raises(ValueError, match='level must be between 0 and 1'):
-        simple_map.get_contours(1.2 * u.DN, area=True)
+        simple_map.get_contours(1.2 * u.dimensionless_unscaled, area=True)
 
     # With no units, check that dimensionless works
     simple_map.meta.pop('bunit')

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1501,12 +1501,6 @@ def test_get_contours_skimage(simple_map):
     with pytest.raises(ValueError, match='level must be a single scalar value'):
         simple_map.get_contours([1.5, 2.5])
 
-    # Area
-    contours_area = simple_map.contour(0.5 * u.DN, area=True)
-    assert len(contours_area) == 1
-    assert u.allclose(contours_area[0].Tx, [0.5, 7.5, 7.5, 0.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
-    assert u.allclose(contours_area[0].Ty, [0.5, 0.5, 7.5, 7.5, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
-
 
 def test_get_contours_invalid_library(simple_map):
     with pytest.raises(ValueError, match="Unknown method 'invalid_method'. Use 'contourpy' or 'skimage'."):
@@ -1552,9 +1546,6 @@ def test_get_contours_inputs(simple_map):
         simple_map.draw_contours(1.5 * u.s)
     with pytest.raises(u.UnitsError, match=re.escape("'s' (time) and 'm' (length) are not convertible")):
         simple_map.get_contours(1.5 * u.s)
-
-    with pytest.raises(ValueError, match='level must be between 0 and 1'):
-        simple_map.contour(1.2 * u.DN, area=True)
 
     # With no units, check that dimensionless works
     simple_map.meta.pop('bunit')


### PR DESCRIPTION
## PR Description


Fixes #7420
Adds a new area parameter to the `get_contour()` method, allowing users to find contours based on the fraction of the total area enclosed. This is particularly useful for X-ray and radio maps where area containment is a relevant metric.

