### PR TITLE
Added input validation for the JSOC `Cutout` attribute

### DIFF
--- a/changelog/8346.bugfix.1.rst
+++ b/changelog/8346.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fixed a bug where the `~sunpy.net.jsoc.attrs.Cutout` class for requesting JSOC cutouts did not require the supplied coordinate to be in the `~sunpy.coordinates.Helioprojective` coordinate frame.

--- a/changelog/8346.bugfix.2.rst
+++ b/changelog/8346.bugfix.2.rst
@@ -1,0 +1,1 @@
+For the `~sunpy.net.jsoc.attrs.Cutout` class for requesting JSOC cutouts, added protection to require the center of the cutout to be on the solar disk when tracking is enabled, due to confusing output from JSOC.


### PR DESCRIPTION
This PR fixes two issues with the JSOC `Cutout` attribute (added in #4595):

- Verifies that the input is a helioprojective coordinate and explicitly documents that the observer frame attribute of the coordinate is ignored.  (This PR does *not* perform any coordinate transformation, so this PR does not close issue #8344.)
- Verifies that the center of the cutout is on the solar disk if tracking is enabled (default setting).  See https://github.com/sunpy/sunpy/issues/8344#issuecomment-3292990861