### PR TITLE
Move solar_angular_radius and coordinate_is_on_solar_disk to sunpy.co…

### DIFF
--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -24,6 +24,7 @@ from .ephemeris import *
 from .frames import *
 from .metaframes import *
 from .screens import PlanarScreen, SphericalScreen
+from .utils import solar_angular_radius, coordinate_is_on_solar_disk
 from .wcs_utils import *
 
 __doc__ += _make_sunpy_graph()

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -9,9 +9,12 @@ from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 from astropy.coordinates.representation import CartesianRepresentation
 
 from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, get_body_heliographic_stonyhurst
+from sunpy.coordinates.frames import Helioprojective
+from sunpy.coordinates import sun
 from sunpy.sun import constants
 
-__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates', 'get_heliocentric_angle']
+__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates',
+           'get_heliocentric_angle', 'solar_angular_radius', 'coordinate_is_on_solar_disk']
 
 
 class GreatArc:
@@ -530,3 +533,77 @@ def get_heliocentric_angle(coordinate_on_solar_disk):
     to_observer = CartesianRepresentation(0, 0, 1) * hcc.observer.radius - normal
     heliocentric_angle = np.arctan2(normal.cross(to_observer).norm(), normal.dot(to_observer))
     return heliocentric_angle.to(u.deg)
+
+
+def _verify_coordinate_helioprojective(coordinates):
+    """
+    Raises an error if the coordinate is not in the
+    `~sunpy.coordinates.frames.Helioprojective` frame.
+
+    Parameters
+    ----------
+    coordinates : `~astropy.coordinates.SkyCoord`, `~astropy.coordinates.BaseCoordinateFrame`
+    """
+    frame = coordinates.frame if hasattr(coordinates, 'frame') else coordinates
+    if not isinstance(frame, Helioprojective):
+        raise ValueError(f"The input coordinate(s) is of type {type(frame).__name__}, "
+                         "but must be in the Helioprojective frame.")
+
+
+def solar_angular_radius(coordinates):
+    """
+    Calculates the solar angular radius as seen by the observer.
+
+    The tangent vector from the observer to the edge of the Sun forms a
+    right-angle triangle with the radius of the Sun as the far side and the
+    Sun-observer distance as the hypotenuse. Thus, the sine of the angular
+    radius of the Sun is ratio of these two distances.
+
+    Parameters
+    ----------
+    coordinates : `~astropy.coordinates.SkyCoord`, `~sunpy.coordinates.frames.Helioprojective`
+        The input coordinate. The coordinate frame must be
+        `~sunpy.coordinates.Helioprojective`.
+
+    Returns
+    -------
+    angle : `~astropy.units.Quantity`
+        The solar angular radius.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.coordinates.solar_angular_radius
+    """
+    _verify_coordinate_helioprojective(coordinates)
+    return sun._angular_radius(coordinates.rsun, coordinates.observer.radius)
+
+
+@u.quantity_input
+def coordinate_is_on_solar_disk(coordinates):
+    """
+    Checks if the helioprojective Cartesian coordinates are on the solar disk.
+
+    The check is performed by comparing the coordinate's angular distance
+    to the angular size of the solar radius. The solar disk is assumed to be
+    a circle i.e., solar oblateness and other effects that cause the solar disk to
+    be non-circular are not taken in to account.
+
+    Parameters
+    ----------
+    coordinates : `~astropy.coordinates.SkyCoord`, `~sunpy.coordinates.frames.Helioprojective`
+        The input coordinate. The coordinate frame must be
+        `~sunpy.coordinates.Helioprojective`.
+
+    Returns
+    -------
+    `~bool`
+        Returns `True` if the coordinate is on disk, `False` otherwise.
+
+    Examples
+    --------
+    .. minigallery:: sunpy.coordinates.coordinate_is_on_solar_disk
+    """
+    _verify_coordinate_helioprojective(coordinates)
+    # Calculate the radial angle from the center of the Sun (do not assume small angles)
+    # and compare it to the angular radius of the Sun
+    return np.arccos(np.cos(coordinates.Tx) * np.cos(coordinates.Ty)) <= solar_angular_radius(coordinates)

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -11,6 +11,12 @@ from astropy.coordinates import SkyCoord
 from astropy.visualization import AsymmetricPercentileInterval
 
 from sunpy.coordinates import Helioprojective, sun
+from sunpy.coordinates.utils import (
+    _verify_coordinate_helioprojective,
+    solar_angular_radius as _solar_angular_radius,
+    coordinate_is_on_solar_disk as _coordinate_is_on_solar_disk,
+)
+from sunpy.util.decorators import deprecated
 
 __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'all_corner_coords_from_map',
