### PR TITLE
Fix GenericMap.plot crash when axes WCS is an APE-14 WCS

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -58,7 +58,7 @@ from sunpy.util.decorators import (
 from sunpy.util.exceptions import SunpyUserWarning, warn_deprecated, warn_metadata, warn_user
 from sunpy.util.functools import seconddispatch
 from sunpy.util.util import _figure_to_base64, fix_duplicate_notes
-from sunpy.visualization import axis_labels_from_ctype, peek_show, wcsaxes_compat
+from sunpy.visualization import axis_labels_from_ctype, axis_labels_from_physical_type, peek_show, wcsaxes_compat
 from sunpy.visualization.colormaps import cm as sunpy_cm
 from sunpy.visualization.visualization import _PrecomputedPixelCornersTransform
 
@@ -2802,9 +2802,14 @@ class GenericMap(NDData):
 
             # WCSAxes has unit identifiers on the tick labels, so no need
             # to add unit information to the label
-            ctype = axes.wcs.wcs.ctype
-            axes.coords[0].set_axislabel(axis_labels_from_ctype(ctype[0], None))
-            axes.coords[1].set_axislabel(axis_labels_from_ctype(ctype[1], None))
+            if hasattr(axes.wcs, 'wcs'):
+                ctype = axes.wcs.wcs.ctype
+                axes.coords[0].set_axislabel(axis_labels_from_ctype(ctype[0], None))
+                axes.coords[1].set_axislabel(axis_labels_from_ctype(ctype[1], None))
+            else:
+                physical_types = axes.wcs.world_axis_physical_types
+                axes.coords[0].set_axislabel(axis_labels_from_physical_type(physical_types[0], None))
+                axes.coords[1].set_axislabel(axis_labels_from_physical_type(physical_types[1], None))
 
         # Take a deep copy here so that a norm in imshow_kwargs doesn't get modified
         # by setting it's vmin and vmax
@@ -2825,7 +2830,7 @@ class GenericMap(NDData):
 
         # Disable autoalignment if it is not necessary
         # TODO: revisit tolerance value
-        if autoalign is True and axes.wcs.wcs.compare(self.wcs.wcs, tolerance=0.01):
+        if autoalign is True and hasattr(axes.wcs, 'wcs') and axes.wcs.wcs.compare(self.wcs.wcs, tolerance=0.01):
             autoalign = False
 
         if autoalign in {True, 'image'}:
@@ -3027,7 +3032,8 @@ class GenericMap(NDData):
             raise TypeError("The axes need to be an instance of WCSAxes. "
                             "To fix this pass set the `projection` keyword "
                             "to this map when creating the axes.")
-        elif warn_different_wcs and not axes.wcs.wcs.compare(self.wcs.wcs, tolerance=0.01):
+        elif warn_different_wcs and (not hasattr(axes.wcs, 'wcs')
+                                        or not axes.wcs.wcs.compare(self.wcs.wcs, tolerance=0.01)):
             warn_user('The map world coordinate system (WCS) is different from the axes WCS. '
                       'The map data axes may not correctly align with the coordinate axes. '
                       'To automatically transform the data to the coordinate axes, specify '

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1227,6 +1227,22 @@ def test_plot_with_norm_none(aia171_test_map):
     aia171_test_map.plot(axes=ax, norm=None, vmin=0, vmax=0)
 
 
+def test_plot_on_ape14_wcs_axes(aia171_test_map):
+    # Regression test for https://github.com/sunpy/sunpy/issues/8416
+    # GenericMap.plot should not crash when the axes WCS is an APE-14
+    # (non-FITS) WCS that has no .wcs attribute.
+    from astropy.wcs.wcsapi import SlicedLowLevelWCS
+
+    # Slicing a FITS WCS produces a SlicedLowLevelWCS (APE-14) with no .wcs attribute.
+    sliced_wcs = SlicedLowLevelWCS(aia171_test_map.wcs, (slice(10, None), slice(10, None)))
+
+    fig = plt.figure()
+    ax = fig.add_subplot(projection=sliced_wcs)
+    # Should not raise AttributeError: 'SlicedLowLevelWCS' object has no attribute 'wcs'
+    aia171_test_map.plot(axes=ax)
+    plt.close(fig)
+
+
 def test_validate_meta(generic_map):
     """Check to see if_validate_meta displays an appropriate error"""
     bad_header = {

--- a/sunpy/visualization/tests/test_visualization.py
+++ b/sunpy/visualization/tests/test_visualization.py
@@ -4,7 +4,29 @@ import astropy.units as u
 from astropy.wcs import WCS
 
 from sunpy.tests.helpers import figure_test
-from sunpy.visualization import show_hpr_impact_angle
+from sunpy.visualization import axis_labels_from_physical_type, show_hpr_impact_angle
+
+
+def test_axis_labels_from_physical_type():
+    assert axis_labels_from_physical_type('custom:pos.helioprojective.lon', None) == \
+        'Helioprojective Longitude (Solar-X)'
+    assert axis_labels_from_physical_type('custom:pos.helioprojective.lat', None) == \
+        'Helioprojective Latitude (Solar-Y)'
+    assert axis_labels_from_physical_type('custom:pos.heliographic.stonyhurst.lon', None) == \
+        'Heliographic Longitude'
+    assert axis_labels_from_physical_type('custom:pos.heliographic.carrington.lon', None) == \
+        'Carrington Longitude'
+    assert axis_labels_from_physical_type('custom:pos.helioprojectiveradial.lon', None) == \
+        'Helioprojective Position Angle'
+    assert axis_labels_from_physical_type('custom:pos.helioprojectiveradial.lat', None) == \
+        'Helioprojective Declination'
+    # Unknown type should fall back to the physical type string itself
+    assert axis_labels_from_physical_type('custom:pos.unknown', None) == 'custom:pos.unknown'
+    # None physical type returns empty string
+    assert axis_labels_from_physical_type(None, None) == ''
+    # Unit is appended when provided
+    assert axis_labels_from_physical_type('custom:pos.helioprojective.lon', 'deg') == \
+        'Helioprojective Longitude (Solar-X) [deg]'
 
 
 @figure_test

--- a/sunpy/visualization/visualization.py
+++ b/sunpy/visualization/visualization.py
@@ -11,7 +11,8 @@ import astropy.units as u
 from astropy.visualization.wcsaxes import CoordinateHelper
 from astropy.wcs.utils import pixel_to_pixel
 
-__all__ = ['peek_show', "axis_labels_from_ctype", "show_hpr_impact_angle"]
+__all__ = ['peek_show', "axis_labels_from_ctype", "axis_labels_from_physical_type",
+           "show_hpr_impact_angle"]
 
 
 def peek_show(func):
@@ -62,6 +63,45 @@ def axis_labels_from_ctype(ctype, unit):
 
     label = labels.get(ctype_short, f"{ctype}")
     if unit is not None:
+        label += f' [{unit}]'
+
+    return label
+
+
+def axis_labels_from_physical_type(physical_type, unit):
+    """
+    Returns an axis label for the given APE-14 physical type and unit.
+
+    Parameters
+    ----------
+    physical_type : `str` or `None`
+        The world axis physical type from `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_physical_types`.
+        If `None`, an empty string is returned.
+    unit : `str`, `None`
+        Required unit. If `None` no unit is added to the label.
+
+    Returns
+    -------
+    `str`
+        "Axis Label [Unit]"
+    """
+    labels = {
+        'custom:pos.helioprojective.lon': 'Helioprojective Longitude (Solar-X)',
+        'custom:pos.helioprojective.lat': 'Helioprojective Latitude (Solar-Y)',
+        'custom:pos.heliographic.stonyhurst.lon': 'Heliographic Longitude',
+        'custom:pos.heliographic.stonyhurst.lat': 'Latitude',
+        'custom:pos.heliographic.carrington.lon': 'Carrington Longitude',
+        'custom:pos.heliographic.carrington.lat': 'Latitude',
+        'custom:pos.helioprojectiveradial.lon': 'Helioprojective Position Angle',
+        'custom:pos.helioprojectiveradial.lat': 'Helioprojective Declination',
+    }
+
+    if physical_type is None:
+        label = ''
+    else:
+        label = labels.get(physical_type, physical_type)
+
+    if unit is not None and label:
         label += f' [{unit}]'
 
     return label


### PR DESCRIPTION
## Summary

Fixes #8416.

`GenericMap.plot` crashed with `AttributeError: 'SlicedLowLevelWCS' object has no attribute 'wcs'` when the axes were created with an APE-14 (non-FITS) WCS as the projection. This happened in three places in `mapbase.py` that assumed `axes.wcs` is always `astropy.wcs.WCS` (FITS WCS).

Changes:

- Add `axis_labels_from_physical_type()` in `sunpy/visualization/visualization.py` that maps APE-14 `world_axis_physical_types` strings to the same human-readable axis labels as `axis_labels_from_ctype()`
- In `GenericMap.plot`, branch on `hasattr(axes.wcs, 'wcs')`: use ctype-based labels for FITS WCS and `world_axis_physical_types`-based labels for APE-14 WCS
- Guard the two `axes.wcs.wcs.compare()` calls (in `plot()` and `_check_axes()`) with `hasattr` checks so they skip comparison when axes.wcs has no `.wcs` attribute

## Test plan

- [ ] `sunpy/map/tests/test_mapbase.py::test_plot_on_ape14_wcs_axes` — new regression test that plots a map on `WCSAxes` backed by a `SlicedLowLevelWCS`
- [ ] `sunpy/visualization/tests/test_visualization.py::test_axis_labels_from_physical_type` — unit tests for the new mapping function
- [ ] Existing `test_as_mpl_axes_aia171` and `test_plot_with_norm_none` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)