### PR TITLE
Adds custom energy bin support for Fermi/GBM TimeSeries

### DIFF
--- a/changelog/7943.feature.rst
+++ b/changelog/7943.feature.rst
@@ -1,2 +1,2 @@
-Added a function :func:`sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries.energy_bins` to give `sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries` with custom energy bins.
-Added a keyword `energy_bands` for creating `sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries` with custom energy bins while initializing it.
+Added a function ``sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries.energy_bins`` to create a new `sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries` with user-specified energy bins.
+You can now pass a keyword ``energy_bands`` to create a `sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries` with custom energy bins.

--- a/changelog/7943.feature.rst
+++ b/changelog/7943.feature.rst
@@ -1,0 +1,2 @@
+Added a function :func:`sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries.energy_bins` to give `sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries` with custom energy bins.
+Added a keyword `energy_bands` for creating `sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries` with custom energy bins while initializing it.

--- a/sunpy/tests/figure_hashes_mpl_382_ft_261_astropy_600_animators_111.json
+++ b/sunpy/tests/figure_hashes_mpl_382_ft_261_astropy_600_animators_111.json
@@ -62,7 +62,7 @@
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hpc_adaptive": "40cb43b7431941e8977449f5ed5d1439e7dddf9f0ec0aa21d0c18f09a25e259c",
   "sunpy.timeseries.sources.tests.test_eve.test_esp_peek": "28b1e7af0e1894d22fd9db90d9e2bc5eb76e291c9e41fa1bb1d33d95bd13cce3",
   "sunpy.timeseries.sources.tests.test_eve.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
-  "sunpy.timeseries.sources.tests.test_fermi_gbm.test_fermi_gbm_peek": "83f0b53ca6f1cd809bd03e4aff80b3c02c8078e552b0c3e90b2cb3cf26932a51",
+  "sunpy.timeseries.sources.tests.test_fermi_gbm.test_fermi_gbm_peek": "1f80410f92458ad609189f4653928a566e8bea207a8dd6794bd65abf691b3ffc",
   "sunpy.timeseries.sources.tests.test_goes.test_goes_peek": "2f01b5430fe0295b7c8bc5bccef6c3356d5eed62c1236a2790e122fba2ead267",
   "sunpy.timeseries.sources.tests.test_goes.test_goes_ylim": "ae61275b7e1d8bbaf075e267e55592b86895afcbf8f846ae44dd78ecd645f6e9",
   "sunpy.timeseries.sources.tests.test_lyra.test_lyra_peek": "48924d42773a4d834342cdce5ad1e005db9980bf6db6525d97a141a08f411aba",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
@@ -62,7 +62,7 @@
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hpc_adaptive": "ee2cc06c8ed27369e1b2cd6b5d16688663ee061e3d84a3ccee09923bae10b16c",
   "sunpy.timeseries.sources.tests.test_eve.test_esp_peek": "28b1e7af0e1894d22fd9db90d9e2bc5eb76e291c9e41fa1bb1d33d95bd13cce3",
   "sunpy.timeseries.sources.tests.test_eve.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
-  "sunpy.timeseries.sources.tests.test_fermi_gbm.test_fermi_gbm_peek": "83f0b53ca6f1cd809bd03e4aff80b3c02c8078e552b0c3e90b2cb3cf26932a51",
+  "sunpy.timeseries.sources.tests.test_fermi_gbm.test_fermi_gbm_peek": "1f80410f92458ad609189f4653928a566e8bea207a8dd6794bd65abf691b3ffc",
   "sunpy.timeseries.sources.tests.test_goes.test_goes_peek": "2f01b5430fe0295b7c8bc5bccef6c3356d5eed62c1236a2790e122fba2ead267",
   "sunpy.timeseries.sources.tests.test_goes.test_goes_ylim": "ae61275b7e1d8bbaf075e267e55592b86895afcbf8f846ae44dd78ecd645f6e9",
   "sunpy.timeseries.sources.tests.test_lyra.test_lyra_peek": "48924d42773a4d834342cdce5ad1e005db9980bf6db6525d97a141a08f411aba",

--- a/sunpy/timeseries/sources/eve.py
+++ b/sunpy/timeseries/sources/eve.py
@@ -112,7 +112,7 @@ class ESPTimeSeries(GenericTimeSeries):
         return fig
 
     @classmethod
