### PR TITLE
updated rhessi.py(Summary lightcurves docstring)

### DIFF
--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -104,7 +104,7 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
 
     Summary lightcurves are quicklook data products intended for rapid assessment and
     are not science-quality data. They are uncorrected for instrumental effects and
-    backgrounds
+    backgrounds.
 
     RHESSI provides summary lightcurves in the following passbands:
 

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -102,6 +102,10 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
     Each spectrometer is coupled to a set of grids with different pitches which enable
     fourier-style imaging as the spacecraft spins.
 
+    Summary lightcurves are quicklook data products intended for rapid assessment and
+    are not science-quality data. They are uncorrected for instrumental effects and
+    backgrounds
+
     RHESSI provides summary lightcurves in the following passbands:
 
     * 3 - 6 keV


### PR DESCRIPTION
## PR Description
Fixes #7786
Improves the description for `RHESSISummaryTimeSeries`.
It now improves on the docstring that explains what is meant by "summary" lightcurves.
