### PR TITLE
Fixed bug loading in sunkit_magex.pfss.map.ADAPTMap

### DIFF
--- a/changelog/7798.bugfix.rst
+++ b/changelog/7798.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed loading of `~sunpy.map.sources.ADAPTMap` if sunkit-magex v1.0.0 is installed.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -202,7 +202,8 @@ class GenericMap(NDData):
             # NOTE: This conditional is due to overlapping map sources in sunpy and pfsspy that
             # lead to a MultipleMatchError if sunpy.map and pfsspy.map are imported.
             # See https://github.com/sunpy/sunpy/issues/7294 for more information.
-            if f'{cls.__module__}.{cls.__name__}' != "pfsspy.map.GongSynopticMap":
+            # This also applies to older versions of sunkit-magex with ADAPTMap.
+            if f'{cls.__module__}.{cls.__name__}' not in  ["pfsspy.map.GongSynopticMap", "sunkit_magex.pfss.map.ADAPTMap"]:
                 cls._registry[cls] = cls.is_datasource_for
 
     def __init__(self, data, header, plot_settings=None, **kwargs):


### PR DESCRIPTION
We have two adapt maps currently, map does not like this:

```
    def _check_registered_widgets(self, data, meta, **kwargs):
    
        candidate_widget_types = list()
    
        for key in self.registry:
    
            # Call the registered validation function for each registered class
            if self.registry[key](data, meta, **kwargs):
                candidate_widget_types.append(key)
    
        n_matches = len(candidate_widget_types)
    
        if n_matches == 0:
            if self.default_widget_type is None:
                raise NoMatchError("No types match specified arguments and no default is set.")
            else:
                candidate_widget_types = [self.default_widget_type]
        elif n_matches > 1:
>           raise MultipleMatchError("Too many candidate types identified "
                                     f"({candidate_widget_types}). "
                                     "Specify enough keywords to guarantee unique type "
                                     "identification.")
E           sunpy.util.datatype_factory_base.MultipleMatchError: Too many candidate types identified ([<class 'sunpy.map.sources.adapt.ADAPTMap'>, <class 'sunkit_magex.pfss.map.ADAPTMap'>]). Specify enough keywords to guarantee unique type identification.

../../.tox/py312/lib/python3.12/site-packages/sunpy/map/map_factory.py:316: MultipleMatchError
```