### PR TITLE
Fixed bug with converting to SPICE ephemeris time

### DIFF
--- a/changelog/8534.bugfix.rst
+++ b/changelog/8534.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in `sunpy.coordinates.spice` when converting times to the time scale/format used by SPICE, which resulted in a time inaccuracy of up to 1.6 ms.

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -162,7 +162,7 @@ class SpiceBaseCoordinateFrame(SunPyBaseCoordinateFrame):
 
 
 def _convert_to_et(time):
-    return (time - _ET_REF_EPOCH).to_value('s')
+    return (time.tdb - _ET_REF_EPOCH).to_value('s')
 
 
 def _astropy_frame_name(spice_frame_name):

--- a/sunpy/coordinates/tests/test_spice.py
+++ b/sunpy/coordinates/tests/test_spice.py
@@ -230,3 +230,13 @@ def test_get_rotation_matrix(spice_test):
                                  [-0.23020788,  0.97314148, 0],
                                  [0, 0, 1]])
     np.testing.assert_allclose(result2, expected_result2, atol=1e-6)
+
+
+def test_ephemeris_time(spice_test):
+    # SPICE uses an approximation for UTC->ET that has an accuracy of only 3e-5 seconds
+    # Test the example in the docstring for the SPICE function utc2et()
+    utc = parse_time('2003-12-19 16:48')
+    np.testing.assert_allclose(spice._convert_to_et(utc), 125124544.183560610, rtol=0, atol=3e-5)
+    # Test the example in the docstring for the SPICE function et2utc()
+    utc = parse_time('1983-04-13 12:09:14.274')
+    np.testing.assert_allclose(spice._convert_to_et(utc), -527644192.5403653, rtol=0, atol=3e-5)


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

`sunpy.coordinates.spice` needs to convert Astropy time to SPICE ephemeris time, which is the number of TDB seconds past J2000.0 in TDB.  However, the code currently performs the subtraction in the scale of the `Time` instance, which is commonly UTC, so the delta is incorrectly UTC seconds instead of TDB seconds.  The error is no greater than ~1.6 ms (irrespective of the magnitude of the delta).  This PR fixes the bug.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
