### PR TITLE
Fixed thread-safety issues, primarily associated with module-level global variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
         - windows: py313
         - macos: py313
         - linux: py312-oldestdeps
+        - linux: py314
+          name: py314 (parallel threads)
+          posargs: --parallel-threads=auto --color=yes
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/changelog/8500.bugfix.rst
+++ b/changelog/8500.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed bugs when using thread-based parallel processing due to unintentionally shared state information.
+This primarily affected these context managers: :func:`~sunpy.coordinates.SphericalScreen`, :func:`~sunpy.coordinates.PlanarScreen`, :func:`~sunpy.coordinates.propagate_with_solar_surface`, and :func:`~sunpy.coordinates.transform_with_sun_center`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ tests-only = [
   "psutil>=6.0.0",
   "pytest-astropy>=0.11.0",
   "pytest-mpl>=0.18.0",
+  "pytest-run-parallel>=0.6.0",
   "pytest>=7.4.0",
 ]
 asdf-tests = [

--- a/sunpy/coordinates/_transformations.py
+++ b/sunpy/coordinates/_transformations.py
@@ -13,6 +13,7 @@ This module contains the functions for converting one
 
 """
 import logging
+import threading
 from copy import deepcopy
 from functools import wraps
 

--- a/sunpy/coordinates/_transformations.py
+++ b/sunpy/coordinates/_transformations.py
@@ -71,12 +71,16 @@ __all__ = ['transform_with_sun_center',
            'propagate_with_solar_surface']
 
 
-# Boolean flag for whether to ignore the motion of the center of the Sun in inertial space
-_ignore_sun_motion = False
-
-
-# If not None, the name of the differential-rotation model to use for any obstime change
-_autoapply_diffrot = None
+# Thread-safe storage of the current states of the transformation options
+# Otherwise, enabling an option on one thread can affect the calculations on another thread
+# Furthermore, context exits may restore a state that was supposed to have ended
+class TransformationOptions(threading.local):
+    def __init__(self):
+        # Boolean flag for whether to ignore the motion of the center of the Sun in inertial space
+        self.ignore_sun_motion = False
+        # If not None, the name of the differential-rotation model to use for any obstime change
+        self.autoapply_diffrot = None
+_transformation_options = TransformationOptions()
 
 
 @sunpycontextmanager
@@ -129,18 +133,16 @@ def transform_with_sun_center():
         (0., 0., 0.)>
     """
     try:
-        global _ignore_sun_motion
-
-        old_ignore_sun_motion = _ignore_sun_motion  # nominally False
+        old_ignore_sun_motion = _transformation_options.ignore_sun_motion  # nominally False
 
         if not old_ignore_sun_motion:
             log.debug("Ignoring the motion of the center of the Sun for transformations")
-        _ignore_sun_motion = True
+        _transformation_options.ignore_sun_motion = True
         yield
     finally:
         if not old_ignore_sun_motion:
             log.debug("Stop ignoring the motion of the center of the Sun for transformations")
-        _ignore_sun_motion = old_ignore_sun_motion
+        _transformation_options.ignore_sun_motion = old_ignore_sun_motion
 
 
 @sunpycontextmanager
@@ -209,19 +211,17 @@ def propagate_with_solar_surface(rotation_model='howard'):
     """
     with transform_with_sun_center():
         try:
-            global _autoapply_diffrot
-
-            old_autoapply_diffrot = _autoapply_diffrot  # nominally False
+            old_autoapply_diffrot = _transformation_options.autoapply_diffrot  # nominally False
 
             log.debug("Enabling automatic solar differential rotation "
                       f"('{rotation_model}') for any changes in obstime")
-            _autoapply_diffrot = rotation_model
+            _transformation_options.autoapply_diffrot = rotation_model
             yield
         finally:
             if not old_autoapply_diffrot:
                 log.debug("Disabling automatic solar differential rotation "
                           "for any changes in obstime")
-            _autoapply_diffrot = old_autoapply_diffrot
+            _transformation_options.autoapply_diffrot = old_autoapply_diffrot
 
 
 # Global counter to keep track of the layer of transformation
@@ -738,7 +738,7 @@ def _affine_params_hcrs_to_hgs(hcrs_time, hgs_time):
 
     # All of the above is calculated for the HGS observation time
     # If the HCRS observation time is different, calculate the translation in origin
-    if not _ignore_sun_motion and np.any(hcrs_time != hgs_time):
+    if not _transformation_options.ignore_sun_motion and np.any(hcrs_time != hgs_time):
         sun_pos_old_icrs = get_body_barycentric('sun', hcrs_time)
         offset_icrf = sun_pos_old_icrs - sun_pos_icrs
     else:
@@ -807,9 +807,9 @@ def hgs_to_hgs(from_coo, to_frame):
     elif _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
-        if _autoapply_diffrot:
+        if _transformation_options.autoapply_diffrot:
             from_coo = from_coo._apply_diffrot((to_frame.obstime - from_coo.obstime).to('day'),
-                                               _autoapply_diffrot)
+                                               _transformation_options.autoapply_diffrot)
         return from_coo.transform_to(HCRS(obstime=to_frame.obstime)).transform_to(to_frame)
 
 

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -6,6 +6,7 @@ the `astropy.coordinates` module.
 """
 import os
 import re
+import threading
 import traceback
 
 import numpy as np
@@ -528,7 +529,14 @@ class Helioprojective(SunPyBaseCoordinateFrame):
 
     rsun = QuantityAttribute(default=_RSUN, unit=u.km)
     observer = ObserverCoordinateAttribute(HeliographicStonyhurst)
-    _assumed_screen = None
+
+    # Thread-safe storage of the currently active screen assumption, if any
+    # Otherwise, the screen on one thread can affect calculations on another thread
+    # Furthermore, context exits may restore a state that was supposed to have ended
+    class _Assumptions(threading.local):
+        def __init__(self):
+            self.screen = None
+    _assumptions = _Assumptions()
 
     @property
     def angular_radius(self):
@@ -590,9 +598,9 @@ class Helioprojective(SunPyBaseCoordinateFrame):
         with np.errstate(invalid='ignore'):
             d = ((-1*b) - np.sqrt(b**2 - 4*c)) / 2  # use the "near" solution
 
-        if self._assumed_screen:
-            d_screen = self._assumed_screen.calculate_distance(self)
-            d = np.fmin(d, d_screen) if self._assumed_screen.only_off_disk else d_screen
+        if self._assumptions.screen:
+            d_screen = self._assumptions.screen.calculate_distance(self)
+            d = np.fmin(d, d_screen) if self._assumptions.screen.only_off_disk else d_screen
 
         # This warning can be triggered in specific draw calls when plt.show() is called
         # we can not easily prevent this, so we check the specific function is being called

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -10,7 +10,8 @@ import astropy.units as u
 from astropy.coordinates.representation import CartesianRepresentation, UnitSphericalRepresentation
 
 from sunpy import log
-from sunpy.coordinates import HeliographicStonyhurst, Helioprojective, _transformations
+from sunpy.coordinates import HeliographicStonyhurst, Helioprojective
+from sunpy.coordinates._transformations import _transformation_options
 from sunpy.util.decorators import _active_contexts
 from sunpy.util.exceptions import warn_user
 
@@ -202,7 +203,7 @@ class SphericalScreen(BaseScreen):
             distance = ((-1*b) + np.sqrt(b**2 - 4*c)) / 2  # use the "far" solution
 
         # Iterate the calculation if differential rotation is being applied
-        if _transformations._autoapply_diffrot is not None and np.any(frame.obstime != self._center.obstime):
+        if _transformation_options.autoapply_diffrot is not None and np.any(frame.obstime != self._center.obstime):
             screen_frame = Helioprojective(observer=self._center, obstime=self._center.obstime)
             distance = self._iterate_calculate_distance(frame, distance, screen_frame)
 
@@ -288,7 +289,7 @@ class PlanarScreen(BaseScreen):
         distance = d_from_plane / rep.dot(direction)
 
         # Iterate the calculation if differential rotation is being applied
-        if _transformations._autoapply_diffrot is not None and np.any(frame.obstime != self._vantage_point.obstime):
+        if _transformation_options.autoapply_diffrot is not None and np.any(frame.obstime != self._vantage_point.obstime):
             screen_frame = Helioprojective(observer=self._vantage_point, obstime=self._vantage_point.obstime)
             distance = self._iterate_calculate_distance(frame, distance, screen_frame)
 

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -11,7 +11,7 @@ from astropy.coordinates.representation import CartesianRepresentation, UnitSphe
 
 from sunpy import log
 from sunpy.coordinates import HeliographicStonyhurst, Helioprojective, _transformations
-from sunpy.util.decorators import ACTIVE_CONTEXTS
+from sunpy.util.decorators import _active_contexts
 from sunpy.util.exceptions import warn_user
 
 __all__ = ['BaseScreen', 'SphericalScreen', 'PlanarScreen']
@@ -33,12 +33,12 @@ class BaseScreen(abc.ABC):
         ...
 
     def __enter__(self):
-        ACTIVE_CONTEXTS.append(self._context_name)
+        _active_contexts.stack.append(self._context_name)
         self._old_assumed_screen = Helioprojective._assumed_screen  # nominally None
         Helioprojective._assumed_screen = self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        if (removed := ACTIVE_CONTEXTS.pop()) != self._context_name:
+        if (removed := _active_contexts.stack.pop()) != self._context_name:
             raise RuntimeError(f"Cannot remove {self._context_name} from tracking stack because {removed} is last active.")
         Helioprojective._assumed_screen = self._old_assumed_screen
 

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -35,13 +35,13 @@ class BaseScreen(abc.ABC):
 
     def __enter__(self):
         _active_contexts.stack.append(self._context_name)
-        self._old_assumed_screen = Helioprojective._assumed_screen  # nominally None
-        Helioprojective._assumed_screen = self
+        self._old_assumed_screen = Helioprojective._assumptions.screen  # nominally None
+        Helioprojective._assumptions.screen = self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         if (removed := _active_contexts.stack.pop()) != self._context_name:
             raise RuntimeError(f"Cannot remove {self._context_name} from tracking stack because {removed} is last active.")
-        Helioprojective._assumed_screen = self._old_assumed_screen
+        Helioprojective._assumptions.screen = self._old_assumed_screen
 
     def _iterate_calculate_distance(self, coord, distance, screen_frame):
         """

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -57,6 +57,8 @@ Examples
 #   ICRS. ICRS is a safe frame to use because the SPICE built-in inertial
 #   frame 'J2000' is ICRS, despite its name.
 
+import threading
+
 import numpy as np
 
 try:
@@ -86,9 +88,12 @@ _ET_REF_EPOCH = Time('J2000', scale='tdb')
 _CLASS_TYPES = {1: 'inertial', 2: 'PCK', 3: 'CK', 4: 'TK', 5: 'dynamic', 6: 'switch'}
 
 
-# Registry of the generated frame classes and center classes
-_frame_registry = {}
-_center_registry = {'SOLAR SYSTEM BARYCENTER': ICRS}
+# Thread-safe registry of the generated frame classes and center classes
+class _Registry(threading.local):
+    def __init__(self):
+        self.frames = {}
+        self.centers = {'SOLAR SYSTEM BARYCENTER': ICRS}
+_registry = _Registry()
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())
@@ -181,7 +186,7 @@ def _is_2d(data):
 
 def _install_center_by_id(center_id):
     center_name = spiceypy.bodc2n(center_id)
-    if center_name in _center_registry.keys():
+    if center_name in _registry.centers.keys():
         return
 
     log.info(f"Creating ICRF frame with {center_name} ({center_id}) origin")
@@ -211,7 +216,7 @@ def _install_center_by_id(center_id):
 
     frame_transform_graph._add_merged_transform(center_cls, ICRS, center_cls)
 
-    _center_registry[center_name] = center_cls
+    _registry.centers[center_name] = center_cls
 
 
 def _install_frame_by_id(frame_id):
@@ -225,7 +230,7 @@ def _install_frame_by_id(frame_id):
 
     # Create a center class (if needed)
     _install_center_by_id(center_id)
-    center_cls = _center_registry[center_name]
+    center_cls = _registry.centers[center_name]
 
     frame_cls = type(astropy_frame_name, (SpiceBaseCoordinateFrame,), {},
                      frame_name=frame_name, center_name=center_name)
@@ -250,7 +255,7 @@ def _install_frame_by_id(frame_id):
 
     frame_transform_graph._add_merged_transform(frame_cls, center_cls, frame_cls)
 
-    _frame_registry[frame_name] = (frame_cls, center_cls)
+    _registry.frames[frame_name] = (frame_cls, center_cls)
 
 
 def _uninstall_frame_by_class(target_class, from_class):
@@ -289,22 +294,20 @@ def initialize(kernels):
     spiceypy.furnsh([str(kernel) for kernel in kernels])
 
     # Remove all existing SPICE frame classes
-    global _frame_registry
-    if _frame_registry:
-        log.info(f"Removing {len(_frame_registry)} existing SPICE frame classes")
-        for spice_frame_name in _frame_registry.keys():
-            frame_cls, center_cls = _frame_registry[spice_frame_name]
+    if _registry.frames:
+        log.info(f"Removing {len(_registry.frames)} existing SPICE frame classes")
+        for spice_frame_name in _registry.frames.keys():
+            frame_cls, center_cls = _registry.frames[spice_frame_name]
             _uninstall_frame_by_class(frame_cls, center_cls)
-        _frame_registry.clear()
+        _registry.frames.clear()
 
     # Remove all non-default SPICE center classes
-    global _center_registry
-    if len(_center_registry) > 1:
-        log.info(f"Removing {len(_center_registry) - 1} existing SPICE origin classes")
-        for spice_center_name, center_cls in _center_registry.items():
+    if len(_registry.centers) > 1:
+        log.info(f"Removing {len(_registry.centers) - 1} existing SPICE origin classes")
+        for spice_center_name, center_cls in _registry.centers.items():
             if center_cls != ICRS:
                 _uninstall_frame_by_class(center_cls, ICRS)
-        _center_registry = {'SOLAR SYSTEM BARYCENTER': ICRS}
+        _registry.centers = {'SOLAR SYSTEM BARYCENTER': ICRS}
 
     # Generate all SPICE frame classes
     for class_num in _CLASS_TYPES.keys():
@@ -343,7 +346,7 @@ def install_frame(spice_frame):
         if frame_name == '':
             raise ValueError(f"{frame_id} is not a valid SPICE frame ID.")
 
-    if frame_name in _frame_registry:
+    if frame_name in _registry.frames:
         log.info(f"{frame_name} (frame_id) has already been installed.")
     else:
         _install_frame_by_id(frame_id)
@@ -463,7 +466,7 @@ def get_fov(instrument, time, *, resolution=100):
         obstime = Time(np.tile(obstime, num_vectors)).reshape((num_vectors, *obstime.shape)).T
 
     fov = SkyCoord(CartesianRepresentation(vectors.T),
-                   frame=_frame_registry[spice_frame][0],
+                   frame=_registry.frames[spice_frame][0],
                    obstime=obstime,
                    representation_type='unitspherical')
     return fov

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -673,9 +673,9 @@ def test_screen_plus_diffrot(off_limb_coord, screen, only_off_disk, distance):
 def test_screen_plus_diffrot_array_obstime(screen, only_off_disk):
     array_obstime = parse_time('2025-05-30') + np.arange(5) * u.day
     observer = HeliographicStonyhurst(0*u.deg, 0*u.deg, 1*u.AU, obstime=array_obstime)
-    coord_2d = SkyCoord([-1000, -750, -500, -250, 0] * u.arcsec,
-                        [600]*5 * u.arcsec,
-                        frame=Helioprojective(observer=observer, obstime=array_obstime))
+    coord_2d = Helioprojective([-1000, -750, -500, -250, 0] * u.arcsec,
+                               [600]*5 * u.arcsec,
+                               observer=observer, obstime=array_obstime)
 
     with propagate_with_solar_surface(), screen(observer[0], only_off_disk=only_off_disk):
         # Confirm that array obstime works

--- a/sunpy/coordinates/tests/test_metaframes.py
+++ b/sunpy/coordinates/tests/test_metaframes.py
@@ -17,6 +17,8 @@ from sunpy.sun.models import differential_rotation
 
 # NorthOffsetFrame is tested in test_offset_frame.py
 
+pytestmark = pytest.mark.thread_unsafe(reason="modifies frame_transform_graph for created frames")
+
 
 ###########################
 # Tests for RotatedSunFrame

--- a/sunpy/coordinates/tests/test_offset_frame.py
+++ b/sunpy/coordinates/tests/test_offset_frame.py
@@ -10,6 +10,8 @@ from sunpy.coordinates import NorthOffsetFrame
 from sunpy.coordinates.tests.helpers import assert_longitude_allclose
 from sunpy.coordinates.tests.strategies import latitudes, longitudes
 
+pytestmark = pytest.mark.thread_unsafe(reason="modifies frame_transform_graph for created frames")
+
 
 def test_null():
     """

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -1101,8 +1101,8 @@ def test_no_aberration_between_geocentric(start_class, end_class):
 
 
 def test_transform_with_sun_center():
-    sun_center = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU,
-                          frame=HeliographicStonyhurst(obstime="2001-01-01"))
+    sun_center = HeliographicStonyhurst(0*u.deg, 0*u.deg, 0*u.AU,
+                                        obstime="2001-01-01")
 
     with transform_with_sun_center():
         result1 = sun_center.transform_to(HeliographicStonyhurst(obstime="2001-02-01"))
