### PR TITLE
Documentation update for measurement

### DIFF
--- a/changelog/8038.trivial.rst
+++ b/changelog/8038.trivial.rst
@@ -1,0 +1,1 @@
+Update documentation for the measurement property in the GenericMap class

--- a/changelog/8038.trivial.rst
+++ b/changelog/8038.trivial.rst
@@ -1,1 +1,1 @@
-Update documentation for `~.measurement` within `~.GenericMap`.
+Added clarification to the docstring for the `.GenericMap.measurement` property about its possible return types.

--- a/changelog/8038.trivial.rst
+++ b/changelog/8038.trivial.rst
@@ -1,1 +1,1 @@
-Update documentation for the measurement property in the GenericMap class
+Update documentation for `~.measurement` within `~.GenericMap`.

--- a/changelog/newfragments/8038.trivial.rst
+++ b/changelog/newfragments/8038.trivial.rst
@@ -1,1 +1,0 @@
-Updated documentation for the ``measurement`` property in the `~.GenericMap`

--- a/changelog/newfragments/8038.trivial.rst
+++ b/changelog/newfragments/8038.trivial.rst
@@ -1,2 +1,1 @@
-Update documentation for the `measurement` property in the `GenericMap` class in `sunpy.map.mapbase.py`.
-
+Updated documentation for the ``measurement`` property in the `~.GenericMap`

--- a/changelog/newfragments/8038.trivial.rst
+++ b/changelog/newfragments/8038.trivial.rst
@@ -1,0 +1,2 @@
+Update documentation for the `measurement` property in the `GenericMap` class in `sunpy.map.mapbase.py`.
+

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1074,18 +1074,15 @@ class GenericMap(NDData):
     @property
     def measurement(self):
         """
-        Returns the primary measurement of the map, typically the wavelength 
-        (from the 'WAVELNTH' FITS keyword). In some cases, it may represent 
-        other observables like LOS magnetograms or continuum intensity.
-
-        By default, it returns the wavelength with units (if 'WAVEUNIT' is present) 
-        or dimensionless if missing. Subclasses of GenericMap may override this 
-        property to return other measurement types.
-
-        Returns:
-         ~astropy.units.Quantity or str:
-         The measurement value (e.g., wavelength or other observable). 
-        Returns None if no relevant keyword is found.
+        The measurement type of the observation.
+        
+        The measurement type can be described by a `str` or a
+        `~astropy.units.Quantity`.  If the latter, it is typically equal to
+        `.GenericMap.wavelength`.
+        
+        See Also
+        --------
+        wavelength : The wavelength of the observation.
          """
         return self.wavelength
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1079,11 +1079,12 @@ class GenericMap(NDData):
         The measurement type can be described by a `str` or a
         `~astropy.units.Quantity`. If the latter, it is typically equal to
         `.GenericMap.wavelength`.
-
+        
         See Also
         --------
         wavelength : The wavelength of the observation.
         """
+
         return self.wavelength
 
     @property

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1075,11 +1075,11 @@ class GenericMap(NDData):
     def measurement(self):
         """
         The measurement type of the observation.
-        
+
         The measurement type can be described by a `str` or a
         `~astropy.units.Quantity`. If the latter, it is typically equal to
         `.GenericMap.wavelength`.
-        
+
         See Also
         --------
         wavelength : The wavelength of the observation.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1077,13 +1077,13 @@ class GenericMap(NDData):
         The measurement type of the observation.
         
         The measurement type can be described by a `str` or a
-        `~astropy.units.Quantity`.  If the latter, it is typically equal to
+        `~astropy.units.Quantity`. If the latter, it is typically equal to
         `.GenericMap.wavelength`.
-        
+
         See Also
         --------
         wavelength : The wavelength of the observation.
-         """
+        """
         return self.wavelength
 
     @property

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1074,12 +1074,20 @@ class GenericMap(NDData):
     @property
     def measurement(self):
         """
-        Measurement wavelength.
+        Returns the primary measurement of the map, typically the wavelength 
+        (from the 'WAVELNTH' FITS keyword). In some cases, it may represent 
+        other observables like LOS magnetograms or continuum intensity.
 
-        This is taken from the 'WAVELNTH' FITS keywords. If the keyword is not
-        present, defaults to `None`. If 'WAVEUNIT' keyword isn't present,
-        defaults to dimensionless units.
-        """
+        By default, it returns the wavelength with units (if 'WAVEUNIT' is present) 
+        or dimensionless if missing. Subclasses of GenericMap may override this 
+        property to return other measurement types.
+
+        Returns:
+         ~astropy.units.Quantity or str:
+         The measurement value (e.g., wavelength or other observable). 
+        Returns None if no relevant keyword is found.
+         """
+
         return self.wavelength
 
     @property

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -1087,7 +1087,6 @@ class GenericMap(NDData):
          The measurement value (e.g., wavelength or other observable). 
         Returns None if no relevant keyword is found.
          """
-
         return self.wavelength
 
     @property


### PR DESCRIPTION
Closes https://github.com/sunpy/sunpy/issues/4802

This PR updates the documentation for the measurement property in the GenericMap class. It clarifies the default behavior of retrieving wavelength from the WAVELNTH FITS keyword, handling missing WAVEUNIT keywords, and how subclasses can override the property to return other observables (e.g., LOS magnetograms, continuum intensity).

Thanks to everyone who helped by sharing their doubts and communication, which significantly improved my understanding of the problem statement.

This update does not affect existing code functionality but improves documentation clarity