### PR TITLE
Enable `pytest-xdist` for figure tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: *merge-check
       - run: *apt-install
       - run: pip install --user -U tox tox-pypi-filter
-      - run: tox -v
+      - run: tox -v -- -n 4
       - run:
           name: Running codecov
           command: bash -e .circleci/codecov_upload.sh -f ".tmp/${TOXENV}/coverage.xml"
@@ -77,7 +77,7 @@ jobs:
       # Generate Reference images
       - run: pip install --user -U tox tox-pypi-filter
       - run: rm -rf /home/circleci/sunpy-figure-tests/figures/$TOXENV/*
-      - run: tox -v -- --mpl-generate-path=/home/circleci/sunpy-figure-tests/figures/$TOXENV | tee toxlog
+      - run: tox -v -- -n 4 --mpl-generate-path=/home/circleci/sunpy-figure-tests/figures/$TOXENV | tee toxlog
       - run: |
           hashlib=$(grep "^figure_hashes.*\.json$" toxlog)
           cp ./sunpy/tests/$hashlib /home/circleci/sunpy-figure-tests/figures/$TOXENV/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ tests-only = [
   "hvpy>=1.1.0",
   "jplephem>=2.19",
   "pytest-astropy>=0.11.0",
-  "pytest-mpl>=0.17.0",
+  "pytest-mpl>=0.18.0",
   "pytest>=7.4.0",
 ]
 asdf-tests = [


### PR DESCRIPTION
Hi, `pytest-mpl` `0.18.0` now supports generating HTML summaries for the figure tests when using `pytest-xdist`