@@ -1112,8 +1112,8 @@ def test_transform_with_sun_center():
     assert_quantity_allclose(result1.lat, sun_center.lat)
     assert_quantity_allclose(result1.radius, sun_center.radius)
 
-    other = SkyCoord(10*u.deg, 20*u.deg, 1*u.AU,
-                     frame=HeliographicStonyhurst(obstime="2001-01-01"))
+    other = HeliographicStonyhurst(10*u.deg, 20*u.deg, 1*u.AU,
+                                   obstime="2001-01-01")
 
     with transform_with_sun_center():
         result2 = other.transform_to(HeliographicCarrington(observer='earth', obstime="2001-02-01"))
@@ -1126,8 +1126,8 @@ def test_transform_with_sun_center():
 def test_transform_with_sun_center_reset():
     # This test sequence ensures that the context manager resets properly
 
-    sun_center = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU,
-                          frame=HeliographicStonyhurst(obstime="2001-01-01"))
+    sun_center = HeliographicStonyhurst(0*u.deg, 0*u.deg, 0*u.AU,
+                                        obstime="2001-01-01")
     end_frame = HeliocentricInertial(obstime="2001-02-01")
 
     # Without the context manager, the coordinate should not point at Sun center
@@ -1206,8 +1206,8 @@ def test_unit_preservation(frame1, frame2, unit):
 
 def test_propagate_with_solar_surface():
     # Test propagating the meridian by 6 days of solar rotation
