### PR TITLE
Rename `sunpy.time.TimeRange.extend()` method to `shift()` to reflect what it actually does

### DIFF
--- a/changelog/8008.deprecation.rst
+++ b/changelog/8008.deprecation.rst
@@ -1,0 +1,1 @@
+Renamed the `sunpy.time.TimeRange` method ``extend()`` to :meth:`sunpy.time.TimeRange.shift` to reflect what the method actually does.

--- a/sunpy/time/tests/test_timerange.py
+++ b/sunpy/time/tests/test_timerange.py
@@ -239,9 +239,9 @@ def test_previous():
     assert timerange.dt == delta
 
 
-def test_extend():
+def test_shift():
     timerange = sunpy.time.TimeRange(tbegin_str, tfin_str)
-    timerange.extend(delta, delta)
+    timerange.shift(delta, delta)
     assert isinstance(timerange, sunpy.time.TimeRange)
     assert timerange.start == start + delta
     assert timerange.end == end + delta

--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -9,7 +9,7 @@ from astropy.time import Time, TimeDelta
 from sunpy import config
 from sunpy.time import is_time_equal, parse_time
 from sunpy.time.time import _variables_for_parse_time_docstring
-from sunpy.util.decorators import add_common_docstring
+from sunpy.util.decorators import add_common_docstring, deprecated
 
 TIME_FORMAT = config.get('general', 'time_format')
 
@@ -401,9 +401,12 @@ class TimeRange:
 
         return self
 
-    def extend(self, dt_start, dt_end):
+    def shift(self, dt_start, dt_end):
         """
-        Extend the time range forwards and backwards.
+        Shift the start and the end of the time range.
+
+        To extend the time range both forwards and backwards, specify a negative value
+        for ``dt_start`` and a positive value for ``dt_end``.
 
         Parameters
         ----------
@@ -415,6 +418,23 @@ class TimeRange:
         # TODO: Support datetime.timedelta
         self._t1 = self._t1 + dt_start
         self._t2 = self._t2 + dt_end
+
+    @deprecated('6.1', alternative='sunpy.time.TimeRange.shift')
+    def extend(self, dt_start, dt_end):
+        """
+        Shift the start and the end of the time range.
+
+        To extend the time range both forwards and backwards, specify a negative value
+        for ``dt_start`` and a positive value for ``dt_end``.
+
+        Parameters
+        ----------
+        dt_start : `astropy.time.TimeDelta`
+            The amount to shift the start time.
+        dt_end : `astropy.time.TimeDelta`
+            The amount to shift the end time.
+        """
+        self.shift(dt_start, dt_end)
 
     def get_dates(self):
         """


### PR DESCRIPTION
The name of the method `sunpy.time.TimeRange.extend()` and its description indicate that the method extends the time range forwards and backwards, which suggests (to me) that the first parameter (`dt_start`) is subtracted from the start time to extend the time range backwards.  However, the method actually _adds_ `dt_start` to the start time, and thus the user needs to supply a negative time delta to extend the time range backwards.  As the parameter description says, this means that `dt_start` is the amount to _shift_ the start time rather than the amount to extend the start time.

This PR renames the method to `shift()` and adds clarifying sentences to its docstring and to the now-deprecated `extend()`.