### PR TITLE
Move coordinate utils

### DIFF
--- a/examples/computer_vision_techniques/mask_disk.py
+++ b/examples/computer_vision_techniques/mask_disk.py
@@ -9,7 +9,8 @@ import matplotlib.pyplot as plt
 
 import sunpy.map
 from sunpy.data.sample import AIA_171_IMAGE
-from sunpy.map.maputils import all_coordinates_from_map, coordinate_is_on_solar_disk
+from sunpy.map.maputils import all_coordinates_from_map
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # We start with the sample data.

--- a/examples/computer_vision_techniques/mask_disk.py
+++ b/examples/computer_vision_techniques/mask_disk.py
@@ -8,9 +8,9 @@ How to mask out all emission from the solar disk.
 import matplotlib.pyplot as plt
 
 import sunpy.map
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 from sunpy.data.sample import AIA_171_IMAGE
 from sunpy.map.maputils import all_coordinates_from_map
-from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # We start with the sample data.

--- a/examples/plotting/masked_composite_plot.py
+++ b/examples/plotting/masked_composite_plot.py
@@ -14,9 +14,9 @@ import matplotlib.pyplot as plt
 import astropy.units as u
 
 import sunpy.data.sample
-from sunpy.map import Map
-from sunpy.map.maputils import all_coordinates_from_map 
 from sunpy.coordinates.utils import coordinate_is_on_solar_disk
+from sunpy.map import Map
+from sunpy.map.maputils import all_coordinates_from_map
 
 ###############################################################################
 # Let's import sample data representing the three types of data we want to

--- a/examples/plotting/masked_composite_plot.py
+++ b/examples/plotting/masked_composite_plot.py
@@ -15,7 +15,8 @@ import astropy.units as u
 
 import sunpy.data.sample
 from sunpy.map import Map
-from sunpy.map.maputils import all_coordinates_from_map, coordinate_is_on_solar_disk
+from sunpy.map.maputils import all_coordinates_from_map 
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # Let's import sample data representing the three types of data we want to

--- a/examples/showcase/hmi_cutout.py
+++ b/examples/showcase/hmi_cutout.py
@@ -18,6 +18,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 import sunpy.map
+import sunpy.coordinates
 from sunpy.data.sample import HMI_LOS_IMAGE
 
 ##############################################################################