@@ -125,24 +131,14 @@ def map_edges(smap):
     return top, bottom, left_hand_side, right_hand_side
 
 
-def _verify_coordinate_helioprojective(coordinates):
-    """
-    Raises an error if the coordinate is not in the
-    `~sunpy.coordinates.frames.Helioprojective` frame.
-
-    Parameters
-    ----------
-    coordinates : `~astropy.coordinates.SkyCoord`, `~astropy.coordinates.BaseCoordinateFrame`
-    """
-    frame = coordinates.frame if hasattr(coordinates, 'frame') else coordinates
-    if not isinstance(frame, Helioprojective):
-        raise ValueError(f"The input coordinate(s) is of type {type(frame).__name__}, "
-                         "but must be in the Helioprojective frame.")
-
-
+@deprecated(since='7.2', alternative='sunpy.coordinates.solar_angular_radius')
 def solar_angular_radius(coordinates):
     """
     Calculates the solar angular radius as seen by the observer.
+
+    .. deprecated:: 7.2
+        `~sunpy.map.solar_angular_radius` is deprecated. Use
+        `~sunpy.coordinates.solar_angular_radius` instead.
 
     The tangent vector from the observer to the edge of the Sun forms a
     right-angle triangle with the radius of the Sun as the far side and the
@@ -160,8 +156,7 @@ def solar_angular_radius(coordinates):
     angle : `~astropy.units.Quantity`
         The solar angular radius.
     """
-    _verify_coordinate_helioprojective(coordinates)
-    return sun._angular_radius(coordinates.rsun, coordinates.observer.radius)
+    return _solar_angular_radius(coordinates)
 
 
 def sample_at_coords(smap, coordinates):
@@ -260,10 +255,15 @@ def contains_solar_center(smap):
     return contains_coordinate(smap, SkyCoord(0*u.arcsec, 0*u.arcsec, frame=smap.coordinate_frame))
 
 
+@deprecated(since='7.2', alternative='sunpy.coordinates.coordinate_is_on_solar_disk')
 @u.quantity_input
 def coordinate_is_on_solar_disk(coordinates):
     """
     Checks if the helioprojective Cartesian coordinates are on the solar disk.
+
+    .. deprecated:: 7.2
+        `~sunpy.map.coordinate_is_on_solar_disk` is deprecated. Use
+        `~sunpy.coordinates.coordinate_is_on_solar_disk` instead.
 
     The check is performed by comparing the coordinate's angular distance
     to the angular size of the solar radius. The solar disk is assumed to be
@@ -281,10 +281,7 @@ def coordinate_is_on_solar_disk(coordinates):
     `~bool`
         Returns `True` if the coordinate is on disk, `False` otherwise.
     """
-    _verify_coordinate_helioprojective(coordinates)
-    # Calculate the radial angle from the center of the Sun (do not assume small angles)
-    # and compare it to the angular radius of the Sun
-    return np.arccos(np.cos(coordinates.Tx) * np.cos(coordinates.Ty)) <= solar_angular_radius(coordinates)
+    return _coordinate_is_on_solar_disk(coordinates)
 
 
 def is_all_off_disk(smap):

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -178,7 +178,7 @@ class Cutout(DataAttr):
         center = SkyCoord(center_x, center_y, frame=bottom_left.frame)
         if tracking:
             # import here so net won't depend on map
-            from sunpy.map.maputils import coordinate_is_on_solar_disk
+            from sunpy.coordinates import coordinate_is_on_solar_disk
             if not coordinate_is_on_solar_disk(center):
                 raise ValueError("Tracking is enabled, but the center of the cutout "
                                  f"(Tx={center_x}, Ty={center_y}) is not on the solar disk.")

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -14,9 +14,9 @@ from sunpy.coordinates import (
     get_earth,
     transform_with_sun_center,
 )
+from sunpy.coordinates import coordinate_is_on_solar_disk
 from sunpy.map import (
     contains_full_disk,
-    coordinate_is_on_solar_disk,
     is_all_off_disk,
     is_all_on_disk,
     map_edges,


### PR DESCRIPTION
## PR Description

Closes #8445.

Both functions operate purely on coordinate frames with no dependency on map data, so `sunpy.map` is the wrong home for them.

Changes:
- Added both functions (and the private `_verify_coordinate_helioprojective` helper) to `sunpy/coordinates/utils.py`
- Exported from `sunpy.coordinates` via `__init__.py`
- Left deprecated wrappers in `sunpy/map/maputils.py` pointing to the new location
- Updated internal imports in `sunpy/physics/differential_rotation.py` and `sunpy/net/jsoc/attrs.py`

## AI Assistance Disclosure

AI tools were used for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
