### PR TITLE
Use a fixed time in the past for the gallery example with STEREO locations

### DIFF
--- a/examples/showcase/where_is_stereo.py
+++ b/examples/showcase/where_is_stereo.py
@@ -27,6 +27,7 @@ from sunpy.time import parse_time
 ##############################################################################
 # Define the time for the plot as the time when this script is run.
 
+# This time is fixed as the ephemeris information for  STEREO-B is no longer generated
 obstime = parse_time('2024-Oct-17 20:23')
 
 ##############################################################################

--- a/examples/showcase/where_is_stereo.py
+++ b/examples/showcase/where_is_stereo.py
@@ -27,7 +27,7 @@ from sunpy.time import parse_time
 ##############################################################################
 # Define the time for the plot as the time when this script is run.
 
-obstime = parse_time('now')
+obstime = parse_time('2024-Oct-17 20:23')
 
 ##############################################################################
 # Define a convenience function to extract the first full orbit from a


### PR DESCRIPTION
The gallery example that reproduces the "Where is STEREO?" plot can no longer plot the location of STEREO-B because ephemeris information is no longer generated (communication with STEREO-B was lost over a decade ago).  This PR changes the example so that instead of generating the plot for "now", it generates it for the time of the sunpy 6.0.3 docs.