### PR TITLE
Fixed a number of bugs associated with parsing time

### DIFF
--- a/changelog/7983.bugfix.1.rst
+++ b/changelog/7983.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fixed a bug in :func:`~sunpy.time.parse_time` where parsing a list of time strings containing "TAI" did not automatically set the time scale to TAI.

--- a/changelog/7983.bugfix.2.rst
+++ b/changelog/7983.bugfix.2.rst
@@ -1,0 +1,1 @@
+Fixed a bug in :func:`~sunpy.time.parse_time` where parsing a list of time strings could incorrectly fail even when parsing the individual elements would succeed.

--- a/changelog/7983.trivial.rst
+++ b/changelog/7983.trivial.rst
@@ -1,0 +1,2 @@
+Fixed some regex bugs in :func:`~sunpy.time.parse_time` that could result in additional, spurious matches for the candidate string format.
+There is a minor performance impact for each spurious match that is attempted to be used for parsing.

--- a/sunpy/time/tests/test_time.py
+++ b/sunpy/time/tests/test_time.py
@@ -194,63 +194,68 @@ def test_parse_time_now():
     assert now.scale == 'utc'
 
 
-def test_parse_time_ISO():
-    dt1 = Time('1966-02-03T20:17:40')
-    assert parse_time('1966-02-03').jd == LANDING.jd
-    assert (
-        parse_time('1966-02-03T20:17:40') == dt1
-    )
-    assert (
-        parse_time('19660203T201740') == dt1
-    )
+@pytest.mark.parametrize(('expected', 'time_string'), [
+    ('2007-05-04T21:08:12.999999', '2007-05-04T21:08:12.999999'),
+    ('2007-05-04T21:08:12.999999', '2007/05/04T21:08:12.999999'),
+    ('2007-05-04T21:08:12.999999', '2007-05-04T21:08:12.999999Z'),
+    ('2007-05-04T21:08:12.999999', '20070504T210812.999999'),
+    ('2007-05-04T21:08:12.999999', '2007/05/04 21:08:12.999999'),
+    ('2007-05-04T21:08:12.999999', '2007-05-04 21:08:12.999999'),
+    ('2007-05-04T21:08:12.999999', '2007-May-04 21:08:12.999999'),
+    ('2007-05-04T21:08:12.999999', '04-May-2007 21:08:12.999999'),
+    ('2007-05-04T21:08:12.999999', '2007:124:21:08:12.999999'),
+    ('2007-05-04T21:08:12', '2007-05-04T21:08:12'),
+    ('2007-05-04T21:08:12', '2007/05/04T21:08:12'),
+    ('2007-05-04T21:08:12', '20070504T210812'),
+    ('2007-05-04T21:08:12', '2007/05/04 21:08:12'),
+    ('2007-05-04T21:08:12', '2007-05-04 21:08:12'),
+    ('2007-05-04T21:08:12', '2007-May-04 21:08:12'),
+    ('2007-05-04T21:08:12', '04-May-2007 21:08:12'),
+    ('2007-05-04T21:08:12', '20070504_210812'),
+    ('2007-05-04T21:08:12', '2007:124:21:08:12'),
+    ('2007-05-04T21:08:12', '20070504210812'),
+    ('2007-05-04T21:08:12', '2007.05.04_21:08:12_UTC'),
+    ('2007-05-04T21:08:12', '2007.05.04_21:08:12'),
+    ('2007-05-04T21:08:00', '20070504T2108'),
+    ('2007-05-04T21:08:00', '2007/05/04 21:08'),
+    ('2007-05-04T21:08:00', '2007-05-04 21:08'),
+    ('2007-05-04T21:08:00', '2007-May-04 21:08'),
+    ('2007-05-04T21:08:00', '20070504_2108'),
+    ('2007-05-04T21:08:00', '200705042108'),
+    ('2007-05-04T21:08:00', '2007/05/04T21:08'),
+    ('2007-05-04', '2007-May-04'),
+    ('2007-05-04', '2007-05-04'),
+    ('2007-05-04', '2007/05/04'),
+    ('2007-05-04', '04-May-2007'),
+])
+def test_parse_time_utc(expected, time_string):
+    dt = parse_time(time_string)
+    assert is_time_equal(dt, Time(expected))
+    assert dt.scale == 'utc'
+    assert dt.format == 'isot'
 
