### PR TITLE
Add to_2d() method to SunPyBaseCoordinateFrame (#8494)

### DIFF
--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -176,6 +176,18 @@ class SunPyBaseCoordinateFrame(BaseCoordinateFrame):
         return (self._data is not None and self._data.norm().unit is u.one
                 and u.allclose(self._data.norm(), 1*u.one))
 
+    def to_2d(self):
+        """
+        Convert the frame to a 2D representation by dropping the distance.
+
+        Returns
+        -------
+        new_frame : `~sunpy.coordinates.frames.SunPyBaseCoordinateFrame`
+            A new frame instance with the same attributes but using a
+            `~astropy.coordinates.UnitSphericalRepresentation`.
+        """
+        return self.realize_frame(self.represent_as('unitspherical'))
+
 
 class BaseHeliographic(SunPyBaseCoordinateFrame):
     """


### PR DESCRIPTION
This PR adds a to_2d() method to the SunPyBaseCoordinateFrame class. This method allows users to easily convert a 3D coordinate frame to a 2D representation by dropping the distance component.
This is particularly useful for resolving UnitConversionError when attempting to stack SkyCoord objects where some frames have distance information (e.g., after calling make_3d()) and others do not. This issue was highlighted in #8494 and affects downstream tools like reproject.