### PR TITLE
Added link to VSO Health Report in Fido VSOClient output

### DIFF
--- a/changelog/7884.feature.rst
+++ b/changelog/7884.feature.rst
@@ -1,0 +1,1 @@
+Add a link to the VSO Health Report in the Fido Results when using the VSOClient.

--- a/sunpy/net/dataretriever/sources/lyra.py
+++ b/sunpy/net/dataretriever/sources/lyra.py
@@ -25,23 +25,24 @@ class LYRAClient(GenericClient):
     4 Results from the LYRAClient:
     Source: http://proba2.oma.be/lyra/data/bsd
     <BLANKLINE>
-           Start Time               End Time        Instrument ... Provider Level
-    ----------------------- ----------------------- ---------- ... -------- -----
-    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999       LYRA ...      ESA     2
-    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999       LYRA ...      ESA     3
-    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999       LYRA ...      ESA     2
-    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999       LYRA ...      ESA     3
+           Start Time               End Time        Instrument  Physobs   Source Provider Level
+    ----------------------- ----------------------- ---------- ---------- ------ -------- -----
+    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999       LYRA irradiance PROBA2      ESA     2
+    2016-01-01 00:00:00.000 2016-01-01 23:59:59.999       LYRA irradiance PROBA2      ESA     3
+    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999       LYRA irradiance PROBA2      ESA     2
+    2016-01-02 00:00:00.000 2016-01-02 23:59:59.999       LYRA irradiance PROBA2      ESA     3
     <BLANKLINE>
     3 Results from the VSOClient:
     Source: https://sdac.virtualsolar.org/cgi/search
+    Data retrieval status: https://docs.virtualsolar.org/wiki/VSOHealthReport
     Total estimated size: 2.914 Gbyte
     <BLANKLINE>
-           Start Time               End Time        Source ... Extent Type   Size
-                                                           ...              Mibyte
-    ----------------------- ----------------------- ------ ... ----------- --------
-    2016-01-01 09:41:00.000 2016-01-01 10:40:00.000 PROBA2 ...         N/A  2328.75
-    2016-01-01 09:41:00.000 2016-01-01 10:40:00.000 PROBA2 ...         N/A 419.0625
-    2016-01-01 09:41:00.000 2016-01-01 10:40:00.000 PROBA2 ...         N/A  30.9375
+           Start Time               End Time        Source Instrument    Wavelength    Provider  Physobs   Wavetype Extent Type   Size
+                                                                          Angstrom                                               Mibyte
+    ----------------------- ----------------------- ------ ---------- ---------------- -------- ---------- -------- ----------- --------
+    2016-01-01 09:41:00.000 2016-01-01 10:40:00.000 PROBA2       LYRA 1200.0 .. 1230.0      ESA irradiance      euv         N/A  2328.75
+    2016-01-01 09:41:00.000 2016-01-01 10:40:00.000 PROBA2       LYRA 1200.0 .. 1230.0      ESA irradiance      euv         N/A 419.0625
+    2016-01-01 09:41:00.000 2016-01-01 10:40:00.000 PROBA2       LYRA 1200.0 .. 1230.0      ESA irradiance      euv         N/A  30.9375
     <BLANKLINE>
     <BLANKLINE>
     """

--- a/sunpy/net/dataretriever/sources/tests/test_noaa.py
+++ b/sunpy/net/dataretriever/sources/tests/test_noaa.py
@@ -215,6 +215,7 @@ def test_srs_start_or_end_out_of_range(srs_client):
     res = srs_client.search(a.Time('1995/12/30', '1996/01/02'))
     assert len(res) == 1
     cur_year = datetime.date.today().year
+    # Will fail on the first day of the next year.
     res = srs_client.search(a.Time(f'{cur_year}/01/01', f'{cur_year+2}/01/01'))
     assert len(res) > 0
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -206,8 +206,8 @@ def test_repr():
         a.Time("2012/1/1", "2012/1/2"), a.Instrument.lyra)
     rep = repr(results)
     rep = rep.split('\n')
-    # 9 header lines, the results table and two blank lines at the end
-    assert len(rep) == 9 + len(list(results)[0]) + 2
+    # 6 preamble lines, 2 table header rule, the results table data and two blank lines at the end
+    assert len(rep) == 6 + 2 + len(results[0]) + 2
 
 
 def filter_queries(queries):

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -206,8 +206,8 @@ def test_repr():
         a.Time("2012/1/1", "2012/1/2"), a.Instrument.lyra)
     rep = repr(results)
     rep = rep.split('\n')
-    # 8 header lines, the results table and two blank lines at the end
-    assert len(rep) == 8 + len(list(results)[0]) + 2
+    # 9 header lines, the results table and two blank lines at the end
+    assert len(rep) == 9 + len(list(results)[0]) + 2
 
 
 def filter_queries(queries):

--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -690,4 +690,4 @@ class VSOClient(BaseClient):
 
     @property
     def info_url(self):
-        return 'https://sdac.virtualsolar.org/cgi/search'
+        return 'https://sdac.virtualsolar.org/cgi/search\nData retrieval status: https://docs.virtualsolar.org/wiki/VSOHealthReport'


### PR DESCRIPTION
This pull request introduces an update to the output of the Fido results when using the VSOClient. The change adds a link to the latest VSO Health Report, which provides up-to-date status on VSO data retrieval. 

### Changes
The output of the Fido results now includes the followinf string: 
`Latest VSO data retrieval status available at https://docs.virtualsolar.org/wiki/VSOHealthReport`
This will provide users with a direct link to the VSO Health Report for more status on the data  retrieval

### Example Output:
```
Results from 1 Provider:

1 Results from the VSOClient:
Source: http://vso.stanford.edu/cgi-bin/search
Total estimated size: 67.789 Mbyte

       Start Time               End Time        Source Instrument   Wavelength   Provider  Physobs  Wavetype Extent Width Extent Length Extent Type   Size  
                                                                     Angstrom                                                                        Mibyte 
----------------------- ----------------------- ------ ---------- -------------- -------- --------- -------- ------------ ------------- ----------- --------
2012-03-04 00:00:00.000 2012-03-04 00:00:01.000    SDO        AIA 171.0 .. 171.0     JSOC intensity   NARROW         4096          4096    FULLDISK 64.64844

Latest VSO data retrieval status available at https://docs.virtualsolar.org/wiki/VSOHealthReport
```
Feel free to leave any feedback or suggestions on this change. Thanks

### Related Issue:
- Resolves #7853 



