### PR TITLE
Fix cache configuration for tests against astropy 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           conda list
           cd /tmp
           pytest -vvv -r a --pyargs sunpy --cov-report=xml --cov=sunpy --cov-config=$GITHUB_WORKSPACE/pyproject.toml $GITHUB_WORKSPACE/docs -n auto --color=yes
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/docs/tutorial/units.rst
+++ b/docs/tutorial/units.rst
@@ -94,7 +94,7 @@ If we try to convert a wavelength to energy using what we learned in the previou
    ...
    astropy...UnitConversionError: 'm' (length) and 'keV' (energy/torque/work) are not convertible
 
-However, we can perform this conversion using the `~astropy.units.equivalencies.spectral` equivalency:
+However, we can perform this conversion using the `~astropy.units.spectral` equivalency:
 
 .. code-block:: python
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -96,5 +96,4 @@ filterwarnings =
     # Devdeps for timeseries raising this
     ignore:This axis already has a converter set and is updating to a potentially incompatible converter:UserWarning
     # Oldestdeps via asdf
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
-    ignore:Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`:DeprecationWarning
+    ignore:.*pkg_resources.*:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -95,3 +95,5 @@ filterwarnings =
     ignore:The `hash` argument is deprecated in favor of `unsafe_hash` and will be removed in or after August 2025:DeprecationWarning
     # Devdeps for timeseries raising this
     ignore:This axis already has a converter set and is updating to a potentially incompatible converter:UserWarning
+    # Oldestdeps via asdf
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -97,3 +97,4 @@ filterwarnings =
     ignore:This axis already has a converter set and is updating to a potentially incompatible converter:UserWarning
     # Oldestdeps via asdf
     ignore:pkg_resources is deprecated as an API:DeprecationWarning
+    ignore:Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`:DeprecationWarning

--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -59,8 +59,8 @@ def tmp_config_dir(request):
     tmpdir = tempfile.TemporaryDirectory()
 
     os.environ["SUNPY_CONFIGDIR"] = str(tmpdir.name)
-    astropy.config.paths.set_temp_config._temp_path = str(tmpdir.name)
-    astropy.config.paths.set_temp_cache._temp_path = str(tmpdir.name)
+    astropy.config.paths.set_temp_config._temp_path = pathlib.Path(tmpdir.name)
+    astropy.config.paths.set_temp_cache._temp_path = pathlib.Path(tmpdir.name)
 
     yield
 

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -326,9 +326,9 @@ class TimeRange:
 
         Parameters
         ----------
-        cadence : `astropy.units.Quantity`, `astropy.time.TimeDelta`
+        cadence : `~astropy.units.quantity.Quantity`, `astropy.time.TimeDelta`
             Cadence.
-        window : `astropy.units.quantity`, `astropy.time.TimeDelta`
+        window : `~astropy.units.quantity.Quantity`, `astropy.time.TimeDelta`
             The length of window.
 
         Returns

--- a/sunpy/visualization/colormaps/color_tables.py
+++ b/sunpy/visualization/colormaps/color_tables.py
@@ -105,7 +105,7 @@ def aia_color_table(wavelength: u.angstrom):
 
     Parameters
     ----------
-    wavelength : `~astropy.units.quantity`
+    wavelength : `~astropy.units.quantity.Quantity`
         Wavelength for the desired AIA color table.
     """
     aia_wave_dict = create_aia_wave_dict()


### PR DESCRIPTION
Astropy 7 switched to using pathlib.Path in internal configuration, but we provide strings in our configuration for testing