### PR TITLE
Cleanup `MapSequence`

### DIFF
--- a/changelog/7827.deprecation.rst
+++ b/changelog/7827.deprecation.rst
@@ -1,0 +1,12 @@
+The following components of `~sunpy.map.MapSequence` are now deprecated and will be removed in v7.1:
+
+- The ``derotate`` keyword argument to `~sunpy.map.MapSequence`. Derotation is not implemented.
+- The ``resample`` keyword argument to `~sunpy.map.MapSequence.peek` and `~sunpy.map.MapSequence.plot`.
+  To reproduce this behavior, use `~sunpy.map.GenericMap.resample` on each map in the sequence before plotting.
+- Deprecate `~sunpy.map.MapSequence.all_maps_same_shape`.
+- Deprecate `~sunpy.map.MapSequence.at_least_one_map_has_mask`. To reproduce this functionality, check whether
+  `~sunpy.map.MapSequence.mask` is None.
+- Deprecate `~sunpy.map.MapSequence.as_array` in favor of `~sunpy.map.MapSequence.data` and
+  `~sunpy.map.MapSequence.mask`. Previously, ``as_array`` returned a masked array if at least one map held a mask
+  and a bare array if not.
+- Deprecate `~sunpy.map.MapSequence.all_meta` in favor of `~sunpy.map.MapSequence.meta`.

--- a/changelog/7827.deprecation.rst
+++ b/changelog/7827.deprecation.rst
@@ -3,7 +3,7 @@ The following components of `~sunpy.map.MapSequence` are now deprecated and will
 - The ``derotate`` keyword argument to `~sunpy.map.MapSequence`. Derotation is not implemented.
 - The ``resample`` keyword argument to `~sunpy.map.MapSequence.peek` and `~sunpy.map.MapSequence.plot`.
   To reproduce this behavior, use `~sunpy.map.GenericMap.resample` on each map in the sequence before plotting.
-- Deprecate `~sunpy.map.MapSequence.all_maps_same_shape`.
+- Deprecate `~sunpy.map.MapSequence.all_maps_same_shape` in favor of `~sunpy.map.MapSequence.all_same_shape`.
 - Deprecate `~sunpy.map.MapSequence.at_least_one_map_has_mask`. To reproduce this functionality, check whether
   `~sunpy.map.MapSequence.mask` is None.
 - Deprecate `~sunpy.map.MapSequence.as_array` in favor of `~sunpy.map.MapSequence.data` and

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -542,7 +542,7 @@ It is often useful to return the image data in a `~sunpy.map.MapSequence` as a s
 
 .. code-block:: python
 
-    >>> map_seq_array = map_seq.as_array()  # doctest: +REMOTE_DATA
+    >>> map_seq_array = map_seq.data  # doctest: +REMOTE_DATA
 
 Since all of the maps in our sequence of the same shape, the first two dimensions of our combined array will be the same as the component maps while the last dimension will correspond to the number of maps in the map sequence.
 We can confirm this by looking at the shape of the above array.

