### PR TITLE
Switch the queried star catalogue in a gallery example

### DIFF
--- a/changelog/7962.doc.rst
+++ b/changelog/7962.doc.rst
@@ -1,0 +1,1 @@
+The gallery example :ref:`sphx_glr_generated_gallery_units_and_coordinates_STEREO_SECCHI_starfield.py` now queries the Hipparcos star catalogue instead of a Gaia star catalogue to avoid several issues with using the latter.


### PR DESCRIPTION
The example "Identifying stars in a STEREO/SECCHI COR2 coronagraph image" currently queries the Gaia DR2 star catalogue for star positions, but that has multiple issues:

- The Gaia star catalogues are so ridiculously large that queries can take multiple minutes to return for large regions.
- As a corollary to above, it appears that Vizier has internal limits that are exceeded for large Gaia queries, and so not all of the entries are even found.  This limitation appears to be before any filtering on columns (e.g., magnitude).  This limitation is also separate from the "row limit" that limits the number of entries that are returned to the user.
- The Gaia star catalogue has masked/NaN values for the parallax and proper motion of some stars, which requires additional cleaning (see #7960).  If this cleaning is not performed, the stars can "disappear" when propagated to the observation time.

The solution to avoid all of the above is to instead query the much much smaller (albeit older) Hipparcos star catalogue (specifically, the 2007 reduction).  It may not be as accurate and up-to-date as the Gaia star catalogues, but we certainly do not need that level of accuracy for this gallery example.