### PR TITLE
Add line breaks to long signatures in API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,8 @@ linkcheck_anchors = False
 
 # -- General configuration ---------------------------------------------------
 
+# Wrap large function/method signatures
+maximum_signature_line_length = 80
 # sphinxext-opengraph
 ogp_image = "https://raw.githubusercontent.com/sunpy/sunpy-logo/master/generated/sunpy_logo_word.png"
 ogp_use_first_image = True


### PR DESCRIPTION
I remember thinking for *ages* that signatures like [make_fitswcs_header](https://docs.sunpy.org/en/stable/generated/api/sunpy.map.header_helper.make_fitswcs_header.html#sunpy.map.header_helper.make_fitswcs_header) were really hard to read. Now, years later, I return with a solution! 🚀 