### PR TITLE
Fixed the version reporting in `sunpy.util.system_info()` for development installations

### DIFF
--- a/changelog/8297.bugfix.rst
+++ b/changelog/8297.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :func:`sunpy.util.system_info` so that the version reported for a development installation of `sunpy` itself or of a dependency is accurate.


### PR DESCRIPTION
This PR fixes the version reporting by `sunpy.util.system_info()` for development installations (see #8295), at least for `sunpy` itself and its core dependencies.  The version retrievable by `importlib.metadata.version()` may not match the code as currently checked out in the development installation, while `__version__` (dynamically generated upon import via `setuptools_scm`) should always be correct (at least for `sunpy` and `astropy`).  Accordingly, this PR will use `__version__`, if available, before falling back to `importlib.metadata.version()`.

We don't want to import every dependency on a call to `system_info()`, which is why this implementation is constrained to looking for `__version__` only on already-imported packages.  For `sunpy` and core dependencies (`astropy`), they will invariably already be imported for any call to `system_info()`.  However, this implementation does not fix the situation where the user has a development installation of an optional dependency (say, `pandas`), but has not imported it prior to calling `system_info()`.  So, we will still need to interpret development versions of optional dependencies with a grain of salt.

Before this PR:
```python
>>> import sunpy; sunpy.__version__
'7.0.0rc4.dev35+g1a2f07181'
>>> import astropy; astropy.__version__
'7.2.dev248+gc33fc0eddc'
>>> sunpy.util.system_info()
...
sunpy: 6.1.dev119+g7259b5058.d20240911
...
astropy: 7.0.0.dev810+gb982985335.d20240911
...
```

After this PR:
```python
>>> import sunpy; sunpy.__version__
'7.0.0rc4.dev38+g46093abd5'
>>> import astropy; astropy.__version__
'7.2.dev248+gc33fc0eddc'
>>> sunpy.util.system_info()
...
sunpy: 7.0.0rc4.dev38+g46093abd5
...
astropy: 7.2.dev248+gc33fc0eddc
...
```

Fixes #8295
