### PR TITLE
Fixed Map logic for permitting DN as a unit

### DIFF
--- a/changelog/8037.bugfix.rst
+++ b/changelog/8037.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed the unintended `~sunpy.map.Map` behavior where any combination of non-FITS units were allowed as long as one of the non-FITS units was DN.
+DN is currently the only non-FITS unit permitted in `~sunpy.map.Map`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -794,18 +794,26 @@ class GenericMap(NDData):
                         'counts / pixel': 'ct/pix',}
         if unit_str.lower() in replacements:
             unit_str = replacements[unit_str.lower()]
-        unit = u.Unit(unit_str, format='fits', parse_strict='silent')
-        if isinstance(unit, u.UnrecognizedUnit):
-            unit = u.Unit(unit_str, parse_strict='silent')
+        unit = u.Unit(unit_str, parse_strict='silent')
+        for base in unit.bases:
             # NOTE: Special case DN here as it is not part of the FITS standard, but
             # is widely used and is also a recognized astropy unit
-            if u.DN not in unit.bases:
+            if base is u.DN:
+                continue
+            try:
+                if isinstance(base, u.UnrecognizedUnit):
+                    raise ValueError
+
+                # Also rejects a unit that is not in the FITS standard but is equivalent to one (e.g., Mx)
+                if u.Unit(base.to_string(format='fits')) is not base:  # to_string() can raise ValueError
+                    raise ValueError
+            except ValueError:
                 warn_metadata(f'Could not parse unit string "{unit_str}" as a valid FITS unit.\n'
                               f'See {_META_FIX_URL} for how to fix metadata before loading it '
                                'with sunpy.map.Map.\n'
                                'See https://fits.gsfc.nasa.gov/fits_standard.html for '
                                'the FITS unit standards.')
-                unit = None
+                return None
         return unit
 
     @property

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1889,6 +1889,12 @@ def test_parse_fits_units(units_string, expected_unit):
     assert out_unit == expected_unit
 
 
+@pytest.mark.parametrize('units_string', ['DN / electron', 'electron', 'Mx'])
+def test_parse_nonfits_units(units_string):
+    with pytest.warns(SunpyMetadataWarning, match='Could not parse unit string'):
+        assert GenericMap._parse_fits_unit(units_string) is None
+
+
 def test_only_cd():
     data = np.ones([6, 6], dtype=np.float64)
     header = {


### PR DESCRIPTION
This PR fixes a bug in the code that allows DN as a Map unit (#7585).  The existing code has a logical flaw: it should be allowing DN as the only non-FITS unit, but instead it allows any combination of non-FITS units as long as one of the units is DN.  For example, while a map with unit "electron" is not allowed, a map with unit "DN / electron" is mistakenly allowed because it includes DN as one of its non-FITS units.

This bugfix has the unfortunate consequence of making `Map` even less permissive by blocking all non-FITS unit combinations (aside from DN), but I feel we ought to fix the inconsistent behavior in 6.0 (see https://github.com/sunpy/sunpy/issues/6823#issuecomment-2610618498).