### PR TITLE
Updated: SRSClient URL to new HTTPS endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,10 @@ jobs:
       toxdeps: tox-pypi-filter
       posargs: -n auto --color=yes
       envs: |
-        - linux: py311-oldestdeps
+        - linux: py313
           libraries:
             apt:
               - libopenjp2-7
-          deps:
-              - pytest==6.2.4
-              - tox-pypi-filter==0.1.0
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,13 @@ jobs:
       toxdeps: tox-pypi-filter
       posargs: -n auto --color=yes
       envs: |
-        - linux: py313
+        - linux: py311-oldestdeps
           libraries:
             apt:
               - libopenjp2-7
+          deps:
+              - pytest==6.2.4
+              - tox-pypi-filter==0.1.0
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/changelog/8054.bugfix.rst
+++ b/changelog/8054.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes the issue https://github.com/sunpy/sunpy/issues/8022. Updated the SRSClient to use the new HTTPS endpoint instead of the outdated FTP link used earlier which caused a CI test to fail.

--- a/changelog/8054.bugfix.rst
+++ b/changelog/8054.bugfix.rst
@@ -1,1 +1,1 @@
-Fixes the issue https://github.com/sunpy/sunpy/issues/8022. Updated the SRSClient to use the new HTTPS endpoint instead of the outdated FTP link used earlier which caused a CI test to fail.
+Corrected the NOAA `~.SRSClient` to use a updated HTTPS server instead of the now defunct FTP.

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -135,7 +135,8 @@ class SRSClient(GenericClient):
     """
     Provides access to the NOAA SWPC solar region summary data.
 
-    Uses the `ftp archive <https://www.ngdc.noaa.gov/stp/spaceweather.html>`__.
+    The data is now retrieved from the NOAA NCEI HTTPS archive:
+    `https://www.ngdc.noaa.gov/stp/space-weather/swpc-products/daily_reports/solar_region_summaries/`__.
 
     Notes
     -----
@@ -162,8 +163,6 @@ class SRSClient(GenericClient):
     """
     pattern = ('https://www.ngdc.noaa.gov/stp/space-weather/swpc-products/daily_reports/solar_region_summaries/'
                '{{year:4d}}/{{month:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}SRS.txt')
-    # Server does not support the normal aioftp passive command.
-    enqueue_file_kwargs = {"passive_commands": ["pasv"]}
 
     @classmethod
     def register_values(cls):

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -135,8 +135,8 @@ class SRSClient(GenericClient):
     """
     Provides access to the NOAA SWPC solar region summary data.
 
-    The data is now retrieved from the NOAA NCEI HTTPS archive:
-    `https://www.ngdc.noaa.gov/stp/space-weather/swpc-products/daily_reports/solar_region_summaries/`__.
+    `The data is retrieved from NOAA's NCEI archive
+    <https://www.ngdc.noaa.gov/stp/space-weather/swpc-products/daily_reports/solar_region_summaries/>`__.
 
     Notes
     -----

--- a/sunpy/net/dataretriever/sources/noaa.py
+++ b/sunpy/net/dataretriever/sources/noaa.py
@@ -160,7 +160,7 @@ class SRSClient(GenericClient):
     <BLANKLINE>
 
     """
-    pattern = ('ftp://ftp.ngdc.noaa.gov/STP/swpc_products/daily_reports/solar_region_summaries/'
+    pattern = ('https://www.ngdc.noaa.gov/stp/space-weather/swpc-products/daily_reports/solar_region_summaries/'
                '{{year:4d}}/{{month:2d}}/{{year:4d}}{{month:2d}}{{day:2d}}SRS.txt')
     # Server does not support the normal aioftp passive command.
     enqueue_file_kwargs = {"passive_commands": ["pasv"]}


### PR DESCRIPTION
## PR Description

Earlier the SRSClient used FTP links to get the Solar Region Summary from NOAA. But NOAA changed migrated from their FTP links towards standard HTTPS links, and thus the CI tests started failing. See issue #8022 for more details.

In this PR I have updated the updates Solar Region Summary (SRS) dataset URL in SRSClient from the outdated FTP link to the new HTTPS endpoint provided by NOAA.

This resolves the issue of the SRS dataset not updating since 16-09-2024, ensuring the latest data is correctly fetched.