@@ -33,7 +34,7 @@ right_corner = SkyCoord(Tx=158*u.arcsec, Ty=350*u.arcsec, frame=magnetogram.coor
 # limb.
 
 hpc_coords = sunpy.map.all_coordinates_from_map(magnetogram)
-mask = ~sunpy.map.coordinate_is_on_solar_disk(hpc_coords)
+mask = ~sunpy.coordinates.coordinate_is_on_solar_disk(hpc_coords)
 magnetogram_big = sunpy.map.Map(magnetogram.data, magnetogram.meta, mask=mask)
 
 ##############################################################################

--- a/examples/showcase/hmi_cutout.py
+++ b/examples/showcase/hmi_cutout.py
@@ -17,8 +17,8 @@ from matplotlib.patches import ConnectionPatch
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
-import sunpy.map
 import sunpy.coordinates
+import sunpy.map
 from sunpy.data.sample import HMI_LOS_IMAGE
 
 ##############################################################################

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -15,6 +15,7 @@ from sunpy.coordinates.utils import (
     get_limb_coordinates,
     get_rectangle_coordinates,
     solar_angle_equivalency,
+    solar_angular_radius
 )
 from sunpy.sun import constants
 from sunpy.util.exceptions import SunpyUserWarning
@@ -418,3 +419,9 @@ def test_get_heliocentric_angle_errors():
     bad_skycoord = SkyCoord(0*u.arcsec, 0*u.arcsec, frame='heliographic_stonyhurst', observer="earth")
     with pytest.raises(ConvertError, match="frame needs a specified obstime"):
         get_heliocentric_angle(bad_skycoord)
+
+def test_solar_angular_radius(aia171_test_map):
+    on_disk = aia171_test_map.center
+    sar = solar_angular_radius(on_disk)
+    assert isinstance(sar, u.Quantity)
+    np.testing.assert_almost_equal(sar.to(u.arcsec).value, 971.80181131, decimal=1)

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -7,17 +7,16 @@ import astropy.units as u
 from astropy.coordinates import ConvertError, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 
-from sunpy.coordinates import HeliographicStonyhurst
 from sunpy.coordinates import frames, get_earth, sun
 from sunpy.coordinates.screens import SphericalScreen
 from sunpy.coordinates.utils import (
     GreatArc,
+    coordinate_is_on_solar_disk,
     get_heliocentric_angle,
     get_limb_coordinates,
     get_rectangle_coordinates,
     solar_angle_equivalency,
     solar_angular_radius,
-    coordinate_is_on_solar_disk
 )
 from sunpy.sun import constants
 from sunpy.util.exceptions import SunpyUserWarning

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -1,3 +1,4 @@
+
 """
 Miscellaneous utilities related to coordinates
 """
@@ -8,7 +9,7 @@ import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 from astropy.coordinates.representation import CartesianRepresentation
 
-from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, get_body_heliographic_stonyhurst
+from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, Helioprojective, get_body_heliographic_stonyhurst, sun
 from sunpy.sun import constants
 
 __all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates', 'get_heliocentric_angle']
@@ -386,6 +387,43 @@ def get_rectangle_coordinates(bottom_left, *, top_right=None,
             top_right = top_right.frame
 
     return bottom_left, top_right
+
+def _verify_coordinate_helioprojective(coordinates):
+    """
+    Raises an error if the coordinate is not in the
+    `~sunpy.coordinates.frames.Helioprojective` frame.
+
+    Parameters
+    ----------
+    coordinates : `~astropy.coordinates.SkyCoord`, `~astropy.coordinates.BaseCoordinateFrame`
+    """
+    frame = coordinates.frame if hasattr(coordinates, 'frame') else coordinates
+    if not isinstance(frame, Helioprojective):
+        raise ValueError(f"The input coordinate(s) is of type {type(frame).__name__}, "
+                         "but must be in the Helioprojective frame.")
+
+def solar_angular_radius(coordinates):
+    """
+    Calculates the solar angular radius as seen by the observer.
+
+    The tangent vector from the observer to the edge of the Sun forms a
+    right-angle triangle with the radius of the Sun as the far side and the
+    Sun-observer distance as the hypotenuse. Thus, the sine of the angular
+    radius of the Sun is ratio of these two distances.
+
+    Parameters
+    ----------
+    coordinates : `~astropy.coordinates.SkyCoord`, `~sunpy.coordinates.frames.Helioprojective`
+        The input coordinate. The coordinate frame must be
+        `~sunpy.coordinates.Helioprojective`.
+
+    Returns
+    -------
+    angle : `~astropy.units.Quantity`
+        The solar angular radius.
+    """
+    _verify_coordinate_helioprojective(coordinates)
+    return sun._angular_radius(coordinates.rsun, coordinates.observer.radius)
 
 
 def solar_angle_equivalency(observer):

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -9,10 +9,16 @@ import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 from astropy.coordinates.representation import CartesianRepresentation
 
-from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, Helioprojective, get_body_heliographic_stonyhurst, sun
+from sunpy.coordinates import (
+    Heliocentric,
+    HeliographicStonyhurst,
+    Helioprojective,
+    get_body_heliographic_stonyhurst,
+    sun,
+)
 from sunpy.sun import constants
 
-__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates', 'get_heliocentric_angle'
+__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates', 'get_heliocentric_angle',
            'solar_angular_radius', 'coordinate_is_on_solar_disk']
 
 

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -9,8 +9,7 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.visualization import AsymmetricPercentileInterval
-from sunpy.coordinates import Helioprojective, sun
-from sunpy.coordinates import utils
+from sunpy.coordinates import sun, utils
 from sunpy.util.decorators import deprecated
 
 __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -9,8 +9,9 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.visualization import AsymmetricPercentileInterval
-
 from sunpy.coordinates import Helioprojective, sun
+from sunpy.coordinates.utils import _verify_coordinate_helioprojective
+from sunpy.util.decorators import deprecated
 
 __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'all_corner_coords_from_map',
@@ -124,7 +125,8 @@ def map_edges(smap):
     right_hand_side = list(product([nx - 1], np.arange(ny))) * u.pix
     return top, bottom, left_hand_side, right_hand_side
 
-
+# moved to utils
+'''
 def _verify_coordinate_helioprojective(coordinates):
     """
     Raises an error if the coordinate is not in the
@@ -138,8 +140,9 @@ def _verify_coordinate_helioprojective(coordinates):
     if not isinstance(frame, Helioprojective):
         raise ValueError(f"The input coordinate(s) is of type {type(frame).__name__}, "
                          "but must be in the Helioprojective frame.")
+'''
 
-
+@deprecated(since="7.0", message="solar_angular_radius moved to coordinates/utils")
 def solar_angular_radius(coordinates):
     """
     Calculates the solar angular radius as seen by the observer.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -10,14 +10,14 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.visualization import AsymmetricPercentileInterval
 from sunpy.coordinates import Helioprojective, sun
-from sunpy.coordinates.utils import _verify_coordinate_helioprojective
+from sunpy.coordinates import utils
 from sunpy.util.decorators import deprecated
 
 __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'all_corner_coords_from_map',
-           'map_edges', 'solar_angular_radius', 'sample_at_coords',
+           'map_edges', 'sample_at_coords',
            'contains_full_disk', 'is_all_off_disk', 'is_all_on_disk',
-           'contains_limb', 'coordinate_is_on_solar_disk',
+           'contains_limb',
            'on_disk_bounding_coordinates',
            'contains_coordinate', 'contains_solar_center',
            'pixelate_coord_path']
@@ -127,7 +127,7 @@ def map_edges(smap):
 
 # moved to utils
 '''
-def _verify_coordinate_helioprojective(coordinates):
+def utils._verify_coordinate_helioprojective(coordinates):
     """
     Raises an error if the coordinate is not in the
     `~sunpy.coordinates.frames.Helioprojective` frame.
@@ -163,7 +163,7 @@ def solar_angular_radius(coordinates):
     angle : `~astropy.units.Quantity`
         The solar angular radius.
     """
-    _verify_coordinate_helioprojective(coordinates)
+    utils._verify_coordinate_helioprojective(coordinates)
     return sun._angular_radius(coordinates.rsun, coordinates.observer.radius)
 
 
@@ -237,10 +237,10 @@ def contains_full_disk(smap):
     within the field of the view of the instrument (although no emission
     from the disk itself is present in the data.)
     """
-    _verify_coordinate_helioprojective(smap.coordinate_frame)
+    utils._verify_coordinate_helioprojective(smap.coordinate_frame)
     edge_of_world = _edge_coordinates(smap)
     # Check that the edge pixels are all beyond the limb yet the Sun center is in the map
-    return np.all(~coordinate_is_on_solar_disk(edge_of_world)) and contains_solar_center(smap)
+    return np.all(~utils.coordinate_is_on_solar_disk(edge_of_world)) and contains_solar_center(smap)
 
 
 def contains_solar_center(smap):
@@ -259,10 +259,10 @@ def contains_solar_center(smap):
     bool
         True if the map contains the solar center.
     """
-    _verify_coordinate_helioprojective(smap.coordinate_frame)
+    utils._verify_coordinate_helioprojective(smap.coordinate_frame)
     return contains_coordinate(smap, SkyCoord(0*u.arcsec, 0*u.arcsec, frame=smap.coordinate_frame))
 
-
+@deprecated(since="7.0", message="solar_angular_radius moved to coordinates/utils")
 @u.quantity_input
 def coordinate_is_on_solar_disk(coordinates):
     """
@@ -284,10 +284,10 @@ def coordinate_is_on_solar_disk(coordinates):
     `~bool`
         Returns `True` if the coordinate is on disk, `False` otherwise.
     """
-    _verify_coordinate_helioprojective(coordinates)
+    utils._verify_coordinate_helioprojective(coordinates)
     # Calculate the radial angle from the center of the Sun (do not assume small angles)
     # and compare it to the angular radius of the Sun
-    return np.arccos(np.cos(coordinates.Tx) * np.cos(coordinates.Ty)) <= solar_angular_radius(coordinates)
+    return np.arccos(np.cos(coordinates.Tx) * np.cos(coordinates.Ty)) <= utils.solar_angular_radius(coordinates)
 
 
 def is_all_off_disk(smap):
@@ -314,10 +314,10 @@ def is_all_off_disk(smap):
     within the field of view of the instrument, even though the solar disk
     itself is not imaged. For such images this function will return `False`.
     """
-    _verify_coordinate_helioprojective(smap.coordinate_frame)
+    utils._verify_coordinate_helioprojective(smap.coordinate_frame)
     edge_of_world = _edge_coordinates(smap)
     # Check that the edge pixels are all beyond the limb and the Sun center is not in the map
-    return np.all(~coordinate_is_on_solar_disk(edge_of_world)) and ~contains_solar_center(smap)
+    return np.all(~utils.coordinate_is_on_solar_disk(edge_of_world)) and ~contains_solar_center(smap)
 
 
 def is_all_on_disk(smap):
@@ -340,9 +340,9 @@ def is_all_on_disk(smap):
         Returns `True` if all map coordinates have an angular radius less than
         the angular radius of the Sun.
     """
-    _verify_coordinate_helioprojective(smap.coordinate_frame)
+    utils._verify_coordinate_helioprojective(smap.coordinate_frame)
     edge_of_world = _edge_coordinates(smap)
-    return np.all(coordinate_is_on_solar_disk(edge_of_world))
+    return np.all(utils.coordinate_is_on_solar_disk(edge_of_world))
 
 
 def contains_limb(smap):
@@ -373,10 +373,10 @@ def contains_limb(smap):
     within the field of view of the instrument, but the solar disk itself is not imaged.
     For such images this function will return `True`.
     """
-    _verify_coordinate_helioprojective(smap.coordinate_frame)
+    utils._verify_coordinate_helioprojective(smap.coordinate_frame)
     if contains_full_disk(smap):
         return True
-    on_disk = coordinate_is_on_solar_disk(_edge_coordinates(smap))
+    on_disk = utils.coordinate_is_on_solar_disk(_edge_coordinates(smap))
     return np.logical_and(np.any(on_disk), np.any(~on_disk))
 
 
@@ -398,7 +398,7 @@ def on_disk_bounding_coordinates(smap):
         top right coordinate of the smallest rectangular region that contains
         all the on-disk pixels in the input map.
     """
-    _verify_coordinate_helioprojective(smap.coordinate_frame)
+    utils._verify_coordinate_helioprojective(smap.coordinate_frame)
     # Check that the input map is not all off disk.
     if is_all_off_disk(smap):
         raise ValueError("The entire map is off disk.")
@@ -407,7 +407,7 @@ def on_disk_bounding_coordinates(smap):
     coordinates = all_coordinates_from_map(smap)
 
     # Find which coordinates are on the disk
-    on_disk = coordinate_is_on_solar_disk(coordinates)
+    on_disk = utils.coordinate_is_on_solar_disk(coordinates)
     on_disk_coordinates = coordinates[on_disk]
 
     # The bottom left and top right coordinates that contain

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -9,6 +9,7 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.visualization import AsymmetricPercentileInterval
+
 from sunpy.coordinates import sun, utils
 from sunpy.util.decorators import deprecated
 

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -20,14 +20,14 @@ from sunpy.map.maputils import (
     contains_full_disk,
     contains_limb,
     contains_solar_center,
-    coordinate_is_on_solar_disk,
+    coordinate_is_on_solar_disk,  #to be removed
     is_all_off_disk,
     is_all_on_disk,
     map_edges,
     on_disk_bounding_coordinates,
     pixelate_coord_path,
     sample_at_coords,
-    solar_angular_radius,
+    solar_angular_radius #to be removed
 )
 
 
@@ -63,7 +63,7 @@ def non_helioprojective_map():
                                                          wavelength=1000*u.angstrom)
     return sunpy.map.Map(data, header)
 
-
+#To be copied over?
 @pytest.fixture
 def non_helioprojective_skycoord():
     return SkyCoord(0 * u.rad, 0 * u.rad, frame="icrs")
@@ -143,13 +143,6 @@ def test_map_edges(all_off_disk_map):
     assert np.all(edges[0][10] == [10, 11] * u.pix)
 
 
-def test_solar_angular_radius(aia171_test_map):
-    on_disk = aia171_test_map.center
-    sar = solar_angular_radius(on_disk)
-    assert isinstance(sar, u.Quantity)
-    np.testing.assert_almost_equal(sar.to(u.arcsec).value, 971.80181131, decimal=1)
-
-
 def test_contains_full_disk(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map):
     assert contains_full_disk(aia171_test_map)
     assert ~contains_full_disk(all_off_disk_map)
@@ -177,7 +170,7 @@ def test_contains_limb(aia171_test_map, all_off_disk_map, all_on_disk_map, strad
     assert ~contains_limb(all_on_disk_map)
     assert contains_limb(straddles_limb_map)
 
-
+#To be moved
 def test_coordinate_is_on_solar_disk(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map):
     off_disk = aia171_test_map.bottom_left_coord
     on_disk = aia171_test_map.center
@@ -247,7 +240,7 @@ def test_verify_coordinate_helioprojective(aia171_test_map, all_off_disk_map, al
     with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
         _verify_coordinate_helioprojective(non_helioprojective_skycoord)
 
-
+#To be moved
 def test_functions_raise_non_frame_coords(non_helioprojective_skycoord):
     with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
         solar_angular_radius(non_helioprojective_skycoord)

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -10,9 +10,8 @@ from astropy.tests.helper import assert_quantity_allclose
 import sunpy.map
 from sunpy.coordinates import HeliographicStonyhurst
 from sunpy.coordinates.frames import HeliographicCarrington
-from sunpy.coordinates.utils import GreatArc
+from sunpy.coordinates.utils import GreatArc, coordinate_is_on_solar_disk, solar_angular_radius, _verify_coordinate_helioprojective
 from sunpy.map.maputils import (
-    _verify_coordinate_helioprojective,
     all_coordinates_from_map,
     all_corner_coords_from_map,
     all_pixel_indices_from_map,
@@ -20,14 +19,12 @@ from sunpy.map.maputils import (
     contains_full_disk,
     contains_limb,
     contains_solar_center,
-    coordinate_is_on_solar_disk,  #to be removed
     is_all_off_disk,
     is_all_on_disk,
     map_edges,
     on_disk_bounding_coordinates,
     pixelate_coord_path,
     sample_at_coords,
-    solar_angular_radius #to be removed
 )
 
 
@@ -170,7 +167,6 @@ def test_contains_limb(aia171_test_map, all_off_disk_map, all_on_disk_map, strad
     assert ~contains_limb(all_on_disk_map)
     assert contains_limb(straddles_limb_map)
 
-#To be moved
 def test_coordinate_is_on_solar_disk(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map):
     off_disk = aia171_test_map.bottom_left_coord
     on_disk = aia171_test_map.center
@@ -239,13 +235,6 @@ def test_verify_coordinate_helioprojective(aia171_test_map, all_off_disk_map, al
         _verify_coordinate_helioprojective(non_helioprojective_map.coordinate_frame)
     with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
         _verify_coordinate_helioprojective(non_helioprojective_skycoord)
-
-#To be moved
-def test_functions_raise_non_frame_coords(non_helioprojective_skycoord):
-    with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
-        solar_angular_radius(non_helioprojective_skycoord)
-    with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
-        coordinate_is_on_solar_disk(non_helioprojective_skycoord)
 
 
 def test_functions_raise_non_frame_map(non_helioprojective_map):

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -10,7 +10,7 @@ from astropy.tests.helper import assert_quantity_allclose
 import sunpy.map
 from sunpy.coordinates import HeliographicStonyhurst
 from sunpy.coordinates.frames import HeliographicCarrington
-from sunpy.coordinates.utils import GreatArc, coordinate_is_on_solar_disk, solar_angular_radius, _verify_coordinate_helioprojective
+from sunpy.coordinates.utils import GreatArc, coordinate_is_on_solar_disk, _verify_coordinate_helioprojective
 from sunpy.map.maputils import (
     all_coordinates_from_map,
     all_corner_coords_from_map,

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -10,7 +10,7 @@ from astropy.tests.helper import assert_quantity_allclose
 import sunpy.map
 from sunpy.coordinates import HeliographicStonyhurst
 from sunpy.coordinates.frames import HeliographicCarrington
-from sunpy.coordinates.utils import GreatArc, coordinate_is_on_solar_disk, _verify_coordinate_helioprojective
+from sunpy.coordinates.utils import GreatArc, _verify_coordinate_helioprojective, coordinate_is_on_solar_disk
 from sunpy.map.maputils import (
     all_coordinates_from_map,
     all_corner_coords_from_map,

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -178,7 +178,7 @@ class Cutout(DataAttr):
         center = SkyCoord(center_x, center_y, frame=bottom_left.frame)
         if tracking:
             # import here so net won't depend on map
-            from sunpy.map.maputils import coordinate_is_on_solar_disk
+            from sunpy.coordinates.utils import coordinate_is_on_solar_disk
             if not coordinate_is_on_solar_disk(center):
                 raise ValueError("Tracking is enabled, but the center of the cutout "
                                  f"(Tx={center_x}, Ty={center_y}) is not on the solar disk.")

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -14,9 +14,9 @@ from sunpy.coordinates import (
     get_earth,
     transform_with_sun_center,
 )
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 from sunpy.map import (
     contains_full_disk,
-    coordinate_is_on_solar_disk,
     is_all_off_disk,
     is_all_on_disk,
     map_edges,


### PR DESCRIPTION
## PR Description

Addresses https://github.com/sunpy/sunpy/issues/8445.

Moves 
- [solar_angular_radius()](https://github.com/sunpy/sunpy/blob/5486ee8cf681944f2fea1e43109c63890f3c7469/sunpy/map/maputils.py#L143-L164)
- [coordinate_is_on_solar_disk()](https://github.com/sunpy/sunpy/blob/5486ee8cf681944f2fea1e43109c63890f3c7469/sunpy/map/maputils.py#L263-L287)

to deprecated and copy moves functions to `sunpy/coordinates/utils.py`.

Fixes associated tests and calls to deprecated functions.
