### PR TITLE
Handle units that does not support FITS format in `GenericMap`.

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -805,7 +805,6 @@ class GenericMap(NDData):
                                'with sunpy.map.Map.\n'
                                'See https://fits.gsfc.nasa.gov/fits_standard.html for '
                                'the FITS unit standards.')
-                unit = None
         return unit
 
     @property

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -253,11 +253,11 @@ def test_std(generic_map):
     np.testing.assert_allclose(generic_map.std(), 10.388294694831615)
 
 
-def test_unit(generic_map):
+def test_unit(generic_map, aia171_test_map):
     assert generic_map.unit == u.DN / u.s
-    generic_map.meta['bunit'] = 'not a unit'
-    with pytest.warns(SunpyMetadataWarning, match='Could not parse unit string "not a unit"'):
-        assert generic_map.unit is None
+    aia171_test_map = aia171_test_map * (1 * (u.electron / u.DN / u.pix**2))
+    with pytest.warns(SunpyMetadataWarning, match='Could not parse unit string "electron / pix2"'):
+        assert aia171_test_map.unit is not None
 
 
 # ==============================================================================


### PR DESCRIPTION
## PR Description

fixes #6823 

see https://github.com/sunpy/sunpy/issues/6823#issuecomment-2611856120