### PR TITLE
Moved `towncrier` from conda to pip in dev env YAML

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -111,6 +111,7 @@ jobs:
           activate-environment: sunpy-test
           environment-file: sunpy-dev-env.yml
           python-version: "3.13"
+          conda-remove-defaults: "true"
       - name: Install sunpy
         shell: bash -el {0}
         run: |

--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -67,7 +67,6 @@ dependencies:
   - sphinx-gallery
   - sphinxcontrib-bibtex
   - sphinxext-opengraph
-  - towncrier
 
   # Installation
   - extension-helpers
@@ -81,3 +80,4 @@ dependencies:
       - sphinx-bootstrap-theme
       - sphinx-changelog
       - sunpy-sphinx-theme
+      - towncrier  # needs to be installed via pip because sphinx-changelog pins the version


### PR DESCRIPTION
For our development environment YAML, `towncrier` is installed by conda, while `sphinx-changelog` has to be installed by pip.  Since `sphinx-changelog` pins the version of `towncrier`, it means that the conda-installed `towncrier` gets uninstalled and then the pinned version of `towncrier` gets installed by pip.  This PR moves `towncrier` from the conda section to the pip section to avoid this reinstallation, and this has no impact to anything else because `towncrier` is not a dependency of any of our conda-installed dependencies.