### PR TITLE
Adds interpolation options for sample_at_coords using scipy

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/sunpy/package-template",
-  "commit": "17602ec8f8d4a4c5722bca00e255e480683f5096",
+  "commit": "e4da826808cc9caf3606609c80a98ed441b9da44",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: ".*(.csv|.fits|.fts|.fit|.header|.txt|tca.*|.json|.asdf)$|^CITATION.rst
 repos:
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.6.7"
+    rev: "v0.6.8"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/changelog/7824.feature.rst
+++ b/changelog/7824.feature.rst
@@ -1,2 +1,2 @@
 The `~sunpy.map.maputils.sample_at_coords` now allows interpolation
-with unstructured data using `~scipy.interpolate.griddata`.
+with `~scipy.interpolate.griddata`.

--- a/changelog/7824.feature.rst
+++ b/changelog/7824.feature.rst
@@ -1,0 +1,2 @@
+The `~sunpy.map.maputils.sample_at_coords` now allows interpolation
+with unstructured data using `~scipy.interpolate.griddata`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,16 +186,9 @@ for line in open('nitpick-exceptions'):
     if line.strip() == "" or line.startswith("#"):
         continue
     dtype, target = line.split(None, 1)
-<<<<<<<
     target = target.strip()
     nitpick_ignore.append((dtype, target))
 
-=======
-master_doc = "index"
-
-# Treat everything in single ` as a Python reference.
-default_role = "py:obj"
->>>>>>>
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyPendingDeprecati
 # The full version, including alpha/beta/rc tags
 from sunpy import __version__
 
+<<<<<<<
 _version = Version(__version__)
 version = release = str(_version)
 # Avoid "post" appearing in version string in rendered docs
@@ -59,6 +60,17 @@ elif _version.is_devrelease:
 is_development = _version.is_devrelease
 is_release = not(_version.is_prerelease or _version.is_devrelease)
 
+=======
+    version = release = _version.base_version
+# Avoid long githashes in rendered Sphinx docs
+elif _version.is_devrelease:
+    version = release = f"{_version.base_version}.dev{_version.dev}"
+is_development = _version.is_devrelease
+is_release = not(_version.is_prerelease or _version.is_devrelease)
+
+project = "sunpy"
+author = "The SunPy Community"
+>>>>>>>
 project = 'sunpy'
 author = 'The SunPy Community'
 copyright = f'{datetime.datetime.now().year}, {author}'
@@ -186,9 +198,16 @@ for line in open('nitpick-exceptions'):
     if line.strip() == "" or line.startswith("#"):
         continue
     dtype, target = line.split(None, 1)
+<<<<<<<
     target = target.strip()
     nitpick_ignore.append((dtype, target))
 
+=======
+master_doc = "index"
+
+# Treat everything in single ` as a Python reference.
+default_role = "py:obj"
+>>>>>>>
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,19 +48,10 @@ from sunpy.util.exceptions import SunpyDeprecationWarning, SunpyPendingDeprecati
 # The full version, including alpha/beta/rc tags
 from sunpy import __version__
 
-<<<<<<<
 _version = Version(__version__)
 version = release = str(_version)
 # Avoid "post" appearing in version string in rendered docs
 if _version.is_postrelease:
-    version = release = _version.base_version
-# Avoid long githashes in rendered Sphinx docs
-elif _version.is_devrelease:
-    version = release = f'{_version.base_version}.dev{_version.dev}'
-is_development = _version.is_devrelease
-is_release = not(_version.is_prerelease or _version.is_devrelease)
-
-=======
     version = release = _version.base_version
 # Avoid long githashes in rendered Sphinx docs
 elif _version.is_devrelease:
@@ -70,9 +61,6 @@ is_release = not(_version.is_prerelease or _version.is_devrelease)
 
 project = "sunpy"
 author = "The SunPy Community"
->>>>>>>
-project = 'sunpy'
-author = 'The SunPy Community'
 copyright = f'{datetime.datetime.now().year}, {author}'
 
 # Register remote data option with doctest

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -166,7 +166,7 @@ def solar_angular_radius(coordinates):
     return sun._angular_radius(coordinates.rsun, coordinates.observer.radius)
 
 
