### PR TITLE
Cap the number of steps to benchmark for the daily ASV run

### DIFF
--- a/.github/workflows/asv-regular.yml
+++ b/.github/workflows/asv-regular.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Add machine info for ASV
         run: asv machine --machine GH-Actions --os ubuntu-latest --arch x64 --cpu "2-core unknown" --ram 7GB
       - name: Run benchmarks for commits since v2.1
-        run: taskset -c 0 asv run --skip-existing-successful v3.0.dev..
+        run: taskset -c 0 asv run --skip-existing-successful --steps 50 v3.0.dev..
       - name: Install SSH Client 🔑
         uses: webfactory/ssh-agent@v0.9.0
         with:


### PR DESCRIPTION
I believe our daily ASV run has not successfully completed in years because it always gets cancelled after 6 hours of run time.  I suspect that total run time would have been in the ballpark of ~40 hours, and I have now made the run time much worse with the hefty benchmarks added in #8060.  It might now take a full week to run the current full range of ~4700 commits (which we should seriously consider shrinking).

This PR caps the number of steps for ASV to benchmark to 50 sampled across the range of commits, so two orders of magnitude fewer data points.  Of course, 50 data points is woefully low to see any trending, so hopefully it turns out that the cap can be increased, but for now, let's start with 50 steps because I'm (fairly) certain that it will actually finish.