-    meridian = SkyCoord(0*u.deg, np.arange(0, 90, 10)*u.deg, 1*u.AU,
-                        frame=HeliocentricInertial, obstime='2001-01-01')
+    meridian = HeliocentricInertial(0*u.deg, np.arange(0, 90, 10)*u.deg, 1*u.AU,
+                                    obstime='2001-01-01')
     dt = 6*u.day
     end_frame = HeliocentricInertial(obstime=meridian.obstime + dt)
 

--- a/sunpy/data/data_manager/tests/test_cache.py
+++ b/sunpy/data/data_manager/tests/test_cache.py
@@ -7,6 +7,9 @@ from sunpy.util.exceptions import SunpyUserWarning
 from .mocks import MOCK_HASH
 
 
+pytestmark = pytest.mark.thread_unsafe(reason="uses shared cache")
+
+
 def test_cache_basic(cache):
     cache.download('https://example.com/abc.text')
     assert cache._downloader.times_called == 1

--- a/sunpy/data/data_manager/tests/test_manager.py
+++ b/sunpy/data/data_manager/tests/test_manager.py
@@ -8,6 +8,7 @@ from sunpy.data.data_manager.tests.mocks import MOCK_HASH, write_to_test_file
 from sunpy.util.exceptions import SunpyUserWarning
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_basic(storage, downloader, data_function):
     data_function()
 
@@ -16,6 +17,7 @@ def test_basic(storage, downloader, data_function):
     assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_download_cache(storage, downloader, data_function):
     """
     Test calling function multiple times does not redownload.
@@ -28,6 +30,7 @@ def test_download_cache(storage, downloader, data_function):
     assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_file_tampered(manager, storage, downloader, data_function):
     """
     Test calling function multiple times does not redownload.
@@ -51,13 +54,14 @@ def test_wrong_hash_provided(manager):
         test_foo()
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_defer_download(manager, storage, downloader, data_function, tmpdir):
     """
     Test that files are not downloaded immediately if defer_download is True,
     but are downloaded when get is called.
     """
     folder = tmpdir.strpath
-    @manager.require('test_file', [f'file://{folder}/another_file'], MOCK_HASH,defer_download=True)
+    @manager.require('test_file', [f'file://{folder}/another_file'], MOCK_HASH, defer_download=True)
     def deferred_function():
         pass
 
@@ -65,6 +69,8 @@ def test_defer_download(manager, storage, downloader, data_function, tmpdir):
     assert downloader.times_called == 0
     assert len(storage._store) == 0
 
+
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_defer_download_get(manager, storage, downloader, data_function, tmpdir):
     folder = tmpdir.strpath
     @manager.require('test_file', [f'file://{folder}/another_file'], MOCK_HASH, defer_download=True)
