### PR TITLE
Update the range for B0 angle that is stated in the docstring

### DIFF
--- a/changelog/8113.doc.rst
+++ b/changelog/8113.doc.rst
@@ -1,0 +1,1 @@
+Fixed a small inaccuracy in the docstring of :func:`sunpy.coordinates.sun.B0` about the range of possible values for B0 angle.

--- a/sunpy/coordinates/sun.py
+++ b/sunpy/coordinates/sun.py
@@ -484,7 +484,7 @@ def print_params(t='now'):
 def B0(time='now'):
     """
     Return the B0 angle for the Sun at a specified time, which is the heliographic latitude of the
-    of the center of the disk of the Sun as seen from Earth. The range of B0 is +/-7.23 degrees.
+    of the center of the disk of the Sun as seen from Earth. The range of B0 is +/-7.25 degrees.
 
     Equivalent definitions include:
         * The heliographic latitude of Earth


### PR DESCRIPTION
As pointed out on Element, the docstring for `sunpy.coordinates.B0()` states that the B0 angle can be as large as 7.23 degrees, but it can actually be as large as 7.25 degrees.  This PR fixes the docstring.

I wrote this back in 2017, possibly with [this page](http://jgiesen.de/sunrot/index.html) as the (uncredited) source.