### PR TITLE
Added an ASV benchmarks CI build for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,40 @@ jobs:
         - linux: linkcheck
           pytest: false
 
+  benchmarks:
+    needs: [core]
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'Run benchmarks')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sunpy repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y libopencv-dev
+          python -m pip install --upgrade pip
+          pip install asv virtualenv
+      - name: Add machine info for ASV
+        run: asv machine --yes
+      - name: Run benchmarks
+        env:
+          OPENBLAS_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OMP_NUM_THREADS: 1
+          ASV_FACTOR: 1.1
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          COLUMNS: 150  # set a large terminal width so that large tables are rendered in 2D
+        run: |
+          ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR --cpu-affinity 0"
+          asv continuous $ASV_OPTIONS ${BASE_SHA} ${GITHUB_SHA}
+
   sdist_verify:
     if: |
       github.event_name == 'workflow_dispatch' || (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,40 +126,6 @@ jobs:
         - linux: linkcheck
           pytest: false
 
-  benchmarks:
-    needs: [core]
-    if: |
-      github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'Run benchmarks')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sunpy repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -y libopencv-dev
-          python -m pip install --upgrade pip
-          pip install asv virtualenv
-      - name: Add machine info for ASV
-        run: asv machine --yes
-      - name: Run benchmarks
-        env:
-          OPENBLAS_NUM_THREADS: 1
-          MKL_NUM_THREADS: 1
-          OMP_NUM_THREADS: 1
-          ASV_FACTOR: 1.1
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          COLUMNS: 150  # set a large terminal width so that large tables are rendered in 2D
-        run: |
-          ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR --cpu-affinity 0"
-          asv continuous $ASV_OPTIONS ${BASE_SHA} ${GITHUB_SHA}
-
   sdist_verify:
     if: |
       github.event_name == 'workflow_dispatch' || (

--- a/.github/workflows/ci_benchmarks.yml
+++ b/.github/workflows/ci_benchmarks.yml
@@ -1,0 +1,43 @@
+name: CI benchmarks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'Run benchmarks')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sunpy repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y libopencv-dev
+          python -m pip install --upgrade pip
+          pip install asv virtualenv
+      - name: Add machine info for ASV
+        run: asv machine --yes
+      - name: Run benchmarks
+        env:
+          OPENBLAS_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OMP_NUM_THREADS: 1
+          ASV_FACTOR: 1.1
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          COLUMNS: 150  # set a large terminal width so that large tables are rendered in 2D
+        run: |
+          ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR --cpu-affinity 0"
+          asv continuous $ASV_OPTIONS ${BASE_SHA} ${GITHUB_SHA}

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,12 +1,11 @@
 {
     "version": 1,
-    "project": "sunpy-benchmarks",
+    "project": "sunpy",
     "project_url": "https://sunpy.org/",
     "repo": "./",
     "branches": [
         "main"
     ],
-    "dvcs": "git",
     "environment_type": "virtualenv",
     "show_commit_url": "https://github.com/sunpy/sunpy/commit/",
     "benchmark_dir": "benchmarks",

--- a/benchmarks/coordinates.py
+++ b/benchmarks/coordinates.py
@@ -1,3 +1,5 @@
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
 import astropy.units as u
 from astropy.coordinates import HCRS, ITRS, HeliocentricMeanEcliptic, SphericalRepresentation
 
@@ -27,7 +29,7 @@ class TransformationHeliographic:
 
     def setup(self, frames, src, dest):
         if src == dest:
-            raise NotImplementedError
+            raise SkipNotImplemented
 
     def time_transform(self, frames, src, dest):
         frames[src].transform_to(frames[dest])
@@ -52,7 +54,7 @@ class TransformationEcliptic:
 
     def setup(self, frames, src, dest):
         if src == dest:
-            raise NotImplementedError
+            raise SkipNotImplemented
 
     def time_transform(self, frames, src, dest):
         frames[src].transform_to(frames[dest])
@@ -77,7 +79,7 @@ class TransformationMagnetic:
 
     def setup(self, frames, src, dest):
         if src == dest:
-            raise NotImplementedError
+            raise SkipNotImplemented
 
     def time_transform(self, frames, src, dest):
         frames[src].transform_to(frames[dest])

--- a/benchmarks/coordinates.py
+++ b/benchmarks/coordinates.py
@@ -1,11 +1,11 @@
 import astropy.units as u
-from astropy.coordinates import HeliocentricMeanEcliptic, SphericalRepresentation
+from astropy.coordinates import HCRS, ITRS, HeliocentricMeanEcliptic, SphericalRepresentation
 
 import sunpy.coordinates.frames as f
 
 
-class Transformation:
-    frame_names = ['HGS', 'HGC', 'HCC', 'HPC', 'HCI', 'HAE', 'HEE', 'GSE', 'GEI']
+class TransformationHeliographic:
+    frame_names = ['HCRS', 'HGS', 'HGC', 'HCC', 'HPC', 'HPR', 'HCI']
 
     params = (frame_names, frame_names)
     param_names = ['src', 'dest']
@@ -15,15 +15,63 @@ class Transformation:
         vect = SphericalRepresentation(0*u.deg, 0*u.deg, 1*u.AU)
         observer = f.HeliographicStonyhurst(vect, obstime=obstime)
         frames = {
+            'HCRS': HCRS(vect, obstime=obstime),
             'HGS': f.HeliographicStonyhurst(vect, obstime=obstime),
             'HGC': f.HeliographicCarrington(vect, obstime=obstime, observer=observer),
             'HCC': f.Heliocentric(vect, obstime=obstime, observer=observer),
             'HPC': f.Helioprojective(vect, obstime=obstime, observer=observer),
+            'HPR': f.HelioprojectiveRadial(vect, obstime=obstime, observer=observer),
             'HCI': f.HeliocentricInertial(vect, obstime=obstime),
+        }
+        return frames
+
+    def setup(self, frames, src, dest):
+        if src == dest:
+            raise NotImplementedError
+
+    def time_transform(self, frames, src, dest):
+        frames[src].transform_to(frames[dest])
+
+
+class TransformationEcliptic:
+    frame_names = ['HAE', 'HEE', 'GSE', 'GEI']
+
+    params = (frame_names, frame_names)
+    param_names = ['src', 'dest']
+
+    def setup_cache(self):
+        obstime = '2023-01-01'
+        vect = SphericalRepresentation(0*u.deg, 0*u.deg, 1*u.AU)
+        frames = {
             'HAE': HeliocentricMeanEcliptic(vect, obstime=obstime, equinox='J2000'),
             'HEE': f.HeliocentricEarthEcliptic(vect, obstime=obstime),
             'GSE': f.GeocentricSolarEcliptic(vect, obstime=obstime),
             'GEI': f.GeocentricEarthEquatorial(vect, obstime=obstime, equinox='J2000'),
+        }
+        return frames
+
+    def setup(self, frames, src, dest):
+        if src == dest:
+            raise NotImplementedError
+
+    def time_transform(self, frames, src, dest):
+        frames[src].transform_to(frames[dest])
+
+
+class TransformationMagnetic:
+    frame_names = ['GEO', 'MAG', 'SM', 'GSM']
+
+    params = (frame_names, frame_names)
+    param_names = ['src', 'dest']
+
+    def setup_cache(self):
+        obstime = '2023-01-01'
+        vect = SphericalRepresentation(0*u.deg, 0*u.deg, 1*u.AU)
+        frames = {
+            'GEO': ITRS(vect, obstime=obstime),
+            'MAG': f.Geomagnetic(vect, obstime=obstime),
+            'SM': f.SolarMagnetic(vect, obstime=obstime),
+            'GSM': f.GeocentricSolarMagnetospheric(vect, obstime=obstime),
         }
         return frames
 

--- a/benchmarks/map.py
+++ b/benchmarks/map.py
@@ -1,4 +1,7 @@
+from io import BytesIO
+
 from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark
+from matplotlib.figure import Figure
 
 import astropy.units as u
 
@@ -79,3 +82,26 @@ class Reproject:
     def peakmem_reproject_to_plus_diffrot(self, maps, algorithm):
         with propagate_with_solar_surface():
             maps[1].reproject_to(maps[0].wcs, algorithm=algorithm)
+
+
+class Autoalign:
+    params = [False, True, 'pcolormesh']
+    param_names = ['autoalign']
+
+    def setup_cache(self):
+        maps = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE, sunpy.data.sample.HMI_LOS_IMAGE)
+        return maps
+
+    def time_autoalign(self, maps, autoalign):
+        fig = Figure()
+        ax = fig.add_subplot(projection=maps[0])
+        maps[1].plot(axes=ax, autoalign=autoalign)
+        buf = BytesIO()
+        fig.savefig(buf, format='png')
+
+    def peakmem_autoalign(self, maps, autoalign):
+        fig = Figure()
+        ax = fig.add_subplot(projection=maps[0])
+        maps[1].plot(axes=ax, autoalign=autoalign)
+        buf = BytesIO()
+        fig.savefig(buf, format='png')

