### PR TITLE
Add annotate parameter to GenericMap.draw_contours

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2582,7 +2582,7 @@ class GenericMap(NDData):
         return contour_args
 
 
-    def draw_contours(self, levels, axes=None, *, fill=False, **contour_args):
+    def draw_contours(self, levels, axes=None, *, annotate=True, fill=False, **contour_args):
         """
         Draw contours of the data.
 
@@ -2595,6 +2595,11 @@ class GenericMap(NDData):
         axes : `matplotlib.axes.Axes`
             The axes on which to plot the contours. Defaults to the current
             axes.
+        annotate : `bool`, optional
+            If `True` (default), the axes are annotated with a title, axis
+            labels, an equal aspect ratio, and a coordinate grid. Set to
+            `False` when overlaying contours on an existing plot that is
+            already annotated.
         fill : `bool`, optional
             Determines the style of the contours:
             - If `False` (default), contours are drawn as lines using :meth:`~matplotlib.axes.Axes.contour`.
@@ -2615,6 +2620,21 @@ class GenericMap(NDData):
 
         axes = self._check_axes(axes)
         levels = self._process_levels_arg(levels)
+
+        if annotate:
+            plot_settings = self.plot_settings.copy()
+            title = plot_settings.get('title', self.latex_name)
+            axes.set_title(title)
+            axes.set_aspect('equal')
+            if hasattr(axes.wcs, 'wcs'):
+                ctype = axes.wcs.wcs.ctype
+                axes.coords[0].set_axislabel(axis_labels_from_ctype(ctype[0], None))
+                axes.coords[1].set_axislabel(axis_labels_from_ctype(ctype[1], None))
+            else:
+                physical_types = axes.wcs.world_axis_physical_types
+                axes.coords[0].set_axislabel(axis_labels_from_physical_type(physical_types[0], None))
+                axes.coords[1].set_axislabel(axis_labels_from_physical_type(physical_types[1], None))
+            wcsaxes_compat.default_wcs_grid(axes)
 
         # Pixel indices
         y, x = np.indices(self.data.shape)

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1540,6 +1540,30 @@ def test_find_contours_inputs(simple_map):
         simple_map.find_contours(1.5 * u.m)
 
 
+def test_draw_contours_annotate(simple_map):
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection=simple_map)
+
+    # With annotate=True (the default), title and axis labels are set
+    simple_map.draw_contours(1.5 * u.dimensionless_unscaled, axes=ax)
+    assert ax.get_title() != ''
+    assert ax.coords[0].get_axislabel() != ''
+    assert ax.coords[1].get_axislabel() != ''
+    assert ax.get_aspect() == 1
+
+    plt.close()
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection=simple_map)
+
+    # With annotate=False, the axes are left unchanged
+    simple_map.draw_contours(1.5 * u.dimensionless_unscaled, axes=ax, annotate=False)
+    assert ax.get_title() == ''
+    assert ax.get_aspect() == 'auto'
+
+    plt.close()
+
+
 def test_print_map(generic_map):
     out_repr = generic_map.__repr__()
     assert isinstance(out_repr, str)
@@ -1674,13 +1698,13 @@ def test_draw_contours_with_transform(sample_171, sample_hmi):
     # Panel 1: Implicit transform
     ax1 = fig.add_subplot(1, 3, 1, projection=aia_map)
     aia_map.plot(axes=ax1, clip_interval=(1, 99.99)*u.percent)
-    hmi_map.draw_contours([-10, 10]*u.percent)
+    hmi_map.draw_contours([-10, 10]*u.percent, annotate=False)
     ax1.set_title('Default, correct behavior')
 
     # Panel 2: Explicit transform
     ax2 = fig.add_subplot(1, 3, 2, projection=aia_map)
     aia_map.plot(axes=ax2, clip_interval=(1, 99.99)*u.percent)
-    hmi_map.draw_contours([-10, 10]*u.percent, transform=ax2.get_transform(hmi_map.wcs))
+    hmi_map.draw_contours([-10, 10]*u.percent, transform=ax2.get_transform(hmi_map.wcs), annotate=False)
     ax2.set_title('Explicitly specifying the correct transform')
 
     # Panel 3: Explicit transform with wacky rotation
@@ -1688,7 +1712,7 @@ def test_draw_contours_with_transform(sample_171, sample_hmi):
     rotate_transform = Affine2D().rotate_deg_around(512, 512, 90)
     composite_transform = rotate_transform + ax3.get_transform(hmi_map.wcs)
     aia_map.plot(axes=ax3, clip_interval=(1, 99.99)*u.percent)
-    hmi_map.draw_contours([-10, 10]*u.percent, transform=composite_transform)
+    hmi_map.draw_contours([-10, 10]*u.percent, transform=composite_transform, annotate=False)
     ax3.set_title('Contours rotated by 90 deg CCW')
 
     return fig

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -221,7 +221,7 @@ def test_plot_masked_aia171_superpixel_conservative_mask_true(aia171_test_map_wi
 @figure_test
 def test_draw_contours_aia(aia171_test_map):
     aia171_test_map.plot()
-    aia171_test_map.draw_contours(u.Quantity(np.arange(1, 100, 10), 'percent'))
+    aia171_test_map.draw_contours(u.Quantity(np.arange(1, 100, 10), 'percent'), annotate=False)
 
 
 @figure_test
@@ -229,13 +229,18 @@ def test_draw_contours_different_wcs(aia171_test_map):
     aia171_test_map._data = aia171_test_map.data.astype('float32')
     rotated_map = aia171_test_map.rotate(30*u.deg, order=3)
     rotated_map.plot()
-    aia171_test_map.draw_contours(u.Quantity(np.arange(1, 100, 10), 'percent'))
+    aia171_test_map.draw_contours(u.Quantity(np.arange(1, 100, 10), 'percent'), annotate=False)
 
 
 @figure_test
 def test_draw_contours_aia_fill(aia171_test_map):
     aia171_test_map.plot()
-    aia171_test_map.draw_contours(u.Quantity(np.arange(1, 100, 10), 'percent'), fill=True)
+    aia171_test_map.draw_contours(u.Quantity(np.arange(1, 100, 10), 'percent'), fill=True, annotate=False)
+
+
+@figure_test
+def test_draw_contours_annotate(aia171_test_map):
+    aia171_test_map.draw_contours(u.Quantity(np.arange(1, 100, 10), 'percent'))
 
 
 @figure_test


### PR DESCRIPTION
Fixes #8331.

## Summary

- Adds `annotate=True` parameter to `GenericMap.draw_contours`. When `True` (the default), it sets the plot title, axis labels, equal aspect ratio, and coordinate grid on the axes — matching the formatting that `GenericMap.plot` applies.
- Pass `annotate=False` when overlaying contours on an existing annotated plot (e.g. after calling `.plot()`).
- Updated existing overlay tests in `test_plotting.py` and `test_mapbase.py` to pass `annotate=False` so their figure output is unchanged.
- Added `test_draw_contours_annotate` as a new figure test (standalone contour-only plot) and a unit test that checks title, axis labels, and aspect ratio are set correctly.

## Test plan

- [x] `python -m pytest sunpy/map/tests/test_mapbase.py -k "draw_contours"` — 1 passed, 1 skipped (remote-data figure test)
- [x] `python -m pytest sunpy/map/tests/test_plotting.py -k "draw_contours"` — 4 passed
- [x] Smoke-tested annotate=True sets title/labels/aspect, annotate=False leaves them unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)