### PR TITLE
Fixed RHESSI server fallthrough

### DIFF
--- a/sunpy/net/dataretriever/sources/rhessi.py
+++ b/sunpy/net/dataretriever/sources/rhessi.py
@@ -91,7 +91,7 @@ def get_base_url():
         try:
             urlopen(server, timeout=1)
             return server
-        except (TimeoutError, RemoteDisconnected, URLError):
+        except (TimeoutError, ConnectionResetError, RemoteDisconnected, URLError):
             pass
     raise OSError(f'Unable to find an online HESSI server from {data_servers}')
 


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

The RHESSI server at Goddard is currently being relocated, and the URL is returning `ConnectionResetError`.  This PR fixes the server fallthrough to the next mirror (at Berkeley).

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
