### PR TITLE
Fixed doctest that depended on a name

### DIFF
--- a/changelog/8348.trivial.rst
+++ b/changelog/8348.trivial.rst
@@ -1,0 +1,1 @@
+Fixed a doctest that depended on the name of the person associated with a data set.

--- a/sunpy/net/cdaweb/helpers.py
+++ b/sunpy/net/cdaweb/helpers.py
@@ -88,7 +88,7 @@ def get_datasets(observatory):
       STB_L2_SWEA_PAD
      STB_L1_SWEA_SPEC
     >>> datasets.loc['STB_L1_SWEA_SPEC']['Label'] # doctest: +REMOTE_DATA
-    np.str_('STEREO Behind IMPACT/SWEA Spectra - J. Luhmann (UCB/SSL)')
+    np.str_('STEREO Behind IMPACT/SWEA Spectra - ...')
     >>> datasets.loc['STB_L1_SWEA_SPEC'][['Start', 'End']] # doctest: +REMOTE_DATA
     <Row index=4>
              Start                     End


### PR DESCRIPTION
We have a failing doctest because the PI for STEREO/IMPACT changed.  It seems prudent to simply replace the name with an ellipsis since we don't particularly care about whose name is returned.