### PR TITLE
Handles Missing 'FILLVAL' Attribute in CDF Variables to Prevent TimeSeries Crash

### DIFF
--- a/changelog/7795.bugfix.rst
+++ b/changelog/7795.bugfix.rst
@@ -1,0 +1,1 @@
+:func:`~sunpy.io._cdf.read_cdf` and `~sunpy.timeseries.TimeSeries` now handle cases where CDF variables do not have a ``FILLVAL`` attribute, preventing crashes during CDF file reading.

--- a/sunpy/io/_cdf.py
+++ b/sunpy/io/_cdf.py
@@ -83,8 +83,12 @@ def read_cdf(fname):
             # Set fillval values to NaN
             # It would be nice to properley mask these values to work with
             # non-floating point (ie. int) dtypes, but this is not possible with pandas
-            if np.issubdtype(data.dtype, np.floating):
-                data[data == attrs['FILLVAL']] = np.nan
+            if 'FILLVAL' in attrs:
+                try :
+                    if np.issubdtype(data.dtype, np.floating):
+                        data[data == attrs['FILLVAL']] = np.nan
+                except ValueError:
+                    continue
 
             # Get units
             if 'UNITS' in attrs:


### PR DESCRIPTION
## PR Description
Solves: #7565
<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->
