### PR TITLE
Fix inconsistent behaviour between local and remote scraper searches

### DIFF
--- a/changelog/8316.bugfix.rst
+++ b/changelog/8316.bugfix.rst
@@ -1,1 +1,1 @@
-Fix inconsistent behaviour between local and remote (http/ftp) ~`sunpy.net.scraper.Scraper` searches. Local searches will no longer crash is directory is not found during search.
+Fix inconsistent behaviour between local and remote (http/ftp) ~`sunpy.net.scraper.Scraper` searches. Local searches will no longer crash if an expected directory does not exist during search.

--- a/changelog/8316.bugfix.rst
+++ b/changelog/8316.bugfix.rst
@@ -1,0 +1,1 @@
+Fix inconsistent behaviour between local and remote (http/ftp) ~`sunpy.net.scraper.Scraper` searches. Local searches will no longer crash is directory is not found during search.

--- a/pytest.ini
+++ b/pytest.ini
@@ -68,3 +68,4 @@ filterwarnings =
     ignore:The QueryResponse class is deprecated
     # parfive sometimes spews this in oldestdeps
     ignore:This download has been started in a thread which is not the main thread. You will not be able to interrupt the download.
+    ignore:`np.compat`:DeprecationWarning:

--- a/pytest.ini
+++ b/pytest.ini
@@ -68,4 +68,3 @@ filterwarnings =
     ignore:The QueryResponse class is deprecated
     # parfive sometimes spews this in oldestdeps
     ignore:This download has been started in a thread which is not the main thread. You will not be able to interrupt the download.
-    ignore:`np.compat`:DeprecationWarning:

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -307,14 +307,14 @@ class Scraper:
             directories = self.range(timerange)
             filepaths = list()
             for directory in directories:
-                # try:
-                for file_i in os.listdir(directory):
-                    fullpath = directory + file_i
-                    if self._url_follows_pattern(fullpath):
-                        if self._check_timerange(fullpath, timerange):
-                            filepaths.append(fullpath)
-                # except FileNotFoundError:
-                #     log.debug(f"Local directory not found: {directory}.")
+                try:
+                    for file_i in os.listdir(directory):
+                        fullpath = directory + file_i
+                        if self._url_follows_pattern(fullpath):
+                            if self._check_timerange(fullpath, timerange):
+                                filepaths.append(fullpath)
+                except FileNotFoundError:
+                    log.debug(f"Local directory not found: {directory}.")
             filepaths = [prefix + path for path in filepaths]
             self.pattern = pattern
             return filepaths
@@ -332,14 +332,14 @@ class Scraper:
             directories = self.range(timerange)
             filepaths = list()
             for directory in directories:
-                # try:
-                for file_i in os.listdir(directory):
-                    fullpath = directory + file_i
-                    if self._url_follows_pattern(fullpath):
-                        if self._check_timerange(fullpath, timerange):
-                            filepaths.append(fullpath)
-                # except FileNotFoundError:
-                #     log.debug(f"Local directory not found: {directory}.")
+                try:
+                    for file_i in os.listdir(directory):
+                        fullpath = directory + file_i
+                        if self._url_follows_pattern(fullpath):
+                            if self._check_timerange(fullpath, timerange):
+                                filepaths.append(fullpath)
+                except FileNotFoundError:
+                    log.debug(f"Local directory not found: {directory}.")
             filepaths = [prefix + path for path in filepaths]
             # Set them back to their original values
             self.pattern, self.datetime_pattern = pattern, datetime_pattern

--- a/sunpy/net/scraper.py
+++ b/sunpy/net/scraper.py
@@ -307,11 +307,14 @@ class Scraper:
             directories = self.range(timerange)
             filepaths = list()
             for directory in directories:
+                # try:
                 for file_i in os.listdir(directory):
                     fullpath = directory + file_i
                     if self._url_follows_pattern(fullpath):
                         if self._check_timerange(fullpath, timerange):
                             filepaths.append(fullpath)
