### PR TITLE
Use `CenteredNorm` for magnetic-field maps

### DIFF
--- a/changelog/8447.bugfix.rst
+++ b/changelog/8447.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with HMI and MDI magnetic-field maps where the data array would always be read during map instantiation.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -605,14 +605,6 @@ class GenericMap(NDData):
     def _meta_hash(self):
         return self.meta.item_hash()
 
-    def _set_symmetric_vmin_vmax(self):
-        """
-        Set symmetric vmin and vmax about zero
-        """
-        threshold = np.nanmax(abs(self.data))
-        self.plot_settings['norm'].vmin = -threshold
-        self.plot_settings['norm'].vmax = threshold
-
     @property
     @cached_property_based_on('_meta_hash')
     def wcs(self):

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -1,6 +1,7 @@
 """SDO Map subclass definitions"""
 
 import numpy as np
+from matplotlib.colors import CenteredNorm
 
 import astropy.units as u
 from astropy.coordinates import CartesianRepresentation, HeliocentricMeanEcliptic
@@ -149,7 +150,7 @@ class HMIMap(GenericMap):
             # This means they are not scaled correctly.
             if self.plot_settings.get('norm') is not None:
                 # Magnetic field maps, not intensity maps
-                self._set_symmetric_vmin_vmax()
+                self.plot_settings['norm'] = CenteredNorm()
         self._nickname = self.detector
 
     @property

--- a/sunpy/map/sources/soho.py
+++ b/sunpy/map/sources/soho.py
@@ -1,6 +1,7 @@
 """SOHO Map subclass definitions"""
 
 import numpy as np
+from matplotlib.colors import CenteredNorm
 
 import astropy.units as u
 from astropy.coordinates import CartesianRepresentation, HeliocentricMeanEcliptic
@@ -313,7 +314,7 @@ class MDIMap(GenericMap):
         super().__init__(data, header, **kwargs)
         if self.unit is not None and self.unit.is_equivalent(u.T):
             # Magnetic field maps, not intensity maps
-            self._set_symmetric_vmin_vmax()
+            self.plot_settings['norm'] = CenteredNorm()
 
     @property
     def _date_obs(self):


### PR DESCRIPTION
To have a symmetric plotting range for magnetic-field maps of HMI and MDI, we currently manually set the `vmin` and `vmax` on the norm (e.g., #5825), but that requires us to read in the data array during instantiation.  I just found out that `matplotlib.colors.CenteredNorm` has existed for many years, so is the far better approach, because then the plotting range is determined only when the data is actually being plotted.