### PR TITLE
Add Github-Action for new release when tags are pushed to the repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,37 @@ jobs:
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
 
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: none
+      checks: none
+      deployments: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+      - name: Generate GitHub Release Notes
+        run: |
+          pip install bleach
+          pandoc -- wrap=none -t markdown_strict CHANGELOG.rst > notes.md
+          python3 -c "import bleach, sys; print(bleach.clean(sys.stdin.read()))" < notes.md > release_notes.md
+          { echo "RELEASE_BODY<<EOF"; cat release_notes.md; echo "EOF"; } >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        uses: "actions/create-release@v1.1.4"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref_name }}
+          body: ${{ env.RELEASE_BODY }}
+          draft: false
+          prerelease: false
+
   notify:
     if: always() && github.event_name == 'workflow_dispatch'
     needs: [publish_pure, online, cron, conda]


### PR DESCRIPTION
## PR Description

fixes #6134

this pr adds a Github-Action that publish a new release when new tag with `v` tag is pushed to repo.
body of release is updated to text returned by `tools/generate_github_changelog.py`


example of [Published release](https://github.com/ankitkhushwaha/sunpy/releases/tag/v6.0.1.3) 