### PR TITLE
Adds Support to `datetime.timedelta` , `astropy.units.Quantity` in `sunpy.time.TimeRange.shift`

### DIFF
--- a/changelog/7931.bugfix.rst
+++ b/changelog/7931.bugfix.rst
@@ -1,1 +1,1 @@
-:meth:`sunpy.time.TimeRange.shift` now adjusts the TimeRange to start or end at the nearest bound of the timeseries if the input timerange is out of bound.
+Fixed a time-ordering bug in :meth:`sunpy.time.TimeRange.shift` when the shifted start time is later than than the shifted end time.

--- a/changelog/7931.bugfix.rst
+++ b/changelog/7931.bugfix.rst
@@ -1,0 +1,1 @@
+:meth:`sunpy.time.TimeRange.shift` now adjusts the TimeRange to start or end at the nearest bound of the timeseries if the input timerange is out of bound.

--- a/changelog/7931.feature.rst
+++ b/changelog/7931.feature.rst
@@ -1,1 +1,1 @@
-:meth:`~sunpy.time.TimeRange.extend` can now accept inputs of type `datetime.timedelta` and `astropy.units.Quantity`.
+:meth:`sunpy.time.TimeRange.shift` can now accept inputs of type `datetime.timedelta` and `astropy.units.Quantity`.

--- a/changelog/7931.feature.rst
+++ b/changelog/7931.feature.rst
@@ -1,0 +1,1 @@
+:meth:`~sunpy.time.TimeRange.extend` can now accept inputs of type `datetime.timedelta` and `astropy.units.Quantity`.

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -239,13 +239,33 @@ def test_previous():
     assert timerange.dt == delta
 
 
-def test_shift():
+@pytest.mark.parametrize(("delta_1", "delta_2"), [
+    (5*u.s, 10*u.s),
+    (5*u.s, delta),
+    (delta, 5*u.s),
+    (timedelta(1,2,3), timedelta(2,2,3)),
+    (timedelta(1,2,3), delta),
+    (delta, timedelta(1,2,3)),
+])
+def test_shift(delta_1, delta_2):
     timerange = sunpy.time.TimeRange(tbegin_str, tfin_str)
-    timerange.shift(delta, delta)
+    timerange.shift(delta_1, delta_2)
     assert isinstance(timerange, sunpy.time.TimeRange)
-    assert timerange.start == start + delta
-    assert timerange.end == end + delta
-    assert timerange.dt == delta
+    assert timerange.start == start + TimeDelta(delta_1)
+    assert timerange.end == end + TimeDelta(delta_2)
+
+
+def test_shift_end_start():
+    # Checks when start + delta_1 > end + delta_2
+    start, end = datetime(2012, 1, 1), datetime(2012, 1, 10)
+    delta_1, delta_2 = timedelta(days=15), timedelta(days=2)
+
+    timerange = sunpy.time.TimeRange(start, end)
+    timerange.shift(delta_1, delta_2)
+    assert isinstance(timerange, sunpy.time.TimeRange)
+    assert timerange.start == Time(end + delta_2)
+    assert timerange.end == Time(start + delta_1)
+    assert timerange.dt == TimeDelta(start + delta_1 - end - delta_2)
 
 
 def test_contains(timerange_a):

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -240,6 +240,8 @@ def test_previous():
 
 
 @pytest.mark.parametrize(("delta_1", "delta_2"), [
+    (delta, delta),
+    (-delta, delta),
     (5*u.s, 10*u.s),
     (5*u.s, delta),
     (delta, 5*u.s),

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -410,14 +410,19 @@ class TimeRange:
 
         Parameters
         ----------
-        dt_start : `astropy.time.TimeDelta`
+        dt_start : `astropy.time.TimeDelta`, `datetime.timedelta`, `astropy.units.Quantity`
             The amount to shift the start time.
-        dt_end : `astropy.time.TimeDelta`
+        dt_end : `astropy.time.TimeDelta`, `datetime.timedelta`, `astropy.units.Quantity`
             The amount to shift the end time.
         """
-        # TODO: Support datetime.timedelta
+        dt_start = TimeDelta(dt_start, scale=self.dt.scale) if not isinstance(dt_start, TimeDelta) else dt_start
+        dt_end = TimeDelta(dt_end, scale=self.dt.scale) if not isinstance(dt_end, TimeDelta) else dt_end
+
         self._t1 = self._t1 + dt_start
         self._t2 = self._t2 + dt_end
+
+        if self._t1 > self._t2:
+            self._t1, self._t2 = self._t2, self._t1
 
     @deprecated('6.1', alternative='sunpy.time.TimeRange.shift')
     def extend(self, dt_start, dt_end):


### PR DESCRIPTION
## PR Description
 
This pr
- [x]  Add Support to `datetime.timedelta`, `astropy.units.Quantity` in `sunpy.time.TimeRange.shift`
- [x] Add Unit tests
- [x] Add changelog 


this added feature also handles cases when `TimeRange.start` + delta_1 > `TimeRange.end` + delta_2