### PR TITLE
Removed 7.0 changelog entry that is now moot

### DIFF
--- a/changelog/8201.bugfix.rst
+++ b/changelog/8201.bugfix.rst
@@ -1,2 +1,0 @@
-Added a warning about off-disk data when calling the `~sunpy.map.Map` method :meth:`~sunpy.map.GenericMap.reproject_to` under the combined context managers of :func:`~sunpy.coordinates.propagate_with_solar_surface` and :func:`~sunpy.coordinates.screens.PlanarScreen`.
-An analogous warning had already been emitted when combining :func:`~sunpy.coordinates.propagate_with_solar_surface` and :func:`~sunpy.coordinates.screens.SphericalScreen`.


### PR DESCRIPTION
This is a bit unorthodox...

#8201 (backported to 6.x) added a warning

#8212 (not backported to 6.x) completely removed the warnings described in the changelog entry for #8201

To avoid potential confusion from the 7.0 changelog referring to warnings that don't actually exist, I think we should treat #8201 as a 6.x-only change and remove its changelog entry from the 7.0 branch.