### PR TITLE
Update visualization.py

### DIFF
--- a/changelog/7992.feature.rst
+++ b/changelog/7992.feature.rst
@@ -1,0 +1,2 @@
+Astropy >= 7.0 uses declination_axis.set_major_formatter(new_format_method) instead of declination_axis._formatter_locator.formatter = new_format_method
+add this in `~sunpy.visualization.visualization.py` under the `show_hpr_impact_angle` function

--- a/sunpy/visualization/visualization.py
+++ b/sunpy/visualization/visualization.py
@@ -94,6 +94,5 @@ def show_hpr_impact_angle(declination_axis):
 
     def new_format_method(values, spacing, format="auto"):
         return old_format_method(values + 90*u.deg, spacing, format=format)
-    # TODO: Astropy >= 7.0 use declination_axis.set_major_formatter(new_format_method)
-    declination_axis._formatter_locator.formatter = new_format_method
+    declination_axis.set_major_formatter(new_format_method)
     declination_axis.set_axislabel('Helioprojective Impact Angle')


### PR DESCRIPTION
Astropy >= 7.0 uses declination_axis.set_major_formatter(new_format_method)
so replaced 

Fixes: #7991 

```python
declination_axis._formatter_locator.formatter = new_format_method
```
with 
```python
declination_axis.set_major_formatter(new_format_method)
```