-    def _parse_file(cls, filepath):
+    def _parse_file(cls, filepath, **kwargs):
         """
         Parses a EVE ESP level 1 data.
         """
@@ -247,7 +247,7 @@ class EVESpWxTimeSeries(GenericTimeSeries):
         return fig
 
     @classmethod
-    def _parse_file(cls, filepath):
+    def _parse_file(cls, filepath, **kwargs):
         """
         Parses an EVE CSV file.
         """

--- a/sunpy/timeseries/sources/fermi_gbm.py
+++ b/sunpy/timeseries/sources/fermi_gbm.py
@@ -14,6 +14,7 @@ import sunpy.io
 import sunpy.io._file_tools
 from sunpy.time import parse_time
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
+from sunpy.util.exceptions import warn_user
 from sunpy.util.metadata import MetaDict
 from sunpy.visualization import peek_show
 
@@ -33,7 +34,7 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
     This summary lightcurve makes use of the CSPEC (daily version) data set which consists of the counts
     accumulated every 4.096 seconds in 128 energy channels for each of the 14 detectors.
 
-    Note that the data is re-binned from the original 128 into the following 8 pre-determined energy channels.
+    Note that by default the data is re-binned from the original 128 into the following 8 pre-determined energy channels.
     The rebinning method treats the counts in each of the original 128 channels as
     all having the energy of the average energy of that channel. For example, the
     counts in an 14.5--15.6 keV original channel would all be accumulated into the
@@ -46,6 +47,18 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
     * 100-300 keV
     * 300-800 keV
     * 800-2000 keV
+
+    Additionally, GBM timeseries with different energy bins ranges can be calculated by using the ``energy_bands`` keyword.
+
+    Parameters
+    ----------
+    energy_bands : `list`, `tuple`
+        The energy ranges to be calculated.
+
+    Returns
+    -------
+    `sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries`
+        with custom energy bins.
 
     Examples
     --------
@@ -72,7 +85,6 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
         self.__header = None
         self.__energy_bins = None
         self.__count_data = None
-
 
     def plot(self, axes=None, columns=None, **kwargs):
         """
@@ -167,25 +179,27 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
             cls.__header = kwargs.pop('header')
             cls.__energy_bins = kwargs.pop('energy_bins')
             cls.__count_data = kwargs.pop('count_data')
+
+        ebands = kwargs.get('energy_bands', [4, 15, 25, 50, 100, 300, 800, 2000]*u.keV)
+        for eband in ebands:
+            if not eband.unit.is_equivalent(u.keV):
+                unit_str, other_str = get_err_str(eband.unit), get_err_str(u.keV)
+                raise u.UnitConversionError(f"{unit_str} and {other_str} are not convertible.")
+        ebands = [eband.to(u.keV) if eband.unit != u.keV else eband for eband in ebands]
+        ebands = sorted(ebands)
+
         # rebin the 128 energy channels into some summary ranges
         # some of default bin ranges are
         # 4-15 keV, 15 - 25 keV, 25-50 keV, 50-100 keV, 100-300 keV, 300-800 keV, 800 - 2000 keV
         # put the data in the units of counts/s/keV
-        summary_counts = _bin_data_for_summary(cls.__energy_bins, cls.__count_data, **kwargs)
-
+        summary_counts, column_labels, ebands = _bin_data_for_summary(
+            cls.__energy_bins, cls.__count_data, ebands
+        )
         # get the time information in datetime format with the correct MET adjustment
         met_ref_time = parse_time('2001-01-01 00:00')  # Mission elapsed time
         gbm_times = met_ref_time + TimeDelta(cls.__count_data['time'], format='sec')
         gbm_times.precision = 9
         gbm_times = gbm_times.isot.astype('datetime64')
-
-        ebands = kwargs.get('energy_bands', [4, 15, 25, 50, 100, 300, 800, 2000]*u.keV)
-        ebands = [eband.to(u.keV) if eband.unit != u.keV else eband for eband in ebands]
-        ebands = sorted(ebands)
-        column_labels = [
-            f"{eband.value}-{next_eband.value} {eband.unit}"
-            for eband, next_eband in zip(ebands, ebands[1:])
-        ]
 
         # Add the units data
         units = OrderedDict((col, u.ct / u.s / eband.unit) for col, eband in zip(column_labels, ebands))
@@ -207,13 +221,27 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
             return kwargs['meta'].get('INSTRUME', '').startswith('GBM')
 
     @classmethod
-    def energy_bins(cls, energy_bands = None):
+    def energy_bins(cls, energy_bands):
         """
