### PR TITLE
Update minimum dependencies for sunpy 6.1

### DIFF
--- a/changelog/7976.breaking.rst
+++ b/changelog/7976.breaking.rst
@@ -1,0 +1,7 @@
+Increased minimum versions for these dependencies:
+
+- asdf-astropy >= 0.5.0
+- astropy >= 6.0.0
+- numpy >= 1.24.0
+- pandas >= 1.5.0
+- sphinx >= 6.0.0

--- a/docs/whatsnew/6.1.rst
+++ b/docs/whatsnew/6.1.rst
@@ -21,7 +21,11 @@ Updates to minimum dependencies
 
 The minimum required versions of the following packages have been updated:
 
+- astropy>=6.0.0
 - matplotlib>=3.6.0
+- numpy>=1.24.0
+- pandas>=1.5.0
+- sphinx>=6.0.0
 
 Support for helioprojective radial coordinates and maps
 =======================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ authors = [
   { name = "The SunPy Community", email = "sunpy@googlegroups.com" },
 ]
 dependencies = [
-  "astropy>=5.3.0",
-  "numpy>=1.23.5",
+  "astropy>=6.0.0",
+  "numpy>=1.24.0",
   "packaging>=23.0",
   "parfive[ftp]>=2.0.0",
   "pyerfa>=2.0.0.1",
@@ -56,7 +56,7 @@ classifiers = [
 [project.optional-dependencies]
 # The list of available extras is also in the installation docs, if you add or remove one please edit it there as well.
 asdf = [
-  "asdf-astropy>=0.4.0",
+  "asdf-astropy>=0.5.0",
   "asdf>=2.13.0",
 ]
 dask = ["dask[array]>=2022.5.2"]
@@ -95,7 +95,7 @@ timeseries = [
   # We need to raise this to ensure the goes netcdf files open.
   "h5py>=3.7.0",
   "matplotlib>=3.6.0",
-  "pandas>=1.4.0",
+  "pandas>=1.5.0",
 ]
 visualization = [
   "matplotlib>=3.6.0",
@@ -124,7 +124,7 @@ tests = [
   "sunpy[all,s3,tests-only]",
 ]
 docs = [
-  "sphinx>=5.0.0",
+  "sphinx>=6.0.0",
   "sphinx-automodapi>=0.14.1",
   "packaging>=23.0",
   "sunpy[all]",

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -3,9 +3,7 @@ from datetime import date, datetime, timezone
 import numpy as np
 import pandas
 import pytest
-from packaging import version
 
-import astropy
 import astropy.time
 from astropy.time import Time
 
@@ -291,11 +289,7 @@ def test_parse_time_astropy_formats(ts, fmt):
     dt = parse_time(ts, format=fmt)
     assert dt.format == fmt
 
-@pytest.mark.xfail(
-    condition=version.parse(astropy.__version__) < version.parse("6.1"),
-    reason="This test fails on Astropy versions below 6.1",
-    strict=True
-)
+
 def test_parse_time_int_float():
     # int and float values are not unique
     # The format has to be mentioned


### PR DESCRIPTION
I checked only our major dependencies against [our dependency policy](https://docs.sunpy.org/en/latest/dev_guide/contents/dependencies.html):

12 months:
- astropy 6.0.0 was released 2023 Nov 27

24 months:
- numpy 1.24.0 was released 2022 Dec 18
- pandas 1.5.0 was released 2022 Sep 19
- sphinx 6.0.0 was released 2022 Dec 29