### PR TITLE
Remove sphinx-hoverxref

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,6 @@ extensions = [
     "sphinxext.opengraph",
     'sphinx_design',
     'sphinx_copybutton',
-    'hoverxref.extension',
     'sphinxcontrib.bibtex',
 ]
 
@@ -235,40 +234,6 @@ intersphinx_mapping = {
     "zeep": ("https://docs.python-zeep.org/en/stable/", None),
     "contourpy": ("https://contourpy.readthedocs.io/en/stable/", None),
     "sphinxcontrib_bibtex": ("https://sphinxcontrib-bibtex.readthedocs.io/en/stable/", None),
-}
-
-# -- Options for hoverxref -----------------------------------------------------
-
-if os.environ.get("READTHEDOCS"):
-    hoverxref_api_host = "https://readthedocs.org"
-
-    if os.environ.get("PROXIED_API_ENDPOINT"):
-        # Use the proxied API endpoint
-        # A RTD thing to avoid a CSRF block when docs are using a custom domain
-        hoverxref_api_host = "/_"
-
-hoverxref_auto_ref = False
-hoverxref_domains = ["py"]
-hoverxref_mathjax = True
-hoverxref_modal_hover_delay = 500
-hoverxref_tooltip_maxwidth = 600  # RTD main window is 696px
-hoverxref_intersphinx = list(intersphinx_mapping.keys())
-hoverxref_role_types = {
-    # Roles within the py domain
-    "attr": "tooltip",
-    "class": "tooltip",
-    "const": "tooltip",
-    "data": "tooltip",
-    "exc": "tooltip",
-    "func": "tooltip",
-    "meth": "tooltip",
-    "mod": "tooltip",
-    "obj": "tooltip",
-    # Roles within the std domain
-    "confval": "tooltip",
-    "hoverxref": "tooltip",
-    "ref": "tooltip",  # Would be used by hoverxref_auto_ref if we set it to True
-    "term": "tooltip",
 }
 
 # -- Options for HTML output ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ docs = [
   "sphinx-gallery>=0.14.0",
   "sphinxext-opengraph>=0.9.0",
   "sunpy-sphinx-theme>=2.0.3",
-  "sphinx-hoverxref>=1.4.0",
   "sphinxcontrib-bibtex",
 ]
 docs-gallery = [

--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -64,7 +64,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-design
   - sphinx-gallery
-  - sphinx-hoverxref
   - sphinxcontrib-bibtex
   - sphinxext-opengraph
   - towncrier


### PR DESCRIPTION
This extension has been deprecated. Users are advised to enable the "Link previews" option in "Settings" > "Addons" > "Link previews" in the Read the Docs admin dashboard for their project to get the same functionality as this extension.