-        Determine GBM timeseries with different energy bins ranges
+        Determine GBM timeseries with different energy bins ranges.
+
         Parameters
         ----------
-        ebands : `list`, `tuple`
-            The energy bins you want.
+        energy_bands : `list`, `tuple`
+            The energy ranges to be calculated.
+
+        Returns
+        -------
+        `sunpy.timeseries.sources.fermi_gbm.GBMSummaryTimeSeries`
+            with custom energy bins.
+
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> import sunpy.timeseries
+        >>> import sunpy.data.sample  # doctest: +REMOTE_DATA
+        >>> gbm = sunpy.timeseries.TimeSeries(sunpy.data.sample.GBM_TIMESERIES, source='GBMSummary')  # doctest: +REMOTE_DATA
+        >>> gbm_ts = gbm.energy_bins([50, 100, 200, 400, 1000] * u.keV)  # doctest: +SKIP
         """
         from sunpy.timeseries.timeseries_factory import TimeSeries
         data, meta, units = cls._parse_hdus(
@@ -226,7 +254,7 @@ class GBMSummaryTimeSeries(GenericTimeSeries):
         return TimeSeries(data, meta, units)
 
 
-def _bin_data_for_summary(energy_bins, count_data, **kwargs):
+def _bin_data_for_summary(energy_bins, count_data, ebands):
     """
     Rebin the 128 energy channels into some summary ranges and put the data in
     the units of counts/s/keV.
@@ -248,21 +276,57 @@ def _bin_data_for_summary(energy_bins, count_data, **kwargs):
         The array of count data to rebin.
     """
     # list of energy bands to sum between
-    ebands = kwargs.get('energy_bands',  [4, 15, 25, 50, 100, 300, 800, 2000]*u.keV)
-    ebands = [eband.to(u.keV) if eband.unit != u.keV else eband for eband in ebands]
+    ebands = ebands
     if len(ebands) <= 1:
-        raise UserWarning("'energy_bands' must contain more than one element.")
-    ebands = sorted(ebands)
+        raise ValueError("'energy_bands' must contain more than one element.")
     e_center = (energy_bins['e_min'] + energy_bins['e_max']) / 2
-    indices = [np.searchsorted(e_center, e.value) for e in ebands]
+    e_min, e_max = round(energy_bins['e_min'].min()), np.ceil(energy_bins['e_max'].max())
 
+    if min(ebands).value >= e_min and max(ebands).value <= e_max:
+        pass
+    # ebands doesn't overlap with energy bins
+    elif max(ebands).value <= e_min or min(ebands).value >= e_max:
+        warn_user(
+            "Data is not available for"
+            f" {min(ebands)}-{max(ebands)}, "
+            "updating energy bins to default value")
+        ebands = [4, 15, 25, 50, 100, 300, 800, 2000] * u.keV
+    else:
+        warn_user("Only Partially Data is available for"
+                f" {e_min} keV-{e_max} keV")
+        # ebands fully overlap with energy bins
+        if min(ebands).value < e_min and max(ebands).value > e_max:
+            ebands = list(filter(lambda x: e_min <= x.value <= e_max, ebands))
+            ebands.append(e_max * u.keV)
+            ebands.insert(0, e_min * u.keV)
+
+        # ebands partially overlap with energy bins
+        elif min(ebands).value >= e_min and max(ebands).value > e_max:
+            ebands = list(filter(lambda x: x.value <= e_max, ebands))
+            ebands.append(e_max * u.keV)
+        elif min(ebands).value < e_min and max(ebands).value <= e_max:
+            ebands = list(filter(lambda x: x.value >= e_min, ebands))
+            ebands.insert(0, e_min * u.keV)
+
+    column_labels = [
+        f"{eband.value}-{next_eband.value} {eband.unit}"
+        for eband, next_eband in zip(ebands, ebands[1:])
+    ]
+    indices = [np.searchsorted(e_center, e.value) for e in ebands]
     summary_counts = []
     for ind_start, ind_end in zip(indices[:-1], indices[1:]):
-        if ind_start != len(e_center) or ind_end != len(e_center):
-            # sum the counts in the energy bands, and find counts/s/keV
-            summed_counts = np.sum(count_data["counts"][:, ind_start:ind_end], axis=1)
-            energy_width = (energy_bins["e_max"][ind_end - 1] - energy_bins["e_min"][ind_start])
-            summary_counts.append(summed_counts/energy_width/count_data["exposure"])
-        else:
-            summary_counts.append([np.nan]*len(count_data["exposure"]))
-    return np.array(summary_counts).T
+        # sum the counts in the energy bands, and find counts/s/keV
+        summed_counts = np.sum(count_data["counts"][:, ind_start:ind_end], axis=1)
+        energy_width = (energy_bins["e_max"][ind_end - 1] - energy_bins["e_min"][ind_start])
+        summary_counts.append(summed_counts/energy_width/count_data["exposure"])
+    return np.array(summary_counts).T, column_labels, ebands
+
+
+def get_err_str(unit: u.UnitBase) -> str:
+    unit_str = unit.to_string("generic")
+    physical_type = unit.physical_type
+    if physical_type != "unknown":
+        unit_str = f"'{unit_str}' ({physical_type})"
+    else:
+        unit_str = f"'{unit_str}'"
+    return unit_str

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -139,7 +139,7 @@ class XRSTimeSeries(GenericTimeSeries):
         return None
 
     @classmethod
-    def _parse_file(cls, filepath):
+    def _parse_file(cls, filepath, **kwargs):
         """
         Parses a GOES/XRS FITS file.
 

