### PR TITLE
Adds FakeClient to reproduce work and error property in UnifiedResponse

### DIFF
--- a/fake_client.py
+++ b/fake_client.py
@@ -1,0 +1,111 @@
+from functools import partial
+from sunpy.net.base_client import BaseClient, convert_row_to_table
+import sunpy.util.net
+
+import sunpy.net.attrs as a
+import sunpy.net
+from sunpy.net.attr import AttrWalker, AttrAnd, AttrOr, DataAttr
+from sunpy.net.base_client import QueryResponseTable
+
+walker = AttrWalker()
+
+@walker.add_creator(AttrOr)
+def create_or(wlk, tree):
+    results = []
+    for sub in tree.attrs:
+        results.append(wlk.create(sub))
+
+    return results
+
+
+@walker.add_creator(AttrAnd, DataAttr)
+def create_and(wlk, tree):
+    result = dict()
+    wlk.apply(tree, result)
+    return [result]
+
+
+@walker.add_applier(a.Time)
+def _(wlk, attr, params):
+    return params.update({'startTime': attr.start.isot,
+                            'endTime': attr.end.isot})
+
+
+@walker.add_applier(a.Level)
+def _(wlk, attr, params):
+    return params.update({'level': attr.value})
+
+
+class ExampleClient(BaseClient):
+    size_column = 'Filesize'
+
+    def search(self, query):
+        queries = walker.create(query)
+        print("Seaching in fake client")
+        results = []
+        for query_parameters in queries:
+            results.append(self._make_search(query_parameters))
+            # try:
+            #     resp = self._make_search(query_parameters)
+            #     results.append(resp)
+            # except ConnectionRefusedError as e:
+            #     # e.client_name = client.__class__.__name__.lower()
+            #     results.append(e)
+
+        return QueryResponseTable(results, client=self)
+    
+    @classmethod
+    def register_values(cls):
+
+        from sunpy.net import attrs
+        adict = {
+        attrs.Instrument: [("LASCO", "Large Angle and Spectrometric Coronagraph")],
+        attrs.Source: [('SOHO', 'Solar and Heliospheric Observatory')],
+        attrs.Provider: [('SDAC', 'Solar Data Analysis Center')],
+        attrs.Detector: [('C1', 'Coronograph 1'),
+                        ('C2', 'Coronograph 2'),
+                        ('C3', 'Coronograph 3')]
+        }
+
+        return adict
+    
+    def _make_search(self, query):
+        raise ConnectionRefusedError                                        
+
+    def _make_filename(path, row, resp, url):
+        # Define a fallback filename based on the information in the search results
+        name = f"row['ID'].fits"
+
+        if resp:
+            cdheader = resp.headers.get("Content-Disposition", None)
+            if cdheader:
+                _, params = sunpy.util.net.parse_header(cdheader)
+                name = params.get('filename', "")
+
+        return path.format(file=name, **row.response_block_map)
+
+    @convert_row_to_table
+    def fetch(self, query_results, *, path, downloader, **kwargs):
+        for row in query_results:
+            filepath = partial(self._make_filename, path, row)
+
+            url = f"https://sfsi.sunpy.org/download/{row['ID']}"
+            downloader.enqueue_file(url, filename=filepath)
+
+    @classmethod
+    def _can_handle_query(cls, *query):
+        query_attrs = set(type(x) for x in query)
+        supported_attrs = {a.Time, a.Level}
+        return supported_attrs.issuperset(query_attrs)
+    
+client = ExampleClient()
+# client.search(a.Time('2014-01-01T00:00:00', '2014-01-01T00:10:00')) 
+print(client.search(a.Time('2014-01-01T00:00:00', '2014-01-01T00:10:00')))
+
+
+
+
+
+
+
+

--- a/fido_test.py
+++ b/fido_test.py
@@ -1,0 +1,11 @@
+from sunpy.net import Fido, attrs as a
+import astropy.units as u
+
+
+result = Fido.search(a.Time('2012/3/4', '2012/3/6'), a.Source.soho) 
+print(result)
+
+# Reproduces the bug where Fido.search crashes entirely even 
+# if one of the client has an error using a FakeClient
+
+

--- a/sunpy/net/__init__.py
+++ b/sunpy/net/__init__.py
@@ -13,5 +13,6 @@ from sunpy.net import jsoc as _
 from sunpy.net import vso as _
 from sunpy.net.fido_factory import Fido
 from sunpy.net.scraper import Scraper
+from fake_client import ExampleClient as _    
 
 __all__ = ["Fido", "Scraper"]

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -54,6 +54,11 @@ class UnifiedResponse(Sequence):
         self._list = []
         self._numfile = 0
         for result in results:
+            if isinstance(result, ConnectionRefusedError):
+                self._list.append(None)
+                client_key = getattr(result, "client_name", len(self._list)-1)
+                self.errors[client_key] = result
+
             if isinstance(result, QueryResponseRow):
                 result = result.as_table()
 
@@ -161,6 +166,24 @@ class UnifiedResponse(Sequence):
         The number of records returned in all responses.
         """
         return self._numfile
+    
+    @property
+    def errors(self):
+        """
+        Returns a list of errors from the query.
+
+        If no errors are present, an empty list is returned.
+        """
+        # assuming that self._list has all the responses including errors
+        err = []
+        for res in self._list:
+            if isinstance(res, QueryResponseTable):
+                err.append(None)
+            else:
+                # connection refused error etc
+                # Not sure about res.errors, need to check
+                err.append(res.errors)
+        return err
 
     def _repr_html_(self):
         nprov = len(self)
@@ -478,8 +501,13 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         candidate_widget_types = self._check_registered_widgets(*query)
         results = []
         for client in candidate_widget_types:
-            tmpclient = client()
-            results.append(tmpclient.search(*query))
+            try:
+                tmpclient = client()
+                results.append(tmpclient.search(*query))
+            except Exception as e:
+                print(f"Error: {e} here")
+                e.client_name = client.__class__.__name__.lower()
+                results.append(e)
 
         # This method is called by `search` and the results are fed into a
         # UnifiedResponse object.


### PR DESCRIPTION
Fixes: #7625 

Here is my plan of action:
Step1: I have reproduced the error that was mentioned in the issue by creating an ExampleClient (code taken from [here](https://docs.sunpy.org/en/stable/topic_guide/extending_fido.html) for the client)
![image](https://github.com/user-attachments/assets/8b2bac42-79d0-4464-b1a8-0f78f0fffc7b)

Step 2: Add an error property in the `UnifiedResponse` class
Step 3: 