### PR TITLE
Enabled differential rotation of a screen

### DIFF
--- a/changelog/8212.bugfix.rst
+++ b/changelog/8212.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an incompatibility between the context manager for applying rotation (:func:`~sunpy.coordinates.propagate_with_solar_surface`) and the context managers for applying screen assumptions (:func:`~sunpy.coordinates.PlanarScreen` and :func:`~sunpy.coordinates.SphericalScreen`), which for example resulted in the discarding of most off-disk data in reprojections.

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -105,6 +105,16 @@ You can now enable the automatic determination of extent for reprojections throu
 
 .. minigallery:: ../examples/map_transformations/reprojection_auto_extent.py
 
+Using a screen with differential rotation
+=========================================
+
+When working with off-disk 2D coordinates, applying a screen assumption (:func:`~sunpy.coordinates.PlanarScreen` or :func:`~sunpy.coordinates.SphericalScreen`) is now fully compatible with applying differential rotation (:func:`~sunpy.coordinates.propagate_with_solar_surface`).
+Most usefully, off-disk data will be preserved when reprojecting a map.
+
+.. minigallery:: ../examples/differential_rotation/reprojected_map.py
+
+As a note of caution, drawing gridlines on the differentially rotated screen can take a lot of computing time.
+
 Access to the JSOC AIA "synoptic" data
 ======================================
 

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -50,7 +50,6 @@ from sunpy.sun import constants
 from sunpy.time import is_time, parse_time
 from sunpy.util import MetaDict, expand_list, extent_in_other_wcs, grid_perimeter
 from sunpy.util.decorators import (
-    ACTIVE_CONTEXTS,
     add_common_docstring,
     cached_property_based_on,
     check_arithmetic_compatibility,
@@ -3167,13 +3166,6 @@ class GenericMap(NDData):
 
         .. minigallery:: sunpy.map.GenericMap.reproject_to
         """
-        # Check if both context managers are active
-        if "sunpy.coordinates._transformations.propagate_with_solar_surface" in ACTIVE_CONTEXTS:
-            if "sunpy.coordinates.screens.SphericalScreen" in ACTIVE_CONTEXTS:
-                warn_user("Using propagate_with_solar_surface and SphericalScreen together results in the loss of off-disk data.")
-            if "sunpy.coordinates.screens.PlanarScreen" in ACTIVE_CONTEXTS:
-                warn_user("Using propagate_with_solar_surface and PlanarScreen together results in the loss of off-disk data.")
-
         try:
             import reproject
         except ImportError as exc:

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -222,3 +222,41 @@ def test_reproject_to_auto_extent_wcs(aia171_test_map, auto_extent, crpix, pixel
     # These parts of the WCS should have changed
     assert_quantity_allclose(reprojected_wcs.wcs.crpix, crpix)
     assert_quantity_allclose(reprojected_wcs.pixel_shape, pixel_shape)
+
+
+@figure_test
+@pytest.mark.parametrize("screen", [sunpy.coordinates.SphericalScreen, sunpy.coordinates.PlanarScreen])
+def test_reproject_to_screen_plus_diffrot(aia171_test_map, screen):
+    new_time = aia171_test_map.date + 5*u.day
+    header = {
+        'naxis1': 150,
+        'naxis2': 150,
+        'crpix1': 75.5,
+        'crpix2': 75.5,
+        'crval1': 0,
+        'crval2': 0,
+        'cdelt1': 20,
+        'cdelt2': 20,
+        'cunit1': 'arcsec',
+        'cunit2': 'arcsec',
+        'ctype1': 'HPLN-TAN',
+        'ctype2': 'HPLT-TAN',
+        'hgln_obs': 0,
+        'hglt_obs': 30,
+        'rsun_ref': aia171_test_map.rsun_meters.value,
+        'dsun_obs': aia171_test_map.dsun.value,
+        'date-obs': new_time.isot,
+        'mjd-obs': new_time.mjd,
+    }
+
+    with sunpy.coordinates.transform_with_sun_center(), screen(aia171_test_map.observer_coordinate, only_off_disk=True):
+        without_diffrot = aia171_test_map.reproject_to(header)
+        with sunpy.coordinates.propagate_with_solar_surface():
+            with_diffrot = aia171_test_map.reproject_to(header)
+
+    fig = Figure(figsize=(11, 4))
+    ax1 = fig.add_subplot(121, projection=without_diffrot)
+    without_diffrot.plot(axes=ax1, title="Without diffrot")
+    ax2 = fig.add_subplot(122, projection=with_diffrot)
+    with_diffrot.plot(axes=ax2, title="With diffrot")
+    return fig

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -15,7 +15,6 @@ from astropy.wcs import WCS
 
 import sunpy.coordinates
 import sunpy.map
-from sunpy.coordinates._transformations import propagate_with_solar_surface
 from sunpy.tests.helpers import figure_test
 from sunpy.util.exceptions import SunpyUserWarning
 
@@ -133,19 +132,6 @@ def test_rsun_mismatch_warning(aia171_test_map, hpc_header):
 
         # Reproject with the mismatched rsun
         aia171_test_map.reproject_to(hpc_header)
-
-
-def test_reproject_to_warn_using_contexts(aia171_test_map, hpc_header):
-    with propagate_with_solar_surface():
-        with sunpy.coordinates.SphericalScreen(aia171_test_map.observer_coordinate):
-            # Check if a warning is raised if both context managers are used at the same time.
-            with pytest.warns(UserWarning, match="Using propagate_with_solar_surface and SphericalScreen together results in the loss of off-disk data."):
-                aia171_test_map.reproject_to(hpc_header)
-
-        with sunpy.coordinates.PlanarScreen(aia171_test_map.observer_coordinate):
-            # Check if a warning is raised if both context managers are used at the same time.
-            with pytest.warns(UserWarning, match="Using propagate_with_solar_surface and PlanarScreen together results in the loss of off-disk data."):
-                aia171_test_map.reproject_to(hpc_header)
 
 
 @figure_test

--- a/sunpy/tests/figure_hashes_mpl_382_ft_261_astropy_702_animators_121.json
+++ b/sunpy/tests/figure_hashes_mpl_382_ft_261_astropy_702_animators_121.json
@@ -68,6 +68,8 @@
   "sunpy.map.tests.test_reproject_to.test_reproject_to_auto_extent[corners]": "38c68217d6de2ee13fe7937a57281344e5686e68d3cc8367e66f58023e4509a6",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_auto_extent[edges]": "0557a116b9155a6c530763288ed389e20f2c24270b258693cf2678a98fb4c763",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_auto_extent[all]": "ebdec2de9108f377ac54f171863795dd1ba7854a04f174a2fa35a5c6ccaafe9e",
+  "sunpy.map.tests.test_reproject_to.test_reproject_to_screen_plus_diffrot[SphericalScreen]": "635663c210e588cc441d86d3710884a00ce0a23d67a549df274284bfa5a22285",
+  "sunpy.map.tests.test_reproject_to.test_reproject_to_screen_plus_diffrot[PlanarScreen]": "30fae92a5cf0b211b07cf19dcd660351aad5da91b67ce8032d6b1b20e211fe0b",
   "sunpy.timeseries.sources.tests.test_eve.test_esp_peek": "28b1e7af0e1894d22fd9db90d9e2bc5eb76e291c9e41fa1bb1d33d95bd13cce3",
   "sunpy.timeseries.sources.tests.test_eve.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.sources.tests.test_fermi_gbm.test_fermi_gbm_peek": "83f0b53ca6f1cd809bd03e4aff80b3c02c8078e552b0c3e90b2cb3cf26932a51",

--- a/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_ft_261_astropy_dev_animators_dev.json
@@ -68,6 +68,8 @@
   "sunpy.map.tests.test_reproject_to.test_reproject_to_auto_extent[corners]": "38c68217d6de2ee13fe7937a57281344e5686e68d3cc8367e66f58023e4509a6",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_auto_extent[edges]": "0557a116b9155a6c530763288ed389e20f2c24270b258693cf2678a98fb4c763",
   "sunpy.map.tests.test_reproject_to.test_reproject_to_auto_extent[all]": "ebdec2de9108f377ac54f171863795dd1ba7854a04f174a2fa35a5c6ccaafe9e",
+  "sunpy.map.tests.test_reproject_to.test_reproject_to_screen_plus_diffrot[SphericalScreen]": "635663c210e588cc441d86d3710884a00ce0a23d67a549df274284bfa5a22285",
+  "sunpy.map.tests.test_reproject_to.test_reproject_to_screen_plus_diffrot[PlanarScreen]": "30fae92a5cf0b211b07cf19dcd660351aad5da91b67ce8032d6b1b20e211fe0b",
   "sunpy.timeseries.sources.tests.test_eve.test_esp_peek": "28b1e7af0e1894d22fd9db90d9e2bc5eb76e291c9e41fa1bb1d33d95bd13cce3",
   "sunpy.timeseries.sources.tests.test_eve.test_eve_peek": "2a22f93af44971411800e4fcd0d93d2128fe2b9e6b97e576e8372c2cd12d7d78",
   "sunpy.timeseries.sources.tests.test_fermi_gbm.test_fermi_gbm_peek": "83f0b53ca6f1cd809bd03e4aff80b3c02c8078e552b0c3e90b2cb3cf26932a51",


### PR DESCRIPTION
Fixes #7173

This PR fixes a long-standing incompatibility between the context manager for applying rotation (`propagate_with_solar_surface()`) and the context managers for applying screen assumptions (`PlanarScreen()` and `SphericalScreen()`), which for example resulted in the discarding of most off-disk data in reprojections.  The incompatibility was because the distance to a differentially rotated screen has no straightforward solution and needs to be numerically solved.  This PR implements a relatively lightweight approach – typically takes at most ~8 linear-interpolation steps – to converge to the solution.

This approach works reasonably fast for reprojections (and also for autoalign plotting!).  However, when plotting gridlines on the differentially rotated screen, so many transformations are performed internally that this approach can take a surprisingly long time.  Of course, the upside is that the gridlines are plotted at all, which was not previously possible.