### PR TITLE
Added coordinate transformation steps and shortcuts in order to avoid origin shifts and unintended aberration corrections

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -26,6 +26,7 @@ default.extend-ignore-identifiers-re = [
     "lightyear",
     "PNGs",
     "setp",
+    "Precess",
     "precess",
     "precessed",
 ]

--- a/changelog/8415.feature.1.rst
+++ b/changelog/8415.feature.1.rst
@@ -1,0 +1,1 @@
+Modified the approach of coordinate transformations between Earth-centered frames in order to avoid internal origin shifts, which could degrade numerical accuracy of coordinates close to Earth center.

--- a/changelog/8415.feature.2.rst
+++ b/changelog/8415.feature.2.rst
@@ -1,0 +1,1 @@
+Modified the approach of coordinate transformations between Earth-centered frames in order to minimize the unintended triggering of a correction for stellar aberration (due to Earth motion).

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -847,7 +847,7 @@ class GeocentricSolarEcliptic(SunPyBaseCoordinateFrame):
 
     Notes
     -----
-    Aberration due to Earth motion is not included.
+    Aberration due to Earth motion is not included when transforming directly to/from this frame.
     """
 
 
@@ -882,7 +882,7 @@ class GeocentricEarthEquatorial(SunPyBaseCoordinateFrame):
     A coordinate or frame in the Geocentric Earth Equatorial (GEI) system.
 
     - The origin is the center of the Earth.
-    - The Z-axis (+90 degrees latitude) is aligned with the Earth's north pole.
+    - The Z-axis (+90 degrees latitude) is aligned with the Earth's mean (not true) north pole.
     - The X-axis (0 degrees longitude and 0 degrees latitude) is aligned with the mean (not true)
       vernal equinox.
 
@@ -896,7 +896,7 @@ class GeocentricEarthEquatorial(SunPyBaseCoordinateFrame):
 
     Notes
     -----
-    Aberration due to Earth motion is not included.
+    Aberration due to Earth motion is not included when transforming directly to/from this frame.
     """
     equinox = TimeFrameAttributeSunPy(default=_J2000)
 


### PR DESCRIPTION
This PR adds a handful of direct transformations and bunch more graph shortcuts in order to:

-  avoid internal origin shifts, which could degrade numerical accuracy of coordinates close to Earth center
- minimize the unintended triggering of a correction for stellar aberration (due to Earth motion)

Fixes #8406