### PR TITLE
Standardize how-to guide names

### DIFF
--- a/docs/how_to/create_a_map.rst
+++ b/docs/how_to/create_a_map.rst
@@ -1,7 +1,7 @@
 .. _sunpy-how-to-create-a-map:
 
 *************************
-How to create a sunpy Map
+Create a `~sunpy.map.Map`
 *************************
 
 One of the primary goals of the Map interface is to make it as easy as possible to create a Map.

--- a/docs/how_to/create_coords.rst
+++ b/docs/how_to/create_coords.rst
@@ -1,7 +1,7 @@
 .. _sunpy-how-to-create-coordinate-objects:
 
 *************************
-Create Coordinate Objects
+Create coordinate objects
 *************************
 
 The easiest interface to work with coordinates is through the `~astropy.coordinates.SkyCoord` class:

--- a/docs/how_to/create_custom_map.rst
+++ b/docs/how_to/create_custom_map.rst
@@ -1,8 +1,8 @@
 .. _sunpy-how-to-custom-maps:
 
-**************************
-Create Custom Maps by Hand
-**************************
+********************************
+Create a custom `~sunpy.map.Map`
+********************************
 
 It is possible to create Maps using custom data, e.g., from a simulation or an observation from a data source that is not explicitly supported by ``sunpy``.
 To do this, you need to provide `sunpy.map.Map` with both the data array as well as appropriate metadata.

--- a/docs/how_to/create_custom_timeseries.rst
+++ b/docs/how_to/create_custom_timeseries.rst
@@ -1,8 +1,8 @@
 .. _sunpy-how-to-custom-timeseries:
 
-************************
-Create Custom TimeSeries
-************************
+**********************************************
+Create a custom `~sunpy.timeseries.Timeseries`
+**********************************************
 
 Sometimes you will have data that you want to transform into a TimeSeries.
 You can use the factory to create a `~sunpy.timeseries.GenericTimeSeries` from a variety of data sources currently including `pandas.DataFrame` and `astropy.table.Table`.

--- a/docs/how_to/create_rectangle_on_map.rst
+++ b/docs/how_to/create_rectangle_on_map.rst
@@ -1,7 +1,7 @@
 .. _sunpy-how-to-create-rectangle-on-map:
 
 *********************************************
-How to draw a rectangle on a `~sunpy.map.Map`
+Draw a rectangle on a `~sunpy.map.Map`
 *********************************************
 
 ``sunpy`` provides a convenient method called :meth:`~sunpy.map.GenericMap.draw_quadrangle` to draw rectangles on maps.

--- a/docs/how_to/fix_map_metadata.rst
+++ b/docs/how_to/fix_map_metadata.rst
@@ -1,7 +1,7 @@
 .. _sunpy-how-to-fix-map-metadata:
 
 *************************
-Fixing incorrect metadata
+Fix incorrect metadata
 *************************
 
 There will be times where you will come across a FITS files with either incorrect, missing or unparsable metadata and reading these files into `~sunpy.map.Map` will cause an error.

--- a/docs/how_to/manipulate_grid_lines.rst
+++ b/docs/how_to/manipulate_grid_lines.rst
@@ -1,8 +1,8 @@
 .. _how-to-manipulate-grid-lines-in-image-plots:
 
-*****************************************
-Manipulate grids lines when plotting Maps
-*****************************************
+*******************************************************
+Manipulate grids lines when plotting a `~sunpy.map.Map`
+*******************************************************
 
 Underneath the hood, `sunpy.map.GenericMap.plot` uses `~astropy.visualization.wcsaxes.WCSAxes` to have to ability to plot images in world coordinates.
 This means that sometimes the standard matplotlib methods to manipulate grid lines may not work as expected.

--- a/docs/how_to/observer_by_coordinate.rst
+++ b/docs/how_to/observer_by_coordinate.rst
@@ -1,8 +1,8 @@
 .. _sunpy-how-to-observer-by-coordinate:
 
-************************************
-Specifying an Observer by Coordinate
-************************************
+*********************************
+Specify an observer by coordinate
+*********************************
 
 For coordinate frames that include the observer location as part of the definition (e.g., `~sunpy.coordinates.Helioprojective`), there are two main ways to specify the observer location (the ``observer`` frame attribute).
 If it makes sense to designate a planetary body as the observer, one can specify the observer to be that body using a string (e.g., ``observer='earth'``), and the observer will be understood to be situated at the center of that body at the time of the coordinate (the ``obstime`` frame attribute).

--- a/docs/how_to/read_asdf_file.rst
+++ b/docs/how_to/read_asdf_file.rst
@@ -1,8 +1,8 @@
 .. _sunpy-how-to-read-an-asdf-file:
 
-****************************
-Read an ASDF file into a Map
-****************************
+*****************************************
+Read an ASDF file into a `~sunpy.map.Map`
+*****************************************
 
 `ASDF <https://asdf-standard.readthedocs.io/en/latest/>`__ is a modern file format designed to meet the needs of the astronomy community [citation needed].
 It has deep integration with Python, SunPy, and Astropy, as well as implementations in other languages.

--- a/docs/how_to/remote_data_manager.rst
+++ b/docs/how_to/remote_data_manager.rst
@@ -1,7 +1,7 @@
 .. _sunpy-how-to-the-remote-data-manager:
 
 ***************************
-Use the Remote Data Manager
+Use the remote data manager
 ***************************
 
 Often, data prep or analysis functions require files to be downloaded from a remote server.

--- a/docs/how_to/search_multiple_wavelengths.rst
+++ b/docs/how_to/search_multiple_wavelengths.rst
@@ -2,9 +2,9 @@
 
 .. _sunpy-how-to-search-for-multiple-wavelengths-with-fido:
 
-*****************************************
-Search for multiple wavelengths with Fido
-*****************************************
+******************************************************
+Search for multiple wavelengths with `~sunpy.net.Fido`
+******************************************************
 
 Use the `~sunpy.net.attrs.Wavelength` to search for a particular wavelength:
 


### PR DESCRIPTION
This standardizes the titles of the how-to guides to:

1. Follow the format of "How do I...<title>"
2. Follow standard capitalization rules