### PR TITLE
Only run cron 3 times a week

### DIFF
--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -9,7 +9,7 @@ on:
     #        │ │ ┌───────── day of the month (1 - 31)
     #        │ │ │ ┌───────── month (1 - 12 or JAN-DEC)
     #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
-    - cron: '0 7 * * *'  # Every day at 07:00 UTC
+    - cron: '0 7 * * 1,3,5'  # Every Mon,Wed,Fri at 07:00 UTC
 
 jobs:
   dispatch_workflows:


### PR DESCRIPTION
The primary motivation for rekindling this discussion is that we are now paying for 30mins of aarch64 builder per cron run.

Discuss.