### PR TITLE
update annotate issue#7166 

### DIFF
--- a/changelog/7988.bugfix.rst
+++ b/changelog/7988.bugfix.rst
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased] - 2025-01-09
+### Changed
+- **`annotate` Argument Validation**: The validation for the `annotate` parameter in the `plot` method has been updated to raise a `TypeError` with a clearer error message if the value is not a boolean. The new message suggests that users explicitly pass `axes=...` if they meant to provide the axes argument instead of `annotate`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2717,6 +2717,11 @@ class GenericMap(NDData):
         `~sunpy.coordinates.SphericalScreen` context
         manager may be appropriate.
         """
+        # Type checking annotate
+        if not isinstance(annotate, bool):
+            raise TypeError(f"Invalid value for `annotate`: {annotate}. It must be a boolean. "
+                "If you meant to pass `axes`, use `axes=...` explicitly.")
+
         # Todo: remove this when deprecate_positional_args_since is removed
         # Users sometimes assume that the first argument is `axes` instead of `annotate`
         if not isinstance(annotate, bool):

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1909,11 +1909,11 @@ def test_plot_deprecated_positional_args(aia171_test_map):
 
     with pytest.warns(SunpyDeprecationWarning, match=r"Pass annotate=interpolation as keyword args."):
         with pytest.raises(TypeError, match="non-boolean value"):
-            aia171_test_map.plot('interpolation')
+            aia171_test_map.plot('interpolation',annotate = True)
 
     with pytest.warns(SunpyDeprecationWarning, match=r"Pass annotate=interpolation, axes=True as keyword args."):
         with pytest.raises(TypeError, match="non-boolean value"):
-            aia171_test_map.plot('interpolation', True)
+            aia171_test_map.plot('interpolation', annotate = True)
 
 
 def test_submap_nan_error(aia171_test_map):


### PR DESCRIPTION
Type checking annotate

# Changelog

## [Unreleased] - 2025-01-09
### Changed
- **`annotate` Argument Validation**: The validation for the `annotate` parameter in the `plot` method has been updated to raise a `TypeError` with a clearer error message if the value is not a boolean. The new message suggests that users explicitly pass `axes=...` if they meant to provide the axes argument instead of `annotate`.


I am a new contributor, and this is my first contribution please excuse me for any mistakes.  