### PR TITLE
Rename `get_contours` to `find_contours`

### DIFF
--- a/changelog/7760.deprecation.rst
+++ b/changelog/7760.deprecation.rst
@@ -1,2 +1,2 @@
-:meth:`sunpy.map.GenericMap.contour` is deprecated in favor of :meth:`sunpy.map.GenericMap.get_contours`.
+:meth:`sunpy.map.GenericMap.contour` is deprecated in favor of :meth:`sunpy.map.GenericMap.find_contours`.
 Note that ContourPy, now used for contour generation, may produce different results and does not support all scikit-image keyword arguments.

--- a/changelog/7760.feature.rst
+++ b/changelog/7760.feature.rst
@@ -1,3 +1,3 @@
-Added :meth:`~sunpy.map.GenericMap.get_contours` for getting contours from a `~sunpy.map.Map`.
+Added :meth:`~sunpy.map.GenericMap.find_contours` for getting contours from a `~sunpy.map.Map`.
 By default the method uses ContourPy for performance reasons and consistency with :meth:`sunpy.map.GenericMap.draw_contours`.
 One can alternatively specify that the method use scikit-image.

--- a/examples/map/map_contouring.py
+++ b/examples/map/map_contouring.py
@@ -29,7 +29,7 @@ print(aiamap.unit)
 # chose a contour level, and use the :meth:`~sunpy.map.GenericMap.contour`
 # method to extract the contours.
 
-contours = aiamap.get_contours(50000 * u.DN)
+contours = aiamap.find_contours(50000 * u.DN)
 
 ##############################################################################
 # Finally, we can plot the map, and add each of the contours in turn.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2715,7 +2715,7 @@ class GenericMap(NDData):
 
         return ret
 
-    @deprecated(since="6.1", alternative="sunpy.map.GenericMap.get_contours")
+    @deprecated(since="6.1", alternative="sunpy.map.GenericMap.find_contours")
     def contour(self, level, **kwargs):
         """
         Returns coordinates of the contours for a given level value.
@@ -2773,7 +2773,7 @@ class GenericMap(NDData):
         contours = [self.wcs.array_index_to_world(c[:, 0], c[:, 1]) for c in contours]
         return contours
 
-    def get_contours(self, level, method='contourpy', **kwargs):
+    def find_contours(self, level, method='contourpy', **kwargs):
         """
         Returns coordinates of the contours for a given level value.
 
@@ -2804,7 +2804,7 @@ class GenericMap(NDData):
         >>> import sunpy.map
         >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
         >>> aia = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)  # doctest: +REMOTE_DATA +IGNORE_WARNINGS
-        >>> contours = aia.get_contours(50000 * u.DN, method='contourpy')  # doctest: +REMOTE_DATA
+        >>> contours = aia.find_contours(50000 * u.DN, method='contourpy')  # doctest: +REMOTE_DATA
         >>> contours[0]  # doctest: +REMOTE_DATA
         <SkyCoord (Helioprojective: obstime=2011-06-07T06:33:02.880, rsun=696000.0 km, observer=<HeliographicStonyhurst Coordinate (obstime=2011-06-07T06:33:02.880, rsun=696000.0 km): (lon, lat, radius) in (deg, deg, m)
             (-0.00406429, 0.04787238, 1.51846026e+11)>): (Tx, Ty) in arcsec

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1464,16 +1464,16 @@ def test_submap_inputs(generic_map2, coords):
 
 def test_contour_deprecation_warning(simple_map):
 
-    with pytest.warns(SunpyDeprecationWarning, match="The contour function is deprecated and may be removed in a future version.\\s+Use sunpy.map.GenericMap.get_contours instead."):
+    with pytest.warns(SunpyDeprecationWarning, match="The contour function is deprecated and may be removed in a future version.\\s+Use sunpy.map.GenericMap.find_contours instead."):
         simple_map.contour(1.5)
 
 
-def test_get_contours_contourpy(simple_map):
+def test_find_contours_contourpy(simple_map):
     data = np.ones(simple_map.data.shape)
     data[4, 4] = 2
     simple_map = sunpy.map.Map(data, simple_map.meta)
     # 4 is the central pixel of the map, so contour half way between 1 and 2
-    contours = simple_map.get_contours(1.5, method='contourpy')
+    contours = simple_map.find_contours(1.5, method='contourpy')
     assert len(contours) == 1
     contour = contours[0]
     assert contour.observer.lat == simple_map.observer_coordinate.frame.lat
@@ -1482,15 +1482,15 @@ def test_get_contours_contourpy(simple_map):
     assert u.allclose(contour.Tx, [-1, 0, 1, 0, -1] * u.arcsec, atol=1e-10 * u.arcsec)
     assert u.allclose(contour.Ty, [ 0, -0.5, 0, 0.5, 0] * u.arcsec, atol=1e-10 * u.arcsec)
     with pytest.raises(ValueError, match='level must be a single scalar value'):
