### PR TITLE
use new pytest asdf plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ tests-only = [
   "hvpy>=1.1.0",
   "jplephem>=2.19",
   "pytest-astropy>=0.11.0",
+  "pytest-asdf-plugin>=0.1.1",
   "pytest-mpl>=0.17.0",
   "pytest>=7.4.0",
 ]


### PR DESCRIPTION
## PR Description

Update test dependencies to use new https://pypi.org/project/pytest-asdf-plugin/ which is a feature-compatible replacement for the bundled asdf pytest plugin (which will soon be deprecated).

For context the pytest-asdf-plugin is responsible for finding and converting schema files into "tests" (to check the schema against the metaschema and validated any contained "examples"). Since both the bundled and now external plugins are feature-compatible there should be no change in test number (or new failures, etc).

On main 2493 tests passed:
https://github.com/sunpy/sunpy/actions/runs/17033516101/job/48280847581#step:10:5692

With this PR 2493 tests passed:
https://github.com/sunpy/sunpy/actions/runs/17048240280/job/48329382329?pr=8327#step:10:5693

However I cannot find a CI run that runs the schema checks (if all runs use `--pyargs` they are possibly all ignoring the schemas: https://github.com/asdf-format/pytest-asdf-plugin/issues/8).