--- a/docs/tutorial/maps.rst
+++ b/docs/tutorial/maps.rst
@@ -530,19 +530,16 @@ For example, the following returns the same information as in :ref:`sunpy-tutori
            [-128.03072  , -128.03072  , -128.03072  , ..., -128.03072  ,
             -128.03072  , -128.03072  ]], dtype=float32)
 
-MapSequences can hold maps that have different shapes.
-To test if all the maps in a `~sunpy.map.MapSequence` have the same shape:
-
-.. code-block:: python
-
-    >>> map_seq.all_maps_same_shape()  # doctest: +REMOTE_DATA
-    np.True_
-
 It is often useful to return the image data in a `~sunpy.map.MapSequence` as a single three dimensional NumPy `~numpy.ndarray`:
 
 .. code-block:: python
 
     >>> map_seq_array = map_seq.data  # doctest: +REMOTE_DATA
+
+.. note::
+
+    MapSequences can hold maps that have different shapes.
+    In the case where not every map has the same shape, trying to cast the sequence as a single three-dimensional array will fail.
 
 Since all of the maps in our sequence of the same shape, the first two dimensions of our combined array will be the same as the component maps while the last dimension will correspond to the number of maps in the map sequence.
 We can confirm this by looking at the shape of the above array.

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -376,16 +376,9 @@ class MapSequence:
             if norm:
                 _handle_norm(norm, kwargs)
                 im.set_norm(norm)
-            if wcsaxes_compat.is_wcsaxes(axes):
-                im.axes.reset_wcs(ani_data[i].wcs)
-                wcsaxes_compat.default_wcs_grid(axes)
-            else:
-                bl = ani_data[i]._get_lon_lat(ani_data[i].bottom_left_coord)
-                tr = ani_data[i]._get_lon_lat(ani_data[i].top_right_coord)
-                x_range = list(u.Quantity([bl[0], tr[0]]).to(ani_data[i].spatial_units[0]).value)
-                y_range = list(u.Quantity([bl[1], tr[1]]).to(ani_data[i].spatial_units[1]).value)
 
-                im.set_extent(np.concatenate((x_range.value, y_range.value)))
+            im.axes.reset_wcs(ani_data[i].wcs)
+            wcsaxes_compat.default_wcs_grid(axes)
 
             if annotate:
                 annotate_frame(i)

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -20,6 +20,10 @@ from sunpy.util.decorators import deprecated, deprecated_renamed_argument
 from sunpy.util.exceptions import warn_user
 from sunpy.visualization import axis_labels_from_ctype, wcsaxes_compat
 
+# NOTE: This is necessary because the deprecated decorator does not currently issue the correct
+# deprecation message. Remove this when that is fixed and/or when the v6.1 deprecations are removed.
+v61_DEPRECATION_MESSAGE = 'The {func} {obj_type} is deprecated and will be removed in sunpy 7.1. Use the {alternative} instead.'
+
 __all__ = ['MapSequence']
 
 
@@ -474,19 +478,19 @@ class MapSequence:
 
         return MapSequenceAnimator(plot_sequence, **kwargs)
 
-    @deprecated(since='6.1', alternative='.data')
+    @deprecated(since='6.1', message=v61_DEPRECATION_MESSAGE, alternative='data property')
     def all_maps_same_shape(self):
         """
         True if all the maps have the same number pixels along both axes.
         """
         return np.all([m.data.shape == self.maps[0].data.shape for m in self.maps])
 
-    @deprecated(since='6.1', alternative='.mask')
+    @deprecated(since='6.1', message=v61_DEPRECATION_MESSAGE, alternative='mask property')
     def at_least_one_map_has_mask(self):
         """
         True if at least one map has a mask
         """
-        return np.any([m.mask is not None for m in self.maps])
+        return self.mask is not None
 
     @property
     def data(self):
@@ -505,7 +509,7 @@ class MapSequence:
                 mask[..., i] = m.mask
         return mask
 
-    @deprecated(since='6.1', alternative='.data and .mask')
+    @deprecated(since='6.1', alternative='data and mask properties', message=v61_DEPRECATION_MESSAGE)
     def as_array(self):
         """
         If all the map shapes are the same, their image data is rendered
@@ -524,7 +528,7 @@ class MapSequence:
         else:
             return data
 
-    @deprecated('6.1', alternative='.meta')
+    @deprecated(since='6.1', message=v61_DEPRECATION_MESSAGE, alternative='meta property')
     def all_meta(self):
         """
         Return all the meta objects as a list.

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -502,7 +502,7 @@ class MapSequence:
     @property
     def mask(self):
         if not np.any([m.mask is not None for m in self.maps]):
-            return
+            return None
         mask = np.zeros_like(self.data, dtype=bool)
         for i, m in enumerate(self):
             if m.mask is not None:

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -474,38 +474,30 @@ class MapSequence:
 
         return MapSequenceAnimator(plot_sequence, **kwargs)
 
-    @property
-    def all_have_same_shape(self):
-        return np.all([m.data.shape == self.maps[0].data.shape for m in self.maps])
-
-    @deprecated(since='6.1', alternative='.all_have_same_shape')
+    @deprecated(since='6.1', alternative='.data')
     def all_maps_same_shape(self):
         """
         True if all the maps have the same number pixels along both axes.
         """
-        return self.all_have_same_shape
+        return np.all([m.data.shape == self.maps[0].data.shape for m in self.maps])
 
-    @property
-    def at_least_one_has_mask(self):
-        return np.any([m.mask is not None for m in self.maps])
-
-    @deprecated(since='6.1', alternative='.at_least_one_has_mask')
+    @deprecated(since='6.1', alternative='.mask')
     def at_least_one_map_has_mask(self):
         """
         True if at least one map has a mask
         """
-        return self.at_least_one_has_mask
+        return np.any([m.mask is not None for m in self.maps])
 
     @property
     def data(self):
-        if not self.all_have_same_shape:
+        if not np.all([m.data.shape == self[0].data.shape for m in self]):
             raise ValueError('Not all maps have the same shape.')
         data = np.asarray([m.data for m in self.maps])
         return np.swapaxes(np.swapaxes(data, 0, 1), 1, 2)
 
     @property
     def mask(self):
-        if not self.at_least_one_has_mask:
+        if not np.any([m.mask is not None for m in self.maps]):
             return
         mask = np.zeros_like(self.data, dtype=bool)
         for i, m in enumerate(self):

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -77,7 +77,7 @@ class MapSequence:
         # Optionally sort data
         if sortby is not None:
             if sortby not in self._sort_methods:
-                raise ValueError(f"sortby must be one of the following: {self._sort_methods.keys()}")
+                raise ValueError(f"sortby must be one of the following: {list(self._sort_methods.keys())}")
             self.maps.sort(key=self._sort_methods[sortby])
 
         if derotate:
@@ -351,7 +351,7 @@ class MapSequence:
                                                    self[i].spatial_units[1]))
 
         if resample:
-            if self.all_maps_same_shape():
+            if self.all_same_shape:
                 resample = u.Quantity(self.maps[0].dimensions) * np.array(resample)
                 ani_data = [amap.resample(resample) for amap in self.maps]
             else:
@@ -459,7 +459,7 @@ class MapSequence:
         from sunpy.visualization.animator.mapsequenceanimator import MapSequenceAnimator
 
         if resample:
-            if self.all_maps_same_shape():
+            if self.all_same_shape:
                 plot_sequence = MapSequence()
                 resample = u.Quantity(self.maps[0].dimensions) * np.array(resample)
                 for amap in self.maps:

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -56,7 +56,7 @@ class MapSequence:
 
     .. note:: The individual components of a `~sunpy.map.MapSequence` can be coaligned
               using the functions in `sunkit_image.coalignment` or using the
-              `~sunpy.map.GenericMap.reproject` method.
+              `~sunpy.map.GenericMap.reproject_to` method.
 
     Examples
     --------
@@ -536,7 +536,7 @@ class MapSequence:
         If all the map shapes are not the same, a ValueError is thrown.
         """
         data = self.data
-        if (mask:=self.mask) is not None:
+        if (mask := self.mask) is not None:
             return ma.masked_array(data, mask=mask)
         else:
             return data

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -57,7 +57,7 @@ def test_deprecations(mapsequence_all_the_same,
                       mapsequence_different):
     # TODO: Remove this in v7.1
     with pytest.warns(SunpyDeprecationWarning,
-                      match="The all_maps_same_shape function is deprecated and will be removed in sunpy 7.1. Use the data property instead."):
+                      match="The all_maps_same_shape function is deprecated and will be removed in sunpy 7.1. Use the all_same_shape property instead."):
         mapsequence_all_the_same.all_maps_same_shape()
     with pytest.warns(SunpyDeprecationWarning,
                       match='The at_least_one_map_has_mask function is deprecated and will be removed in sunpy 7.1. Use the mask property instead.'):

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -64,7 +64,7 @@ def test_deprecations(mapsequence_all_the_same,
         mapsequence_all_the_same.at_least_one_map_has_mask()
     with pytest.warns(SunpyDeprecationWarning,
                       match='The as_array function is deprecated and will be removed in sunpy 7.1. Use the data and mask properties instead.'):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Not all maps have the same shape.'):
             mapsequence_different.as_array()
     with pytest.warns(SunpyDeprecationWarning,
                       match="The all_meta function is deprecated and will be removed in sunpy 7.1. Use the meta property instead."):
@@ -77,7 +77,7 @@ def test_deprecations(mapsequence_all_the_same,
 
 def test_as_array_different_shapes(mapsequence_different):
     # Should raise a ValueError if the mapsequence has differently shaped maps
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Not all maps have the same shape.'):
         mapsequence_different.data
 
 

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -60,7 +60,7 @@ def test_deprecations(mapsequence_all_the_same,
                       match="The all_maps_same_shape function is deprecated and will be removed in sunpy 7.1. Use the data property instead."):
         mapsequence_all_the_same.all_maps_same_shape()
     with pytest.warns(SunpyDeprecationWarning,
-                      match='The all_maps_same_shape function is deprecated and will be removed in sunpy 7.1. Use the mask property instead.'):
+                      match='The at_least_one_map_has_mask function is deprecated and will be removed in sunpy 7.1. Use the mask property instead.'):
         mapsequence_all_the_same.at_least_one_map_has_mask()
     with pytest.raises(ValueError):
         with pytest.warns(SunpyDeprecationWarning,

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -62,9 +62,9 @@ def test_deprecations(mapsequence_all_the_same,
     with pytest.warns(SunpyDeprecationWarning,
                       match='The at_least_one_map_has_mask function is deprecated and will be removed in sunpy 7.1. Use the mask property instead.'):
         mapsequence_all_the_same.at_least_one_map_has_mask()
-    with pytest.raises(ValueError):
-        with pytest.warns(SunpyDeprecationWarning,
-                          match='The as_array function is deprecated and will be removed in sunpy 7.1. Use the data property instead.'):
+    with pytest.warns(SunpyDeprecationWarning,
+                      match='The as_array function is deprecated and will be removed in sunpy 7.1. Use the data and mask properties instead.'):
+        with pytest.raises(ValueError):
             mapsequence_different.as_array()
     with pytest.warns(SunpyDeprecationWarning,
                       match="The all_meta function is deprecated and will be removed in sunpy 7.1. Use the meta property instead."):

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -53,72 +53,55 @@ def mapsequence_different(aia171_test_map):
     return sunpy.map.Map([aia171_test_map, aia171_test_map.superpixel((4, 4) * u.pix)], sequence=True)
 
 
-def test_all_maps_same_shape(mapsequence_all_the_same, mapsequence_different):
-    """Make sure that Mapsequence knows if all the maps have the same shape"""
-    with pytest.warns(SunpyDeprecationWarning, match='The all_maps_same_shape function is deprecated'):
-        assert mapsequence_all_the_same.all_maps_same_shape()
-        assert not mapsequence_different.all_maps_same_shape()
-
-
-def test_at_least_one_map_has_mask(mapsequence_all_the_same,
-                                   mapsequence_all_the_same_all_have_masks,
-                                   mapsequence_all_the_same_some_have_masks):
-    """ Test that we can detect the presence of at least one masked map."""
-    with pytest.warns(SunpyDeprecationWarning, match='The at_least_one_map_has_mask function is deprecated'):
-        assert not mapsequence_all_the_same.at_least_one_map_has_mask()
-        assert mapsequence_all_the_same_all_have_masks.at_least_one_map_has_mask()
-        assert mapsequence_all_the_same_some_have_masks.at_least_one_map_has_mask()
+def test_deprecations(mapsequence_all_the_same,
+                      mapsequence_different):
+    # TODO: Remove this in v7.1
+    with pytest.warns(SunpyDeprecationWarning,
+                      match="The all_maps_same_shape function is deprecated and will be removed in sunpy 7.1. Use the data property instead."):
+        mapsequence_all_the_same.all_maps_same_shape()
+    with pytest.warns(SunpyDeprecationWarning,
+                      match='The all_maps_same_shape function is deprecated and will be removed in sunpy 7.1. Use the mask property instead.'):
+        mapsequence_all_the_same.at_least_one_map_has_mask()
+    with pytest.raises(ValueError):
+        with pytest.warns(SunpyDeprecationWarning,
+                          match='The as_array function is deprecated and will be removed in sunpy 7.1. Use the data property instead.'):
+            mapsequence_different.as_array()
+    with pytest.warns(SunpyDeprecationWarning,
+                      match="The all_meta function is deprecated and will be removed in sunpy 7.1. Use the meta property instead."):
+        mapsequence_all_the_same.all_meta()
+    with pytest.raises(NotImplementedError):
+        with pytest.warns(SunpyDeprecationWarning,
+                          match='"derotate" was deprecated in version 6.1 and will be removed in a future version.'):
+            sunpy.map.MapSequence(derotate=True)
 
 
 def test_as_array_different_shapes(mapsequence_different):
-    # Should raise a ValueError if the mapsequence has differently shaped maps in
-    # it.
+    # Should raise a ValueError if the mapsequence has differently shaped maps
     with pytest.raises(ValueError):
-        with pytest.warns(SunpyDeprecationWarning, match='The as_array function is deprecated'):
-            mapsequence_different.as_array()
+        mapsequence_different.data
 
 
 def test_as_array_no_masks(mapsequence_all_the_same):
     # Test the case when none of the maps have a mask
-    with pytest.warns(SunpyDeprecationWarning, match='The as_array function is deprecated'):
-        returned_array = mapsequence_all_the_same.as_array()
+    returned_array = mapsequence_all_the_same.data
     assert isinstance(returned_array, np.ndarray)
-    assert returned_array.ndim == 3
-    assert len(returned_array.shape) == 3
-    assert returned_array.shape[0] == 128
-    assert returned_array.shape[1] == 128
-    assert returned_array.shape[2] == 2
-    assert np.ma.getmask(returned_array) is np.ma.nomask
+    assert returned_array.shape == (128, 128, 2)
+    assert mapsequence_all_the_same.mask is None
 
 
 def test_as_array_all_masks(mapsequence_all_the_same_all_have_masks):
     # Test the case when all the maps have masks
-    with pytest.warns(SunpyDeprecationWarning, match='The as_array function is deprecated'):
-        returned_array = mapsequence_all_the_same_all_have_masks.as_array()
-    assert isinstance(returned_array, np.ma.masked_array)
-    data = np.ma.getdata(returned_array)
-    assert data.ndim == 3
-    assert len(data.shape) == 3
-    assert data.shape[0] == 128
-    assert data.shape[1] == 128
-    assert data.shape[2] == 2
-    mask = np.ma.getmask(returned_array)
-    assert mask.ndim == 3
-    assert len(mask.shape) == 3
-    assert mask.shape[0] == 128
-    assert mask.shape[1] == 128
-    assert mask.shape[2] == 2
+    data = mapsequence_all_the_same_all_have_masks.data
+    assert data.shape == (128, 128, 2)
+    mask = mapsequence_all_the_same_all_have_masks.mask
+    assert mask.shape == (128, 128, 2)
     assert mask.dtype == bool
 
 
 def test_as_array_some_masks(mapsequence_all_the_same_some_have_masks):
-    # Test the case when some of the maps have masks
-    with pytest.warns(SunpyDeprecationWarning, match='The as_array function is deprecated'):
-        returned_array = mapsequence_all_the_same_some_have_masks.as_array()
-    assert isinstance(returned_array, np.ma.masked_array)
-    data = np.ma.getdata(returned_array)
+    data = mapsequence_all_the_same_some_have_masks.data
     assert data.shape == (128, 128, 3)
-    mask = np.ma.getmask(returned_array)
+    mask = mapsequence_all_the_same_some_have_masks.mask
     assert mask.shape == (128, 128, 3)
     assert np.all(mask[0:2, 0:3, 0])
     assert np.all(mask[0:2, 0:3, 1])
@@ -126,15 +109,12 @@ def test_as_array_some_masks(mapsequence_all_the_same_some_have_masks):
 
 
 def test_all_meta(mapsequence_all_the_same):
-    """Tests that the correct number of map meta objects are returned, and
-    that they are all map meta objects."""
-    with pytest.warns(SunpyDeprecationWarning, match="The all_meta function is deprecated"):
-        mapsequence_all_the_same.all_meta()
     meta = mapsequence_all_the_same.meta
     assert len(meta) == 2
     assert np.all(np.asarray([isinstance(h, MetaDict) for h in meta]))
     assert np.all(np.asarray(
-        [meta[i] == mapsequence_all_the_same[i].meta for i in range(0, len(meta))]))
+        [meta[i] == mapsequence_all_the_same[i].meta for i in range(0, len(meta))]
+    ))
 
 
 def test_repr(mapsequence_all_the_same, mapsequence_different_maps):
@@ -156,13 +136,6 @@ def test_repr(mapsequence_all_the_same, mapsequence_different_maps):
     assert obtained_out.startswith(object.__repr__(mapsequence_different_maps))
     assert len(mapsequence_different_maps) == 2
     assert expected_out1 in obtained_out or expected_out2 in obtained_out
-
-
-def test_derotate():
-    with pytest.raises(NotImplementedError):
-        with pytest.warns(SunpyDeprecationWarning,
-                          match='"derotate" was deprecated in version 6.1 and will be removed in a future version.'):
-            sunpy.map.MapSequence(derotate=True)
 
 
 def test_repr_html(mapsequence_all_the_same):

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -309,7 +309,7 @@ def test_jsoc_cutout_attrs(client, jsoc_test_email, aia171_test_map):
     assert len(files) == 6
     m = sunpy.map.Map(files, sequence=True)
     assert m.all_maps_same_shape()
-    assert m.as_array().shape == (1085, 1085, 6)
+    assert m.data.shape == (1085, 1085, 6)
 
 
 def test_row_and_warning(mocker, client, jsoc_response_double):

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -308,7 +308,6 @@ def test_jsoc_cutout_attrs(client, jsoc_test_email, aia171_test_map):
     files = client.get_request(req)
     assert len(files) == 6
     m = sunpy.map.Map(files, sequence=True)
-    assert m.all_maps_same_shape()
     assert m.data.shape == (1085, 1085, 6)
 
 


### PR DESCRIPTION
This PR does a bunch of miscellaneous cleanup on `MapSequence`. Some of it is more controversial than others so I'm happy to remove some parts or move things to other parts as needed. Overall, my aim has been to make the API closer to that of `GenericMap` but with an added dimension. 

Summary of changes below:

- Deprecate the `derotate` keyword. As far as I can tell, this has never actually done anything. 
- Refactor logic of how sort-by methods are selected. This is all internal
- Deprecate the `resample` kwarg in `plot`. This is a separation-of-concerns issue. Why should `plot` be doing any resampling? If you want to plot a resampled map, resample it yourself first.
- Deprecate `resample` in `peek`. See above.
- Do not allow for non-WCS axes to be passed to `plot`. We've not allowed this on `Map` for a long time. I'm not even sure it would work here. I've not deprecated this because I consider it undocumented behavior to begin with.
- Deprecate the method `all_maps_same_shape`. I don't see any need for this to be part of the public API. 
- Deprecate the method `at_least_one_map_has_mask`. Same as above.
- Deprecate the method `as_array` in favor of the new properties `data` and `mask`. Previously, `as_array` returned a masked array if at least one map held a mask and a bare array if not. This refactor now separates these properties similar to how `GenericMap` treats them
- Deprecate the method `all_meta` in favor of the new property `meta`

My aim was to deprecate things rather than remove them outright as that would constitute a breaking change. However, if there's no opposition, I'm also happy to outright break things. 