### PR TITLE
Fixed handling of array obstime for a differentially rotated screen

### DIFF
--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -672,3 +672,22 @@ def test_screen_plus_diffrot(off_limb_coord, screen, only_off_disk, distance):
     with propagate_with_solar_surface(), screen(new_observer, only_off_disk=only_off_disk):
         olc_3d = off_limb_coord.make_3d()
     assert_quantity_allclose(olc_3d.distance, distance)
+
+
+@pytest.mark.parametrize('only_off_disk', [False, True])
+@pytest.mark.parametrize('screen', [SphericalScreen, PlanarScreen])
+def test_screen_plus_diffrot_array_obstime(screen, only_off_disk):
+    array_obstime = parse_time('2025-05-30') + np.arange(5) * u.day
+    observer = HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU, obstime=array_obstime)
+    coord_2d = SkyCoord([-1000, -750, -500, -250, 0] * u.arcsec,
+                        [600]*5 * u.arcsec,
+                        frame=Helioprojective(observer=observer, obstime=array_obstime))
+
+    with propagate_with_solar_surface(), screen(observer[0], only_off_disk=only_off_disk):
+        # Confirm that array obstime works
+        coord_3d = coord_2d.make_3d()
+
+        # Confirm that calculated distances match the calculation when done individually
+        for point_2d, point_3d in zip(coord_2d, coord_3d):
+            point_2d_3d = point_2d.make_3d()
+            assert_quantity_allclose(point_2d_3d.separation_3d(point_3d), 0*u.m, atol=1*u.m)


### PR DESCRIPTION
Fixes #8224 

I forgot to use an `np.any()` to handle array obstime.

The reason for the other code changes is because support for array obstime means that it's possible to sneak in a point with zero differential rotation, and that point converges on the very first iteration.  That conflicted with my skipping of an array initialization under an implicit assumption that no point would converge immediately.  Anyway, I rearranged the logic so that it is now safe for immediate convergence.

I don't think this needs a separate changelog entry from #8212.