-def get_neighboring_indices(indices, position, dimensions):
+def _get_neighboring_indices(indices, position, dimensions):
     """
     Get the neighboring indices relative to given indices.
 
@@ -193,22 +193,22 @@ def get_neighboring_indices(indices, position, dimensions):
            [0, 1, 2, 3, 4]])
 
     >>> # Right neighbors
-    >>> get_neighboring_indices(indices, [1, 0], [5, 5])
+    >>> _get_neighboring_indices(indices, [1, 0], [5, 5])
     array([[1, 2, 3, 4],
            [0, 1, 2, 3]])
 
     >>> # Left neighbors
-    >>> get_neighboring_indices(indices, [-1, 0], [5, 5])
+    >>> _get_neighboring_indices(indices, [-1, 0], [5, 5])
     array([[0, 1, 2, 3],
            [1, 2, 3, 4]])
 
     >>> # Top neighbors
-    >>> get_neighboring_indices(indices, [0, 1], [5, 5])
+    >>> _get_neighboring_indices(indices, [0, 1], [5, 5])
     array([[0, 1, 2, 3],
            [1, 2, 3, 4]])
 
     >>> # Bottom neighbors
-    >>> get_neighboring_indices(indices, [0, -1], [5, 5])
+    >>> _get_neighboring_indices(indices, [0, -1], [5, 5])
     array([[1, 2, 3, 4],
            [0, 1, 2, 3]])
 
@@ -289,9 +289,11 @@ def sample_at_coords(
     for position in neighbor_positions:
         extended_indices = np.append(
             extended_indices,
-            get_neighboring_indices(indices, position, dimensions),
+            _get_neighboring_indices(indices, position, dimensions),
             axis=1,
         )
+
+    extended_indices = np.unique(extended_indices, axis=1)
 
     map_coordinates = smap.wcs.array_index_to_world(*extended_indices)
     interpolated_values = griddata(

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -251,11 +251,11 @@ def sample_at_coords(
 
         ``nearest``
           sampled values are interpolated using
-          `~scipy.interpolate.NearestNDInterpolator`.
+          `~scipy.interpolate.NearestANDInterpolator`.
 
         ``linear``
           sampled values are interpolated using
-          `~scipy.interpolate.LinearNDInterpolator`.
+          `~scipy.interpolate.LinearANDInterpolator`.
 
         ``cubic``
           sampled values are interpolated using

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -206,8 +206,10 @@ def test_on_disk_bounding_coordinates(aia171_test_map):
     np.testing.assert_almost_equal(tr.Ty.to(u.arcsec).value, 971.63586861, decimal=1)
 
 
-def test_data_at_coordinates(aia171_test_map, aia_test_arc):
-    data = sample_at_coords(aia171_test_map, aia_test_arc.coordinates())
+@pytest.mark.parametrize("method", ["astropy", "nearest"])
+def test_data_at_coordinates(aia171_test_map, aia_test_arc, method):
+    data = sample_at_coords(aia171_test_map, aia_test_arc.coordinates(),
+                            method=method)
     pixels = np.asarray(np.rint(
         aia171_test_map.world_to_pixel(aia_test_arc.coordinates())), dtype=int)
     x = pixels[0, :]


### PR DESCRIPTION
Closes #6827 

## PR Description

This is a vectorized rewrite of the attempt in #6885.

For interpolation methods other than `astropy` and `nearest`, the end-points of the arc along which to sample may not be included in the interpolation. So, it is often better to add the 4 nearest neighbors to the simplices found by `smap.wcs.world_to_array_index` (which uses `astropy.wcs.WCS.all_world2pix`). See below (hollow markers are grid points; red grid points are used for interpolation; blue markers are the arc along which to interpolate):

![plot_neighbor_finder](https://github.com/user-attachments/assets/72d78d84-7322-42c5-9207-94e91640d2c9)

Also, here is a comparison of all supported interpolation methods.

![compare_methods](https://github.com/user-attachments/assets/ce844dca-03d4-4ccf-8251-228fd9f15493)

`astropy` and `nearest` agrees exactly, as expected. But there can be quite large differences in the other interpolation methods. I'm wondering if anyone has a good test for higher-order interpolation, perhaps one with a denser map and less noise?