### PR TITLE
Switch pre-commit to use file and type or type_or rather than exclude

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,8 @@ repos:
         exclude: *exclude_sunpy_dirs
       - id: check-yaml
         types: [yaml]
+      - id: check-toml
+        types: [toml]
       - id: debug-statements
         types: [python]
         exclude: *exclude_sunpy_dirs


### PR DESCRIPTION
Switch to specifying the type/s and file/s we want the checks to run on rather than excluding those that we don't. I think this is more explicit and marginally more maintainable. If we add `.md` files just need to add `markdown` to the `types` or `types_or`

Related to https://github.com/sunpy/package-template/pull/248 and https://github.com/sunpy/package-template/issues/247
