### PR TITLE
Fixed a desync bug with property caching in `Map`

### DIFF
--- a/changelog/8158.bugfix.rst
+++ b/changelog/8158.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with the caching of `~sunpy.map.Map` properties ``observer_coordinate`` and ``wcs`` where modifying the metadata to be invalid would confuse the cache.

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -20,6 +20,7 @@ from astropy.io import fits
 from astropy.io.fits.verify import VerifyWarning
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.visualization import wcsaxes
+from astropy.wcs import InconsistentAxisTypesError
 
 import sunpy
 import sunpy.coordinates
@@ -212,6 +213,22 @@ def test_wcs_cache(aia171_test_map):
 
     new_wcs = aia171_test_map.wcs
     assert new_wcs.wcs.crpix[0] == new_crpix
+
+
+def test_wcs_error_not_cached(aia171_test_map):
+    # Create a cached value for the property
+    _ = aia171_test_map.wcs
+
+    # Modify the WCS in a bad way
+    aia171_test_map.meta['ctype1'] = 'HPLN-ARC'
+
+    # Try and fail to recalculate the property
+    with pytest.raises(InconsistentAxisTypesError):
+        _ = aia171_test_map.wcs
+
+    # Try again and fail again to recalculate the property
+    with pytest.raises(InconsistentAxisTypesError):
+        _ = aia171_test_map.wcs
 
 
 def test_obs_coord_cache(aia171_test_map):

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -270,11 +270,11 @@ def cached_property_based_on(attr_name):
             if (old_attr_val is _NOT_FOUND or
                     new_attr_val != old_attr_val or
                     prop_key not in cache):
-                # Store the new attribute value
-                cache[attr_name] = new_attr_val
                 # Recompute the property
                 new_val = prop(instance)
                 cache[prop_key] = new_val
+                # Store the new attribute value after the property is computed successfully
+                cache[attr_name] = new_attr_val
 
             return cache[prop_key]
         return inner


### PR DESCRIPTION
A couple of our `Map` properties (`wcs` and `observer_coordinate`) have their values cached, and those values are recomputed if the metadata changes at all.  This PR fixes a bug in the decorator code where the hash of the modified metadata was updated prior to the property being calculated, which meant that if the calculation errored, the cache would left in a state where it claimed to have a new value matching the new metadata, but instead still had the old value.

Before this PR:
```python
>>> import sunpy.map
>>> from sunpy.data.sample import AIA_171_IMAGE
>>> aiamap = sunpy.map.Map(AIA_171_IMAGE)
>>> aiamap.wcs
WCS Keywords

Number of WCS axes: 2
CTYPE : 'HPLN-TAN' 'HPLT-TAN'
CRVAL : 0.00089530541880571 0.00038493926472939
CRPIX : 512.5 512.5
PC1_1 PC1_2  : 0.99999706448085 0.0024230207763071
PC2_1 PC2_2  : -0.0024230207763071 0.99999706448085
CDELT : 0.00066744222222222 0.00066744222222222
NAXIS : 1024  1024

>>> aiamap.meta['ctype1'] = 'garbage'
>>> aiamap.wcs
...
InconsistentAxisTypesError: ERROR 4 in wcs_types() at line 3205 of file cextern\wcslib\C\wcs.c:
Unmatched celestial axes.

>>> aiamap.wcs  # Calling the property again pulls the old cached value instead of repeating the error
WCS Keywords

Number of WCS axes: 2
CTYPE : 'HPLN-TAN' 'HPLT-TAN'
CRVAL : 0.00089530541880571 0.00038493926472939
CRPIX : 512.5 512.5
PC1_1 PC1_2  : 0.99999706448085 0.0024230207763071
PC2_1 PC2_2  : -0.0024230207763071 0.99999706448085
CDELT : 0.00066744222222222 0.00066744222222222
NAXIS : 1024  1024
```