-    dt2 = Time('2007-05-04T21:08:12.999999')
-    dt3 = Time('2007-05-04T21:08:12')
-    dt4 = Time('2007-05-04T21:08:00')
-    dt5 = Time('2007-05-04')
-
-    assert parse_time('20070504210812') == dt3
-    assert parse_time('200705042108') == dt4
-
-    lst = [
-        ('2007-05-04T21:08:12.999999', dt2),
-        ('20070504T210812.999999', dt2),
-        ('2007/05/04 21:08:12.999999', dt2),
-        ('2007-05-04 21:08:12.999999', dt2),
-        ('2007/05/04 21:08:12', dt3),
-        ('2007-05-04 21:08:12', dt3),
-        ('2007-05-04 21:08', dt4),
-        ('2007-05-04T21:08:12', dt3),
-        ('20070504T210812', dt3),
-        ('20070504T2108', dt4),
-        ('2007-May-04 21:08:12', dt3),
-        ('2007-May-04 21:08', dt4),
-        ('2007-May-04', dt5),
-        ('2007-05-04', dt5),
-        ('2007/05/04', dt5),
-        ('04-May-2007', dt5),
-        ('04-May-2007 21:08:12.999999', dt2),
-        ('20070504_2108', dt4),
-        ('20070504_210812', dt3),
-        ('2007.05.04_21:08:12_UTC', dt3),
-        ('2007.05.04_21:08:12', dt3),
-    ]
-
-    for k, v in lst:
-        dt = parse_time(k)
-        assert is_time_equal(dt, v)
-        assert dt.format == 'isot'
+    # Confirm that passing the string within a list gives the same answer
+    assert is_time_equal(dt, parse_time([time_string])[0])
 
 
-def test_parse_time_tai():
-    tai_format = Time('2007-05-04T21:08:12', scale='tai')
-    tai_format_micro = Time('2007-05-04T21:08:12.999999', scale='tai')
-    parsed_tai = parse_time('2007.05.04_21:08:12_TAI')
-    parsed_tai_micro = parse_time('2007.05.04_21:08:12.999999_TAI')
-    assert tai_format == parsed_tai
-    assert tai_format.scale == parsed_tai.scale
-    assert tai_format_micro == parsed_tai_micro
-    assert tai_format_micro.scale == parsed_tai_micro.scale
+@pytest.mark.parametrize(('expected', 'time_string'), [
+    ('2007-05-04T21:08:12.999999', '2007.05.04_21:08:12.999999_TAI'),
+    ('2007-05-04T21:08:12', '2007.05.04_21:08:12_TAI'),
+])
+def test_parse_time_tai(expected, time_string):
+    dt = parse_time(time_string)
+    assert is_time_equal(dt, Time(expected, scale='tai'))
+    assert dt.scale == 'tai'
+    assert dt.format == 'isot'
+
+    # Confirm that passing the string within a list gives the same answer
+    assert is_time_equal(dt, parse_time([time_string])[0])
+
+
+def test_parse_astropy_fallback():
+    # If none of our string formats match, parse_time should simply pass through to Time
+    assert parse_time('J2000') == Time('J2000')
+    assert parse_time(['J2000']) == Time(['J2000'])
 
 
 def test_parse_time_leap_second():

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -218,54 +218,38 @@ def convert_time_astropy(time_string, **kwargs):
     return time_string
 
 
-@convert_time.register(list)
-def convert_time_list(time_list, format=None, **kwargs):
-    item = time_list[0]
-    # If we have a list of strings, need to get the correct format from our
-    # list of custom formats.
-    if isinstance(item, str) and format is None:
-        if 'TAI' in item:
-            kwargs['scale'] = 'tai'
-        string_format = _get_time_fmt(item)
-        return Time.strptime(time_list, string_format, **kwargs)
-
-    # Otherwise return the default method
-    return convert_time.dispatch(object)(time_list, format, **kwargs)
-
-
 @convert_time.register(str)
+@convert_time.register(list)
 def convert_time_str(time_string, **kwargs):
-    if 'TAI' in time_string:
-        kwargs['scale'] = 'tai'
+    is_single_string = isinstance(time_string, str)
+    is_string_list = isinstance(time_string, list) and isinstance(time_string[0], str)
 
-    for time_format in TIME_FORMAT_LIST:
-        try:
+    if is_single_string or is_string_list:
+        first_item = time_string[0] if is_string_list else time_string
+        if 'TAI' in first_item:
+            kwargs['scale'] = 'tai'
+
+        for time_format in TIME_FORMAT_LIST:
             try:
