### PR TITLE
Added a warning when combining `PlanarScreen` with `propagate_with_solar_surface`

### DIFF
--- a/changelog/8201.bugfix.rst
+++ b/changelog/8201.bugfix.rst
@@ -1,0 +1,2 @@
+Added a warning about off-disk data when calling the `~sunpy.map.Map` method :meth:`~sunpy.map.GenericMap.reproject_to` under the combined context managers of :func:`~sunpy.coordinates.propagate_with_solar_surface` and :func:`~sunpy.coordinates.screens.PlanarScreen`.
+An analogous warning had already been emitted when combining :func:`~sunpy.coordinates.propagate_with_solar_surface` and :func:`~sunpy.coordinates.screens.SphericalScreen`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -3168,8 +3168,11 @@ class GenericMap(NDData):
         .. minigallery:: sunpy.map.GenericMap.reproject_to
         """
         # Check if both context managers are active
-        if ACTIVE_CONTEXTS.get('propagate_with_solar_surface', False) and ACTIVE_CONTEXTS.get('assume_spherical_screen', False):
-            warn_user("Using propagate_with_solar_surface and SphericalScreen together result in loss of off-disk data.")
+        if ACTIVE_CONTEXTS.get('propagate_with_solar_surface', False):
+            if ACTIVE_CONTEXTS.get('assume_spherical_screen', False):
+                warn_user("Using propagate_with_solar_surface and SphericalScreen together results in the loss of off-disk data.")
+            if ACTIVE_CONTEXTS.get('assume_planar_screen', False):
+                warn_user("Using propagate_with_solar_surface and PlanarScreen together results in the loss of off-disk data.")
 
         try:
             import reproject

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -139,7 +139,12 @@ def test_reproject_to_warn_using_contexts(aia171_test_map, hpc_header):
     with propagate_with_solar_surface():
         with sunpy.coordinates.SphericalScreen(aia171_test_map.observer_coordinate):
             # Check if a warning is raised if both context managers are used at the same time.
-            with pytest.warns(UserWarning, match="Using propagate_with_solar_surface and SphericalScreen together result in loss of off-disk data."):
+            with pytest.warns(UserWarning, match="Using propagate_with_solar_surface and SphericalScreen together results in the loss of off-disk data."):
+                aia171_test_map.reproject_to(hpc_header)
+
+        with sunpy.coordinates.PlanarScreen(aia171_test_map.observer_coordinate):
+            # Check if a warning is raised if both context managers are used at the same time.
+            with pytest.warns(UserWarning, match="Using propagate_with_solar_surface and PlanarScreen together results in the loss of off-disk data."):
                 aia171_test_map.reproject_to(hpc_header)
 
 


### PR DESCRIPTION
Combining a (spherical) screen with `propagate_with_solar_surface` has an issue with off-disk data (#7173), so we added a warning when calling `reproject_to()` (#7437).  When the planar screen was implemented (#7115), we neglected to add a warning for it as well.  This PR fixes that.