+                # except FileNotFoundError:
+                #     log.debug(f"Local directory not found: {directory}.")
             filepaths = [prefix + path for path in filepaths]
             self.pattern = pattern
             return filepaths
@@ -329,11 +332,14 @@ class Scraper:
             directories = self.range(timerange)
             filepaths = list()
             for directory in directories:
+                # try:
                 for file_i in os.listdir(directory):
                     fullpath = directory + file_i
                     if self._url_follows_pattern(fullpath):
                         if self._check_timerange(fullpath, timerange):
                             filepaths.append(fullpath)
+                # except FileNotFoundError:
+                #     log.debug(f"Local directory not found: {directory}.")
             filepaths = [prefix + path for path in filepaths]
             # Set them back to their original values
             self.pattern, self.datetime_pattern = pattern, datetime_pattern

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -357,9 +357,6 @@ def test_files_range_same_directory_months_remote_new_format():
                      'http://www.srl.caltech.edu/STEREO/DATA/HET/Ahead/1minute/AeH07Sep.1m']
 
 
-
-
-
 @pytest.mark.xfail
 @pytest.mark.remote_data
 def test_ftp():
@@ -595,7 +592,6 @@ def test_http_404_error_debug_message_new_format(caplog):
                 assert "Directory http://test.com/ not found." in caplog.text
 
 
-
 def test_check_timerange():
     with pytest.warns(SunpyDeprecationWarning, match="pattern has been replaced with the format keyword"):
         s = Scraper('%Y.fits')
@@ -619,6 +615,7 @@ def test_check_timerange():
     assert not s._check_timerange('2014.fits', TimeRange("2002-01-01", "2013-01-02"))
     # Interval above both boundaries
     assert not s._check_timerange('2014.fits', TimeRange("2022-01-01", "2025-01-02"))
+
 
 def test_check_timerange_new_pattern():
     s = Scraper(format='{{year:4d}}.fits')
@@ -646,8 +643,12 @@ def test_check_timerange_new_pattern():
     # Only 2-digit Year
     assert s._check_timerange('14.fits', TimeRange("2013-06-01", "2014-01-01"))
 
+
 def test_local_expected_directory_doesnt_exist(tmp_path):
-    (tmp_path / '2025' / '01' / '01').mkdir(parents=True)
+    path = (tmp_path / '2025' / '01' / '01')
+    path.mkdir(parents=True)
+    with (path / 'test.txt').open('w') as file:
+        file.write('')
     s = Scraper(format='file://'+str(tmp_path)+'/{{year:4d}}/{{month:2d}}/{{day:2d}}/{{file}}')
     files = s.filelist(TimeRange("2025-01-01", "2025-01-02"))
     assert len(files) == 1

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -357,6 +357,9 @@ def test_files_range_same_directory_months_remote_new_format():
                      'http://www.srl.caltech.edu/STEREO/DATA/HET/Ahead/1minute/AeH07Sep.1m']
 
 
+
+
+
 @pytest.mark.xfail
 @pytest.mark.remote_data
 def test_ftp():
@@ -642,3 +645,9 @@ def test_check_timerange_new_pattern():
 
     # Only 2-digit Year
     assert s._check_timerange('14.fits', TimeRange("2013-06-01", "2014-01-01"))
+
+def test_local_expected_directory_doesnt_exist(tmp_path):
+    (tmp_path / '2025' / '01' / '01').mkdir(parents=True)
+    s = Scraper(format='file://'+str(tmp_path)+'/{{year:4d}}/{{month:2d}}/{{day:2d}}/{{file}}')
+    files = s.filelist(TimeRange("2025-01-01", "2025-01-02"))
+    assert len(files) == 1


### PR DESCRIPTION
## PR Description

* Local searches crash and exit early if an expected directory does not exist
* Remote searches handle these kind of error and continue
* This PR adds the same functionality to local searches

Closes #8315