### PR TITLE
Combine Fido search results from the same client

### DIFF
--- a/changelog/8029.feature.rst
+++ b/changelog/8029.feature.rst
@@ -1,1 +1,1 @@
-Now responses from the same client are combined a single response for `~sunpy.net.Fido.search`.
+Search results from the same underlying client are combined where possible into a single response when you use `~sunpy.net.Fido.search`.

--- a/changelog/8029.feature.rst
+++ b/changelog/8029.feature.rst
@@ -1,1 +1,1 @@
-Adds the ability to combine responses from the same client into a single Table for `~sunpy.net.Fido.search`
+Now responses from the same client are combined a single response for `~sunpy.net.Fido.search`.

--- a/changelog/8029.feature.rst
+++ b/changelog/8029.feature.rst
@@ -1,1 +1,1 @@
-Search results from the same underlying client are combined where possible into a single response when you use `~sunpy.net.Fido.search`.
+Search results from the same underlying client are combined where possible into a single response when you use `~sunpy.net.fido_factory.UnifiedDownloaderFactory.search`.

--- a/changelog/8029.feature.rst
+++ b/changelog/8029.feature.rst
@@ -1,0 +1,1 @@
+Adds the ability to combine responses from the same client into a single Table for `~sunpy.net.Fido.search`

--- a/sunpy/net/cdaweb/test/test_cdaweb.py
+++ b/sunpy/net/cdaweb/test/test_cdaweb.py
@@ -9,9 +9,8 @@ from sunpy.net.cdaweb.attrs import Dataset
 def test_query():
     res = Fido.search(a.Time('2018-11-01', '2018-11-01 01:00:00'),
                       Dataset('WI_H1_SWE') | Dataset('WI_H5_SWE'))
-    assert len(res) == 2
-    assert len(res[0]) == 1
-    assert len(res[1]) == 2
+    assert len(res) == 1
+    assert len(res[0]) == 3
 
     files = Fido.fetch(res)
     assert len(files) == 3

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -45,7 +45,7 @@ class UnifiedResponse(Sequence):
     index the second dimension with ``::2``.
     """
 
-    def __init__(self, *results, combine=False):
+    def __init__(self, *results, combine=True):
         """
         Parameters
         ----------
@@ -174,7 +174,7 @@ class UnifiedResponse(Sequence):
         if isinstance(ret, QueryResponseTable | QueryResponseColumn | QueryResponseRow):
             return ret
 