-        simple_map.get_contours([1.5, 2.5])
+        simple_map.find_contours([1.5, 2.5])
 
 
-def test_get_contours_skimage(simple_map):
+def test_find_contours_skimage(simple_map):
     data = np.ones(simple_map.data.shape)
     data[4, 4] = 2
     simple_map = sunpy.map.Map(data, simple_map.meta)
     # 4 is the central pixel of the map, so contour half way between 1 and 2
-    contours = simple_map.get_contours(1.5, method='skimage')
+    contours = simple_map.find_contours(1.5, method='skimage')
     assert len(contours) == 1
     contour = contours[0]
     assert contour.observer.lat == simple_map.observer_coordinate.frame.lat
@@ -1499,37 +1499,37 @@ def test_get_contours_skimage(simple_map):
     assert u.allclose(contour.Tx, [0, -1, 0, 1, 0] * u.arcsec, atol=1e-10 * u.arcsec)
     assert u.allclose(contour.Ty, [0.5, 0, -0.5, 0, 0.5] * u.arcsec, atol=1e-10 * u.arcsec)
     with pytest.raises(ValueError, match='level must be a single scalar value'):
-        simple_map.get_contours([1.5, 2.5])
+        simple_map.find_contours([1.5, 2.5])
 
 
-def test_get_contours_invalid_library(simple_map):
+def test_find_contours_invalid_library(simple_map):
     with pytest.raises(ValueError, match="Unknown method 'invalid_method'. Use 'contourpy' or 'skimage'."):
-        simple_map.get_contours(1.5, method='invalid_method')
+        simple_map.find_contours(1.5, method='invalid_method')
 
 
-def test_get_contours_units(simple_map):
+def test_find_contours_units(simple_map):
     # Check that contouring with units works as intended
     simple_map.meta['bunit'] = 'm'
     # Same units
-    contours = simple_map.get_contours(1.5 * u.m)
+    contours = simple_map.find_contours(1.5 * u.m)
     assert len(contours) == 1
 
     # Different units, but convertible
-    contours_cm = simple_map.get_contours(150 * u.cm)
+    contours_cm = simple_map.find_contours(150 * u.cm)
     for c1, c2 in zip(contours, contours_cm):
         assert np.all(c1 == c2)
 
     # Percentage
-    contours_percent = simple_map.get_contours(50 * u.percent)
+    contours_percent = simple_map.find_contours(50 * u.percent)
     high = np.max(simple_map.data)
     low = np.min(simple_map.data)
     middle = high - (high - low) / 2
-    contours_ref = simple_map.get_contours(middle * simple_map.unit)
+    contours_ref = simple_map.find_contours(middle * simple_map.unit)
     for c1, c2 in zip(contours_percent, contours_ref):
         assert np.all(c1 == c2)
 
 
-def test_get_contours_inputs(simple_map):
+def test_find_contours_inputs(simple_map):
     with pytest.raises(ValueError, match='Contour levels must be increasing'):
         simple_map.draw_contours([10, -10] * u.dimensionless_unscaled)
     with pytest.raises(ValueError, match=re.escape('The provided level (1000.0) is not smaller than the maximum data value (80)')):
@@ -1540,22 +1540,22 @@ def test_get_contours_inputs(simple_map):
     with pytest.raises(TypeError, match='The levels argument has no unit attribute'):
         simple_map.draw_contours(1.5)
     with pytest.raises(TypeError, match='The levels argument has no unit attribute'):
-        simple_map.get_contours(1.5)
+        simple_map.find_contours(1.5)
 
     with pytest.raises(u.UnitsError, match=re.escape("'s' (time) and 'm' (length) are not convertible")):
         simple_map.draw_contours(1.5 * u.s)
     with pytest.raises(u.UnitsError, match=re.escape("'s' (time) and 'm' (length) are not convertible")):
-        simple_map.get_contours(1.5 * u.s)
+        simple_map.find_contours(1.5 * u.s)
 
     # With no units, check that dimensionless works
     simple_map.meta.pop('bunit')
     simple_map.draw_contours(1.5 * u.dimensionless_unscaled)
-    simple_map.get_contours(1.5 * u.dimensionless_unscaled)
+    simple_map.find_contours(1.5 * u.dimensionless_unscaled)
 
     with pytest.raises(u.UnitsError, match='This map has no unit'):
         simple_map.draw_contours(1.5 * u.m)
     with pytest.raises(u.UnitsError, match='This map has no unit'):
-        simple_map.get_contours(1.5 * u.m)
+        simple_map.find_contours(1.5 * u.m)
 
 
 def test_print_map(generic_map):


### PR DESCRIPTION
As discussed in #7910, this PR changes `GenericMap.get_contours` to `GenericMap.find_contours`

Fixes #7910