### PR TITLE
Fix map sources to always fall back to default values for `date` and `reference_date`

### DIFF
--- a/changelog/7810.bugfix.rst
+++ b/changelog/7810.bugfix.rst
@@ -1,2 +1,3 @@
-Fall back to `sunpy.map.GenericMap.reference_date` in `~sunpy.map.sources.AIAMap` if the ``T_OBS``
-key is missing from the metadata instead of returning None.
+All map sources that override ``date`` or ``reference_date`` now fall back to
+`sunpy.map.GenericMap.date` if the needed source-specific metadata for these
+properties cannot be found.

--- a/changelog/7810.bugfix.rst
+++ b/changelog/7810.bugfix.rst
@@ -1,3 +1,3 @@
 All map sources that override ``date`` or ``reference_date`` now fall back to
-`sunpy.map.GenericMap.date` if the needed source-specific metadata for these
+the corresponding properties on `sunpy.map.GenericMap` if the needed source-specific metadata for these
 properties cannot be found.

--- a/changelog/7810.bugfix.rst
+++ b/changelog/7810.bugfix.rst
@@ -1,0 +1,2 @@
+Fall back to `sunpy.map.GenericMap.reference_date` in `~sunpy.map.sources.AIAMap` if the ``T_OBS``
+key is missing from the metadata instead of returning None.

--- a/sunpy/map/sources/adapt.py
+++ b/sunpy/map/sources/adapt.py
@@ -2,7 +2,6 @@
 ADAPT Map subclass definitions
 """
 
-from astropy.time import Time
 
 from sunpy.map.mapbase import GenericMap, SpatialPair
 from sunpy.time import parse_time
@@ -45,7 +44,7 @@ class ADAPTMap(GenericMap):
 
     @property
     def date(self):
-        return Time(self.meta.get('date-obs') or self.meta.get('maptime') or super().date)
+        return self._get_date('date-obs') or self._get_date('maptime') or super().date
 
     def _set_date(self, date):
         self.meta['date-obs'] = parse_time(date).utc.isot

--- a/sunpy/map/sources/gong.py
+++ b/sunpy/map/sources/gong.py
@@ -5,7 +5,6 @@ import numpy as np
 
 import astropy.units as u
 from astropy.coordinates import EarthLocation, SkyCoord
-from astropy.time import Time
 
 from sunpy.coordinates import get_earth
 from sunpy.map import GenericMap
@@ -56,10 +55,11 @@ class GONGSynopticMap(GenericMap):
     def date(self):
         # The FITS file has a date that is made from the date-obs and time-obs keywords
         # Which is not what date-obs is supposed to be.
-        if 'time-obs' in self.meta:
-            return Time(f"{self.meta.get('date-obs')} {self.meta.get('time-obs')}")
-        else:
-            return Time(self.meta.get('date-obs'))
+        if date_obs := self.meta.get('date-obs'):
+            if time_obs := self.meta.get('time-obs'):
+                date_obs = f"{date_obs} {time_obs}"
+            date_obs = parse_time(date_obs)
+        return date_obs or super().date
 
     def _set_date(self, date):
         if 'time-obs' in self.meta:

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -151,7 +151,7 @@ class HMIMap(GenericMap):
 
         DATE-OBS is derived from T_OBS by subtracting half the exposure time, so would not be a reference time.
         """
-        return self._get_date('T_OBS')
+        return self._get_date('T_OBS') or super().reference_date
 
     def _set_reference_date(self, date):
         self.meta['T_OBS'] = parse_time(date).utc.isot
@@ -215,7 +215,7 @@ class HMISynopticMap(HMIMap):
         """
         Image observation time.
         """
-        return self._get_date('T_OBS')
+        return self._get_date('T_OBS') or super().date
 
     def _set_date(self, date):
         self.meta['T_OBS'] = parse_time(date).utc.isot
@@ -225,7 +225,7 @@ class HMISynopticMap(HMIMap):
         """
         The reference date for the coordinate system.
         """
