### PR TITLE
Fixed some issues related to WCSAxes in astropy 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       toxdeps: tox-pypi-filter
       posargs: -n auto --color=yes
       envs: |
-        - linux: py313
+        - linux: py312
           libraries:
             apt:
               - libopenjp2-7
@@ -54,6 +54,7 @@ jobs:
             apt:
               - libopenjp2-7
         - linux: py310
+        - linux: py313
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/changelog/7857.bugfix.rst
+++ b/changelog/7857.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with axis labels when plotting a `~sunpy.map.Map` that could conflict with automatic label positioning in astropy 7.0.

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -577,7 +577,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
         # we can not easily prevent this, so we check the specific function is being called
         # within the stack trace.
         stack_trace = traceback.format_stack()
-        matching_string = 'wcsaxes.*_draw_grid'
+        matching_string = 'wcsaxes.*(_draw_grid|_update_ticks)'
         bypass = any([re.search(matching_string, string) for string in stack_trace])
         if not bypass and np.all(np.isnan(d)) and np.any(np.isfinite(cos_alpha)):
             warn_user("The conversion of these 2D helioprojective coordinates to 3D is all NaNs "

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2656,13 +2656,9 @@ class GenericMap(NDData):
 
             # WCSAxes has unit identifiers on the tick labels, so no need
             # to add unit information to the label
-            spatial_units = [None, None]
             ctype = axes.wcs.wcs.ctype
-
-            axes.set_xlabel(axis_labels_from_ctype(ctype[0],
-                                                   spatial_units[0]))
-            axes.set_ylabel(axis_labels_from_ctype(ctype[1],
-                                                   spatial_units[1]))
+            axes.coords[0].set_axislabel(axis_labels_from_ctype(ctype[0], None))
+            axes.coords[1].set_axislabel(axis_labels_from_ctype(ctype[1], None))
 
         # Take a deep copy here so that a norm in imshow_kwargs doesn't get modified
         # by setting it's vmin and vmax


### PR DESCRIPTION
Fixes #7856

- Set WCSAxes axis labels properly because WCSAxes can now swap the axes
- Expanded the suppression of the Helioprojective NaN warning (see #5817) because ticks are now updated through lots of code paths