### PR TITLE
Ensured that the SDO Map reference date is in the same scale as the observation time

### DIFF
--- a/changelog/8477.breaking.rst
+++ b/changelog/8477.breaking.rst
@@ -1,0 +1,1 @@
+Adjusted the ``reference_date`` property of `~sunpy.map.sources.AIAMap` and `~sunpy.map.sources.HMIMap` so that its return value is in the same time scale as the ``date`` property, in order to avoid subtle user mistakes.

--- a/sunpy/map/sources/sdo.py
+++ b/sunpy/map/sources/sdo.py
@@ -5,6 +5,7 @@ from matplotlib.colors import CenteredNorm
 
 import astropy.units as u
 from astropy.coordinates import CartesianRepresentation, HeliocentricMeanEcliptic
+from astropy.time import Time
 from astropy.visualization import AsinhStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
 
@@ -82,7 +83,6 @@ class AIAMap(GenericMap):
         """
         return self.meta.get('telescop', '').split('/')[0]
 
-
     @property
     def reference_date(self):
         """
@@ -90,7 +90,8 @@ class AIAMap(GenericMap):
 
         DATE-OBS is derived from T_OBS by subtracting half the exposure time, so would not be a reference time.
         """
-        return self._get_date('T_OBS') or super().reference_date
+        date = self._get_date('T_OBS') or super().reference_date
+        return Time(date, scale=self.date.scale) if date.scale != self.date.scale else date
 
     def _set_reference_date(self, date):
         self.meta['t_obs'] = parse_time(date).utc.isot
@@ -189,7 +190,8 @@ class HMIMap(GenericMap):
 
         DATE-OBS is derived from T_OBS by subtracting half the exposure time, so would not be a reference time.
         """
-        return self._get_date('T_OBS') or super().reference_date
+        date = self._get_date('T_OBS') or super().reference_date
+        return Time(date, scale=self.date.scale) if date.scale != self.date.scale else date
 
     def _set_reference_date(self, date):
         self.meta['T_OBS'] = parse_time(date).utc.isot

--- a/sunpy/map/sources/tests/test_aia_source.py
+++ b/sunpy/map/sources/tests/test_aia_source.py
@@ -30,10 +30,12 @@ def test_aia_map(aia_map):
 
 
 def test_reference_date(aia_map):
+    assert aia_map.reference_date.scale == aia_map.date.scale
     assert aia_map.reference_date.isot in ["2011-02-15T00:00:01.340", "2013-06-24T17:31:31.840"]
 
 
 def test_date(aia_map):
+    assert aia_map.date.scale == "utc"
     assert aia_map.date.isot in ["2011-02-15T00:00:00.340", "2013-06-24T17:31:30.840"]
 
 

--- a/sunpy/map/sources/tests/test_hmi_source.py
+++ b/sunpy/map/sources/tests/test_hmi_source.py
@@ -52,13 +52,17 @@ def test_is_datasource_for(hmi_map, hmi_bharp_map, hmi_cea_sharp_map, hmi_sharp_
 
 
 def test_reference_date(hmi_map, hmi_bharp_map, hmi_cea_sharp_map, hmi_sharp_map):
-    assert hmi_map.reference_date.isot == "2014-03-01T00:01:25.000"
-    assert hmi_bharp_map.reference_date.isot == "2014-06-09T23:48:07.532"
-    assert hmi_cea_sharp_map.reference_date.isot == "2024-06-28T00:00:08.212"
-    assert hmi_sharp_map.reference_date.isot == "2024-06-28T00:00:08.212"
+    for m in [hmi_map, hmi_bharp_map, hmi_cea_sharp_map, hmi_sharp_map]:
+        assert m.reference_date.scale == m.date.scale
+    assert hmi_map.reference_date.isot == "2014-03-01T00:00:50.000"
+    assert hmi_bharp_map.reference_date.isot == "2014-06-09T23:47:32.532"
+    assert hmi_cea_sharp_map.reference_date.isot == "2024-06-27T23:59:31.212"
+    assert hmi_sharp_map.reference_date.isot == "2024-06-27T23:59:31.212"
 
 
 def test_date(hmi_map, hmi_bharp_map, hmi_cea_sharp_map, hmi_sharp_map):
+    for m in [hmi_map, hmi_bharp_map, hmi_cea_sharp_map, hmi_sharp_map]:
+        assert m.date.scale == "utc"
     assert hmi_map.date.isot == "2014-03-01T00:00:27.900"
     assert hmi_bharp_map.date.isot == "2014-06-09T23:46:25.000"
     assert hmi_cea_sharp_map.date.isot == "2024-06-27T23:58:46.200"


### PR DESCRIPTION
For both `AIAMap` and `HMIMap`, the `.date` property typically comes from `DATE-OBS`, while the `.reference_date` property typically comes from `T_OBS` (unless `T_OBS` has been removed during a processing step).  Potentially confusingly, `DATE-OBS` is in UTC, while `T_OBS` is in TAI.  As `Time` objects, this is not technically a problem, because the time scale is part of the object.  However, because times are almost always in UTC, it is quite common for a user to not be super-diligent about time scales  (e.g., before converting to strings or `datetime` objects), so user code can get tripped up with `.reference_date` being in a different time scale than `.date`.

This PR changes the `.reference_date` property for both `AIAMap` and `HMIMap` so that the returned time is in the same time scale as the `.date` property.  If `.date` happens to be in TAI, then `.reference_date` will also be TAI.  But, typically, this means that `.reference_date` now returns UTC time.  The conversion from TAI to UTC is lossless, and a user can explicitly convert it (back) to TAI time if that's what they want.

xref #7682 and #7758