@@ -76,6 +82,7 @@ def test_defer_download_get(manager, storage, downloader, data_function, tmpdir)
     assert len(storage._store) == 1
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_skip_all(manager, storage, downloader, data_function):
     """
     Test skip_hash_check redownloads data.
@@ -89,6 +96,7 @@ def test_skip_all(manager, storage, downloader, data_function):
     assert Path(storage._store[0]['file_path']).name == ('sunpy.test_file')
 
 
+@pytest.mark.thread_unsafe(reason="uses filesystem")
 def test_override_file(manager, data_function, tmpdir):
     """
     Test the override_file functionality.
@@ -135,6 +143,7 @@ def test_override_file(manager, data_function, tmpdir):
     data_function(default_tester)
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_override_file_remote(manager, downloader, data_function):
     replace_url = 'https://example.com/another_file'
     data_function()
@@ -160,6 +169,7 @@ def test_wrong_hash_error(manager, storage):
         foo()
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_file_changed(data_function, storage):
     # Download the file first
     data_function()
@@ -174,6 +184,7 @@ def test_file_changed(data_function, storage):
         data_function()
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_delete_db(sqlmanager, sqlstorage):
     # Download the file
     @sqlmanager.require('test_file', ['https://example.com/test_file'], MOCK_HASH)
@@ -189,6 +200,7 @@ def test_delete_db(sqlmanager, sqlstorage):
     test_function()
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_same_file_id_different_module(downloader, storage,
                                        data_function, data_function_from_fake_module):
     # Uses name 'test_file' to refer to the file
