### PR TITLE
Fixes a unit test since `sunpy.io` expands wildcard input with OS-independent sorting

### DIFF
--- a/changelog/8093.bugfix.rst
+++ b/changelog/8093.bugfix.rst
@@ -1,1 +1,0 @@
-Marks `~sunpy.map.tests.test_patterns` as xfail for the tests to pass on windows.

--- a/changelog/8093.bugfix.rst
+++ b/changelog/8093.bugfix.rst
@@ -1,0 +1,1 @@
+Marks `~sunpy.map.tests.test_patterns` as xfail for the tests to pass on windows.

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -133,6 +133,9 @@ def test_patterns(eit_fits_directory):
     assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
 
     # Test that returned maps are sorted
+    # Sorting based on Strings rather than Path Objects which makes the sorting os independent
+    # This was added because on Windows the sorting was different than on Linux
+    # Windows(and possibly other OSs) use a case-insensitive sort, while Linux uses a case-sensitive sort
     files_sorted = sorted(str(file) for file in pathlib.Path(pattern).parent.glob('*'))
     maps_sorted = [sunpy.map.Map(os.fspath(f)) for f in files_sorted]
     assert all(m.date == m_s.date for m, m_s in zip(maps, maps_sorted))

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -93,7 +93,7 @@ def test_composite():
 # Want to check that patterns work, so ignore this warning that comes from
 # the AIA test data
 
-
+@pytest.mark.xfail()
 @pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in header")
 def test_patterns(eit_fits_directory):
     # Test different Map pattern matching

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -93,7 +93,7 @@ def test_composite():
 # Want to check that patterns work, so ignore this warning that comes from
 # the AIA test data
 
-@pytest.mark.xfail()
+
 @pytest.mark.filterwarnings("ignore:Invalid 'BLANK' keyword in header")
 def test_patterns(eit_fits_directory):
     # Test different Map pattern matching
@@ -133,7 +133,7 @@ def test_patterns(eit_fits_directory):
     assert ([isinstance(amap, sunpy.map.GenericMap) for amap in maps])
 
     # Test that returned maps are sorted
-    files_sorted = sorted(list(pathlib.Path(pattern).parent.glob('*')))
+    files_sorted = sorted(str(file) for file in pathlib.Path(pattern).parent.glob('*'))
     maps_sorted = [sunpy.map.Map(os.fspath(f)) for f in files_sorted]
     assert all(m.date == m_s.date for m, m_s in zip(maps, maps_sorted))
 


### PR DESCRIPTION
Fixes: #8092

~This is a temporary fix for windows to pass the tests. I have marked the test `test_patterns` in `test_map_factory.py` as xfail.~

Edit by @ayshih: Fixes the test (see #8092 for discussion)