-                ts, add_one_day = _regex_parse_time(time_string, time_format)
-            except TypeError:
-                break
-            if ts is None:
-                continue
-            t = Time.strptime(ts, time_format, **kwargs)
-            if add_one_day:
-                t += _ONE_DAY_TIMEDELTA
-            return t
-        except ValueError:
-            pass
+                try:
+                    ts, add_one_day = _regex_parse_time(first_item, time_format)
+                except TypeError:
+                    break
+                if ts is None:
+                    continue
+                if is_single_string:
+                    t = Time.strptime(ts, time_format, **kwargs)
+                    if add_one_day:
+                        t += _ONE_DAY_TIMEDELTA
+                else:
+                    # For a list of strings, we do not try to correct 24:00:00
+                    t = Time.strptime(time_string, time_format, **kwargs)
+                return t
+            except ValueError:
+                pass
 
     # when no format matches, call default function
     return convert_time.dispatch(object)(time_string, **kwargs)
-
-
-def _get_time_fmt(time_string):
-    """
-    Try all the formats in TIME_FORMAT_LIST to work out which one applies to
-    the time string.
-    """
-    for time_format in TIME_FORMAT_LIST:
-        ts, _ = _regex_parse_time(time_string, time_format)
-        if ts is not None:
-            return time_format
 
 
 def _variables_for_parse_time_docstring():

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -224,6 +224,8 @@ def convert_time_list(time_list, format=None, **kwargs):
     # If we have a list of strings, need to get the correct format from our
     # list of custom formats.
     if isinstance(item, str) and format is None:
+        if 'TAI' in item:
+            kwargs['scale'] = 'tai'
         string_format = _get_time_fmt(item)
         return Time.strptime(time_list, string_format, **kwargs)
 

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -24,6 +24,7 @@ __all__ = [
 
 # Mapping of time format codes to regular expressions.
 REGEX = {
+    '.': r'\.',
     '%Y': r'(?P<year>\d{4})',
     '%j': r'(?P<dayofyear>\d{3})',
     '%m': r'(?P<month>\d{1,2})',

--- a/sunpy/time/time.py
+++ b/sunpy/time/time.py
@@ -106,7 +106,7 @@ def _regex_parse_time(inp, format):
     # understand the former.
     for key, value in REGEX.items():
         format = format.replace(key, value)
-    match = re.match(format, inp)
+    match = re.match(f"{format}$", inp)
     if match is None:
         return None, None
 


### PR DESCRIPTION
This PR fixes a number of bugs that affect the parsing of time strings, primarily when they are in a list.

First, the parsing of a list of time strings (as opposed to a single time string) does not automatically set the TAI time scale as it should when "TAI" appears in the time strings:
```python
>>> parse_time("2016.05.04_21:08:12_TAI")
<Time object: scale='tai' format='isot' value=2016-05-04T21:08:12.000>
>>> parse_time(["2016.05.04_21:08:12_TAI"])
<Time object: scale='utc' format='isot' value=['2016-05-04T21:08:12.000']>
```

Second, the regex matching to find candidate time formats is sloppy, so there can be spurious matches that will not parse successfully:

- Periods are not escaped in the regex string, so they become wildcards
- Trailing characters are allowed

These spurious matches do not cause issues for parsing a single time string – aside from a small performance impact – because the code logic will keep trying candidate time formats until one works.  However...

Third, the code logic for parsing a list of time strings is different from parsing a single time string: it tries only the first candidate time format, so a spurious match that comes before the true match results in errors:
```python
>>> parse_time("2007-05-04T21:08:12.999Z")
<Time object: scale='utc' format='isot' value=2007-05-04T21:08:12.999>
>>> parse_time(["2007-05-04T21:08:12.999Z"])
...
ValueError: unconverted data remains: Z
```
and
```python
>>> "parse_time("20070504T210800")
<Time object: scale='utc' format='isot' value=2007-05-04T21:08:00.000>
>>> parse_time(["20070504T210800"])
...
ValueError: time data '20070504T210800' does not match format '%Y%m%dT%H%M%S.%f'
```

A corollary to the above is that the code also doesn't fall back to astropy's parsing if there is no matching format in sunpy:
```python
>>> parse_time('J2000')
<Time object: scale='tt' format='jyear_str' value=J2000.000>
>>> parse_time(['J2000'])
...
TypeError: strptime() argument 1 must be str, not <class 'NoneType'>
```