-        return self._get_date('T_OBS')
+        return self._get_date('T_OBS') or super().reference_date
 
     def _set_reference_date(self, date):
         self.meta['T_OBS'] = parse_time(date).utc.isot

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -78,7 +78,7 @@ class AIAMap(GenericMap):
 
         DATE-OBS is derived from T_OBS by subtracting half the exposure time, so would not be a reference time.
         """
-        return self._get_date('T_OBS')
+        return self._get_date('T_OBS') or super().reference_date
 
     def _set_reference_date(self, date):
         self.meta['t_obs'] = parse_time(date).utc.isot

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -137,7 +137,7 @@ class LASCOMap(GenericMap):
     def date(self):
         if date := self.meta.get('date-obs', self.meta.get('date_obs')):
             # If the header has already been fixed, no need to concatenate
-            if time := self.meta.get('time-obs', self.meta.get('time_obs')) and 'T' not in date:
+            if (time := self.meta.get('time-obs', self.meta.get('time_obs'))) and 'T' not in date:
                 date = f"{date}T{time}"
             date = parse_time(date)
         return date or super().date

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -135,12 +135,12 @@ class LASCOMap(GenericMap):
 
     @property
     def date(self):
-        date = self.meta.get('date-obs', self.meta.get('date_obs'))
-        # If the header has already been fixed, no need to concatenate
-        if 'T' not in date:
-            time = self.meta.get('time-obs', self.meta.get('time_obs'))
-            date = f"{date}T{time}"
-        return parse_time(date) or super().date
+        if date := self.meta.get('date-obs', self.meta.get('date_obs')):
+            # If the header has already been fixed, no need to concatenate
+            if time := self.meta.get('time-obs', self.meta.get('time_obs')) and 'T' not in date:
+                date = f"{date}T{time}"
+            date = parse_time(date)
+        return date or super().date
 
     def _set_date(self, date):
         if 'time-obs' in self.meta:

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -136,12 +136,11 @@ class LASCOMap(GenericMap):
     @property
     def date(self):
         date = self.meta.get('date-obs', self.meta.get('date_obs'))
-        # In case someone fixes the header
-        if 'T' in date:
-            return parse_time(date)
-
-        time = self.meta.get('time-obs', self.meta.get('time_obs'))
-        return parse_time(f"{date}T{time}")
+        # If the header has already been fixed, no need to concatenate
+        if 'T' not in date:
+            time = self.meta.get('time-obs', self.meta.get('time_obs'))
+            date = f"{date}T{time}"
+        return parse_time(date) or super().date
 
     def _set_date(self, date):
         if 'time-obs' in self.meta:
@@ -286,7 +285,7 @@ class MDISynopticMap(MDIMap):
 
         This is taken from the 'DATE-OBS' or 'T_OBS' keywords.
         """
-        return self._get_date('date-obs') or self._get_date('t_obs')
+        return self._get_date('date-obs') or self._get_date('t_obs') or super().date
 
     def _set_date(self, date):
         self.meta['date-obs'] = self.meta['t_obs'] = parse_time(date).utc.isot

--- a/sunpy/map/sources/tests/test_aia_source.py
+++ b/sunpy/map/sources/tests/test_aia_source.py
@@ -1,6 +1,7 @@
 """
 Test cases for AIAMap subclass.
 """
+import copy
 
 import pytest
 
@@ -87,3 +88,11 @@ def test_new_instance_preserves_plot_settings(aia_map):
 def test_wcs(aia_map):
     # Smoke test that WCS is valid and can transform from pixels to world coordinates
     aia_map.pixel_to_world(0*u.pix, 0*u.pix)
+
+
+def test_missing_tobs(aia_map):
+    # Should fall back to base reference_date for reference date if T_OBS is missing
+    new_meta = copy.deepcopy(aia_map.meta)
+    new_meta.pop('T_OBS')
+    new_aia_map = aia_map._new_instance(aia_map.data, new_meta)
+    assert new_aia_map.reference_date == super(type(new_aia_map), new_aia_map).reference_date


### PR DESCRIPTION
This PR ensures that for all the map sources that override `date` or `reference_date`, if the needed source-specific metadata is missing, that they fall back to the default behavior as given in `GenericMap.date` and `GenericMap.reference_date`.

In the case of AIA, we use the "T_OBS" key for `reference_date` to compute our coordinate frames. However, in cases where this key is missing, `reference_date` becomes None and no coordinate frame (and by extension WCS) can be calculated for the map. With this PR , `reference_date` just falls back to the generic case if "T_OBS" is missing.