### PR TITLE
Switch the star query approach for a gallery example

### DIFF
--- a/changelog/7965.doc.rst
+++ b/changelog/7965.doc.rst
@@ -1,0 +1,1 @@
+The gallery example :ref:`sphx_glr_generated_gallery_units_and_coordinates_STEREO_SECCHI_starfield.py` now queries the Gaia star catalogue directly instead of going through Vizier.


### PR DESCRIPTION
(see #7960 and #7962 for earlier attempts to improve this example)

The example "Identifying stars in a STEREO/SECCHI COR2 coronagraph image" has two issues.  First, the Vizier query is extremely slow and can fail to return all of the stars if the query region is large.  Second, the Gaia entries can have masked/NaN values that need to be handled.

This PR:

- Replaces the `astroquery.vizier` approach to query the Gaia catalogue with a `astroquery.gaia` approach, which is much faster and appears to correctly return all matching stars
- Handles masked/NaN values (a la #7960)

Credit goes to Gabe Dima for pointing out that `astroquery.gaia` has much better performance