### PR TITLE
Fix PVi_m regex because i can range from 1 to 99

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1526,7 +1526,7 @@ class GenericMap(NDData):
         """
         Return any PV values in the metadata.
         """
-        pattern = re.compile('pv[0-9]_[0-9]{1,2}$', re.IGNORECASE)
+        pattern = re.compile(r'pv[1-9]\d?_(?:0|[1-9]\d?)$', re.IGNORECASE)
         pv_keys = [k for k in self.meta.keys() if pattern.match(k)]
 
         pv_values = []


### PR DESCRIPTION
For FITS WCS `PVi_m` parameters:
- `i` can range from 1 to 99
- `m` can range from 0 to 99

This PR fixes the regex in the just-merged #7961 because that regex allowed:
- `i` in the range 0 to 9
- `m` in the range 0 to 99, or also 00

@Cadair has noted how much he enjoys reviewing regex, so I have gone ahead and added him as a reviewer