### PR TITLE
Handle Missing FILLVAL in read_cdf for Non-Standard CDF Files

### DIFF
--- a/sunpy/io/_cdf.py
+++ b/sunpy/io/_cdf.py
@@ -89,9 +89,10 @@ def read_cdf(fname, **kwargs):
             # Set fillval values to NaN
             # It would be nice to properley mask these values to work with
             # non-floating point (ie. int) dtypes, but this is not possible with pandas
-            if np.issubdtype(data.dtype, np.floating):
+            if np.issubdtype(data.dtype, np.floating) and 'FILLVAL' in attrs:
                 data[data == attrs['FILLVAL']] = np.nan
-
+            else:
+                warn_user("FILLVAL attribute missing in variable attributes.")
             # Get units
             if 'UNITS' in attrs:
                 unit_str = attrs['UNITS']

--- a/sunpy/io/tests/test_cdf.py
+++ b/sunpy/io/tests/test_cdf.py
@@ -8,8 +8,7 @@ from sunpy.io._cdf import read_cdf
 from sunpy.timeseries import GenericTimeSeries
 
 filepath = get_test_filepath('solo_L2_epd-ept-north-hcad_20200713_V02.cdf')
-
-
+           
 def test_read_cdf():
     all_ts = read_cdf(filepath)
     assert isinstance(all_ts, list)


### PR DESCRIPTION

## PR Description

Description:
This PR addresses an issue where read_cdf crashes when a CDF file lacks the FILLVAL attribute. A conditional check was added to verify the presence of FILLVAL in variable attributes before attempting to replace its values with NaN. Logs a warning when FILLVAL is missing to notify the user while maintaining functionality.

Changes:
Updated sunpy/io/_cdf.py to include a safe fallback for missing FILLVAL.
Added a warning message using Python's warnings module for better user awareness.

Testing:
All existing tests pass.