### PR TITLE
Speed up mesh-based autoalign plotting of Maps

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,7 @@
 default.extend-ignore-identifiers-re = [
     "ANDed",
     "arange",
+    "iy",
     "iy1",
     "iy2",
     "EIS",

--- a/changelog/8161.bugfix.rst
+++ b/changelog/8161.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where autoalign plotting of a `~sunpy.map.Map` would not expand the plot limits in some cases.

--- a/changelog/8161.feature.rst
+++ b/changelog/8161.feature.rst
@@ -1,0 +1,1 @@
+Autoalign plotting for `~sunpy.map.Map` is now significantly faster, especially for interactive plots.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2769,11 +2769,9 @@ class GenericMap(NDData):
 
         When combining ``autoalign`` functionality with
         `~sunpy.coordinates.Helioprojective` coordinates, portions of the map that are
-        beyond the solar disk may not appear, which may also inhibit Matplotlib's
-        autoscaling of the plot limits. The plot limits can be set manually.
-        To preserve the off-disk parts of the map, using the
-        `~sunpy.coordinates.SphericalScreen` context
-        manager may be appropriate.
+        beyond the solar disk may not appear.  To preserve the off-disk parts of the
+        map, using the `~sunpy.coordinates.SphericalScreen` context manager may be
+        appropriate.
         """
         # Todo: remove this when deprecate_positional_args_since is removed
         # Users sometimes assume that the first argument is `axes` instead of `annotate`
@@ -2865,6 +2863,17 @@ class GenericMap(NDData):
                                   shading='flat',
                                   transform=PrecomputedTransform() + axes.transData,
                                   **imshow_args)
+
+            # Calculate the bounds of the mesh in the pixel space of the axes
+            good = np.logical_and(np.isfinite(axes_x), np.isfinite(axes_y))
+            good_x, good_y = axes_x[good], axes_y[good]
+            min_x, max_x = np.min(good_x), np.max(good_x)
+            min_y, max_y = np.min(good_y), np.max(good_y)
+
+            # Update the plot limits
+            ret.sticky_edges.x[:] = [min_x, max_x]
+            ret.sticky_edges.y[:] = [min_y, max_y]
+            axes.update_datalim([(min_x, min_y), (max_x, max_y)])
         else:
             ret = axes.imshow(data, **imshow_args)
 

--- a/sunpy/map/tests/conftest.py
+++ b/sunpy/map/tests/conftest.py
@@ -43,6 +43,19 @@ def aia171_test_map():
 
 
 @pytest.fixture
+def adjusted_test_maps(aia171_test_map, hmi_test_map):
+    # The test maps have wildly different observation times, which throws off compositing
+    hmi_test_map.meta['date-obs'] = aia171_test_map.meta['date-obs']
+    hmi_test_map.meta['t_obs'] = aia171_test_map.meta['t_obs']
+    # Also set the HMI observer location to be the same as the AIA observer location
+    del hmi_test_map.meta['crln_obs']
+    del hmi_test_map.meta['crlt_obs']
+    hmi_test_map.meta['hgln_obs'] = aia171_test_map.observer_coordinate.lon.to_value('deg')
+    hmi_test_map.meta['hglt_obs'] = aia171_test_map.observer_coordinate.lat.to_value('deg')
+    return aia171_test_map, hmi_test_map
+
+
+@pytest.fixture
 def aia171_roll_map(aia171_test_map):
     return aia171_test_map.rotate(-45*u.deg)
 

--- a/sunpy/map/tests/test_compositemap.py
+++ b/sunpy/map/tests/test_compositemap.py
@@ -18,21 +18,10 @@ pytestmark = [pytest.mark.filterwarnings('ignore:Missing metadata for observer')
 
 
 @pytest.fixture
-def adjusted_test_maps(aia171_test_map, hmi_test_map):
-    # The test maps have wildly different observation times, which throws off compositing
-    hmi_test_map.meta['date-obs'] = aia171_test_map.meta['date-obs']
-    hmi_test_map.meta['t_obs'] = aia171_test_map.meta['t_obs']
-    # Also set the HMI observer location to be the same as the AIA observer location
-    del hmi_test_map.meta['crln_obs']
-    del hmi_test_map.meta['crlt_obs']
-    hmi_test_map.meta['hgln_obs'] = aia171_test_map.observer_coordinate.lon.to_value('deg')
-    hmi_test_map.meta['hglt_obs'] = aia171_test_map.observer_coordinate.lat.to_value('deg')
-    return aia171_test_map, hmi_test_map
-
-@pytest.fixture
 def composite_test_map(adjusted_test_maps):
     aia171_test_map, hmi_test_map = adjusted_test_maps
     return sunpy.map.Map(aia171_test_map, hmi_test_map, composite=True)
+
 
 @pytest.fixture
 def composite_test_map_prealigned(adjusted_test_maps):

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -367,6 +367,20 @@ def test_plot_autoalign_bad_inputs(aia171_test_map):
 
 
 @figure_test
+def test_plot_autoalign_datalim(adjusted_test_maps):
+    # Test whether the plot limits are expanded by the overplotted map
+    aia171_test_map = adjusted_test_maps[0].submap([20, 20]*u.pixel, top_right=[100, 80]*u.pixel)
+    hmi_test_map = adjusted_test_maps[1].submap([0, 0]*u.pixel, top_right=[120, 80]*u.pixel)
+    hmi_test_map.meta['crota2'] = 150
+
+    fig = Figure()
+    ax = fig.add_subplot(projection=aia171_test_map)
+    aia171_test_map.plot(axes=ax)
+    hmi_test_map.plot(axes=ax, autoalign=True, alpha=0.75)
+    return fig
+
+
+@figure_test
 def test_plot_autoalign_pixel_alignment(aia171_test_map):
     # Verify that autoalign=True does not affect pixel alignment
     x, y = (z.value for z in aia171_test_map.reference_pixel)

--- a/sunpy/tests/figure_hashes_mpl_382_ft_261_astropy_600_animators_111.json
+++ b/sunpy/tests/figure_hashes_mpl_382_ft_261_astropy_600_animators_111.json
@@ -54,7 +54,7 @@
   "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "8802a9b36bb9679067b5c45d752f5cb9e6757a51c41d9809e0b3e131786ada02",
   "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "47a0270b7442614eed65f9416f8ca11478d46e21187ca9a5bd2ded86c70dec99",
   "sunpy.map.tests.test_plotting.test_map_draw_extent": "f987c66a132e92c7f40c92e7733cfc92c0cb1d7c33a79376c0edfad71ee655ab",
-  "sunpy.map.tests.test_plotting.test_plot_autoalign": "352a8c7ece7f3439750a199cfa345d1ef23e6c14d545a94f67a6eb2e2257e898",
+  "sunpy.map.tests.test_plotting.test_plot_autoalign": "af9add011298a1dc5aea4571f26d580b30fccc53fd5307984ea47a691e6a4662",
   "sunpy.map.tests.test_plotting.test_plot_autoalign_pixel_alignment": "03e6e20d752c9de9f45022ea1819ca9bbd95950b0852f9138b28448636d533b6",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hgs": "c1dc26bedf3d24690364637e1a7d6fde165445049e633e8407ad2ccf42416fcb",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hpc_interpolation": "b82e6462d4ccb8c188b5f6deac3258326ba6840ef624c18f044a9d4cadce3cf2",

--- a/sunpy/tests/figure_hashes_mpl_382_ft_261_astropy_600_animators_111.json
+++ b/sunpy/tests/figure_hashes_mpl_382_ft_261_astropy_600_animators_111.json
@@ -55,6 +55,7 @@
   "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "47a0270b7442614eed65f9416f8ca11478d46e21187ca9a5bd2ded86c70dec99",
   "sunpy.map.tests.test_plotting.test_map_draw_extent": "f987c66a132e92c7f40c92e7733cfc92c0cb1d7c33a79376c0edfad71ee655ab",
   "sunpy.map.tests.test_plotting.test_plot_autoalign": "af9add011298a1dc5aea4571f26d580b30fccc53fd5307984ea47a691e6a4662",
+  "sunpy.map.tests.test_plotting.test_plot_autoalign_datalim": "6a1e6268dfb044e32de4a4153f1fb918133ca5497916c5e351fccffc8a3b495a",
   "sunpy.map.tests.test_plotting.test_plot_autoalign_pixel_alignment": "03e6e20d752c9de9f45022ea1819ca9bbd95950b0852f9138b28448636d533b6",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hgs": "c1dc26bedf3d24690364637e1a7d6fde165445049e633e8407ad2ccf42416fcb",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hpc_interpolation": "b82e6462d4ccb8c188b5f6deac3258326ba6840ef624c18f044a9d4cadce3cf2",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
@@ -54,7 +54,7 @@
   "sunpy.map.tests.test_plotting.test_draw_limb_different_observer": "bba8a5d3d8e5e3e3a7d36060d9730e4545c5250367902cf97048c33049f330f3",
   "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "fcbf6be2894be891f458d2bc305702564cb451052bc727b0175e7b6ad527801c",
   "sunpy.map.tests.test_plotting.test_map_draw_extent": "c51113113a46c838b07b049a3f17940184b99b0a56200fbd63e6cf2bf1e3c86c",
-  "sunpy.map.tests.test_plotting.test_plot_autoalign": "dc61f7444a64f9c5c8830dbad0efed15812fd4f55b237cb9cc4cd2f7b2a05975",
+  "sunpy.map.tests.test_plotting.test_plot_autoalign": "197f06eced7fe4bf8496cf5f3ba4e4cc379ac108be0f212d605007c1e3db062c",
   "sunpy.map.tests.test_plotting.test_plot_autoalign_pixel_alignment": "dd407fa27c34d512e5a98f811a2533868b0dab67895c4d4f2b53b4bc52f781b0",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hgs": "90452e9e8f248f8798a794ba70e157bf0eb87a083bda55a8ffc846c2024b1363",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hpc_interpolation": "adca79ed26b0139f29c5c0bec63d1a818fe8ba0cd718923d952210e6e8ca801c",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
@@ -55,6 +55,7 @@
   "sunpy.map.tests.test_plotting.test_draw_limb_heliographic_stonyhurst": "fcbf6be2894be891f458d2bc305702564cb451052bc727b0175e7b6ad527801c",
   "sunpy.map.tests.test_plotting.test_map_draw_extent": "c51113113a46c838b07b049a3f17940184b99b0a56200fbd63e6cf2bf1e3c86c",
   "sunpy.map.tests.test_plotting.test_plot_autoalign": "197f06eced7fe4bf8496cf5f3ba4e4cc379ac108be0f212d605007c1e3db062c",
+  "sunpy.map.tests.test_plotting.test_plot_autoalign_datalim": "a5af424f5d70394d4e39a7066793463bec0adae17c9ab46a451640957822bc8d",
   "sunpy.map.tests.test_plotting.test_plot_autoalign_pixel_alignment": "dd407fa27c34d512e5a98f811a2533868b0dab67895c4d4f2b53b4bc52f781b0",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hgs": "90452e9e8f248f8798a794ba70e157bf0eb87a083bda55a8ffc846c2024b1363",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_hpc_interpolation": "adca79ed26b0139f29c5c0bec63d1a818fe8ba0cd718923d952210e6e8ca801c",

--- a/sunpy/visualization/visualization.py
+++ b/sunpy/visualization/visualization.py
@@ -107,7 +107,7 @@ class _PrecomputedPixelCornersTransform(Transform):
     """
     A matplotlib transform that precomputes the pixel->pixel transformation from a
     given data WCS to the WCS of the given WCSAxes, and stores it as a lookup table
-    to avoid redundant coordinate transformations.  This transformation is computed
+    to avoid redundant coordinate transformations. This transformation is computed
     only for the pixel corners of the data WCS (e.g., (-0.5, -0.5) for the bottom-
     left corner), so the transform may not return desired values when called with
     pixel coordinates other than at the corners of pixels.

--- a/sunpy/visualization/visualization.py
+++ b/sunpy/visualization/visualization.py
@@ -4,9 +4,12 @@ This module provides plotting support in iPython.
 from functools import wraps
 
 import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.transforms import Transform
 
 import astropy.units as u
 from astropy.visualization.wcsaxes import CoordinateHelper
+from astropy.wcs.utils import pixel_to_pixel
 
 __all__ = ['peek_show', "axis_labels_from_ctype", "show_hpr_impact_angle"]
 
@@ -97,3 +100,26 @@ def show_hpr_impact_angle(declination_axis):
     # TODO: Astropy >= 7.0 use declination_axis.set_major_formatter(new_format_method)
     declination_axis._formatter_locator.formatter = new_format_method
     declination_axis.set_axislabel('Helioprojective Impact Angle')
+
+
+# TODO: Consider making this transform class public
+class _PrecomputedPixelCornersTransform(Transform):
+    """
+    A matplotlib transform that precomputes the pixel->pixel transformation from a
+    given data WCS to the WCS of the given WCSAxes, and stores it as a lookup table
+    to avoid redundant coordinate transformations.  This transformation is computed
+    only for the pixel corners of the data WCS (e.g., (-0.5, -0.5) for the bottom-
+    left corner), so the transform may not return desired values when called with
+    pixel coordinates other than at the corners of pixels.
+    """
+    input_dims = 2
+    output_dims = 2
+
+    def __init__(self, axes, data_wcs):
+        super().__init__()
+        self.data_y, self.data_x = np.indices(np.array(data_wcs.array_shape) + 1) - 0.5
+        self.axes_x, self.axes_y = pixel_to_pixel(data_wcs, axes.wcs, self.data_x, self.data_y)
+
+    def transform_non_affine(self, values):
+        ix, iy = np.ceil(values).astype(int).T
+        return np.stack([self.axes_x[iy, ix], self.axes_y[iy, ix]], axis=1)


### PR DESCRIPTION
For autoalign plotting of Maps (using `pcolormesh()` internally), it's nice that we can pass matplotlib the pixel->pixel transformation via the `transform` keyword, but that means that matplotlib performs the transformation with every rendering update (e.g., panning).  Instead, we can refactor the approach so that the pixel->pixel transformation is performed only once, and then panning performance greatly improves.  `pcolormesh()` still needs time to render all the data pixels, but `autoalign=True` is far less miserable now for interactive plots.

As a bonus, because we compute the transformation ourselves instead of having matplotlib do it, we can now properly update the plot limits.  Previously, matplotlib's automatic detection would get thrown off by any NaNs in the coordinates.