### PR TITLE
Fixed the introspection of our own requirements

### DIFF
--- a/changelog/8294.bugfix.rst
+++ b/changelog/8294.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where :func:`sunpy.util.system_info` would report `sunpy` as an optional dependency of itself instead of properly reporting all of the optional dependencies.

--- a/sunpy/util/sysinfo.py
+++ b/sunpy/util/sysinfo.py
@@ -14,7 +14,7 @@ from sunpy.util import warn_user
 __all__ = ['system_info', 'find_dependencies', 'missing_dependencies_by_extra']
 
 
-def get_requirements(package):
+def get_requirements(package, *, expand_groups=False):
     """
     This wraps `importlib.metadata.requires` to not be garbage.
 
@@ -22,6 +22,9 @@ def get_requirements(package):
     ----------
     package : str
         Package you want requirements for.
+
+    expand_groups : bool
+        If `True`, expand any requirement that is a group of the specified package.
 
     Returns
     -------
@@ -43,7 +46,32 @@ def get_requirements(package):
         if package_name in requires_dict[group]:
             continue
         requires_dict[group][package_name] = req
+
+    if expand_groups:
+        # First expand each self-referential package requirement into the individual groups
+        for group, group_reqs in requires_dict.items():
+            if package in group_reqs and (extras := group_reqs[package].extras):
+                requires_dict[group].update(dict.fromkeys(extras))
+                del group_reqs[package]
+
+        # Resolve each group, recursing as necessary
+        for group in requires_dict:
+            _resolve_group(group, requires_dict)
+
     return requires_dict
+
+
+def _resolve_group(group, requires_dict):
+    """
+    Return a fully resolved list of requirements for a group.
+    If the group requires another group, recurse to fully resolve that group first.
+    The dictionary is permanently updated with the fully resolved requirements.
+    """
+    for req_name, req in requires_dict[group].copy().items():
+        if req is None:  # req==None means that req_name is an unresolved group
+            requires_dict[group].update(_resolve_group(req_name, requires_dict))
+            del requires_dict[group][req_name]
+    return requires_dict[group]
 
 
 def resolve_requirement_versions(package_versions):
@@ -82,7 +110,7 @@ def find_dependencies(package="sunpy", extras=None):
     which should be installed to match the requirements and return any which are
     missing.
     """
-    requirements = get_requirements(package)
+    requirements = get_requirements(package, expand_groups=True)
     installed_requirements = {}
     missing_requirements = defaultdict(list)
     extras = extras or ["required"]
@@ -125,7 +153,7 @@ def missing_dependencies_by_extra(package="sunpy", exclude_extras=None):
     dependencies associated with no extras.
     """
     exclude_extras = exclude_extras or []
-    requirements = get_requirements(package)
+    requirements = get_requirements(package)  # groups do not need to be expanded here
     missing_dependencies = {}
     for group in requirements.keys():
         if group in exclude_extras:
@@ -149,7 +177,7 @@ def system_info():
     """
     Prints ones' system info in an "attractive" fashion.
     """
-    requirements = get_requirements("sunpy")
+    requirements = get_requirements("sunpy", expand_groups=True)
     groups = get_keys_list(requirements)
     extra_groups = get_extra_groups(groups, ['all', 'dev'])
     base_reqs = get_keys_list(requirements['required'])

--- a/sunpy/util/tests/test_sysinfo.py
+++ b/sunpy/util/tests/test_sysinfo.py
@@ -59,6 +59,9 @@ def test_find_dependencies():
     for package in EXTRA_DEPS:
         assert package in installed
 
+    # There should not be any self-referential dependency on sunpy
+    assert "sunpy" not in installed
+
 
 def test_missing_dependencies_by_extra():
     missing = missing_dependencies_by_extra()
@@ -98,4 +101,10 @@ def test_format_requirement_string():
 def test_system_info(capsys):
     system_info()
     captured = capsys.readouterr()
-    assert "\nsunpy Installation Information\n" in captured.out
+    lines = captured.out.splitlines()
+    assert "sunpy Installation Information" in lines
+
+    # sunpy should not be listed as an optional dependency
+    index = lines.index("Optional Dependencies")
+    for line in lines[index + 2:]:
+        assert not line.startswith("sunpy:")


### PR DESCRIPTION
Since 6.0, `sunpy.util.system_info()` stopped reporting on our optional dependencies because it couldn't resolve our nested group requirements.  I don't know if this implementation is the best way to do it, but it works.

Before this PR:
```python
>>> import sunpy
>>> sunpy.util.system_info()
==============================
sunpy Installation Information
==============================

General
#######
OS: Windows 11 10.0.26100
Arch: 64bit, (Intel64 Family 6 Model 85 Stepping 7, GenuineIntel)
sunpy: 6.1.dev119+g7259b5058.d20240911
Installation path: C:\Users\ayshih\AppData\Local\mambaforge\envs\py312\Lib\site-packages\sunpy-6.1.dev119+g7259b5058.d20240911.dist-info

Required Dependencies
#####################
astropy: 7.0.0.dev810+gb982985335.d20240911
numpy: 2.1.1
packaging: 24.1
parfive: 2.1.0
pyerfa: 2.0.1.4
requests: 2.32.3

Optional Dependencies
#####################
sunpy: 6.1.dev119+g7259b5058.d20240911
```

After this PR:
```python
>>> import sunpy
>>> sunpy.util.system_info()
==============================
sunpy Installation Information
==============================

General
#######
OS: Windows 11 10.0.26100
Arch: 64bit, (Intel64 Family 6 Model 85 Stepping 7, GenuineIntel)
sunpy: 6.1.dev119+g7259b5058.d20240911
Installation path: C:\Users\ayshih\AppData\Local\mambaforge\envs\py312\Lib\site-packages\sunpy-6.1.dev119+g7259b5058.d20240911.dist-info

Required Dependencies
#####################
astropy: 7.0.0.dev810+gb982985335.d20240911
numpy: 2.1.1
packaging: 24.1
parfive: 2.1.0
pyerfa: 2.0.1.4
requests: 2.32.3

Optional Dependencies
#####################
asdf-astropy: 0.6.1
beautifulsoup4: 4.12.3
cdflib: 1.3.1
drms: 0.8.0
glymur: 0.13.6
h5netcdf: 1.3.0
h5py: 3.11.0
lxml: 5.3.0
matplotlib: 3.9.2
mpl-animators: 1.2.3
opencv-python: 4.10.0
pandas: 2.2.2
python-dateutil: 2.9.0
reproject: 0.14.0
scipy: 1.14.1
spiceypy: 6.0.0
tqdm: 4.66.5
zeep: 4.2.1
```