--- a/sunpy/timeseries/sources/lyra.py
+++ b/sunpy/timeseries/sources/lyra.py
@@ -123,7 +123,7 @@ class LYRATimeSeries(GenericTimeSeries):
         return axes[0].get_figure()
 
     @classmethod
-    def _parse_file(cls, filepath):
+    def _parse_file(cls, filepath, **kwargs):
         """
         Parses Lyra FITS data files to create TimeSeries.
 

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -137,7 +137,7 @@ class NOAAIndicesTimeSeries(GenericTimeSeries):
         return axes.get_figure()
 
     @classmethod
-    def _parse_file(cls, filepath):
+    def _parse_file(cls, filepath, **kwargs):
         suffix = Path(filepath).suffix
         if suffix == '.json':
             return cls._parse_json_file(filepath)
@@ -261,7 +261,7 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         return axes
 
     @classmethod
-    def _parse_file(cls, filepath):
+    def _parse_file(cls, filepath, **kwargs):
         suffix = Path(filepath).suffix
         if suffix == '.json':
             return cls._parse_json_file(filepath)

--- a/sunpy/timeseries/sources/norh.py
+++ b/sunpy/timeseries/sources/norh.py
@@ -116,7 +116,7 @@ class NoRHTimeSeries(GenericTimeSeries):
         return fig
 
     @classmethod
-    def _parse_file(cls, filepath):
+    def _parse_file(cls, filepath, **kwargs):
         """
         This method parses NoRH FITS files.
 

--- a/sunpy/timeseries/sources/rhessi.py
+++ b/sunpy/timeseries/sources/rhessi.py
@@ -177,7 +177,7 @@ class RHESSISummaryTimeSeries(GenericTimeSeries):
         return axes
 
     @classmethod