-        return UnifiedResponse(*ret)
+        return UnifiedResponse(*ret, combine=self._combine)
 
     def path_format_keys(self):
         """

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -97,13 +97,23 @@ class UnifiedResponse(Sequence):
                     # This makes the merging of tables easier
                     provider_groups = defaultdict(list)
 
+                    hasProvider = True
+
                     for client_res in client_results:
-                        provider = client_res['Provider'][0]
-                        provider_groups[provider].append(client_res)
+                        provider = client_res['Provider'][0] if 'Provider' in client_res.colnames else None
+                        hasProvider = 'Provider' in client_res.colnames
+
+                        if hasProvider:
+                            provider_groups[provider].append(client_res)
 
                     # This stacks the results from the same provider(of the same client) together
-                    for provider, client_res in provider_groups.items():
-                        new_result = vstack(client_res, metadata_conflicts='silent')
+                    if hasProvider:
+                        for provider, client_res in provider_groups.items():
+                            new_result = vstack(client_res, metadata_conflicts='silent')
+                            self._list.append(new_result)
+                            self._numfile += len(new_result)
+                    else:
+                        new_result = vstack(client_results, metadata_conflicts='silent')
                         self._list.append(new_result)
                         self._numfile += len(new_result)
 

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -556,7 +556,6 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         for client in candidate_widget_types:
             tmpclient  = client()
             result = tmpclient.search(*query)
-            print("Result Object", result.client.__class__.__name__)
             results.append(result)
 
         # This method is called by `search` and the results are fed into a

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -88,17 +88,13 @@ class UnifiedResponse(Sequence):
                 # from the same provider have the same table schema.
                 provider_groups = defaultdict(list)
 
-                hasProvider = True
-
                 for client_res in client_results:
-                    provider = client_res['Provider'][0] if 'Provider' in client_res.colnames else None
-                    hasProvider = 'Provider' in client_res.colnames
-
-                    if hasProvider:
+                    if 'Provider' in client_res.colnames:
+                        provider = client_res['Provider'][0]
                         provider_groups[provider].append(client_res)
 
                 # This stacks the results from the same provider(of the same client) together
-                if hasProvider:
+                if 'Provider' in client_results[0].colnames:
                     for provider, client_res in provider_groups.items():
                         new_result = vstack(client_res, metadata_conflicts='silent')
                         self._list.append(new_result)

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -572,7 +572,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         candidate_widget_types = self._check_registered_widgets(*query)
         results = []
         for client in candidate_widget_types:
-            tmpclient  = client()
+            tmpclient = client()
             results.append(tmpclient.search(*query))
 
         # This method is called by `search` and the results are fed into a

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -82,27 +82,30 @@ class UnifiedResponse(Sequence):
 
 
         if self._combine:
-            print("Combining results")
-            # for client, client_results in combined_results.items():
-            #     if len(client_results) == 1:
-            #         self._list.append(results[0])
-            #         self._numfile += len(results[0])
-            #     else:
-            #         new_result = vstack(client_results, metadata_conflicts='silent')
-            #         self._list.append(new_result)
-            #         self._numfile += len(new_result)
-
             for client_cls, client_results in combined_results.items():
                 if len(client_results) == 1:
                     # Single result for this client: no need to merge
                     new_result = client_results[0]
-                else:
-                    print(client_results, type(client_results), len(client_results))
-                    # Merge results from the same client
-                    new_result = vstack(client_results, metadata_conflicts='silent')
 
-            self._list.append(new_result)
-            self._numfile += len(new_result)
+                    self._list.append(new_result)
+                    self._numfile += len(new_result)
+
+                else:
+                    # Group the results from a client based on provider
+                    # For Example: all results from VSOclient which are from the
+                    # provider JSOC will be grouped together
+                    # This makes the merging of tables easier
+                    provider_groups = defaultdict(list)
+
+                    for client_res in client_results:
+                        provider = client_res['Provider'][0]
+                        provider_groups[provider].append(client_res)
+
+                    # This stacks the results from the same provider(of the same client) together
+                    for provider, client_res in provider_groups.items():
+                        new_result = vstack(client_res, metadata_conflicts='silent')
+                        self._list.append(new_result)
+                        self._numfile += len(new_result)
 
 
     def __len__(self):

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -593,15 +593,6 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         # UnifiedResponse object.
         return results
 
-        # def _make_query_to_client(self, *query):
-        # for client in candidate_widget_types:
-        #     tmpclient = client()
-        #     results.append(tmpclient.search(*query))
-
-        # # This method is called by `search` and the results are fed into a
-        # # UnifiedResponse object.
-        # return results
-
     def __repr__(self):
         return object.__repr__(self) + "\n" + self._print_clients()
 

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -74,7 +74,6 @@ class UnifiedResponse(Sequence):
             if self._combine:
                 client_key = result.client.__class__
                 combined_results[client_key].append(result)
-                # combined_results[result.client.__class__.__name__] = combined_results.get(result.client.__class__.__name__, []) + [result]
             else:
                 self._list.append(result)
                 self._numfile += len(result)

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -585,8 +585,7 @@ class UnifiedDownloaderFactory(BasicRegistrationFactory):
         results = []
         for client in candidate_widget_types:
             tmpclient  = client()
-            result = tmpclient.search(*query)
-            results.append(result)
+            results.append(tmpclient.search(*query))
 
         # This method is called by `search` and the results are fed into a
         # UnifiedResponse object.

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -84,7 +84,7 @@ class UnifiedResponse(Sequence):
             for client_cls, client_results in combined_results.items():
                 # Group the results from a client based on provider
                 # For Example: all results from VSOclient which are from the
-                # provider will be grouped together, this is because the results
+                # same provider, (say, JSOC) will be grouped together, this is because the results
                 # from the same provider have the same table schema.
                 provider_groups = defaultdict(list)
 

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -82,6 +82,10 @@ class UnifiedResponse(Sequence):
 
         if self._combine:
             for client_cls, client_results in combined_results.items():
+                # Group the results from a client based on provider
+                # For Example: all results from VSOclient which are from the
+                # provider will be grouped together, this is because the results
+                # from the same provider have the same table schema.
                 provider_groups = defaultdict(list)
 
                 hasProvider = True
@@ -93,6 +97,7 @@ class UnifiedResponse(Sequence):
                     if hasProvider:
                         provider_groups[provider].append(client_res)
 
+                # This stacks the results from the same provider(of the same client) together
                 if hasProvider:
                     for provider, client_res in provider_groups.items():
                         new_result = vstack(client_res, metadata_conflicts='silent')

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -267,12 +267,8 @@ def test_fido_indexing(queries):
     # this.
     assume(query1.attrs[1].start != query2.attrs[1].start)
 
-
-    # TODO: Potentially branch out into two cases
     res = Fido.search(query1 | query2)
     if(len(res) != 1):
-        print(query1, query2)
-
         assert isinstance(res[1:], UnifiedResponse)
         assert len(res[1:]) == 1
         assert isinstance(res[0:1], UnifiedResponse)

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -343,6 +343,7 @@ def test_combined_response_vso_time():
     assert t1 == t2
 
 
+
 @pytest.mark.remote_data
 def test_combined_response_jsoc():
     results = Fido.search(a.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'),

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -363,10 +363,8 @@ def test_combined_response_jsoc():
         if min_time is None or t < min_time:
             min_time = t
 
-    t1 = TimeRange(min_time, max_time)
-    t2 = TimeRange('2020-01-01 00:00:45', '2020-01-03 00:00:45')
-    assert t1.start.iso == t2.start.iso
-    assert t1.end.iso == t2.end.iso
+    assert min_time == '2020-01-01 00:00:45'
+    assert max_time == '2020-01-03 00:00:45'
 
 
 @pytest.mark.remote_data
@@ -560,7 +558,10 @@ def test_path_format_keys():
     # Need to pass combine=False otherwise combine=True will take union of the
     # columns for multiple tables which will not have the same keys
     # because path_format_keys() takes intersection of the keys in the tables
+    print(t1.path_format_keys(), t2.path_format_keys())
     unif = UnifiedResponse(t1, t2, combine=False)
+
+    # assert unif.path_format_keys() == {'start_time', '_excite_', '01_wibble', 'end_time'}
     assert unif.path_format_keys() == {'_excite_'}
 
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -377,18 +377,12 @@ def test_combined_response_jsoc():
 
 @pytest.mark.remote_data
 def test_combined_response_lyra():
-    # To check if the dataretrivers are working correctly on combining the results
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 23:59:59.999') | a.Time('2020-01-03', '2020-01-03 23:59:59.999')), a.Instrument.lyra)
-    print(results)
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
-
-
-    # Testing that the entire time range is covered
     t1 = TimeRange(results[-1][0]["Start Time"], results[-1][-1]["End Time"])
     t2 = TimeRange('2020-01-01', '2020-01-03 23:59:59.999')
-    print(t1, t2)
-    t1 == t2
+    assert t1 == t2
 
 @pytest.mark.remote_data
 def test_combine_attr():

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -268,34 +268,60 @@ def test_fido_indexing(queries):
     assume(query1.attrs[1].start != query2.attrs[1].start)
 
     res = Fido.search(query1 | query2)
+
+    assert isinstance(res[0:1], UnifiedResponse)
+    assert len(res[0:1]) == 1
+
+    assert isinstance(res[0:1, 0], UnifiedResponse)
+    assert len(res[0:1, 0]) == 1
+
+    assert isinstance(res[0][0], QueryResponseRow)
+
+    aa = res[0, 0]
+    assert isinstance(aa, QueryResponseRow)
+
+    aa = res[0, 'Instrument']
+    assert isinstance(aa, QueryResponseColumn)
+
+    aa = res[0, ('Instrument',)]
+    assert isinstance(aa, QueryResponseTable)
+    for table in aa:
+        assert len(table.columns) == 1
+
+    aa = res[0, :]
+    assert isinstance(aa, QueryResponseTable)
+
+    aa = res[0, 1:]
+    assert isinstance(aa, QueryResponseTable)
+
+    if len(res.keys()) == len(res):
+        aa = res[res.keys()[0], 1:]
+        assert isinstance(aa, QueryResponseTable)
+        aa = res[res.keys()[0], 'Instrument']
+        assert isinstance(aa, QueryResponseColumn)
+
+    with pytest.raises(IndexError):
+        res[0, 0, 0]
+
+    with pytest.raises(IndexError):
+        res["saldkal"]
+
+    with pytest.raises(IndexError):
+        res[1.0132]
+
     if(len(res) != 1):
+        assert len(res) == 2
         assert isinstance(res[1:], UnifiedResponse)
         assert len(res[1:]) == 1
-        assert isinstance(res[0:1], UnifiedResponse)
-        assert len(res[0:1]) == 1
 
         assert isinstance(res[1:, 0], UnifiedResponse)
         assert len(res[1:, 0]) == 1
-        assert isinstance(res[0:1, 0], UnifiedResponse)
-        assert len(res[0:1, 0]) == 1
 
-        assert isinstance(res[0][0], QueryResponseRow)
         assert isinstance(res[1][0], QueryResponseRow)
         assert isinstance(res[1, 0:1], QueryResponseTable)
 
-        aa = res[0, 0]
-        assert isinstance(aa, QueryResponseRow)
-
-        aa = res[0, 'Instrument']
-        assert isinstance(aa, QueryResponseColumn)
-
         aa = res[:, 'Instrument']
         assert isinstance(aa, UnifiedResponse)
-        for table in aa:
-            assert len(table.columns) == 1
-
-        aa = res[0, ('Instrument',)]
-        assert isinstance(aa, QueryResponseTable)
         for table in aa:
             assert len(table.columns) == 1
 
@@ -305,59 +331,18 @@ def test_fido_indexing(queries):
         assert len(aa) == 2
         assert len(aa[0]) == 1
 
-        aa = res[0, :]
-        assert isinstance(aa, QueryResponseTable)
-
-        aa = res[0, 1:]
-        assert isinstance(aa, QueryResponseTable)
-
-        if len(res.keys()) == len(res):
-            aa = res[res.keys()[0], 1:]
-            assert isinstance(aa, QueryResponseTable)
-            aa = res[res.keys()[0], 'Instrument']
-            assert isinstance(aa, QueryResponseColumn)
-
-        with pytest.raises(IndexError):
-            res[0, 0, 0]
-
-        with pytest.raises(IndexError):
-            res["saldkal"]
-
-        with pytest.raises(IndexError):
-            res[1.0132]
-
         if isinstance(res, UnifiedResponse):
             assert len(res) != 1
     else:
-        # only 1 result
         assert len(res) == 1
         assert isinstance(res[1:], UnifiedResponse)
         assert len(res[1:]) == 0
-        assert isinstance(res[0:1], UnifiedResponse)
-        assert len(res[0:1]) == 1
 
         assert isinstance(res[1:, 0], UnifiedResponse)
         assert len(res[1:, 0]) == 0
-        assert isinstance(res[0:1, 0], UnifiedResponse)
-        assert len(res[0:1, 0]) == 1
-
-        assert isinstance(res[0][0], QueryResponseRow)
-        # assert isinstance(res[1][0], QueryResponseRow)
-        # assert isinstance(res[1, 0:1], QueryResponseTable)
-
-        aa = res[0, 0]
-        assert isinstance(aa, QueryResponseRow)
-
-        aa = res[0, 'Instrument']
-        assert isinstance(aa, QueryResponseColumn)
 
         aa = res[:, 'Instrument']
         assert isinstance(aa, UnifiedResponse)
-        for table in aa:
-            assert len(table.columns) == 1
-
-        aa = res[0, ('Instrument',)]
-        assert isinstance(aa, QueryResponseTable)
         for table in aa:
             assert len(table.columns) == 1
 
@@ -366,27 +351,6 @@ def test_fido_indexing(queries):
         assert isinstance(aa, UnifiedResponse)
         assert len(aa) == 1
         assert len(aa[0]) == 1
-
-        aa = res[0, :]
-        assert isinstance(aa, QueryResponseTable)
-
-        aa = res[0, 1:]
-        assert isinstance(aa, QueryResponseTable)
-
-        if len(res.keys()) == len(res):
-            aa = res[res.keys()[0], 1:]
-            assert isinstance(aa, QueryResponseTable)
-            aa = res[res.keys()[0], 'Instrument']
-            assert isinstance(aa, QueryResponseColumn)
-
-        with pytest.raises(IndexError):
-            res[0, 0, 0]
-
-        with pytest.raises(IndexError):
-            res["saldkal"]
-
-        with pytest.raises(IndexError):
-            res[1.0132]
 
         if isinstance(res, UnifiedResponse):
             assert len(res) == 1

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -309,53 +309,31 @@ def test_fido_indexing(queries):
     with pytest.raises(IndexError):
         res[1.0132]
 
-    if(len(res) != 1):
-        assert len(res) == 2
-        assert isinstance(res[1:], UnifiedResponse)
-        assert len(res[1:]) == 1
+    assert len(res) == (2 if len(res) != 1 else 1)
+    assert isinstance(res[1:], UnifiedResponse)
+    assert len(res[1:]) == (1 if len(res) != 1 else 0)
 
-        assert isinstance(res[1:, 0], UnifiedResponse)
-        assert len(res[1:, 0]) == 1
+    assert isinstance(res[1:, 0], UnifiedResponse)
+    assert len(res[1:, 0]) == (1 if len(res) != 1 else 0)
 
+    if len(res) != 1:
         assert isinstance(res[1][0], QueryResponseRow)
         assert isinstance(res[1, 0:1], QueryResponseTable)
 
-        aa = res[:, 'Instrument']
-        assert isinstance(aa, UnifiedResponse)
-        for table in aa:
-            assert len(table.columns) == 1
+    aa = res[:, 'Instrument']
+    assert isinstance(aa, UnifiedResponse)
+    for table in aa:
+        assert len(table.columns) == 1
 
-        aa = res[:, 0]
+    aa = res[:, 0]
 
-        assert isinstance(aa, UnifiedResponse)
-        assert len(aa) == 2
-        assert len(aa[0]) == 1
-
-        if isinstance(res, UnifiedResponse):
-            assert len(res) != 1
-    else:
-        assert len(res) == 1
-        assert isinstance(res[1:], UnifiedResponse)
-        assert len(res[1:]) == 0
-
-        assert isinstance(res[1:, 0], UnifiedResponse)
-        assert len(res[1:, 0]) == 0
-
-        aa = res[:, 'Instrument']
-        assert isinstance(aa, UnifiedResponse)
-        for table in aa:
-            assert len(table.columns) == 1
-
-        aa = res[:, 0]
-
-        assert isinstance(aa, UnifiedResponse)
-        assert len(aa) == 1
-        assert len(aa[0]) == 1
-
-        if isinstance(res, UnifiedResponse):
-            assert len(res) == 1
+    assert isinstance(aa, UnifiedResponse)
+    assert len(aa) == 2 if len(aa) != 1 else 1
+    assert len(aa[0]) == 1
 
 
+    if isinstance(res, UnifiedResponse):
+        assert len(res) == (2 if len(res) != 1 else 1)
 
 
 @pytest.mark.remote_data
@@ -584,9 +562,7 @@ def test_path_format_keys():
     t2 = QueryResponseTable({'End Time': ['2011/01/01', '2011/01/02'],
                              '!excite!': ['cat', 'rabbit']})
     assert t2.path_format_keys() == {'_excite_', 'end_time'}
-    # Need to pass combine=False otherwise combine=True will take union of the
-    # columns for multiple tables which will not have the same keys
-    # because path_format_keys() takes intersection of the keys in the tables
+
     unif = UnifiedResponse(t1, t2)
 
     # assert unif.path_format_keys() == {'start_time', '_excite_', '01_wibble', 'end_time'}

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -336,6 +336,11 @@ def test_combined_response():
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
 
+    # Testing that the entire time range is covered
+    t1 = TimeRange(results[-1][0]["Start Time"], results[-1][-1]["End Time"])
+    t2 = TimeRange('2020-01-01', '2020-01-03 00:00:10')
+    assert t1 == t2
+
 @pytest.mark.remote_data
 def test_combine_attr():
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -340,7 +340,6 @@ def test_combined_response_vsoc():
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
 
-    # Testing that the entire time range is covered
     t1 = TimeRange(results[-1][0]["Start Time"], results[-1][-1]["End Time"])
     t2 = TimeRange('2020-01-01', '2020-01-03 00:00:10')
     assert t1 == t2

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -377,7 +377,7 @@ def test_combined_response_vso_time():
 
 
     results = Fido.search(a.Time('2020-01-01', '2020-01-01 00:00:10'), a.Instrument.aia | a.Wavelength(171*u.angstrom))
-    assert len(results) == 2
+    assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
     assert isinstance(results[1], QueryResponseTable)
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -267,8 +267,13 @@ def test_fido_indexing(queries):
     # this.
     assume(query1.attrs[1].start != query2.attrs[1].start)
 
-    res = Fido.search(query1 | query2, combine=False)
-    assert len(res) == 2
+
+    # TODO: Potentially branch out into two cases
+    res = Fido.search(query1 | query2)
+    if(len(res) != 1):
+        print(query1, query2)
+    else:
+        assert len(res) == 1
 
     assert isinstance(res[1:], UnifiedResponse)
     assert len(res[1:]) == 1
@@ -560,11 +565,10 @@ def test_path_format_keys():
     # Need to pass combine=False otherwise combine=True will take union of the
     # columns for multiple tables which will not have the same keys
     # because path_format_keys() takes intersection of the keys in the tables
-    print(t1.path_format_keys(), t2.path_format_keys())
     unif = UnifiedResponse(t1, t2, combine=False)
 
     # assert unif.path_format_keys() == {'start_time', '_excite_', '01_wibble', 'end_time'}
-    assert unif.path_format_keys() == {'_excite_'}
+    assert unif.path_format_keys() == {'start_time', '_excite_', '01_wibble', 'end_time'}
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -342,6 +342,17 @@ def test_combined_response_vso_time():
     t2 = TimeRange('2020-01-01', '2020-01-03 00:00:10')
     assert t1 == t2
 
+    # Tables from 2 different providers dont get combines
+    results = Fido.search(a.Time('2020-01-01', '2020-01-01 00:00:10'), a.Instrument.aia | a.Instrument.lasco , combine=True)
+    assert len(results) == 2
+    assert isinstance(results[0], QueryResponseTable)
+    assert isinstance(results[1], QueryResponseTable)
+
+
+    results = Fido.search(a.Time('2020-01-01', '2020-01-01 00:00:10'), a.Instrument.aia | a.Wavelength(171*u.angstrom) , combine=True)
+    assert len(results) == 2
+    assert isinstance(results[0], QueryResponseTable)
+    assert isinstance(results[1], QueryResponseTable)
 
 @pytest.mark.remote_data
 def test_combined_response_jsoc():

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -332,9 +332,28 @@ def test_fido_indexing(queries):
 @pytest.mark.remote_data
 def test_combined_response():
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
+                  a.Instrument('AIA'), combine=True)
+    assert len(results) == 1
+    assert isinstance(results[0], QueryResponseTable)
+
+@pytest.mark.remote_data
+def test_combine_attr():
+    results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
+                  a.Instrument('AIA'), combine=True)
+    assert len(results) == 1
+    assert isinstance(results[0], QueryResponseTable)
+
+    results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
                   a.Instrument('AIA'))
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
+
+    results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
+                  a.Instrument('AIA'), combine=False)
+    assert len(results) == 2
+    assert isinstance(results[0], QueryResponseTable)
+
+
 
 
 @no_vso

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -302,9 +302,6 @@ def test_fido_indexing(queries):
 
     aa = res[:, 0]
 
-    if(len(aa) == 1):
-        print("here aa = res[:, 0]", aa)
-
     assert isinstance(aa, UnifiedResponse)
     assert len(aa) == 2
     assert len(aa[0]) == 1
@@ -345,11 +342,11 @@ def test_combined_response_vso_time():
     t2 = TimeRange('2020-01-01', '2020-01-03 00:00:10')
     assert t1 == t2
 
+
 @pytest.mark.remote_data
 def test_combined_response_jsoc():
     results = Fido.search(a.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'),
             a.jsoc.Series('hmi.v_45s') | a.jsoc.Series('aia.lev1_euv_12s'), combine=True)
-    print(results)
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
 
@@ -366,11 +363,8 @@ def test_combined_response_jsoc():
         if min_time is None or t < min_time:
             min_time = t
 
-    print(max_time, min_time)
     t1 = TimeRange(min_time, max_time)
-    print("hi")
     t2 = TimeRange('2020-01-01 00:00:45', '2020-01-03 00:00:45')
-    print(t1, t2)
     assert t1.start.iso == t2.start.iso
     assert t1.end.iso == t2.end.iso
 
@@ -383,6 +377,7 @@ def test_combined_response_lyra():
     t1 = TimeRange(results[-1][0]["Start Time"], results[-1][-1]["End Time"])
     t2 = TimeRange('2020-01-01', '2020-01-03 23:59:59.999')
     assert t1 == t2
+
 
 @pytest.mark.remote_data
 def test_combine_attr():
@@ -400,7 +395,6 @@ def test_combine_attr():
                   a.Instrument('AIA'), combine=False)
     assert len(results) == 2
     assert isinstance(results[0], QueryResponseTable)
-
 
 
 @no_vso

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -380,6 +380,7 @@ def test_combined_response_lyra():
     assert t1 == t2
 
 
+
 @pytest.mark.remote_data
 def test_combine_attr():
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -301,6 +301,10 @@ def test_fido_indexing(queries):
         assert len(table.columns) == 1
 
     aa = res[:, 0]
+
+    if(len(aa) == 1):
+        print("here aa = res[:, 0]", aa)
+
     assert isinstance(aa, UnifiedResponse)
     assert len(aa) == 2
     assert len(aa[0]) == 1
@@ -566,7 +570,10 @@ def test_path_format_keys():
     t2 = QueryResponseTable({'End Time': ['2011/01/01', '2011/01/02'],
                              '!excite!': ['cat', 'rabbit']})
     assert t2.path_format_keys() == {'_excite_', 'end_time'}
-    unif = UnifiedResponse(t1, t2)
+    # Need to pass combine=False otherwise combine=True will take union of the
+    # columns for multiple tables which will not have the same keys
+    # because path_format_keys() takes intersection of the keys in the tables
+    unif = UnifiedResponse(t1, t2, combine=False)
     assert unif.path_format_keys() == {'_excite_'}
 
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -365,17 +365,8 @@ def test_combined_response_jsoc():
                            a.jsoc.Series('hmi.m_45s'))
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
-    # Testing that the entire time range is covered
-    max_time = None
-    min_time = None
-    for t in results['jsoc']['T_REC']:
-        if max_time is None or t > max_time:
-            max_time = t
-        if min_time is None or t < min_time:
-            min_time = t
-
-    assert min_time == '2020-01-01 00:00:45'
-    assert max_time == '2020-01-03 00:00:45'
+    assert results['jsoc']['T_REC'][0] == '2020.01.01_00:00:45_TAI'
+    assert results['jsoc']['T_REC'][-1] == '2020.01.03_00:00:45_TAI'
 
 
 @pytest.mark.remote_data

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -356,7 +356,6 @@ def test_combined_response_vso_time():
     results = Fido.search(a.Time('2020-01-01', '2020-01-01 00:00:10'), a.Instrument.aia | a.Wavelength(171*u.angstrom))
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
-    assert isinstance(results[1], QueryResponseTable)
 
 @pytest.mark.remote_data
 def test_combined_response_jsoc():
@@ -381,24 +380,6 @@ def test_combined_response_lyra():
     t1 = TimeRange(results[-1][0]["Start Time"], results[-1][-1]["End Time"])
     t2 = TimeRange('2020-01-01', '2020-01-03 23:59:59.999')
     assert t1 == t2
-
-
-@pytest.mark.remote_data
-def test_combine_attr():
-    results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
-                  a.Instrument('AIA'))
-    assert len(results) == 1
-    assert isinstance(results[0], QueryResponseTable)
-
-    results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
-                  a.Instrument('AIA'))
-    assert len(results) == 1
-    assert isinstance(results[0], QueryResponseTable)
-
-    results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
-                  a.Instrument('AIA'))
-    assert len(results) == 2
-    assert isinstance(results[0], QueryResponseTable)
 
 
 @no_vso

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -333,6 +333,7 @@ def test_fido_indexing(queries):
     if isinstance(res, UnifiedResponse):
         assert len(res) != 1
 
+
 @pytest.mark.remote_data
 def test_combined_response_vso_time():
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -331,7 +331,6 @@ def test_fido_indexing(queries):
     assert len(aa) == 2 if len(aa) != 1 else 1
     assert len(aa[0]) == 1
 
-
     if isinstance(res, UnifiedResponse):
         assert len(res) == (2 if len(res) != 1 else 1)
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -334,7 +334,7 @@ def test_fido_indexing(queries):
         assert len(res) != 1
 
 @pytest.mark.remote_data
-def test_combined_response_vsoc():
+def test_combined_response_vso_time():
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
                   a.Instrument('AIA'), combine=True)
     assert len(results) == 1

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -267,7 +267,7 @@ def test_fido_indexing(queries):
     # this.
     assume(query1.attrs[1].start != query2.attrs[1].start)
 
-    res = Fido.search(query1 | query2)
+    res = Fido.search(query1 | query2, combine=False)
     assert len(res) == 2
 
     assert isinstance(res[1:], UnifiedResponse)
@@ -328,6 +328,13 @@ def test_fido_indexing(queries):
 
     if isinstance(res, UnifiedResponse):
         assert len(res) != 1
+
+@pytest.mark.remote_data
+def test_combined_response():
+    results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
+                  a.Instrument('AIA'))
+    assert len(results) == 1
+    assert isinstance(results[0], QueryResponseTable)
 
 
 @no_vso

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -347,7 +347,6 @@ def test_combined_response_vso_time():
 
 @pytest.mark.remote_data
 def test_combined_response_jsoc():
-    # Combining attributes other than time
     results = Fido.search(a.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'),
             a.jsoc.Series('hmi.v_45s') | a.jsoc.Series('aia.lev1_euv_12s'), combine=True)
     print(results)

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -272,74 +272,136 @@ def test_fido_indexing(queries):
     res = Fido.search(query1 | query2)
     if(len(res) != 1):
         print(query1, query2)
-    else:
-        assert len(res) == 1
 
-    assert isinstance(res[1:], UnifiedResponse)
-    assert len(res[1:]) == 1
-    assert isinstance(res[0:1], UnifiedResponse)
-    assert len(res[0:1]) == 1
+        assert isinstance(res[1:], UnifiedResponse)
+        assert len(res[1:]) == 1
+        assert isinstance(res[0:1], UnifiedResponse)
+        assert len(res[0:1]) == 1
 
-    assert isinstance(res[1:, 0], UnifiedResponse)
-    assert len(res[1:, 0]) == 1
-    assert isinstance(res[0:1, 0], UnifiedResponse)
-    assert len(res[0:1, 0]) == 1
+        assert isinstance(res[1:, 0], UnifiedResponse)
+        assert len(res[1:, 0]) == 1
+        assert isinstance(res[0:1, 0], UnifiedResponse)
+        assert len(res[0:1, 0]) == 1
 
-    assert isinstance(res[0][0], QueryResponseRow)
-    assert isinstance(res[1][0], QueryResponseRow)
-    assert isinstance(res[1, 0:1], QueryResponseTable)
+        assert isinstance(res[0][0], QueryResponseRow)
+        assert isinstance(res[1][0], QueryResponseRow)
+        assert isinstance(res[1, 0:1], QueryResponseTable)
 
-    aa = res[0, 0]
-    assert isinstance(aa, QueryResponseRow)
+        aa = res[0, 0]
+        assert isinstance(aa, QueryResponseRow)
 
-    aa = res[0, 'Instrument']
-    assert isinstance(aa, QueryResponseColumn)
-
-    aa = res[:, 'Instrument']
-    assert isinstance(aa, UnifiedResponse)
-    for table in aa:
-        assert len(table.columns) == 1
-
-    aa = res[0, ('Instrument',)]
-    assert isinstance(aa, QueryResponseTable)
-    for table in aa:
-        assert len(table.columns) == 1
-
-    aa = res[:, 0]
-
-    assert isinstance(aa, UnifiedResponse)
-    assert len(aa) == 2
-    assert len(aa[0]) == 1
-
-    aa = res[0, :]
-    assert isinstance(aa, QueryResponseTable)
-
-    aa = res[0, 1:]
-    assert isinstance(aa, QueryResponseTable)
-
-    if len(res.keys()) == len(res):
-        aa = res[res.keys()[0], 1:]
-        assert isinstance(aa, QueryResponseTable)
-        aa = res[res.keys()[0], 'Instrument']
+        aa = res[0, 'Instrument']
         assert isinstance(aa, QueryResponseColumn)
 
-    with pytest.raises(IndexError):
-        res[0, 0, 0]
+        aa = res[:, 'Instrument']
+        assert isinstance(aa, UnifiedResponse)
+        for table in aa:
+            assert len(table.columns) == 1
 
-    with pytest.raises(IndexError):
-        res["saldkal"]
+        aa = res[0, ('Instrument',)]
+        assert isinstance(aa, QueryResponseTable)
+        for table in aa:
+            assert len(table.columns) == 1
 
-    with pytest.raises(IndexError):
-        res[1.0132]
+        aa = res[:, 0]
 
-    if isinstance(res, UnifiedResponse):
-        assert len(res) != 1
+        assert isinstance(aa, UnifiedResponse)
+        assert len(aa) == 2
+        assert len(aa[0]) == 1
+
+        aa = res[0, :]
+        assert isinstance(aa, QueryResponseTable)
+
+        aa = res[0, 1:]
+        assert isinstance(aa, QueryResponseTable)
+
+        if len(res.keys()) == len(res):
+            aa = res[res.keys()[0], 1:]
+            assert isinstance(aa, QueryResponseTable)
+            aa = res[res.keys()[0], 'Instrument']
+            assert isinstance(aa, QueryResponseColumn)
+
+        with pytest.raises(IndexError):
+            res[0, 0, 0]
+
+        with pytest.raises(IndexError):
+            res["saldkal"]
+
+        with pytest.raises(IndexError):
+            res[1.0132]
+
+        if isinstance(res, UnifiedResponse):
+            assert len(res) != 1
+    else:
+        # only 1 result
+        assert len(res) == 1
+        assert isinstance(res[1:], UnifiedResponse)
+        assert len(res[1:]) == 0
+        assert isinstance(res[0:1], UnifiedResponse)
+        assert len(res[0:1]) == 1
+
+        assert isinstance(res[1:, 0], UnifiedResponse)
+        assert len(res[1:, 0]) == 0
+        assert isinstance(res[0:1, 0], UnifiedResponse)
+        assert len(res[0:1, 0]) == 1
+
+        assert isinstance(res[0][0], QueryResponseRow)
+        # assert isinstance(res[1][0], QueryResponseRow)
+        # assert isinstance(res[1, 0:1], QueryResponseTable)
+
+        aa = res[0, 0]
+        assert isinstance(aa, QueryResponseRow)
+
+        aa = res[0, 'Instrument']
+        assert isinstance(aa, QueryResponseColumn)
+
+        aa = res[:, 'Instrument']
+        assert isinstance(aa, UnifiedResponse)
+        for table in aa:
+            assert len(table.columns) == 1
+
+        aa = res[0, ('Instrument',)]
+        assert isinstance(aa, QueryResponseTable)
+        for table in aa:
+            assert len(table.columns) == 1
+
+        aa = res[:, 0]
+
+        assert isinstance(aa, UnifiedResponse)
+        assert len(aa) == 1
+        assert len(aa[0]) == 1
+
+        aa = res[0, :]
+        assert isinstance(aa, QueryResponseTable)
+
+        aa = res[0, 1:]
+        assert isinstance(aa, QueryResponseTable)
+
+        if len(res.keys()) == len(res):
+            aa = res[res.keys()[0], 1:]
+            assert isinstance(aa, QueryResponseTable)
+            aa = res[res.keys()[0], 'Instrument']
+            assert isinstance(aa, QueryResponseColumn)
+
+        with pytest.raises(IndexError):
+            res[0, 0, 0]
+
+        with pytest.raises(IndexError):
+            res["saldkal"]
+
+        with pytest.raises(IndexError):
+            res[1.0132]
+
+        if isinstance(res, UnifiedResponse):
+            assert len(res) == 1
+
+
 
 
 @pytest.mark.remote_data
 def test_combined_response_vso_time():
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
-                  a.Instrument('AIA'), combine=True)
+                  a.Instrument('AIA'))
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
 
@@ -348,13 +410,13 @@ def test_combined_response_vso_time():
     assert t1 == t2
 
     # Tables from 2 different providers dont get combines
-    results = Fido.search(a.Time('2020-01-01', '2020-01-01 00:00:10'), a.Instrument.aia | a.Instrument.lasco , combine=True)
+    results = Fido.search(a.Time('2020-01-01', '2020-01-01 00:00:10'), a.Instrument.aia | a.Instrument.lasco)
     assert len(results) == 2
     assert isinstance(results[0], QueryResponseTable)
     assert isinstance(results[1], QueryResponseTable)
 
 
-    results = Fido.search(a.Time('2020-01-01', '2020-01-01 00:00:10'), a.Instrument.aia | a.Wavelength(171*u.angstrom) , combine=True)
+    results = Fido.search(a.Time('2020-01-01', '2020-01-01 00:00:10'), a.Instrument.aia | a.Wavelength(171*u.angstrom))
     assert len(results) == 2
     assert isinstance(results[0], QueryResponseTable)
     assert isinstance(results[1], QueryResponseTable)
@@ -362,7 +424,7 @@ def test_combined_response_vso_time():
 @pytest.mark.remote_data
 def test_combined_response_jsoc():
     results = Fido.search(a.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'),
-            a.jsoc.Series('hmi.v_45s') | a.jsoc.Series('aia.lev1_euv_12s'), combine=True)
+            a.jsoc.Series('hmi.v_45s') | a.jsoc.Series('aia.lev1_euv_12s'))
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
 
@@ -387,7 +449,7 @@ def test_combined_response_lyra():
 @pytest.mark.remote_data
 def test_combine_attr():
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
-                  a.Instrument('AIA'), combine=True)
+                  a.Instrument('AIA'))
     assert len(results) == 1
     assert isinstance(results[0], QueryResponseTable)
 
@@ -397,7 +459,7 @@ def test_combine_attr():
     assert isinstance(results[0], QueryResponseTable)
 
     results = Fido.search((a.Time('2020-01-01', '2020-01-01 00:00:10') | a.Time('2020-01-03', '2020-01-03 00:00:10')) &
-                  a.Instrument('AIA'), combine=False)
+                  a.Instrument('AIA'))
     assert len(results) == 2
     assert isinstance(results[0], QueryResponseTable)
 
@@ -565,7 +627,7 @@ def test_path_format_keys():
     # Need to pass combine=False otherwise combine=True will take union of the
     # columns for multiple tables which will not have the same keys
     # because path_format_keys() takes intersection of the keys in the tables
-    unif = UnifiedResponse(t1, t2, combine=False)
+    unif = UnifiedResponse(t1, t2)
 
     # assert unif.path_format_keys() == {'start_time', '_excite_', '01_wibble', 'end_time'}
     assert unif.path_format_keys() == {'start_time', '_excite_', '01_wibble', 'end_time'}

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -343,7 +343,6 @@ def test_combined_response_vso_time():
     assert t1 == t2
 
 
-
 @pytest.mark.remote_data
 def test_combined_response_jsoc():
     results = Fido.search(a.Time('2014-01-01T00:00:00', '2014-01-01T01:00:00'),
@@ -378,7 +377,6 @@ def test_combined_response_lyra():
     t1 = TimeRange(results[-1][0]["Start Time"], results[-1][-1]["End Time"])
     t2 = TimeRange('2020-01-01', '2020-01-03 23:59:59.999')
     assert t1 == t2
-
 
 
 @pytest.mark.remote_data

--- a/text.txt
+++ b/text.txt
@@ -1,8 +1,0 @@
-Results from 1 Provider:
-
-0 Results from the ABCMeta:
-Source: <property object at 0x0000023151CAC270>
-Error: ConnectionError('No online VSO mirrors could be found.')
-
-<No columns>
-

--- a/text.txt
+++ b/text.txt
@@ -1,0 +1,8 @@
+Results from 1 Provider:
+
+0 Results from the ABCMeta:
+Source: <property object at 0x0000023151CAC270>
+Error: ConnectionError('No online VSO mirrors could be found.')
+
+<No columns>
+


### PR DESCRIPTION
Fixes #2237 

Changes: 
- Combine Fido search results from the same client.
- Adds test for this.

Example:
Before
![image](https://github.com/user-attachments/assets/43ed0d19-de2a-4e05-b7d6-ff50ce08d516)

After
![image](https://github.com/user-attachments/assets/699a7aac-e710-4794-9f13-6e0e2fccaff1)