### PR TITLE
Use string for JSOC email in cutouts example instead of os var

### DIFF
--- a/examples/acquiring_data/downloading_cutouts.py
+++ b/examples/acquiring_data/downloading_cutouts.py
@@ -6,8 +6,6 @@ Requesting cutouts of AIA images from the JSOC
 This example shows how to request a cutout of a series of
 AIA images from the JSOC.
 """
-import os
-
 import matplotlib.pyplot as plt
 
 import astropy.units as u
@@ -40,7 +38,7 @@ cutout = a.jsoc.Cutout(bottom_left, top_right=top_right, tracking=True)
 # like so: jsoc_email = "your_email@example.com"
 # See `this page <http://jsoc.stanford.edu/ajax/register_email.html>`__ for more details.
 
-jsoc_email = os.environ["JSOC_EMAIL"]
+jsoc_email = "JSOC_EMAIL"
 
 #####################################################
 # Now we are ready to construct the query. Note that all of this is


### PR DESCRIPTION
## PR Description

Running locally on sunpy==7.0.0 on Windows I had to change to use a string for my e-mail, which is also how the comment above says it needs to be done.  This updates the example to be easier to work with. 
Note, this is my first time ever using sunpy so maybe I did something wrong 🙃 🎉 