-    def _parse_file(cls, filepath):
+    def _parse_file(cls, filepath, **kwargs):
         """
         Parses rhessi FITS data files to create TimeSeries.
 

--- a/sunpy/timeseries/sources/tests/test_fermi_gbm.py
+++ b/sunpy/timeseries/sources/tests/test_fermi_gbm.py
@@ -6,6 +6,7 @@ import astropy.units as u
 import sunpy.timeseries
 from sunpy.data.test import get_test_filepath
 from sunpy.tests.helpers import figure_test
+from sunpy.util import SunpyUserWarning
 
 fermi_gbm_filepath = get_test_filepath('gbm.fits')
 
@@ -35,36 +36,69 @@ def test_fermi_gbm_peek(fermi_gbm_test_ts):
 
 
 def test_fermi_gbm_default_energy_bins():
+    # Checks for default_ebin, custom_ebin, out-for-bound ebin
+    custom_bin = [45, 95, 150, 270, 500] * u.keV
     ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath)
+    ts_gbm_1 = ts_gbm.energy_bins(custom_bin)
+    ts_gbm_2 = sunpy.timeseries.TimeSeries(fermi_gbm_filepath,
+                                           energy_bands = custom_bin)
+    with pytest.warns(SunpyUserWarning, match = "Data is not available for"):
+        ts_gbm_3 = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, energy_bands = [20, 40, 60, 80, 100] * u.eV)
+    with pytest.warns(SunpyUserWarning, match = "Data is not available for"):
+        ts_gbm_4 = ts_gbm.energy_bins([20, 40, 60, 80, 100] * u.eV)
+
     cols_list = [
-        '4.0-15.0 keV', '15.0-25.0 keV', '25.0-50.0 keV',
-        '50.0-100.0 keV', '100.0-300.0 keV', '300.0-800.0 keV',
-        '800.0-2000.0 keV'
+        '4.0-15.0 keV', '15.0-25.0 keV', '25.0-50.0 keV', '50.0-100.0 keV',
+        '100.0-300.0 keV', '300.0-800.0 keV', '800.0-2000.0 keV'
+    ]
+    cols_list_ = [
+        f"{ebin.value}-{next_ebin.value} {ebin.unit}"
+        for ebin, next_ebin in zip(custom_bin, custom_bin[1:])
     ]
     assert np.all(ts_gbm.to_dataframe().columns == cols_list)
+    assert np.all(ts_gbm_1.to_dataframe().columns == cols_list_)
+    assert np.all(ts_gbm_2.to_dataframe().columns == cols_list_)
+    assert np.all(ts_gbm_3.to_dataframe().columns == cols_list)
+    assert np.all(ts_gbm_4.to_dataframe().columns == cols_list)
 
 
 @pytest.mark.parametrize("energy_bins", [
-    [45, 95, 150, 270, 500] * u.keV,
-    [45, 95, 75, 300, 200] * u.keV,
-    [50, 100, 300, 400] * u.J,
-    [200 * u.keV, 1000 * u.keV, 1 * u.J, 30 * u.J],
-    [2 * u.eV, 5 * u.J, 32 * u.keV, 7 * u.J]
+    [2 * u.eV, 100 * u.eV, 50 * u.keV, 200 * u.keV],
+    [50 * u.keV, 200 * u.keV, 2500 * u.keV],
+    [2 * u.eV, 100 * u.eV, 50 * u.keV, 200 * u.keV, 2500 * u.keV]
 ])
 def test_fermi_gbm_custom_energy_bins(fermi_gbm_test_ts, energy_bins):
+    # Checks for fully overlapped ebin, partial ebin ranges
+    e_min, e_max = 4*u.keV, 2000*u.keV
     ts_gbm_base = fermi_gbm_test_ts
-    ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, energy_bands=energy_bins)
+    with pytest.warns(SunpyUserWarning, match = "Only Partially Data is available for"):
+        ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, energy_bands=energy_bins)
+    with pytest.warns(SunpyUserWarning, match = "Only Partially Data is available for"):
+        ts_gbm_energy_bins = ts_gbm_base.energy_bins(energy_bins)
+    with pytest.warns(SunpyUserWarning, match = "Only Partially Data is available for"):
+        ts_gbm_energy_bins__ = ts_gbm.energy_bins(energy_bins)
 
-    ts_gbm_energy_bins = ts_gbm_base.energy_bins(energy_bins)
-    ts_gbm_energy_bins__ = ts_gbm.energy_bins(energy_bins)
+    energy_bins = [ebin.to(u.keV) if ebin.unit != u.keV else ebin for ebin in energy_bins]
     energy_bins = sorted(energy_bins)
-    col_list = [
-        f'{(first.to(u.keV)).value}-{(second.to(u.keV)).value} keV'
-        for first, second in zip(energy_bins, energy_bins[1:])
+    # This only checks for fully overlapped ebin and partial ebin ranges
+    if min(energy_bins) < e_min and max(energy_bins) > e_max:
+        energy_bins = list(filter(lambda x: e_min <= x <= e_max, energy_bins))
+        energy_bins.append(e_max * u.keV)
+        energy_bins.insert(0, e_min * u.keV)
+    elif min(energy_bins) >= e_min and max(energy_bins) > e_max:
+        energy_bins = list(filter(lambda x: x <= e_max, energy_bins))
+        energy_bins.append(e_max)
+    elif min(energy_bins) < e_min and max(energy_bins) <= e_max:
+        energy_bins = list(filter(lambda x: x >= e_min, energy_bins))
+        energy_bins.insert(0, e_min * u.keV)
+
+    cols_list_ = [
+        f"{ebin.value}-{next_ebin.value} keV"
+        for ebin, next_ebin in zip(energy_bins, energy_bins[1:])
     ]
-    assert np.all(ts_gbm.to_dataframe().columns == col_list)
-    assert np.all(ts_gbm_energy_bins.to_dataframe().columns == col_list)
-    assert np.all(ts_gbm_energy_bins__.to_dataframe().columns == col_list)
+    assert np.all(ts_gbm.to_dataframe().columns == cols_list_)
+    assert np.all(ts_gbm_energy_bins.to_dataframe().columns == cols_list_)
+    assert np.all(ts_gbm_energy_bins__.to_dataframe().columns == cols_list_)
 
 
 @pytest.mark.parametrize("energy_bins", [
@@ -72,7 +106,18 @@ def test_fermi_gbm_custom_energy_bins(fermi_gbm_test_ts, energy_bins):
     []
 ])
 def test_fermi_gbm_invalid_energy_bins(fermi_gbm_test_ts, energy_bins):
-    with pytest.raises(UserWarning, match = "'energy_bands' must contain more than one element."):
+    with pytest.raises(ValueError, match = "'energy_bands' must contain more than one element."):
         sunpy.timeseries.TimeSeries(fermi_gbm_filepath, energy_bands=energy_bins)
-    with pytest.raises(UserWarning, match = "'energy_bands' must contain more than one element."):
+    with pytest.raises(ValueError, match = "'energy_bands' must contain more than one element."):
+        fermi_gbm_test_ts.energy_bins(energy_bins)
+
+
+@pytest.mark.parametrize("energy_bins", [
+    [4*u.keV, 10*u.m, 20*u.keV],
+    [4*u.keV, 10*u.mag, 20*u.keV]
+])
+def test_fermi_gbm_invalid_unit_energy_bins(fermi_gbm_test_ts, energy_bins):
+    with pytest.raises(u.UnitConversionError, match = r"are not convertible.$"):
+        sunpy.timeseries.TimeSeries(fermi_gbm_filepath, energy_bands=energy_bins)
+    with pytest.raises(u.UnitConversionError, match = r"are not convertible.$"):
         fermi_gbm_test_ts.energy_bins(energy_bins)

--- a/sunpy/timeseries/sources/tests/test_fermi_gbm.py
+++ b/sunpy/timeseries/sources/tests/test_fermi_gbm.py
@@ -1,3 +1,7 @@
+import numpy as np
+import pytest
+
+import astropy.units as u
 
 import sunpy.timeseries
 from sunpy.data.test import get_test_filepath
@@ -19,12 +23,56 @@ def test_fermi_gbm():
 
 
 def test_fermi_gbm_plot_column(fermi_gbm_test_ts):
-    ax = fermi_gbm_test_ts.plot(columns=['4-15 keV', '100-300 keV'])
+    ax = fermi_gbm_test_ts.plot(columns=['4.0-15.0 keV', '100.0-300.0 keV'])
     assert len(ax.lines) == 2
-    assert '4-15 keV' == ax.lines[0].get_label()
-    assert '100-300 keV' == ax.lines[1].get_label()
+    assert '4.0-15.0 keV' == ax.lines[0].get_label()
+    assert '100.0-300.0 keV' == ax.lines[1].get_label()
 
 
 @figure_test
 def test_fermi_gbm_peek(fermi_gbm_test_ts):
     fermi_gbm_test_ts.peek()
+
+
+def test_fermi_gbm_default_energy_bins():
+    ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath)
+    cols_list = [
+        '4.0-15.0 keV', '15.0-25.0 keV', '25.0-50.0 keV',
+        '50.0-100.0 keV', '100.0-300.0 keV', '300.0-800.0 keV',
+        '800.0-2000.0 keV'
+    ]
+    assert np.all(ts_gbm.to_dataframe().columns == cols_list)
+
+
+@pytest.mark.parametrize("energy_bins", [
+    [45, 95, 150, 270, 500] * u.keV,
+    [45, 95, 75, 300, 200] * u.keV,
+    [50, 100, 300, 400] * u.J,
+    [200 * u.keV, 1000 * u.keV, 1 * u.J, 30 * u.J],
+    [2 * u.eV, 5 * u.J, 32 * u.keV, 7 * u.J]
+])
+def test_fermi_gbm_custom_energy_bins(fermi_gbm_test_ts, energy_bins):
+    ts_gbm_base = fermi_gbm_test_ts
+    ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, energy_bands=energy_bins)
+
+    ts_gbm_energy_bins = ts_gbm_base.energy_bins(energy_bins)
+    ts_gbm_energy_bins__ = ts_gbm.energy_bins(energy_bins)
+    energy_bins = sorted(energy_bins)
+    col_list = [
+        f'{(first.to(u.keV)).value}-{(second.to(u.keV)).value} keV'
+        for first, second in zip(energy_bins, energy_bins[1:])
+    ]
+    assert np.all(ts_gbm.to_dataframe().columns == col_list)
+    assert np.all(ts_gbm_energy_bins.to_dataframe().columns == col_list)
+    assert np.all(ts_gbm_energy_bins__.to_dataframe().columns == col_list)
+
+
+@pytest.mark.parametrize("energy_bins", [
+    [3 * u.eV],
+    []
+])
+def test_fermi_gbm_invalid_energy_bins(fermi_gbm_test_ts, energy_bins):
+    with pytest.raises(UserWarning, match = "'energy_bands' must contain more than one element."):
+        sunpy.timeseries.TimeSeries(fermi_gbm_filepath, energy_bands=energy_bins)
+    with pytest.raises(UserWarning, match = "'energy_bands' must contain more than one element."):
+        fermi_gbm_test_ts.energy_bins(energy_bins)

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -390,7 +390,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
 
             cls = types[0]
 
-            data_header_unit_tuple = cls._parse_hdus(pairs, **kwargs)
+            data_header_unit_tuple = cls._parse_hdus(pairs,  **kwargs)
             return self._parse_arg(data_header_unit_tuple)
 
     @seconddispatch

--- a/sunpy/timeseries/timeseries_factory.py
+++ b/sunpy/timeseries/timeseries_factory.py
@@ -390,7 +390,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
 
             cls = types[0]
 
-            data_header_unit_tuple = cls._parse_hdus(pairs)
+            data_header_unit_tuple = cls._parse_hdus(pairs, **kwargs)
             return self._parse_arg(data_header_unit_tuple)
 
     @seconddispatch
@@ -523,7 +523,7 @@ class TimeSeriesFactory(BasicRegistrationFactory):
         meta = kwargs.pop("meta", None)
         units = kwargs.pop("units", None)
         if filepath:
-            data, meta, units = WidgetType._parse_file(filepath)
+            data, meta, units = WidgetType._parse_file(filepath, **kwargs)
 
         # Now return a TimeSeries from the given file.
         return WidgetType(data, meta, units, **kwargs)


### PR DESCRIPTION
## PR Description

This pr implement feature [#7940](https://github.com/sunpy/sunpy/issues/7940)

TODO
- [x] Implemented feature #7940 
- [x] Added tests
- [x] updated docstring
- [x] Added changelog
- [x] update figure_test hashes  

for calculating different energy bins 

```
import sunpy.timeseries
from sunpy.data.test import get_test_filepath
from sunpy.tests.helpers import figure_test

fermi_gbm_filepath = get_test_filepath('gbm.fits') 

ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath, energy_bands = (12,4,345,54,56,65) *u.keV)

ts_gbm = sunpy.timeseries.TimeSeries(fermi_gbm_filepath)
ts_gbm.energy_bins([232,45,77,323] *u.keV)


