### PR TITLE
Fixed bug with tilted and offset planar screen

### DIFF
--- a/changelog/7814.bugfix.rst
+++ b/changelog/7814.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a calculation bug when using `~sunpy.coordinates.PlanarScreen` when it is both tilted (the plane is not perpendicular to the observer-Sun direction) and offset (the plane does not go through Sun center).

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -187,10 +187,10 @@ class PlanarScreen(BaseScreen):
         super().__init__(**kwargs)
 
     def calculate_distance(self, frame):
-        direction = self._vantage_point.transform_to(frame).cartesian
-        direction = CartesianRepresentation(1, 0, 0) * frame.observer.radius - direction
-        direction /= direction.norm()
-        d_from_plane = (frame.observer.radius - self._distance_from_center) * direction.x
+        obs_to_vantage = self._vantage_point.transform_to(frame).cartesian
+        vantage_to_sun = CartesianRepresentation(1, 0, 0) * frame.observer.radius - obs_to_vantage
+        direction = vantage_to_sun / vantage_to_sun.norm()
+        d_from_plane = frame.observer.radius * direction.x - self._distance_from_center
         rep = frame.represent_as(UnitSphericalRepresentation)
         distance = d_from_plane / rep.dot(direction)
         return distance

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -518,6 +518,11 @@ def off_limb_coord():
     return SkyCoord(Tx=[-1000, 300, 1000]*u.arcsec, Ty=[-1000, 300, 1000]*u.arcsec, frame=frame)
 
 
+@pytest.fixture
+def non_earth_coord():
+    return SkyCoord(70*u.deg, 20*u.deg, 1*u.AU, obstime='2020-01-01', frame=HeliographicStonyhurst)
+
+
 @pytest.mark.parametrize('screen_class', [
     SphericalScreen,
     PlanarScreen,
@@ -556,5 +561,26 @@ def test_planar_screen(off_limb_coord, only_off_disk, distance_from_center, dist
 ])
 def test_spherical_screen(off_limb_coord, only_off_disk, distance):
     with SphericalScreen(off_limb_coord.observer, only_off_disk=only_off_disk):
+        olc_3d = off_limb_coord.make_3d()
+    assert u.quantity.allclose(olc_3d.distance, distance)
+
+
+@pytest.mark.parametrize(('only_off_disk', 'distance_from_center', 'distance'), [
+    (False, 0*u.m, [0.96419505, 0.98918004, 1.00321100]*u.AU),
+    (True, 0*u.m, [0.96419505, 0.97910333, 1.00321100]*u.AU),
+    (False, 1*u.Rsun, [0.94916557, 0.97376111, 0.98757335]*u.AU),
+])
+def test_planar_screen_askew(off_limb_coord, only_off_disk, distance_from_center, distance, non_earth_coord):
+    with PlanarScreen(non_earth_coord, distance_from_center=distance_from_center, only_off_disk=only_off_disk):
+        olc_3d = off_limb_coord.make_3d()
+    assert u.quantity.allclose(olc_3d.distance, distance)
+
+
+@pytest.mark.parametrize(('only_off_disk', 'distance'), [
+    (False, [0.96348934, 0.98911699, 1.00251206]*u.AU),
+    (True, [0.96348934, 0.97910333, 1.00251206]*u.AU),
+])
+def test_spherical_screen_askew(off_limb_coord, only_off_disk, distance, non_earth_coord):
+    with SphericalScreen(non_earth_coord, only_off_disk=only_off_disk):
         olc_3d = off_limb_coord.make_3d()
     assert u.quantity.allclose(olc_3d.distance, distance)


### PR DESCRIPTION
As (self-)caught by @wtbarnes, there's a calculation bug for a planar screen (added in #7115) that is both tilted (the plane is not perpendicular to the observer-Sun direction) and offset (the plane does not go through Sun center).  The incorrect code is:
```python
d_from_plane = (frame.observer.radius - self._distance_from_center) * direction.x
```
when it should be
```python
d_from_plane = frame.observer.radius * direction.x - self._distance_from_center
```
I also changed some variable names on earlier lines to facilitate future maintenance.