### PR TITLE
Handle missing 'FILLVAL' attribute in CDF reader

### DIFF
--- a/sunpy/io/_cdf.py
+++ b/sunpy/io/_cdf.py
@@ -90,7 +90,11 @@ def read_cdf(fname, **kwargs):
             # It would be nice to properley mask these values to work with
             # non-floating point (ie. int) dtypes, but this is not possible with pandas
             if np.issubdtype(data.dtype, np.floating):
-                data[data == attrs['FILLVAL']] = np.nan
+                if 'FILLVAL' in attrs:
+                    data[data == attrs['FILLVAL']] = np.nan
+                else:
+                    log.debug(f"No 'FILLVAL' attribute found for variable {var_key}.")
+
 
             # Get units
             if 'UNITS' in attrs:


### PR DESCRIPTION


## PR Description

This PR addresses an issue in the ```_cdf.py``` file where the CDF reader would raise a ```KeyError``` if the ```FILLVAL``` attribute was not present in the variable attributes of a CDF file. The fix ensures the code checks for the existence of 'FILLVAL' before accessing it, providing a more robust and error-free experience.

1. Added a conditional check to verify if 'FILLVAL' exists in attrs before attempting to use it.
2. If 'FILLVAL' is not present, a debug log message is generated to notify the user.
3. Prevents unnecessary crashes when processing CDF files that lack the 'FILLVAL' attribute.

![Screenshot 2024-12-10 100617](https://github.com/user-attachments/assets/4620934d-0103-4eef-9157-db029d9bcd26)


This fixes #7565 

