### PR TITLE
Use 3.12 for doc-gallery builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,7 @@ jobs:
     needs: [docs]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
-      # Due to mplcario, we need to use Python 3.10 for the wheels
-      default_python: '3.10'
+      default_python: '3.12'
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
@@ -101,6 +100,7 @@ jobs:
             apt:
               - libopenjp2-7
               - graphviz
+              - libcairo2-dev
         - linux: py312-online
           posargs: -n auto --dist loadgroup --color=yes
           libraries:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
             apt:
               - libopenjp2-7
               - graphviz
-              - libcairo2-dev
         - linux: py312-online
           posargs: -n auto --dist loadgroup --color=yes
           libraries:


### PR DESCRIPTION
No idea if this helps.

Check that astropy is new version on the doc builds. 