### PR TITLE
Remove dead legacy sunpy.config configuration listing

### DIFF
--- a/changelog/8481.trivial.rst
+++ b/changelog/8481.trivial.rst
@@ -1,0 +1,3 @@
+Removed unreachable legacy configuration listing code that referenced
+the deprecated sunpy.config module.
+

--- a/sunpy/util/config.py
+++ b/sunpy/util/config.py
@@ -117,12 +117,6 @@ def print_config():
         print("  " + file_)
 
     print("\nCONFIGURATION:")
-    for section in sunpy.config.sections():
-        print(f"  [{section}]")
-        for option in sunpy.config.options(section):
-            print(f"  {option} = {sunpy.config.get(section, option)}")
-        print("")
-
 
 def _is_writable_dir(p):
     """


### PR DESCRIPTION
While looking at the configuration utilities, I noticed that this block
was still referencing `sunpy.config`.

That module has been removed as part of the SunPy 8.x configuration
changes, so this code path is effectively dead and would error if it
were ever reached.

Since it no longer reflects the current configuration system and has
no functional use, this PR removes the leftover legacy code. The
configuration header output is left in place in case this functionality
is reintroduced in the future.

This change does not alter any user-facing behavior and is purely a
cleanup of unreachable legacy code.
