### PR TITLE
Changed source-code links in documentation to go to GitHub

### DIFF
--- a/changelog/8179.doc.rst
+++ b/changelog/8179.doc.rst
@@ -1,0 +1,1 @@
+The source-code links now go to the GitHub repository instead of rendered versions of the source code.


### PR DESCRIPTION
This is copied largely from [matplotlib](https://github.com/matplotlib/matplotlib/blob/6dcfa9d94bff3d672b59a57e98b1d94ed624b02a/doc/conf.py#L792-L860).  Let's see if it works.