@@ -209,6 +221,7 @@ def test_same_file_id_different_module(downloader, storage,
     assert Path(storage._store[1]['file_path']).name == 'fake_module.test_file'
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_namespacing_with_manager_override_file(module_patched_manager, downloader,
                                                 storage, data_function_from_fake_module):
     # Download a file using manager.require()
@@ -251,6 +264,7 @@ def test_namespacing_with_manager_override_file(module_patched_manager, download
     assert Path(storage._store[0]['file_path']).name == 'fake_module.test_file'
 
 
+@pytest.mark.thread_unsafe(reason="uses shared downloader")
 def test_file_deleted_redownload(storage, downloader, data_function):
     # Checks that if a file is deleted, a warning is raised and the file is re-downloaded.
 

--- a/sunpy/io/_cdf.py
+++ b/sunpy/io/_cdf.py
@@ -17,6 +17,9 @@ from sunpy.util.exceptions import warn_user
 
 __all__ = ['read_cdf']
 
+# Force initialization of leapsecond table to avoid potential race condition when threading
+CDFepoch.breakdown_tt2000(0)
+
 
 def read_cdf(fname, **kwargs):
     """

--- a/sunpy/map/sources/tests/helpers.py
+++ b/sunpy/map/sources/tests/helpers.py
@@ -1,4 +1,9 @@
+import copy
+
+
 def _test_private_date_setters(map_object):
+    map_object = copy.deepcopy(map_object)  # for thread safety
+
     map_object._set_date("2012-03-04 05:06:07")
     assert map_object.date.isot == "2012-03-04T05:06:07.000"
 

--- a/sunpy/map/sources/tests/test_hmi_synoptic_source.py
+++ b/sunpy/map/sources/tests/test_hmi_synoptic_source.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 
 import astropy.units as u
@@ -49,6 +51,7 @@ def test_private_date_setters(hmi_synoptic):
 
 
 def test_unit(hmi_synoptic):
+    hmi_synoptic = copy.deepcopy(hmi_synoptic)  # for thread safety
     assert hmi_synoptic.unit == u.G
     assert hmi_synoptic.unit == u.Unit("Mx/cm^2")
     assert hmi_synoptic.unit.to_string() == 'Mx / cm2'

--- a/sunpy/map/sources/tests/test_wispr_source.py
+++ b/sunpy/map/sources/tests/test_wispr_source.py
@@ -1,4 +1,5 @@
 """Tests for PSP/WISPR"""
+import copy
 from textwrap import dedent
 
 import numpy as np
@@ -291,6 +292,7 @@ def test_exposure_time(wispr_map):
 def test_processing_level(wispr_map):
     assert wispr_map.processing_level == 1
 
+    wispr_map = copy.deepcopy(wispr_map)  # for thread safety
     for value, expected in [
             ('L1', 1),
             ('L2', 2),
@@ -303,6 +305,8 @@ def test_processing_level(wispr_map):
 
 def test_detector(wispr_map):
     assert wispr_map.detector == 'Outer'
+
+    wispr_map = copy.deepcopy(wispr_map)  # for thread safety
 
     wispr_map.meta['DETECTOR'] = 1
     assert wispr_map.detector == 'Inner'

--- a/sunpy/map/tests/test_compositemap.py
+++ b/sunpy/map/tests/test_compositemap.py
@@ -1,6 +1,8 @@
 """
 Test Composite Map
 """
+import copy
+
 import matplotlib as mpl
 import numpy as np
 import pytest
@@ -92,6 +94,7 @@ def test_plot_composite_map_mplkwargs(composite_test_map):
 
 
 def test_remove_composite_map(composite_test_map):
+    composite_test_map = copy.deepcopy(composite_test_map)  # for thread safety
     composite_test_map.remove_map(0)
     with pytest.raises(IndexError):
         composite_test_map.get_map(1)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -154,6 +154,8 @@ def test_wcs_sip(aia171_test_map):
 
 
 def test_wcs_cache(aia171_test_map):
+    aia171_test_map = deepcopy(aia171_test_map)  # for thread safety
+
     wcs1 = aia171_test_map.wcs
     wcs2 = aia171_test_map.wcs
     # Check that without any changes to the header, retrieving the wcs twice
@@ -170,6 +172,8 @@ def test_wcs_cache(aia171_test_map):
 
 
 def test_wcs_error_not_cached(aia171_test_map):
+    aia171_test_map = deepcopy(aia171_test_map)  # for thread safety
+
     # Create a cached value for the property
     _ = aia171_test_map.wcs
 
@@ -186,6 +190,8 @@ def test_wcs_error_not_cached(aia171_test_map):
 
 
 def test_obs_coord_cache(aia171_test_map):
+    aia171_test_map = deepcopy(aia171_test_map)  # for thread safety
+
     coord1 = aia171_test_map.observer_coordinate
     coord2 = aia171_test_map.observer_coordinate
     assert coord1 is coord2
@@ -246,6 +252,7 @@ def test_nickname(generic_map):
 
 def test_nickname_set(generic_map):
     assert generic_map.nickname == 'bar'
+    generic_map = deepcopy(generic_map)  # for thread safety
     generic_map.nickname = 'hi'
     assert generic_map.nickname == 'hi'
 
@@ -287,6 +294,7 @@ def test_date_scale(generic_map):
     # Check that default time scale is UTC
     assert 'timesys' not in generic_map.meta
     assert generic_map.date.scale == 'utc'
+    generic_map = deepcopy(generic_map)  # for thread safety
     generic_map.meta['timesys'] = 'tai'
     assert generic_map.date.scale == 'tai'
 
@@ -301,11 +309,13 @@ def test_detector(generic_map):
 
 def test_timeunit(generic_map):
     assert generic_map.timeunit == u.Unit('s')
+    generic_map = deepcopy(generic_map)  # for thread safety
     generic_map.meta['timeunit'] = 'h'
     assert generic_map.timeunit == u.Unit('h')
 
 
 def test_exposure_time(generic_map):
+    generic_map = deepcopy(generic_map)  # for thread safety
     exptime = 2 * u.s
     generic_map.meta['exptime'] = exptime.to_value('s')
     assert generic_map.exposure_time == exptime
@@ -488,6 +498,7 @@ _CD_KEYWORDS = ['CD1_1', 'CD1_2', 'CD2_1', 'CD2_2']
 @pytest.mark.parametrize('i', [1, 2])
 @pytest.mark.parametrize('j', [1, 2])
 def test_rotation_matrix_defaults(generic_map, i, j, key):
+    generic_map = deepcopy(generic_map)  # for thread safety
     # Check that missing rotation keywords are set to correct defaults
     #
     # Relevant bit of the FITS standard:
@@ -619,6 +630,8 @@ def test_world_pixel_roundtrip(simple_map):
 
 
 def test_swapped_ctypes(simple_map):
+    simple_map = deepcopy(simple_map)  # for thread safety
+
     # Check that CTYPES different from normal work fine
     simple_map.meta['ctype1'] = 'HPLT-TAN'   # Usually HPLN
     simple_map.meta['ctype2'] = 'HPLN-TAN'   # Usually HPLT
@@ -1563,6 +1576,7 @@ def test_find_contours_inputs(simple_map):
     with pytest.raises(ValueError, match=re.escape('The provided level (1000.0) is not smaller than the maximum data value (80)')):
         simple_map.draw_contours(1000 * u.dimensionless_unscaled, fill=True)
 
+    simple_map = deepcopy(simple_map)  # for thread safety
     simple_map.meta['bunit'] = 'm'
 
     with pytest.raises(TypeError, match='The levels argument has no unit attribute'):
@@ -1628,6 +1642,8 @@ def test_parse_submap_quantity_inputs(aia171_test_map):
 
 
 def test_wavelength_properties(simple_map):
+    simple_map = deepcopy(simple_map)  # for thread safety
+
     simple_map.meta.pop('waveunit', None)
     simple_map.meta['wavelnth'] = 1
     assert simple_map.measurement == 1 * u.one
@@ -1643,7 +1659,7 @@ def test_wavelength_properties(simple_map):
 
 
 def test_meta_modifications(aia171_test_map):
-    aiamap = aia171_test_map
+    aiamap = deepcopy(aia171_test_map)  # for thread safety
     old_cdelt1 = aiamap.meta['cdelt1']
     aiamap.meta['cdelt1'] = 20
 
@@ -1669,6 +1685,7 @@ def test_no_wcs_observer_info(heliographic_test_map):
     assert wcs_aux.dsun_obs is not None
 
     # Remove observer information, and change coordinate system to HeliographicStonyhurst
+    heliographic_test_map = deepcopy(heliographic_test_map)  # for thread safety
     heliographic_test_map.meta.pop('HGLN_OBS')
     heliographic_test_map.meta.pop('HGLT_OBS')
     heliographic_test_map.meta.pop('DSUN_OBS')

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1430,6 +1430,7 @@ def test_repr_html(aia171_test_map):
     assert "Bad pixels are shown in red: 1 infinite" in html_string
 
 
+@pytest.mark.thread_unsafe(reason="mocks web browser")
 def test_quicklook(mocker, aia171_test_map):
     mockwbopen = mocker.patch('webbrowser.open_new_tab')
     aia171_test_map.quicklook()

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -391,6 +391,7 @@ def test_units(generic_map):
     assert generic_map.spatial_units == ('arcsec', 'arcsec')
 
 
+@pytest.mark.thread_unsafe(reason="bug fixed in matplotlib dev")
 def test_cmap(generic_map):
     assert generic_map.cmap == matplotlib.colormaps['gray']
 

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -122,6 +122,7 @@ def test_repr_html(mapsequence_all_the_same):
         assert m._repr_html_() in html_string
 
 
+@pytest.mark.thread_unsafe(reason="mocks web browser")
 def test_quicklook(mocker, mapsequence_all_the_same):
     mockwbopen = mocker.patch('webbrowser.open_new_tab')
     mapsequence_all_the_same.quicklook()

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -4,6 +4,7 @@ Test mapsequence functionality
 
 import numpy as np
 import pytest
+from matplotlib.figure import Figure
 
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
@@ -206,7 +207,11 @@ def test_mapsequence_plot_uint8_norm():
     # This code used to fail in this case.
     coconuts = sunpy.map.Map([get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")]*10,sequence=True)
     [coconut.plot_settings.pop("norm") for coconut in coconuts]
-    moving_coconut = coconuts.plot()
+
+    fig = Figure()
+    ax = fig.add_subplot(projection=coconuts[0])
+
+    moving_coconut = coconuts.plot(axes=ax)
     moving_coconut._step()
 
 
@@ -215,15 +220,23 @@ def test_mapsequence_plot_uint8_norm_clip_interval():
     # This code used to fail in this case.
     coconuts = sunpy.map.Map([get_test_filepath("2013_06_24__17_31_30_84__SDO_AIA_AIA_193.jp2")]*10,sequence=True)
     [coconut.plot_settings.pop("norm") for coconut in coconuts]
-    moving_coconut = coconuts.plot(clip_interval=(1, 99.99)*u.percent)
+
+    fig = Figure()
+    ax = fig.add_subplot(projection=coconuts[0])
+
+    moving_coconut = coconuts.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
     moving_coconut._step()
 
 
 @skip_glymur
 def test_mapsequence_plot_set_norm_pass_vmin_vmax(aia171_test_map):
-    # CHecking that passing in interval values works if the map has a norm
+    # Checking that passing in interval values works if the map has a norm
     coconuts = sunpy.map.Map([aia171_test_map]*10,sequence=True)
-    moving_coconut = coconuts.plot(clip_interval=(1, 99.99)*u.percent)
+
+    fig = Figure()
+    ax = fig.add_subplot(projection=coconuts[0])
+
+    moving_coconut = coconuts.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
     moving_coconut._step()
-    moving_coconut = coconuts.plot(vmin=100, vmax=1000)
+    moving_coconut = coconuts.plot(axes=ax, vmin=100, vmax=1000)
     moving_coconut._step()

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -55,6 +55,7 @@ def test_reproject_to_hgs(aia171_test_map, hgs_header):
     aia171_test_map.reproject_to(hgs_header).plot()
 
 
+@pytest.mark.thread_unsafe(reason="bug fixed in matplotlib dev")
 @check_figures_equal(extensions=["png"])
 def test_reproject_to_hgs_wcs(fig_test, fig_ref, aia171_test_map, hgs_header):
     with warnings.catch_warnings():
@@ -73,6 +74,7 @@ def test_reproject_to_hgs_wcs(fig_test, fig_ref, aia171_test_map, hgs_header):
         wcs_map.plot(axes=ax_test)
 
 
+@pytest.mark.thread_unsafe(reason="bug fixed in matplotlib dev")
 @check_figures_equal(extensions=["png"])
 def test_reproject_to_hpc_default(fig_test, fig_ref, aia171_test_map, hpc_header):
     with warnings.catch_warnings():

--- a/sunpy/net/tests/test_attr.py
+++ b/sunpy/net/tests/test_attr.py
@@ -7,6 +7,8 @@ from sunpy.net import attr
 from sunpy.net.attr import AttrMeta, make_tuple
 from sunpy.net.dataretriever import GenericClient
 
+pytestmark = pytest.mark.thread_unsafe(reason="uses shared Attr registry")
+
 
 class Instrument(attr.SimpleAttr):
     """

--- a/sunpy/net/tests/test_attr_walker.py
+++ b/sunpy/net/tests/test_attr_walker.py
@@ -19,12 +19,8 @@ class RA1(attr.Range):
     pass
 
 
-@pytest.fixture
-def walker():
-    return attr.AttrWalker()
-
-
-def test_creator(walker):
+def test_creator():
+    walker = attr.AttrWalker()  # cannot be a fixture due thread safety
     CALLED = False
 
     @walker.add_creator(SA2)
@@ -46,7 +42,8 @@ def test_creator(walker):
     assert CALLED
 
 
-def test_applier(walker):
+def test_applier():
+    walker = attr.AttrWalker()  # cannot be a fixture due thread safety
     CALLED = False
 
     @walker.add_applier(SA2)
@@ -68,7 +65,8 @@ def test_applier(walker):
     assert CALLED
 
 
-def test_creator_converter(walker):
+def test_creator_converter():
+    walker = attr.AttrWalker()  # cannot be a fixture due thread safety
     CALLED = False
 
     @walker.add_creator(SA1)
@@ -92,7 +90,8 @@ def test_creator_converter(walker):
     assert CALLED
 
 
-def test_applier_converter(walker):
+def test_applier_converter():
+    walker = attr.AttrWalker()  # cannot be a fixture due thread safety
     CALLED = False
 
     @walker.add_applier(SA1)

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -444,6 +444,7 @@ def test_vso_fetch_hmi(tmpdir):
     assert len(files) == 1
 
 
+@pytest.mark.thread_unsafe(reason="mocks a method")
 def test_fido_no_time(mocker):
     jsoc_mock = mocker.patch("sunpy.net.jsoc.JSOCClient.search")
     jsoc_mock.return_value = jsoc.JSOCResponse()

--- a/sunpy/net/tests/test_scraper.py
+++ b/sunpy/net/tests/test_scraper.py
@@ -276,6 +276,7 @@ def test_connection_error():
             scraper._httpfilelist(time)
 
 
+@pytest.mark.thread_unsafe(reason="changing log level is not thread safe")
 def test_http_404_error_debug_message(caplog):
     with caplog.at_level(logging.DEBUG, logger='sunpy'):
         def patch_range(self, range):

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -26,6 +26,8 @@ from sunpy.tests.mocks import MockObject
 from sunpy.time import parse_time
 from sunpy.util.exceptions import SunpyConnectionWarning, SunpyUserWarning
 
+pytestmark = pytest.mark.thread_unsafe(reason="extensive mocking")
+
 
 @pytest.fixture(scope="session")
 def check_vso_alive():

--- a/sunpy/tests/helpers.py
+++ b/sunpy/tests/helpers.py
@@ -132,6 +132,7 @@ def no_vso(f):
     from sunpy.net import Fido
     from sunpy.net.vso import VSOClient
 
+    @pytest.mark.thread_unsafe(reason="modifies Fido registry")
     @wraps(f)
     def wrapper(*args, **kwargs):
         Fido.registry[VSOClient] = lambda *args: False

--- a/sunpy/tests/tests/test_mocks.py
+++ b/sunpy/tests/tests/test_mocks.py
@@ -58,11 +58,13 @@ def test_MockObject_get(mocked_mockobject):
         mocked_mockobject['not-here']
 
 
-def test_MockObject_set_get(mocked_mockobject):
+def test_MockObject_set_get():
     """
     Setting attributes in `MockObject` using bracket notation *not* dot
     notation.
     """
+    # Need a thread-safe version of the fixture, but recursion prevents copying
+    mocked_mockobject = MockObject(records=12)
 
     # Only change the value of existing & new items using 'bracket' notation
     mocked_mockobject['records'] = 45

--- a/sunpy/timeseries/sources/tests/test_noaa.py
+++ b/sunpy/timeseries/sources/tests/test_noaa.py
@@ -1,4 +1,5 @@
 import pytest
+from matplotlib.figure import Figure
 
 import sunpy.timeseries
 from sunpy.data.test import get_test_filepath
@@ -25,7 +26,9 @@ def test_noaa_pre_json():
 
 
 def test_noaa_json_pre_plot_column(noaa_pre_json_test_ts):
-    ax = noaa_pre_json_test_ts.plot(columns=['sunspot', 'sunspot high', 'sunspot low'])
+    fig = Figure()
+    ax = fig.add_subplot()
+    noaa_pre_json_test_ts.plot(axes=ax, columns=['sunspot', 'sunspot high', 'sunspot low'])
     assert len(ax.lines) == 3
     assert 'sunspot' == ax.lines[0].get_label()
     assert 'sunspot high' == ax.lines[1].get_label()
@@ -33,7 +36,9 @@ def test_noaa_json_pre_plot_column(noaa_pre_json_test_ts):
 
 
 def test_noaa_json_ind_plot_column(noaa_ind_json_test_ts):
-    ax = noaa_ind_json_test_ts.plot(columns=['sunspot SWO', 'sunspot SWO smooth'])
+    fig = Figure()
+    ax = fig.add_subplot()
+    noaa_ind_json_test_ts.plot(axes=ax, columns=['sunspot SWO', 'sunspot SWO smooth'])
     assert len(ax.lines) == 2
     assert 'sunspot SWO' == ax.lines[0].get_label()
     assert 'sunspot SWO smooth' == ax.lines[1].get_label()

--- a/sunpy/timeseries/sources/tests/test_noaa.py
+++ b/sunpy/timeseries/sources/tests/test_noaa.py
@@ -25,6 +25,7 @@ def test_noaa_pre_json():
     assert isinstance(ts_noaa_pre, sunpy.timeseries.sources.noaa.NOAAPredictIndicesTimeSeries)
 
 
+@pytest.mark.thread_unsafe(reason="pandas registers/deregisters converters to the matplotlib global registry")
 def test_noaa_json_pre_plot_column(noaa_pre_json_test_ts):
     fig = Figure()
     ax = fig.add_subplot()
@@ -35,6 +36,7 @@ def test_noaa_json_pre_plot_column(noaa_pre_json_test_ts):
     assert 'sunspot low' == ax.lines[2].get_label()
 
 
+@pytest.mark.thread_unsafe(reason="pandas registers/deregisters converters to the matplotlib global registry")
 def test_noaa_json_ind_plot_column(noaa_ind_json_test_ts):
     fig = Figure()
     ax = fig.add_subplot()

--- a/sunpy/timeseries/tests/test_timeseries_factory.py
+++ b/sunpy/timeseries/tests/test_timeseries_factory.py
@@ -156,6 +156,7 @@ def test_read_cdf_empty_variable():
     sunpy_cdf._known_units = known_units
 
 
+@pytest.mark.thread_unsafe(reason="changing log level is not thread safe")
 def test_read_empty_cdf(caplog):
     with caplog.at_level(logging.DEBUG, logger='sunpy'):
         ts_empty = sunpy.timeseries.TimeSeries(swa_filepath)

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -520,6 +520,7 @@ def test_repr_html_(generic_ts):
     assert isinstance(html_string, str)
 
 
+@pytest.mark.thread_unsafe(reason="mocks web browser")
 def test_quicklook(mocker, generic_ts):
     mockwbopen = mocker.patch('webbrowser.open_new_tab')
     generic_ts.quicklook()

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -11,9 +11,11 @@ from tempfile import NamedTemporaryFile
 from collections import OrderedDict
 from collections.abc import Iterable
 
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib.figure import Figure
 
 import astropy
 import astropy.units as u
@@ -286,59 +288,46 @@ class GenericTimeSeries:
                 'tab:green', 'tab:olive', 'tab:cyan', 'palegreen', 'pink'
                 ]
         dat = self.to_dataframe()
-        fig, axs = plt.subplots(
+        fig = Figure(figsize=(6, 10), layout="constrained")
+        axs = fig.subplots(
             nrows=len(self.columns),
             ncols=1,
             sharex=True,
-            constrained_layout=True,
-            figsize=(6, 10),
         )
-        # If all channels have the same unit, then one shared y-axis
-        # label is set. Otherwise, each subplot has its own yaxis label.
-        for i in range(len(self.columns)):
-            if len(self.columns) == 1:
-                axs.plot(
-                    dat.index,
-                    dat[self.columns[i]].values,
-                    color=cols[i%len(cols)],
-                    label=self.columns[i],
-                )
-                if (dat[self.columns[i]].values < 0).any() is np.bool_(False):
-                    axs.set_yscale("log")
-                axs.legend(frameon=False, handlelength=0)
-                axs.set_ylabel(self.units[self.columns[i]])
-            else:
-                axs[i].plot(
-                    dat.index,
-                    dat[self.columns[i]].values,
-                    color=cols[i%len(cols)],
-                    label=self.columns[i],
-                )
-                if (dat[self.columns[i]].values < 0).any() is np.bool_(False):
-                    axs[i].set_yscale("log")
-                axs[i].legend(frameon=False, handlelength=0)
-                axs[i].set_ylabel(self.units[self.columns[i]])
-        plt.xticks(rotation=30)
+        for i, (ax, column) in enumerate(zip(axs, self.columns)):
+            values = dat[column].values
+            ax.plot(
+                dat.index,
+                values,
+                color=cols[i%len(cols)],
+                label=column,
+            )
+            if np.all(values >= 0):
+                axs[i].set_yscale("log")
+            ax.legend(frameon=False, handlelength=0)
+            ax.set_ylabel(self.units[column])
+            ax.tick_params("x", rotation=30)
         spc = _figure_to_base64(fig)
-        plt.close(fig)
         # Make histograms for each column of data. The histograms are
         # created using the Astropy hist method that uses Scott's rule
         # for bin sizes.
         hlist = []
-        for i in range(len(dat.columns)):
-            if set(np.isnan(dat[self.columns[i]].values)) != {True}:
-                fig = plt.figure(figsize=(5, 3), constrained_layout=True)
+        for i, column in enumerate(dat.columns):
+            values = dat[column].values
+            if np.any(np.isfinite(values)):
+                fig = Figure(figsize=(5, 3), layout="constrained")
+                ax = fig.add_subplot()
                 hist(
-                    dat[self.columns[i]].values[~np.isnan(dat[self.columns[i]].values)],
+                    values[np.isfinite(values)],
+                    ax=ax,
                     log=True,
                     bins="scott",
                     color=cols[i%len(cols)],
                 )
-                plt.title(self.columns[i] + " [click for other channels]")
-                plt.xlabel(self.units[self.columns[i]])
-                plt.ylabel("# of occurrences")
+                ax.set_title(column + " [click for other channels]")
+                ax.set_xlabel(self.units[column])
+                ax.set_ylabel("# of occurrences")
                 hlist.append(_figure_to_base64(fig))
-                plt.close(fig)
 
         # This loop creates a formatted list of base64 images that is passed
         # directly into the JS script below, so all images are written into
@@ -720,8 +709,6 @@ class GenericTimeSeries:
         Validate data for plotting, and get default axes/columns if not passed
         by the user.
         """
-        import matplotlib.pyplot as plt
-
         self._validate_data_for_plotting()
         if columns is None:
             columns = self.columns
@@ -738,7 +725,6 @@ class GenericTimeSeries:
         """
         Shared code to set x-axis properties.
         """
-        import matplotlib.dates as mdates
         if isinstance(ax, np.ndarray):
             ax = ax[-1]
 
@@ -766,8 +752,6 @@ class GenericTimeSeries:
         **kwargs : `dict`
             Any additional plot arguments that should be used when plotting.
         """
-        import matplotlib.pyplot as plt
-
         # Now make the plot
         figure = plt.figure()
         self.plot(columns=columns, **kwargs)

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -1,6 +1,7 @@
 """
 This module provides sunpy specific decorators.
 """
+import threading
 from inspect import cleandoc
 from functools import wraps
 from contextlib import contextmanager
@@ -13,7 +14,6 @@ from astropy.utils.decorators import deprecated_renamed_argument as _deprecated_
 from sunpy.util.exceptions import SunpyDeprecationWarning
 
 __all__ = [
-    'ACTIVE_CONTEXTS',
     'deprecated',
     'deprecated_renamed_argument',
     'cached_property_based_on',
@@ -23,8 +23,13 @@ __all__ = [
 ]
 _NUMPY_COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None
 _NOT_FOUND = object()
-# Stack (i.e., LIFO) of active contexts as a list of fully qualified name strings
-ACTIVE_CONTEXTS = []
+
+
+# Thread-safe stack (i.e., LIFO) of active contexts as a list of fully qualified name strings
+class _ActiveContexts(threading.local):
+    def __init__(self):
+        self.stack = []
+_active_contexts = _ActiveContexts()
 
 
 def deprecated(
@@ -255,7 +260,7 @@ def sunpycontextmanager(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         func_name = f"{func.__module__}.{func.__qualname__}"
-        ACTIVE_CONTEXTS.append(func_name)
+        _active_contexts.stack.append(func_name)
         gen = func(*args, **kwargs)
         value = next(gen)
         try:
@@ -264,7 +269,7 @@ def sunpycontextmanager(func):
             gen.throw(e)
         else:
             next(gen, None)
-            if (removed := ACTIVE_CONTEXTS.pop()) != func_name:
+            if (removed := _active_contexts.stack.pop()) != func_name:
                 raise RuntimeError(f"Cannot remove {func_name} from tracking stack because {removed} is last active.")
     return contextmanager(wrapper)
 

--- a/sunpy/util/tests/test_config.py
+++ b/sunpy/util/tests/test_config.py
@@ -21,6 +21,8 @@ from sunpy.util.config import (
     print_config,
 )
 
+pytestmark = pytest.mark.thread_unsafe(reason="modifies environment variable and filesystem")
+
 USER = os.path.expanduser('~')
 
 

--- a/sunpy/util/tests/test_config.py
+++ b/sunpy/util/tests/test_config.py
@@ -1,7 +1,5 @@
-import io
 import os
 from pathlib import Path
-from contextlib import redirect_stdout
 
 import pytest
 
@@ -59,10 +57,9 @@ def test_get_user_configdir(tmpdir, tmp_path, undo_config_dir_patch):
     del os.environ["SUNPY_CONFIGDIR"]
 
 
-def test_print_config_files(tmpdir, tmp_path, undo_download_dir_patch):
-    with io.StringIO() as buf, redirect_stdout(buf):
-        print_config()
-        printed = buf.getvalue()
+def test_print_config_files(capsys, tmpdir, tmp_path, undo_download_dir_patch):
+    print_config()
+    printed = capsys.readouterr().out
     assert "time_format = %Y-%m-%d %H:%M:%S" in printed
     assert _find_config_files()[0] in printed
     assert get_and_create_download_dir() in printed

--- a/sunpy/util/tests/test_decorators.py
+++ b/sunpy/util/tests/test_decorators.py
@@ -2,7 +2,7 @@ import warnings
 
 import pytest
 
-from sunpy.util.decorators import ACTIVE_CONTEXTS, deprecated, sunpycontextmanager
+from sunpy.util.decorators import _active_contexts, deprecated, sunpycontextmanager
 from sunpy.util.exceptions import SunpyDeprecationWarning
 
 
@@ -41,23 +41,23 @@ def test_context_tracking():
     ctx2_name = f"{ctx2.__module__}.{ctx2.__qualname__}"
 
     # Check that no sunpy contexts are active before entering
-    assert ACTIVE_CONTEXTS == []
+    assert _active_contexts.stack == []
 
     with ctx1():
         # Check that the context is active while inside
-        assert ACTIVE_CONTEXTS == [ctx1_name]
+        assert _active_contexts.stack == [ctx1_name]
 
         with ctx2():
             # Check nesting of contexts
-            assert ACTIVE_CONTEXTS == [ctx1_name, ctx2_name]
+            assert _active_contexts.stack == [ctx1_name, ctx2_name]
 
             with ctx1():
                 # Check a repeated context in the nesting
-                assert ACTIVE_CONTEXTS == [ctx1_name, ctx2_name, ctx1_name]
+                assert _active_contexts.stack == [ctx1_name, ctx2_name, ctx1_name]
 
             # Check that only the last context is removed and not its duplicate
-            assert ACTIVE_CONTEXTS == [ctx1_name, ctx2_name]
+            assert _active_contexts.stack == [ctx1_name, ctx2_name]
 
-        assert ACTIVE_CONTEXTS == [ctx1_name]
+        assert _active_contexts.stack == [ctx1_name]
 
-    assert ACTIVE_CONTEXTS == []
+    assert _active_contexts.stack == []

--- a/sunpy/util/tests/test_metadata.py
+++ b/sunpy/util/tests/test_metadata.py
@@ -248,6 +248,10 @@ def test_setitem_existing_entry(seas_metadict):
     """
     Test `MetaDict.__setitem__(...)` on an existing entry.
     """
+    seas_metadict = copy.deepcopy(seas_metadict)  # for thread safety
+
+    assert seas_metadict['NORWEGIAN'] != 'Scandinavia'
+
     len_before = len(seas_metadict)
     seas_metadict['NORWEGIAN'] = 'Scandinavia'
     assert len(seas_metadict) == len_before
@@ -261,6 +265,7 @@ def test_setitem_new_entry(seas_metadict):
 
     Add a new entry
     """
+    seas_metadict = copy.deepcopy(seas_metadict)  # for thread safety
     len_before = len(seas_metadict)
     seas_metadict['Irish'] = 'N.Europe'
     assert len(seas_metadict) == len_before + 1
@@ -272,6 +277,7 @@ def test_delitem(seas_metadict):
     """
     Test `MetaDict.__delitem__(...)`.
     """
+    seas_metadict = copy.deepcopy(seas_metadict)  # for thread safety
     len_before = len(seas_metadict)
     del seas_metadict['NoRwEgIaN']
     del seas_metadict['baltic']
@@ -348,6 +354,8 @@ def test_pop(seas_metadict):
     """
     Test `MetaDict.pop(...)`
     """
+    seas_metadict = copy.deepcopy(seas_metadict)  # for thread safety
+
     # Nothing to 'pop', nothing should change
     len_before = len(seas_metadict)
     seas_metadict.pop('kara') is None

--- a/sunpy/util/tests/test_util.py
+++ b/sunpy/util/tests/test_util.py
@@ -1,3 +1,4 @@
+import copy
 from inspect import cleandoc
 
 import numpy as np
@@ -62,10 +63,17 @@ def test_expand_list():
     (['a1234', 'b', [], (['c', 'd']), (), ['e'], b'fghj'], ['a1234', 'b', 'c', 'd', 'e', b'fghj']),
     (iter(['c', 'd']), ['c', 'd']),
     (zip(['1', '2'], ['3', '4']), ['1', '3', '2', '4']),
-    (Results(["a", "b", "c"]), ["a", "b", "c"]),
-    ([open(get_test_filepath('aia_171_level1.fits'), 'rb')], open(get_test_filepath('aia_171_level1.fits'), 'rb').readlines())
+    (Results(["a", "b", "c"]), ["a", "b", "c"])
 ])
 def test_expand_list_generator(input_data, expected_output):
+    input_data = copy.deepcopy(input_data)  # for thread safety
+    assert list(util.expand_list_generator(input_data)) == expected_output
+
+
+def test_expand_list_generator_file():
+    # Not included in the above parametrization for thread safety
+    input_data = [open(get_test_filepath('aia_171_level1.fits'), 'rb')]
+    expected_output = open(get_test_filepath('aia_171_level1.fits'), 'rb').readlines()
     assert list(util.expand_list_generator(input_data)) == expected_output
 
 

--- a/sunpy/visualization/colormaps/tests/test_cm.py
+++ b/sunpy/visualization/colormaps/tests/test_cm.py
@@ -30,6 +30,8 @@ def test_invalid_suit_filter(invalid_filter):
     with pytest.raises(ValueError, match=r"Invalid Band"):
         ct.suit_color_table(invalid_filter)
 
+
+@pytest.mark.thread_unsafe(reason="bug fixed in matplotlib dev")
 # Checks that colormaps are imported by MPL
 def test_get_cmap():
     for cmap in cm.cmlist.keys():


### PR DESCRIPTION
The following thread-safety bugs are confirmed to be fixed by using `pytest-run-parallel`.  A couple of tests were rewritten to use a lower-level coordinate frame instance instead of `SkyCoord` because `pytest-run-parallel` flags `SkyCoord` as not thread-safe (because one `SkyCoord` method we don't use calls `warnings.catch_warnings()`) and then refuses to run the test in parallel.
* Fixes #8498
* Fixes #8499 
* Fixes the analogous thread-safety issue with our `Helioprojective` screens (e.g., `SphericalScreen`)
* Fixes thread-safety issue with `TimeSeries` HTML summary (introduced #5951) because pyplot was unnecessarily used for the figures, plus the code internals had some issues

Also fixed, but not confirmed with `pytest-run-parallel` because we don't want to run `pytest-run-parallel` on online tests:
* Fixes the analogous thread-safety issue with the frame/center registry for `sunpy.coordinates.spice`

---

The following changes are not for user-facing bugs, but rather so that the test suite can run completely successfully under `pytest-run-parallel`.
  * Modifying a pytest fixture is not thread-safe given how `pytest-run-parallel` works, so make a deep copy where needed
  * Modifying an object specified as part of parameterized test is not thread-safe, so make a deep copy where needed
  * Modifying tests to not use pyplot (for now, only doing so for tests that are not figure tests)
  * Mark tests that have no clear/straightforward path to being made thread-safe