--- a/benchmarks/map.py
+++ b/benchmarks/map.py
@@ -1,3 +1,5 @@
+from asv_runner.benchmarks.mark import skip_benchmark
+
 import astropy.units as u
 
 import sunpy.data.sample
@@ -14,6 +16,9 @@ class Creation:
     def time_create_map(self, name):
         sunpy.map.Map(self.filename)
 
+    # Skipped due to a bug in pympler.asizeof
+    # https://github.com/pympler/pympler/issues/151
+    @skip_benchmark
     def mem_create_map(self, name):
         return sunpy.map.Map(self.filename)
 

--- a/benchmarks/map.py
+++ b/benchmarks/map.py
@@ -1,4 +1,4 @@
-from asv_runner.benchmarks.mark import skip_benchmark
+from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark
 
 import astropy.units as u
 
@@ -49,7 +49,7 @@ class Rotate:
 
     def setup(self, aiamap, method, order):
         if method == 'opencv' and order not in {0, 1, 3}:
-            raise NotImplementedError
+            raise SkipNotImplemented
 
     def time_rotate(self, aiamap, method, order):
         aiamap.rotate(30*u.deg, method=method, order=order)

--- a/benchmarks/map.py
+++ b/benchmarks/map.py
@@ -4,6 +4,7 @@ import astropy.units as u
 
 import sunpy.data.sample
 import sunpy.map
