### PR TITLE
Fix Map's handling of PVi_m values

### DIFF
--- a/changelog/7961.bugfix.rst
+++ b/changelog/7961.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed two bugs associated with the handling of WCS ``PVi_m`` values by `~sunpy.map.Map`.
+``PVi_m`` values were incorrectly retrieved from the first alternative WCS description (e.g., ``PV1_1A``) instead of the primary WCS description (e.g., ``PV1_1``).
+Also, ``PVi_m`` values were misassigned when ``m`` was a two-digit number (i.e., 10 through 99).

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1491,12 +1491,12 @@ class GenericMap(NDData):
         """
         Return any PV values in the metadata.
         """
-        pattern = re.compile('pv[0-9]_[0-9]', re.IGNORECASE)
+        pattern = re.compile('pv[0-9]_[0-9]{1,2}$', re.IGNORECASE)
         pv_keys = [k for k in self.meta.keys() if pattern.match(k)]
 
         pv_values = []
         for k in pv_keys:
-            i, m = int(k[2]), int(k[4])
+            i, m = int(k[2]), int(k[4:])
             pv_values.append((i, m, self.meta[k]))
         return pv_values
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1491,7 +1491,7 @@ class GenericMap(NDData):
         """
         Return any PV values in the metadata.
         """
-        pattern = re.compile('pv[0-9]_[0-9]a', re.IGNORECASE)
+        pattern = re.compile('pv[0-9]_[0-9]', re.IGNORECASE)
         pv_keys = [k for k in self.meta.keys() if pattern.match(k)]
 
         pv_values = []

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -166,6 +166,37 @@ def test_wcs(aia171_test_map):
     np.testing.assert_allclose(wcs.wcs.pc, aia171_test_map.rotation_matrix)
 
 
+def test_wcs_pv():
+    # Test that PVi_m values are preserved in the reconstructed WCS
+    zpn_header = {
+        'ctype1': 'HPLN-ZPN',
+        'ctype2': 'HPLT-ZPN',
+        'cunit1': 'arcsec',
+        'cunit2': 'arcsec',
+        'pv1_0': 0,
+        'pv1_1': 0,
+        'pv1_2': 90,
+        'pv1_3': 180,
+        'pv2_1': 1,
+        'pv2_5': 0.2,
+        'pv2_10': 0.1,
+        'date-obs': '2025-01-01',
+        'hglt_obs': 0,
+        'hgln_obs': 0,
+        'dsun_obs': 1e13,
+    }
+    zpn_map = sunpy.map.Map((np.zeros((10, 10)), zpn_header))
+    pv_values = zpn_map.wcs.wcs.get_pv()
+    assert len(pv_values) == 7
+    assert pv_values[0] == (1, 0, 0)
+    assert pv_values[1] == (1, 1, 0)
+    assert pv_values[2] == (1, 2, 90)
+    assert pv_values[3] == (1, 3, 180)
+    assert pv_values[4] == (2, 1, 1.0)
+    assert pv_values[5] == (2, 5, 0.2)
+    assert pv_values[6] == (2, 10, 0.1)
+
+
 def test_wcs_cache(aia171_test_map):
     wcs1 = aia171_test_map.wcs
     wcs2 = aia171_test_map.wcs


### PR DESCRIPTION
WCS projections can specify `PVi_m` parameters, but Map's handling of those values is bugged (introduced in https://github.com/sunpy/sunpy/pull/5501/commits/fb0554f543bf2e19fed2f70de47c6b4cdc309c89).  Due to an errant 'a' in a regular expression:

https://github.com/sunpy/sunpy/blob/5668bba8ae896c8147c8db4fc7be88b2b04b1fa9/sunpy/map/mapbase.py#L1494

the code looks for `PVi_mA` values (i.e., for the "A" alternative WCS description) instead of `PVi_m` values (for the primary WCS description).  This flub may have resulted from the fact that the FITS standard writes `PVi_ma` where `a` stands in for a blank character or for 'A' through 'Z'.

This bug is only apparent when the WCS projection is one that requires non-default `PVi_m` parameters and there does not exist an "A" alternative WCS description that happens to be a duplicate of the primary WCS description.

This PR also fixes an additional bug the `PVi_m` value would be misassigned when `m` is a two-digit number (i.e., 10 through 99).  For example, `PV2_10` would be assigned to `PV2_1` (and would overwrite the correct value of `PV2_1`).