### PR TITLE
remove more changelogs

### DIFF
--- a/changelog/8211.trivial.rst
+++ b/changelog/8211.trivial.rst
@@ -1,1 +1,0 @@
-Fixed a bug with the internal tracking of active context managers that could result in incorrect tracking of complex nesting.

--- a/changelog/8212.bugfix.rst
+++ b/changelog/8212.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed an incompatibility between the context manager for applying rotation (:func:`~sunpy.coordinates.propagate_with_solar_surface`) and the context managers for applying screen assumptions (:func:`~sunpy.coordinates.PlanarScreen` and :func:`~sunpy.coordinates.SphericalScreen`), which for example resulted in the discarding of most off-disk data in reprojections.

--- a/changelog/8236.bugfix.rst
+++ b/changelog/8236.bugfix.rst
@@ -1,2 +1,0 @@
-Ensure that `~sunpy.map.GenericMap` uses the private accessor for the ``date-obs`` key, which can be overridden by a source subclass.
-This fixes ``EITMap.reference_date``.


### PR DESCRIPTION
To follow the branching release checklist. 

We can then update the 7.1dev tag so we get better numbers.