+from sunpy.coordinates import propagate_with_solar_surface
 
 
 class Creation:
@@ -55,3 +56,26 @@ class Rotate:
 
     def peakmem_rotate(self, aiamap, method, order):
         aiamap.rotate(30*u.deg, method=method, order=order)
+
+
+class Reproject:
+    params = ['interpolation', 'adaptive']
+    param_names = ['algorithm']
+
+    def setup_cache(self):
+        maps = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE, sunpy.data.sample.HMI_LOS_IMAGE)
+        return maps
+
+    def time_reproject_to(self, maps, algorithm):
+        maps[1].reproject_to(maps[0].wcs, algorithm=algorithm)
+
+    def peakmem_reproject_to(self, maps, algorithm):
+        maps[1].reproject_to(maps[0].wcs, algorithm=algorithm)
+
+    def time_reproject_to_plus_diffrot(self, maps, algorithm):
+        with propagate_with_solar_surface():
+            maps[1].reproject_to(maps[0].wcs, algorithm=algorithm)
+
+    def peakmem_reproject_to_plus_diffrot(self, maps, algorithm):
+        with propagate_with_solar_surface():
+            maps[1].reproject_to(maps[0].wcs, algorithm=algorithm)

--- a/docs/dev_guide/contents/ci_jobs.rst
+++ b/docs/dev_guide/contents/ci_jobs.rst
@@ -51,3 +51,9 @@ Currently we have several stages of CI jobs, some run on a pull request and some
       Likely to break due to upstream changes we can't fix and have to wait to be resolved.
     * "conda" - Check the offline test suite when using conda instead of pip/pypi.
       Likely to break due to packaging upstream we can't fix and have to wait to be resolved.
+
+6. "benchmarks" - only upon request on a pull request
+   This runs our suite of ``asv`` benchmarks on a pull request to check whether merging the pull request would increase or decrease performance.
+   This approach to checking for performance changes can have false positives or false negatives, so should not be the sole source of information when evaluating the performance impact of a pull request.
+
+   To enable this build, add the label "Run benchmarks" to the pull request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools>=62.1",
-  "setuptools_scm[toml]>=8.0.0",
+  "setuptools_scm[toml]>=8.0.1",
   "wheel",
   "extension-helpers",
   # Comments on numpy build requirement range:


### PR DESCRIPTION
We have some benchmarks using `asv` (cf. #6392) that we haven't really been taking advantage of.  This PR enables the checking of any performance differences for a given PR through a dedicated `benchmarks` CI build.  This CI build is turned on by adding the label "Run benchmarks" to that given PR.~, and will run after the `core` CI build passes.~

This PR also adds a bunch more ASV benchmarks:
- Coordinate transformations between frames that had been added in the past two years
- Reprojection
- Reprojection plus differential rotation
- Plotting maps with the various settings of `autoalign`

---
Only relevant because of how `asv` builds its working environment, this PR also bumps the minimum required version of `setuptools_scm` due to a bad bug with 8.0.0 (that release is even yanked).