### PR TITLE
Fix EIT L0 reference_date fail

### DIFF
--- a/changelog/8236.bugfix.rst
+++ b/changelog/8236.bugfix.rst
@@ -1,1 +1,2 @@
-Ensure that ``GenericMap`` uses source specific accessor for the ``date-obs`` key. This fixes ``EITMap.reference_date``.
+Ensure that `~sunpy.map.GenericMap` uses the private accessor for the ``date-obs`` key, which can be overridden by a source subclass.
+This fixes ``EITMap.reference_date``.

--- a/changelog/8236.bugfix.rst
+++ b/changelog/8236.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure that ``GenericMap`` uses source specific accessor for the ``date-obs`` key. This fixes ``EITMap.reference_date``.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -930,10 +930,10 @@ class GenericMap(NDData):
     @property
     def _date_obs(self):
         # Get observation date from date-obs, falling back to date_obs
-        time = self._get_date('date-obs')
-        if is_time(self.meta.get('date_obs', None)):
-            time = time or self._get_date('date_obs')
-        return time
+        if is_time(self.meta.get("date-obs", None)):
+            return self._get_date('date-obs')
+        elif is_time(self.meta.get('date_obs', None)):
+            return self._get_date('date_obs')
 
     @property
     def reference_date(self):
@@ -967,7 +967,7 @@ class GenericMap(NDData):
         """
         return (
             self._get_date('date-avg') or
-            self._get_date('date-obs') or
+            self._date_obs or
             self._get_date('date-beg') or
             self._get_date('date-end') or
             self.date

--- a/sunpy/map/sources/tests/test_eit_source.py
+++ b/sunpy/map/sources/tests/test_eit_source.py
@@ -76,3 +76,4 @@ def test_wcs(eit_map):
 def test_old_eit_date():
     eit_map = get_dummy_map_from_header(get_test_filepath("seit_00171_fd_19961211_1900.header"))
     assert eit_map.date.value == '1996-12-11T19:00:14.254'
+    assert eit_map.reference_date.value == '1996-12-11T19:00:14.254'


### PR DESCRIPTION
This fix might be a little controversial, but we have a few map sources which use `_date_obs` so we should probably honor that.