### PR TITLE
Fix: Handle invalid cases properly by catching errors in Fido fetch [#7655]

### DIFF
--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -526,8 +526,17 @@ class JSOCClient(BaseClient):
                         fname = path.strip(ext)
                     else:
                         fname = path
-                    fname = fname.format(file=filename)
-                    fname = os.path.expanduser(fname)
+                   
+
+                    date_value=request.data.get('date') or request.data.get("DATE") or ""
+
+                    try :
+                        fname = fname.format(file=filename,date=date_value)
+                    except KeyError as e :
+                        log.warning(f"Skipping invalid key in path : {e}")
+                        fname=fname.replace(f"{{{e.args[0]}}}","")
+
+                    fname = os.path.expanduser(fname)   
                     paths.append(fname)
 
         dl_set = True


### PR DESCRIPTION
Issue : Error on "date" or any other invalid case .

![Image displaying the main issue](https://github.com/user-attachments/assets/a0b85dd3-fdb8-4fac-bf74-deedd5c6290f)

The code being for this issue :

![Code for the Issue](https://github.com/user-attachments/assets/011c3b5f-56cc-4839-81c3-4c3a137cb124)

Despite being True , on 'date' being on query , it throws error when passing 'date'
- i couldnt find the exact solution i.e being able to accept  'date'

But alternatively made it so that , it does not cause any error , but ignores that query-component , in case it is valid. And just show a Warning .

changes being :


![Changes](https://github.com/user-attachments/assets/62c875e0-a0d4-4c9f-b2d1-43c5ec70688c)
Where the code passes through try and catch block , and in case it throws error in try block , it will go through catch block , and replace that component with empty string and , put a Warning .

if There are need for any changes or improvements, kindly let me know :smiley_cat: 

