### PR TITLE
Scraper Fido Clients for Hinode SOT FG and SP data

### DIFF
--- a/changelog/8566.feature.rst
+++ b/changelog/8566.feature.rst
@@ -1,0 +1,1 @@
+Added a Fido client for retrieving Hinode SOT SP and FG data for all levels from the two official data archives.

--- a/changelog/8566.feature.rst
+++ b/changelog/8566.feature.rst
@@ -1,1 +1,1 @@
-Added a Fido client for retrieving Hinode SOT SP and FG data for all levels from the two official data archives.
+Added a Fido client for retrieving Hinode SOT SP and FG data for all levels (0, 1, 2, 2.1) from the two official archives.

--- a/docs/reference/net.rst
+++ b/docs/reference/net.rst
@@ -36,10 +36,13 @@ Dataretriever
 .. automodapi:: sunpy.net.dataretriever
    :headings: ^"
 
+.. automodapi:: sunpy.net.dataretriever.attrs.adapt
+   :headings: ^"
+
 .. automodapi:: sunpy.net.dataretriever.attrs.goes
    :headings: ^"
 
-.. automodapi:: sunpy.net.dataretriever.attrs.adapt
+.. automodapi:: sunpy.net.dataretriever.attrs.hinode
    :headings: ^"
 
 JSOC

--- a/sunpy/net/attrs.py
+++ b/sunpy/net/attrs.py
@@ -17,6 +17,7 @@ attrs specific to them, under:
 
 * `a.adapt <sunpy.net.dataretriever.attrs.adapt>`
 * `a.goes <sunpy.net.dataretriever.attrs.goes>`
+* `a.hinode <sunpy.net.dataretriever.attrs.hinode>`
 * `a.hek <sunpy.net.hek.attrs>`
 * `a.helio <sunpy.net.helio.attrs>`
 * `a.jsoc <sunpy.net.jsoc.attrs>`

--- a/sunpy/net/dataretriever/__init__.py
+++ b/sunpy/net/dataretriever/__init__.py
@@ -15,6 +15,7 @@ from .sources.eve import *
 from .sources.fermi_gbm import *
 from .sources.goes import *
 from .sources.gong import *
+from .sources.hinode import *
 from .sources.lyra import *
 from .sources.noaa import *
 from .sources.norh import *

--- a/sunpy/net/dataretriever/attrs/__init__.py
+++ b/sunpy/net/dataretriever/attrs/__init__.py
@@ -1,3 +1,3 @@
-from . import adapt, goes
+from . import adapt, goes, hinode
 
-__all__ = ['adapt', 'goes']
+__all__ = ['adapt', 'goes', 'hinode']

--- a/sunpy/net/dataretriever/attrs/hinode.py
+++ b/sunpy/net/dataretriever/attrs/hinode.py
@@ -1,0 +1,15 @@
+from sunpy.net.attr import SimpleAttr
+
+__all__ = ['SOTDetector']
+
+
+# Define a custom __dir__ to restrict tab-completion to __all__
+def __dir__():
+    return __all__
+
+
+class SOTDetector(SimpleAttr):
+    """
+    Solar Optical Telescope (SOT) instrument, e.g., 'FG' or 'SP'.
+    """
+    pass

--- a/sunpy/net/dataretriever/sources/hinode.py
+++ b/sunpy/net/dataretriever/sources/hinode.py
@@ -1,0 +1,196 @@
+from sunpy.net import attrs as a
+from sunpy.net.dataretriever.attrs import hinode as hattrs
+from sunpy.net.dataretriever.client import GenericClient, QueryResponse
+from sunpy.net.scraper import Scraper
+from sunpy.time import TimeRange
+
+__all__ = ['HinodeSOTFGClient', 'HinodeSOTSPClient']
+
+
+_ARCHIVE_URLS = (
+    'https://data.darts.isas.jaxa.jp/pub/hinode/sot/',
+    'https://sot.lmsal.com/data/sot/',
+)
+_SP_LEVEL_DIRS_MAP = {
+    '0': 'level0',
+    '1': 'level1hao',
+    '2': 'level2hao',
+    '2.1': 'level2.1hao',
+}
+
+class HinodeSOTFGClient(GenericClient):
+    """
+    Provides access to the Hinode Solar Optical Telescope (SOT)  Filtergraph (FG) data archive.
+
+    Hosted by the `Data ARchives and Transmission System (DARTS) archive <https://darts.isas.jaxa.jp/en>`__.
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido, attrs as a
+    >>> results = Fido.search(a.Time("2013-07-13 00:13:32", "2013-07-13 00:13:33"),
+    ...                       a.Instrument.sot, a.Level(0), a.hinode.SOTDetector('FG'))  # doctest: +REMOTE_DATA
+    >>> results  # doctest: +REMOTE_DATA
+    <sunpy.net.fido_factory.UnifiedResponse object at ...>
+    Results from 1 Provider:
+    <BLANKLINE>
+    1 Results from the HinodeSOTFGClient:
+    Source: https://data.darts.isas.jaxa.jp/pub/hinode/sot/
+    <BLANKLINE>
+           Start Time               End Time        Instrument Source Provider Level SOTDetector
+    ----------------------- ----------------------- ---------- ------ -------- ----- -----------
+    2013-07-13 00:13:32.000 2013-07-13 00:13:32.999        SOT HINODE    DARTS     0          FG
+    <BLANKLINE>
+    <BLANKLINE>
+    """
+    required = {a.Time, a.Instrument, a.Level, hattrs.SOTDetector}
+    pattern = (
+        "https://data.darts.isas.jaxa.jp/pub/hinode/sot/level{Level}/{{year:4d}}/{{month:2d}}/{{day:2d}}/FG/"
+        "H{{hour:2d}}00/"
+        "FG{{year:4d}}{{month:2d}}{{day:2d}}_"
+        "{{hour:2d}}{{minute:2d}}{{second:2d}}.{{}}.fits"
+    )
+
+    @classmethod
+    def _attrs_module(cls):
+        return 'hinode', 'sunpy.net.dataretriever.attrs.hinode'
+
+    @classmethod
+    def register_values(cls):
+        from sunpy.net import attrs as a
+
+        return {
+            a.Instrument: [("SOT", "Hinode Solar Optical Telescope")],
+            a.Source: [("Hinode", "Hinode / Solar-B")],
+            a.Provider: [("DARTS", "ISAS/JAXA DARTS archive")],
+            a.Level: [("0", "Level 0"), ("1", "Level 1")],
+            a.hinode.SOTDetector: [("FG", "Filtergraph")],
+        }
+
+    @property
+    def info_url(self):
+        return _ARCHIVE_URLS[0]
+
+    def post_search_hook(self, exdict, matchdict):
+        rowdict = super().post_search_hook(exdict, matchdict)
+        return rowdict
+
+    def search(self, *args, **kwargs):
+        matchdict = self._get_match_dict(*args, **kwargs)
+        level = str(matchdict['Level'][0])
+        if level not in ['0', '1']:
+            return QueryResponse([], client=self)
+        formatted_pattern = self.pattern.replace('{Level}', level)
+        patterns = [formatted_pattern, formatted_pattern.replace(_ARCHIVE_URLS[0], _ARCHIVE_URLS[1])]
+        tr = TimeRange(matchdict['Start Time'], matchdict['End Time'])
+        rows = []
+        seen_urls = set()
+        for pat in patterns:
+            scraper = Scraper(format=pat)
+            try:
+                filemeta = scraper._extract_files_meta(tr, matcher=matchdict)
+            except Exception:
+                filemeta = []
+            for i in filemeta:
+                url = i.get('url', '')
+                if url and url not in seen_urls:
+                    seen_urls.add(url)
+                    rows.append(self.post_search_hook(i, matchdict))
+            if filemeta:
+                break
+        rows.sort(key=lambda x: x['Start Time'])
+        return QueryResponse(rows, client=self)
+
+
+class HinodeSOTSPClient(GenericClient):
+    """
+    Provides access to the Hinode Solar Optical Telescope (SOT)  Spectral-polarimeter (SP) data archive.
+
+    Hosted by the `Data ARchives and Transmission System (DARTS) archive <https://darts.isas.jaxa.jp/en>`__.
+
+    Examples
+    --------
+    >>> from sunpy.net import Fido, attrs as a
+    >>> results = Fido.search(a.Time("2013-07-13 10:02:00", "2013-07-13 10:03:00"),
+    ...                       a.Instrument.sot, a.Level(0), a.hinode.SOTDetector('SP'))  # doctest: +REMOTE_DATA
+    >>> results  # doctest: +REMOTE_DATA
+    <sunpy.net.fido_factory.UnifiedResponse object at ...>
+    Results from 1 Provider:
+    <BLANKLINE>
+    3 Results from the HinodeSOTSPClient:
+    Source: https://data.darts.isas.jaxa.jp/pub/hinode/sot/
+    <BLANKLINE>
+           Start Time               End Time        Instrument Source Provider Level SOTDetector
+    ----------------------- ----------------------- ---------- ------ -------- ----- -----------
+    2013-07-13 10:02:50.000 2013-07-13 10:02:50.000        SOT Hinode    DARTS     0          SP
+    2013-07-13 10:02:54.000 2013-07-13 10:02:54.000        SOT Hinode    DARTS     0          SP
+    2013-07-13 10:02:58.000 2013-07-13 10:02:58.000        SOT Hinode    DARTS     0          SP
+    <BLANKLINE>
+    <BLANKLINE>
+    """
+    required = {a.Time, a.Instrument, a.Level, hattrs.SOTDetector}
+
+    # Pattern for level 0 data
+    pattern_level0 = (
+        "https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/{{year:4d}}/{{month:2d}}/{{day:2d}}/SP4D/H{{hour:2d}}00/"
+        "SP4D{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.{{}}.fits"
+    )
+    # Pattern for level 1, 2, 2.1 data
+    pattern_other = (
+        "https://data.darts.isas.jaxa.jp/pub/hinode/sot/{{level_dir}}/{{year:4d}}/{{month:2d}}/{{day:2d}}/SP3D/"
+        "{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}/"
+        "SP3D{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_{{}}.fits"
+    )
+
+    @classmethod
+    def _attrs_module(cls):
+        return 'hinode', 'sunpy.net.dataretriever.attrs.hinode'
+
+    @classmethod
+    def register_values(cls):
+        from sunpy.net import attrs as a
+
+        return {
+            a.Instrument: [("SOT", "Hinode Solar Optical Telescope")],
+            a.Source: [("Hinode", "Hinode / Solar-B")],
+            a.Provider: [("DARTS", "ISAS/JAXA DARTS archive")],
+            a.Level: [("0", "Level 0"), ("1", "Level 1"), ("2", "Level 2"), ("2.1", "Level 2.1")],
+            a.hinode.SOTDetector: [("SP", "Spectro-Polarimeter")],
+        }
+
+    @property
+    def info_url(self):
+        return _ARCHIVE_URLS[0]
+
+    def post_search_hook(self, exdict, matchdict):
+        rowdict = super().post_search_hook(exdict, matchdict)
+        rowdict['End Time'] = rowdict['Start Time']
+        rowdict['Source'] = 'Hinode'
+        rowdict['Provider'] = 'DARTS'
+        return rowdict
+
+    def search(self, *args, **kwargs):
+        matchdict = self._get_match_dict(*args, **kwargs)
+        level = str(matchdict['Level'][0])
+        level_dir = _SP_LEVEL_DIRS_MAP[level]
+        if level == '0':
+            patterns = [self.pattern_level0, self.pattern_level0.replace(_ARCHIVE_URLS[0], _ARCHIVE_URLS[1])]
+        else:
+            patterns = [self.pattern_other, self.pattern_other.replace(_ARCHIVE_URLS[0], _ARCHIVE_URLS[1])]
+        tr = TimeRange(matchdict['Start Time'], matchdict['End Time'])
+        rows = []
+        seen_urls = set()
+        for pat in patterns:
+            scraper = Scraper(format=pat, level_dir=level_dir)
+            try:
+                filemeta = scraper._extract_files_meta(tr, matcher=matchdict)
+            except Exception:
+                filemeta = []
+            for i in filemeta:
+                url = i.get('url', '')
+                if url and url not in seen_urls:
+                    seen_urls.add(url)
+                    rows.append(self.post_search_hook(i, matchdict))
+            if filemeta:
+                break
+        rows.sort(key=lambda x: x['Start Time'])
+        return QueryResponse(rows, client=self)

--- a/sunpy/net/dataretriever/sources/hinode.py
+++ b/sunpy/net/dataretriever/sources/hinode.py
@@ -7,22 +7,32 @@ from sunpy.time import TimeRange
 __all__ = ['HinodeSOTFGClient', 'HinodeSOTSPClient']
 
 
-_ARCHIVE_URLS = (
-    'https://data.darts.isas.jaxa.jp/pub/hinode/sot/',
-    'https://sot.lmsal.com/data/sot/',
-)
-_SP_LEVEL_DIRS_MAP = {
-    '0': 'level0',
-    '1': 'level1hao',
-    '2': 'level2hao',
-    '2.1': 'level2.1hao',
+_ARCHIVE_URLS = {
+    'DARTS': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/',
+    'LMSAL': 'https://sot.lmsal.com/data/sot/',
 }
+
+
+def _get_archive_url(matchdict):
+    """
+    Defaults to DARTS unless LMSAL is the only provider selected.
+    """
+    providers = [p.upper() for p in matchdict.get('Provider', [])]
+    if providers == ['LMSAL']:
+        return _ARCHIVE_URLS['LMSAL']
+    return _ARCHIVE_URLS['DARTS']
+
 
 class HinodeSOTFGClient(GenericClient):
     """
-    Provides access to the Hinode Solar Optical Telescope (SOT)  Filtergraph (FG) data archive.
+    Provides access to the Hinode Solar Optical Telescope (SOT) Filtergraph (FG) data archive.
 
-    Hosted by the `Data ARchives and Transmission System (DARTS) archive <https://darts.isas.jaxa.jp/en>`__.
+    Data is available from two archives:
+
+    - `DARTS archive <https://darts.isas.jaxa.jp/en>`__ (default)
+    - `LMSAL archive <https://www.lmsal.com/solarsoft/hinode/doc/hinode_sot_analysis_guide.html>`__
+
+    Use ``a.Provider('LMSAL')`` to retrieve from LMSAL instead.
 
     Examples
     --------
@@ -43,8 +53,9 @@ class HinodeSOTFGClient(GenericClient):
     <BLANKLINE>
     """
     required = {a.Time, a.Instrument, a.Level, hattrs.SOTDetector}
-    pattern = (
-        "https://data.darts.isas.jaxa.jp/pub/hinode/sot/level{Level}/{{year:4d}}/{{month:2d}}/{{day:2d}}/FG/"
+    optional = {a.Source, a.Provider}
+    _pattern = (
+        "{archive}level{Level}/{{year:4d}}/{{month:2d}}/{{day:2d}}/FG/"
         "H{{hour:2d}}00/"
         "FG{{year:4d}}{{month:2d}}{{day:2d}}_"
         "{{hour:2d}}{{minute:2d}}{{second:2d}}.{{}}.fits"
@@ -61,51 +72,55 @@ class HinodeSOTFGClient(GenericClient):
         return {
             a.Instrument: [("SOT", "Hinode Solar Optical Telescope")],
             a.Source: [("Hinode", "Hinode / Solar-B")],
-            a.Provider: [("DARTS", "ISAS/JAXA DARTS archive")],
+            a.Provider: [("DARTS", "ISAS/JAXA DARTS archive"),
+                         ("LMSAL", "Lockheed Martin Solar and Astrophysics Laboratory")],
             a.Level: [("0", "Level 0"), ("1", "Level 1")],
             a.hinode.SOTDetector: [("FG", "Filtergraph")],
         }
 
     @property
     def info_url(self):
-        return _ARCHIVE_URLS[0]
-
-    def post_search_hook(self, exdict, matchdict):
-        rowdict = super().post_search_hook(exdict, matchdict)
-        return rowdict
+        return _ARCHIVE_URLS['DARTS']
 
     def search(self, *args, **kwargs):
         matchdict = self._get_match_dict(*args, **kwargs)
         level = str(matchdict['Level'][0])
         if level not in ['0', '1']:
             return QueryResponse([], client=self)
-        formatted_pattern = self.pattern.replace('{Level}', level)
-        patterns = [formatted_pattern, formatted_pattern.replace(_ARCHIVE_URLS[0], _ARCHIVE_URLS[1])]
+        archive_url = _get_archive_url(matchdict)
+        pat = self._pattern.replace('{archive}', archive_url).replace('{Level}', level)
         tr = TimeRange(matchdict['Start Time'], matchdict['End Time'])
         rows = []
-        seen_urls = set()
-        for pat in patterns:
-            scraper = Scraper(format=pat)
-            try:
-                filemeta = scraper._extract_files_meta(tr, matcher=matchdict)
-            except Exception:
-                filemeta = []
-            for i in filemeta:
-                url = i.get('url', '')
-                if url and url not in seen_urls:
-                    seen_urls.add(url)
-                    rows.append(self.post_search_hook(i, matchdict))
-            if filemeta:
-                break
+        scraper = Scraper(format=pat)
+        try:
+            filemeta = scraper._extract_files_meta(tr, matcher=matchdict)
+        except Exception:
+            filemeta = []
+        for i in filemeta:
+            if i.get('url'):
+                rows.append(self.post_search_hook(i, matchdict))
         rows.sort(key=lambda x: x['Start Time'])
         return QueryResponse(rows, client=self)
 
 
 class HinodeSOTSPClient(GenericClient):
     """
-    Provides access to the Hinode Solar Optical Telescope (SOT)  Spectral-polarimeter (SP) data archive.
+    Provides access to the Hinode Solar Optical Telescope (SOT) Spectral-polarimeter (SP) data archive.
 
-    Hosted by the `Data ARchives and Transmission System (DARTS) archive <https://darts.isas.jaxa.jp/en>`__.
+    Data is available from two archives:
+
+    - `DARTS archive <https://darts.isas.jaxa.jp/en>`__ (default)
+    - `LMSAL archive <https://www.lmsal.com/solarsoft/hinode/doc/hinode_sot_analysis_guide.html>`__
+
+    Use ``a.Provider('LMSAL')`` to retrieve from LMSAL instead.
+
+    .. note::
+
+        Level 1 observations are grouped by observation start time in directories .
+        Each directory can contain hundreds of individual scan files spanning a time range longer
+        than the observation start time. As the scraper uses the directory timestamp for all files
+        within it, all returned level 1 results will share the same observation start time.
+        A search must include the observation start time in its time range to find level 1 files.
 
     Examples
     --------
@@ -128,18 +143,28 @@ class HinodeSOTSPClient(GenericClient):
     <BLANKLINE>
     """
     required = {a.Time, a.Instrument, a.Level, hattrs.SOTDetector}
-
-    # Pattern for level 0 data
-    pattern_level0 = (
-        "https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/{{year:4d}}/{{month:2d}}/{{day:2d}}/SP4D/H{{hour:2d}}00/"
-        "SP4D{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.{{}}.fits"
-    )
-    # Pattern for level 1, 2, 2.1 data
-    pattern_other = (
-        "https://data.darts.isas.jaxa.jp/pub/hinode/sot/{{level_dir}}/{{year:4d}}/{{month:2d}}/{{day:2d}}/SP3D/"
-        "{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}/"
-        "SP3D{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_{{}}.fits"
-    )
+    optional = {a.Source, a.Provider}
+    _patterns = {
+        '0': (
+            "{archive}level0/{{year:4d}}/{{month:2d}}/{{day:2d}}/SP4D/H{{hour:2d}}00/"
+            "SP4D{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.{{}}.fits"
+        ),
+        '1': (
+            "{archive}level1hao/{{year:4d}}/{{month:2d}}/{{day:2d}}/SP3D/"
+            "{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}/"
+            "SP3D{{}}.fits"
+        ),
+        '2': (
+            "{archive}level2hao/{{year:4d}}/{{month:2d}}/{{day:2d}}/SP3D/"
+            "{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}/"
+            "{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}.fits"
+        ),
+        '2.1': (
+            "{archive}level2.1hao/{{year:4d}}/{{month:2d}}/{{day:2d}}/SP3D/"
+            "{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}/"
+            "{{year:4d}}{{month:2d}}{{day:2d}}_{{hour:2d}}{{minute:2d}}{{second:2d}}_L2.1.fits"
+        ),
+    }
 
     @classmethod
     def _attrs_module(cls):
@@ -152,45 +177,41 @@ class HinodeSOTSPClient(GenericClient):
         return {
             a.Instrument: [("SOT", "Hinode Solar Optical Telescope")],
             a.Source: [("Hinode", "Hinode / Solar-B")],
-            a.Provider: [("DARTS", "ISAS/JAXA DARTS archive")],
+            a.Provider: [("DARTS", "ISAS/JAXA DARTS archive"),
+                         ("LMSAL", "Lockheed Martin Solar and Astrophysics Laboratory")],
             a.Level: [("0", "Level 0"), ("1", "Level 1"), ("2", "Level 2"), ("2.1", "Level 2.1")],
             a.hinode.SOTDetector: [("SP", "Spectro-Polarimeter")],
         }
 
     @property
     def info_url(self):
-        return _ARCHIVE_URLS[0]
+        return _ARCHIVE_URLS['DARTS']
 
     def post_search_hook(self, exdict, matchdict):
         rowdict = super().post_search_hook(exdict, matchdict)
         rowdict['End Time'] = rowdict['Start Time']
         rowdict['Source'] = 'Hinode'
-        rowdict['Provider'] = 'DARTS'
+        providers = [p.upper() for p in matchdict.get('Provider', [])]
+        rowdict['Provider'] = 'LMSAL' if providers == ['LMSAL'] else 'DARTS'
         return rowdict
 
     def search(self, *args, **kwargs):
         matchdict = self._get_match_dict(*args, **kwargs)
         level = str(matchdict['Level'][0])
-        level_dir = _SP_LEVEL_DIRS_MAP[level]
-        if level == '0':
-            patterns = [self.pattern_level0, self.pattern_level0.replace(_ARCHIVE_URLS[0], _ARCHIVE_URLS[1])]
-        else:
-            patterns = [self.pattern_other, self.pattern_other.replace(_ARCHIVE_URLS[0], _ARCHIVE_URLS[1])]
+        pattern_template = self._patterns.get(level)
+        if pattern_template is None:
+            return QueryResponse([], client=self)
+        archive_url = _get_archive_url(matchdict)
+        pattern = pattern_template.replace('{archive}', archive_url)
         tr = TimeRange(matchdict['Start Time'], matchdict['End Time'])
         rows = []
-        seen_urls = set()
-        for pat in patterns:
-            scraper = Scraper(format=pat, level_dir=level_dir)
-            try:
-                filemeta = scraper._extract_files_meta(tr, matcher=matchdict)
-            except Exception:
-                filemeta = []
-            for i in filemeta:
-                url = i.get('url', '')
-                if url and url not in seen_urls:
-                    seen_urls.add(url)
-                    rows.append(self.post_search_hook(i, matchdict))
-            if filemeta:
-                break
+        scraper = Scraper(format=pattern)
+        try:
+            filemeta = scraper._extract_files_meta(tr, matcher=matchdict)
+        except Exception:
+            filemeta = []
+        for i in filemeta:
+            if i.get('url'):
+                rows.append(self.post_search_hook(i, matchdict))
         rows.sort(key=lambda x: x['Start Time'])
         return QueryResponse(rows, client=self)

--- a/sunpy/net/dataretriever/sources/tests/test_hinode.py
+++ b/sunpy/net/dataretriever/sources/tests/test_hinode.py
@@ -1,4 +1,3 @@
-import tempfile
 from unittest import mock
 
 import pytest
@@ -19,41 +18,8 @@ def sp_client():
     return hinode.HinodeSOTSPClient()
 
 
-class DummyDownloader:
-    def __init__(self):
-        self.calls = []
-
-    def enqueue_file(self, url, filename, **kwargs):
-        self.calls.append((url, filename, kwargs))
-
-    def download(self):
-        return self.calls
-
-
-def mock_query_object(client, detector='FG', level='1', url=None):
-    if url is None:
-        if detector == 'FG':
-            url = ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/'
-                   '2011/12/13/FG/H0600/FG20111213_060000.0.fits')
-        else:
-            url = ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/'
-                   '2011/12/13/SP3D/20111213_020000/20111213_020000_L1.0.fits')
-
-    obj = {
-        'Start Time': parse_time('2011-12-13T06:00:00'),
-        'End Time': parse_time('2011-12-13T06:00:00'),
-        'Instrument': 'SOT',
-        'SOTDetector': detector,
-        'Level': level,
-        'Source': 'Hinode',
-        'Provider': 'DARTS',
-        'url': url,
-    }
-    return QueryResponse([obj], client=client)
-
-
 @pytest.mark.parametrize(
-    ('client_cls', 'detector', 'level', 'expected'),
+    ('client_cls', 'detector', 'level', 'can_handle'),
     [
         (hinode.HinodeSOTFGClient, 'FG', '0', True),
         (hinode.HinodeSOTFGClient, 'FG', '1', True),
@@ -66,155 +32,35 @@ def mock_query_object(client, detector='FG', level='1', url=None):
         (hinode.HinodeSOTSPClient, 'FG', '1', False),
     ],
 )
-def test_can_handle_query(client_cls, detector, level, expected):
+def test_can_handle_query(client_cls, detector, level, can_handle):
     query = (
         a.Time('2011-12-13 06:00', '2011-12-13 07:00'),
         a.Instrument('SOT'),
         a.Level(level),
         a.hinode.SOTDetector(detector),
     )
-    assert client_cls._can_handle_query(*query) is expected
+    assert client_cls._can_handle_query(*query) is can_handle
 
 
 @pytest.mark.parametrize(
-    ('level', 'timerange', 'filesmeta', 'expected_urls'),
+    ('client_cls', 'detector', 'provider', 'can_handle'),
     [
-        (
-            1,
-            ('2011-12-13 06:00', '2011-12-13 06:15'),
-            [
-                {
-                    'year': 2011,
-                    'month': 12,
-                    'day': 13,
-                    'hour': 6,
-                    'minute': 10,
-                    'second': 0,
-                    'subsec': 0,
-                    'url': ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/'
-                            '2011/12/13/FG/H0600/FG20111213_061000.0.fits'),
-                },
-                {
-                    'year': 2011,
-                    'month': 12,
-                    'day': 13,
-                    'hour': 6,
-                    'minute': 0,
-                    'second': 0,
-                    'subsec': 0,
-                    'url': ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/'
-                            '2011/12/13/FG/H0600/FG20111213_060000.0.fits'),
-                },
-            ],
-            [
-                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/2011/12/13/FG/H0600/FG20111213_060000.0.fits',
-                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/2011/12/13/FG/H0600/FG20111213_061000.0.fits',
-            ],
-        ),
-        (
-            0,
-            ('2013-07-13 00:13:32', '2013-07-13 00:13:33'),
-            [{
-                'year': 2013,
-                'month': 7,
-                'day': 13,
-                'hour': 0,
-                'minute': 13,
-                'second': 32,
-                'subsec': 7,
-                'url': ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/'
-                        '2013/07/13/FG/H0000/FG20130713_001332.7.fits'),
-            }],
-            ['https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/FG/H0000/FG20130713_001332.7.fits'],
-        ),
+        (hinode.HinodeSOTFGClient, 'FG', 'DARTS', True),
+        (hinode.HinodeSOTFGClient, 'FG', 'LMSAL', True),
+        (hinode.HinodeSOTSPClient, 'SP', 'DARTS', True),
+        (hinode.HinodeSOTSPClient, 'SP', 'LMSAL', True),
+        (hinode.HinodeSOTSPClient, 'SP', 'Fake', False),
     ],
 )
-def test_search_fg(fg_client, level, timerange, filesmeta, expected_urls):
-    with mock.patch('sunpy.net.dataretriever.client.Scraper._extract_files_meta', return_value=filesmeta):
-        qr = fg_client.search(
-            a.Time(*timerange),
-            a.Instrument('SOT'),
-            a.Level(level),
-            a.hinode.SOTDetector('FG'),
-        )
-
-    assert [str(u) for u in qr['url']] == expected_urls
-    assert qr['Level'][0] == str(level)
-    assert qr['SOTDetector'][0] == 'FG'
-
-
-@pytest.mark.parametrize(
-    ('level', 'timerange', 'filesmeta', 'expected_urls'),
-    [
-        (
-            1,
-            ('2011-12-13 02:00', '2011-12-13 04:30'),
-            [
-                {
-                    'year': 2011,
-                    'month': 12,
-                    'day': 13,
-                    'hour': 2,
-                    'minute': 0,
-                    'second': 0,
-                    'url': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_020000/20111213_020000_L1.0.fits',
-                },
-                {
-                    'year': 2011,
-                    'month': 12,
-                    'day': 13,
-                    'hour': 4,
-                    'minute': 30,
-                    'second': 0,
-                    'url': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_043000/20111213_043000_L1.0.fits',
-                },
-            ],
-            [
-                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_020000/20111213_020000_L1.0.fits',
-                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_043000/20111213_043000_L1.0.fits',
-            ],
-        ),
-        (
-            0,
-            ('2013-07-13 10:02:00', '2013-07-13 10:03:00'),
-            [
-                {
-                    'year': 2013,
-                    'month': 7,
-                    'day': 13,
-                    'hour': 10,
-                    'minute': 2,
-                    'second': 50,
-                    'url': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100250.1.fits',
-                },
-                {
-                    'year': 2013,
-                    'month': 7,
-                    'day': 13,
-                    'hour': 10,
-                    'minute': 2,
-                    'second': 54,
-                    'url': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100254.0.fits',
-                },
-            ],
-            [
-                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100250.1.fits',
-                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100254.0.fits',
-            ],
-        ),
-    ],
-)
-def test_search_sp(sp_client, level, timerange, filesmeta, expected_urls):
-    with mock.patch('sunpy.net.dataretriever.client.Scraper._extract_files_meta', return_value=filesmeta):
-        qr = sp_client.search(
-            a.Time(*timerange),
-            a.Instrument('SOT'),
-            a.Level(level),
-            a.hinode.SOTDetector('SP'),
-        )
-
-    assert len(qr) == len(expected_urls)
-    assert [str(u) for u in qr['url']] == expected_urls
+def test_can_handle_query_provider(client_cls, detector, provider, can_handle):
+    query = (
+        a.Time('2011-12-13 06:00', '2011-12-13 07:00'),
+        a.Instrument('SOT'),
+        a.Level(1),
+        a.hinode.SOTDetector(detector),
+        a.Provider(provider),
+    )
+    assert client_cls._can_handle_query(*query) is can_handle
 
 
 REAL_URL_CASES = [
@@ -224,6 +70,15 @@ REAL_URL_CASES = [
         '2013-07-13 00:13:32',
         '2013-07-13 00:13:33',
         'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/FG/H0000/FG20130713_001332.7.fits',
+        'DARTS',
+    ),
+    (
+        'FG',
+        '1',
+        '2011-12-13 06:04:30',
+        '2011-12-13 06:04:32',
+        'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/2011/12/13/FG/H0600/FG20111213_060430.3.fits',
+        'DARTS',
     ),
     (
         'SP',
@@ -231,31 +86,113 @@ REAL_URL_CASES = [
         '2013-07-13 10:02:50',
         '2013-07-13 10:02:51',
         'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100250.1.fits',
+        'DARTS',
+    ),
+    (
+        'SP',
+        '1',
+        '2011-12-13 02:50:04',
+        '2011-12-13 02:50:05',
+        'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_025004/SP3D20111213_025004.4C.fits',
+        'DARTS',
+    ),
+    (
+        'SP',
+        '2',
+        '2011-12-13 02:50:04',
+        '2011-12-13 02:50:05',
+        'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level2hao/2011/12/13/SP3D/20111213_025004/20111213_025004.fits',
+        'DARTS',
+    ),
+    (
+        'SP',
+        '2.1',
+        '2011-12-13 02:50:04',
+        '2011-12-13 02:50:05',
+        'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level2.1hao/2011/12/13/SP3D/20111213_025004/20111213_025004_L2.1.fits',
+        'DARTS',
+    ),
+    (
+        'SP',
+        '2',
+        '2011-12-13 02:50:04',
+        '2011-12-13 02:50:05',
+        'https://sot.lmsal.com/data/sot/level2hao/2011/12/13/SP3D/20111213_025004/20111213_025004.fits',
+        'LMSAL',
     ),
 ]
 
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize(
-    ('detector', 'level', 'start', 'end', 'expected_url'),
+    ('detector', 'level', 'start', 'end', 'expected_url', 'provider'),
     REAL_URL_CASES,
 )
-def test_real_archive_urls(fg_client, sp_client, detector, level, start, end,
-                           expected_url):
+def test_real_archive_urls(fg_client, sp_client, detector, level, start, end, expected_url, provider):
     hinode_client = fg_client if detector == 'FG' else sp_client
     qr = hinode_client.search(
         a.Time(start, end),
         a.Instrument('SOT'),
         a.Level(level),
         a.hinode.SOTDetector(detector),
+        a.Provider(provider),
     )
 
-    assert len(qr) == 1
-    assert qr[0]['url'] == expected_url
+    assert len(qr) >= 1
+    assert expected_url in list(qr['url'])
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        file = hinode_client.fetch(qr, path=tmpdir)
-    assert file[0].split('/')[-1] == expected_url.split('/')[-1]
+
+@pytest.mark.parametrize(
+    ('client_cls', 'detector', 'level', 'provider'),
+    [
+        (
+            hinode.HinodeSOTFGClient,
+            'FG',
+            1,
+            'LMSAL',
+        ),
+        (
+            hinode.HinodeSOTFGClient,
+            'FG',
+            1,
+            'DARTS',
+        ),
+        (
+            hinode.HinodeSOTSPClient,
+            'SP',
+            2,
+            'LMSAL',
+        ),
+        (
+            hinode.HinodeSOTSPClient,
+            'SP',
+            2,
+            'DARTS',
+        ),
+    ],
+)
+def test_search_provider_url(client_cls, detector, level, provider):
+    lmsal_url = 'https://sot.lmsal.com/data/sot/'
+    darts_url = 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/'
+    fake_url = (lmsal_url if provider == 'LMSAL' else darts_url) + 'level' + str(level) + 'hao' + '/somefile.fits'
+    filesmeta = [{
+        'year': 2011, 'month': 12, 'day': 13,
+        'hour': 6, 'minute': 0, 'second': 0,
+        'url': fake_url,
+    }]
+    client = client_cls()
+    with mock.patch('sunpy.net.dataretriever.client.Scraper._extract_files_meta', return_value=filesmeta):
+        qr = client.search(
+            a.Time('2011-12-13 06:00', '2011-12-13 06:15'),
+            a.Instrument('SOT'),
+            a.Level(level),
+            a.hinode.SOTDetector(detector),
+            a.Provider(provider),
+        )
+    assert len(qr) == 1
+    assert qr[0]['Provider'] == provider
+    assert qr[0]['url'].startswith(lmsal_url if provider == 'LMSAL' else darts_url)
+
 
 def test_search_unsupported_fg_level(fg_client):
     qr = fg_client.search(
@@ -267,41 +204,32 @@ def test_search_unsupported_fg_level(fg_client):
     assert len(qr) == 0
 
 
-def test_dummy_fetch_fg(fg_client, tmp_path):
-    downloader = DummyDownloader()
-    qr = mock_query_object(fg_client)
-
-    result = fg_client.fetch(
-        qr[0],
-        path=tmp_path / '{sotdetector}' / '{file}',
-        downloader=downloader,
-    )
-
-    assert result == downloader.calls
-    assert downloader.calls == [
-        (
-            'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/2011/12/13/FG/H0600/FG20111213_060000.0.fits',
-            tmp_path / 'FG' / 'FG20111213_060000.0.fits',
-            {},
-        ),
-    ]
-
-
-def test_dummy_fetch_sp(sp_client, tmp_path):
-    downloader = DummyDownloader()
-    qr = mock_query_object(sp_client, detector='SP', url='https://example.com/20111213_020000/file_a.fits')
-    result = sp_client.fetch(qr, path=tmp_path, downloader=downloader)
-
-    assert result == downloader.calls
-    assert downloader.calls == [
-        ('https://example.com/20111213_020000/file_a.fits', tmp_path / 'file_a.fits', {}),
-    ]
-
-
 def test_attr_reg():
     assert hasattr(a, 'hinode')
     assert a.hinode.SOTDetector.fg == a.hinode.SOTDetector('FG')
     assert a.hinode.SOTDetector.sp == a.hinode.SOTDetector('SP')
+
+
+def mock_query_object(client, detector='FG', level='1', url=None):
+    if url is None:
+        if detector == 'FG':
+            url = ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/'
+                   '2011/12/13/FG/H0600/FG20111213_060430.3.fits')
+        else:
+            url = ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/'
+                   '2011/12/13/SP3D/20111213_025004/SP3D20111213_025004.4C.fits')
+
+    obj = {
+        'Start Time': parse_time('2011-12-13T06:00:00'),
+        'End Time': parse_time('2011-12-13T06:00:00'),
+        'Instrument': 'SOT',
+        'SOTDetector': detector,
+        'Level': level,
+        'Source': 'Hinode',
+        'Provider': 'DARTS',
+        'url': url,
+    }
+    return QueryResponse([obj], client=client)
 
 
 def test_show(fg_client):

--- a/sunpy/net/dataretriever/sources/tests/test_hinode.py
+++ b/sunpy/net/dataretriever/sources/tests/test_hinode.py
@@ -1,0 +1,314 @@
+import tempfile
+from unittest import mock
+
+import pytest
+
+import sunpy.net.dataretriever.sources.hinode as hinode
+from sunpy.net import attrs as a
+from sunpy.net.dataretriever.client import QueryResponse
+from sunpy.time import parse_time
+
+
+@pytest.fixture
+def fg_client():
+    return hinode.HinodeSOTFGClient()
+
+
+@pytest.fixture
+def sp_client():
+    return hinode.HinodeSOTSPClient()
+
+
+class DummyDownloader:
+    def __init__(self):
+        self.calls = []
+
+    def enqueue_file(self, url, filename, **kwargs):
+        self.calls.append((url, filename, kwargs))
+
+    def download(self):
+        return self.calls
+
+
+def mock_query_object(client, detector='FG', level='1', url=None):
+    if url is None:
+        if detector == 'FG':
+            url = ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/'
+                   '2011/12/13/FG/H0600/FG20111213_060000.0.fits')
+        else:
+            url = ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/'
+                   '2011/12/13/SP3D/20111213_020000/20111213_020000_L1.0.fits')
+
+    obj = {
+        'Start Time': parse_time('2011-12-13T06:00:00'),
+        'End Time': parse_time('2011-12-13T06:00:00'),
+        'Instrument': 'SOT',
+        'SOTDetector': detector,
+        'Level': level,
+        'Source': 'Hinode',
+        'Provider': 'DARTS',
+        'url': url,
+    }
+    return QueryResponse([obj], client=client)
+
+
+@pytest.mark.parametrize(
+    ('client_cls', 'detector', 'level', 'expected'),
+    [
+        (hinode.HinodeSOTFGClient, 'FG', '0', True),
+        (hinode.HinodeSOTFGClient, 'FG', '1', True),
+        (hinode.HinodeSOTFGClient, 'SP', '1', False),
+        (hinode.HinodeSOTFGClient, 'FG', '2', False),
+        (hinode.HinodeSOTSPClient, 'SP', '0', True),
+        (hinode.HinodeSOTSPClient, 'SP', '1', True),
+        (hinode.HinodeSOTSPClient, 'SP', '2', True),
+        (hinode.HinodeSOTSPClient, 'SP', '2.1', True),
+        (hinode.HinodeSOTSPClient, 'FG', '1', False),
+    ],
+)
+def test_can_handle_query(client_cls, detector, level, expected):
+    query = (
+        a.Time('2011-12-13 06:00', '2011-12-13 07:00'),
+        a.Instrument('SOT'),
+        a.Level(level),
+        a.hinode.SOTDetector(detector),
+    )
+    assert client_cls._can_handle_query(*query) is expected
+
+
+@pytest.mark.parametrize(
+    ('level', 'timerange', 'filesmeta', 'expected_urls'),
+    [
+        (
+            1,
+            ('2011-12-13 06:00', '2011-12-13 06:15'),
+            [
+                {
+                    'year': 2011,
+                    'month': 12,
+                    'day': 13,
+                    'hour': 6,
+                    'minute': 10,
+                    'second': 0,
+                    'subsec': 0,
+                    'url': ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/'
+                            '2011/12/13/FG/H0600/FG20111213_061000.0.fits'),
+                },
+                {
+                    'year': 2011,
+                    'month': 12,
+                    'day': 13,
+                    'hour': 6,
+                    'minute': 0,
+                    'second': 0,
+                    'subsec': 0,
+                    'url': ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/'
+                            '2011/12/13/FG/H0600/FG20111213_060000.0.fits'),
+                },
+            ],
+            [
+                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/2011/12/13/FG/H0600/FG20111213_060000.0.fits',
+                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/2011/12/13/FG/H0600/FG20111213_061000.0.fits',
+            ],
+        ),
+        (
+            0,
+            ('2013-07-13 00:13:32', '2013-07-13 00:13:33'),
+            [{
+                'year': 2013,
+                'month': 7,
+                'day': 13,
+                'hour': 0,
+                'minute': 13,
+                'second': 32,
+                'subsec': 7,
+                'url': ('https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/'
+                        '2013/07/13/FG/H0000/FG20130713_001332.7.fits'),
+            }],
+            ['https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/FG/H0000/FG20130713_001332.7.fits'],
+        ),
+    ],
+)
+def test_search_fg(fg_client, level, timerange, filesmeta, expected_urls):
+    with mock.patch('sunpy.net.dataretriever.client.Scraper._extract_files_meta', return_value=filesmeta):
+        qr = fg_client.search(
+            a.Time(*timerange),
+            a.Instrument('SOT'),
+            a.Level(level),
+            a.hinode.SOTDetector('FG'),
+        )
+
+    assert [str(u) for u in qr['url']] == expected_urls
+    assert qr['Level'][0] == str(level)
+    assert qr['SOTDetector'][0] == 'FG'
+
+
+@pytest.mark.parametrize(
+    ('level', 'timerange', 'filesmeta', 'expected_urls'),
+    [
+        (
+            1,
+            ('2011-12-13 02:00', '2011-12-13 04:30'),
+            [
+                {
+                    'year': 2011,
+                    'month': 12,
+                    'day': 13,
+                    'hour': 2,
+                    'minute': 0,
+                    'second': 0,
+                    'url': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_020000/20111213_020000_L1.0.fits',
+                },
+                {
+                    'year': 2011,
+                    'month': 12,
+                    'day': 13,
+                    'hour': 4,
+                    'minute': 30,
+                    'second': 0,
+                    'url': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_043000/20111213_043000_L1.0.fits',
+                },
+            ],
+            [
+                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_020000/20111213_020000_L1.0.fits',
+                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1hao/2011/12/13/SP3D/20111213_043000/20111213_043000_L1.0.fits',
+            ],
+        ),
+        (
+            0,
+            ('2013-07-13 10:02:00', '2013-07-13 10:03:00'),
+            [
+                {
+                    'year': 2013,
+                    'month': 7,
+                    'day': 13,
+                    'hour': 10,
+                    'minute': 2,
+                    'second': 50,
+                    'url': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100250.1.fits',
+                },
+                {
+                    'year': 2013,
+                    'month': 7,
+                    'day': 13,
+                    'hour': 10,
+                    'minute': 2,
+                    'second': 54,
+                    'url': 'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100254.0.fits',
+                },
+            ],
+            [
+                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100250.1.fits',
+                'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100254.0.fits',
+            ],
+        ),
+    ],
+)
+def test_search_sp(sp_client, level, timerange, filesmeta, expected_urls):
+    with mock.patch('sunpy.net.dataretriever.client.Scraper._extract_files_meta', return_value=filesmeta):
+        qr = sp_client.search(
+            a.Time(*timerange),
+            a.Instrument('SOT'),
+            a.Level(level),
+            a.hinode.SOTDetector('SP'),
+        )
+
+    assert len(qr) == len(expected_urls)
+    assert [str(u) for u in qr['url']] == expected_urls
+
+
+REAL_URL_CASES = [
+    (
+        'FG',
+        '0',
+        '2013-07-13 00:13:32',
+        '2013-07-13 00:13:33',
+        'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/FG/H0000/FG20130713_001332.7.fits',
+    ),
+    (
+        'SP',
+        '0',
+        '2013-07-13 10:02:50',
+        '2013-07-13 10:02:51',
+        'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level0/2013/07/13/SP4D/H1000/SP4D20130713_100250.1.fits',
+    ),
+]
+
+
+@pytest.mark.remote_data
+@pytest.mark.parametrize(
+    ('detector', 'level', 'start', 'end', 'expected_url'),
+    REAL_URL_CASES,
+)
+def test_real_archive_urls(fg_client, sp_client, detector, level, start, end,
+                           expected_url):
+    hinode_client = fg_client if detector == 'FG' else sp_client
+    qr = hinode_client.search(
+        a.Time(start, end),
+        a.Instrument('SOT'),
+        a.Level(level),
+        a.hinode.SOTDetector(detector),
+    )
+
+    assert len(qr) == 1
+    assert qr[0]['url'] == expected_url
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file = hinode_client.fetch(qr, path=tmpdir)
+    assert file[0].split('/')[-1] == expected_url.split('/')[-1]
+
+def test_search_unsupported_fg_level(fg_client):
+    qr = fg_client.search(
+        a.Time('2011-12-13 06:00', '2011-12-13 07:00'),
+        a.Instrument('SOT'),
+        a.Level(2),
+        a.hinode.SOTDetector('FG'),
+    )
+    assert len(qr) == 0
+
+
+def test_dummy_fetch_fg(fg_client, tmp_path):
+    downloader = DummyDownloader()
+    qr = mock_query_object(fg_client)
+
+    result = fg_client.fetch(
+        qr[0],
+        path=tmp_path / '{sotdetector}' / '{file}',
+        downloader=downloader,
+    )
+
+    assert result == downloader.calls
+    assert downloader.calls == [
+        (
+            'https://data.darts.isas.jaxa.jp/pub/hinode/sot/level1/2011/12/13/FG/H0600/FG20111213_060000.0.fits',
+            tmp_path / 'FG' / 'FG20111213_060000.0.fits',
+            {},
+        ),
+    ]
+
+
+def test_dummy_fetch_sp(sp_client, tmp_path):
+    downloader = DummyDownloader()
+    qr = mock_query_object(sp_client, detector='SP', url='https://example.com/20111213_020000/file_a.fits')
+    result = sp_client.fetch(qr, path=tmp_path, downloader=downloader)
+
+    assert result == downloader.calls
+    assert downloader.calls == [
+        ('https://example.com/20111213_020000/file_a.fits', tmp_path / 'file_a.fits', {}),
+    ]
+
+
+def test_attr_reg():
+    assert hasattr(a, 'hinode')
+    assert a.hinode.SOTDetector.fg == a.hinode.SOTDetector('FG')
+    assert a.hinode.SOTDetector.sp == a.hinode.SOTDetector('SP')
+
+
+def test_show(fg_client):
+    mock_qr = mock_query_object(fg_client)
+    qrshow0 = mock_qr.show()
+    qrshow1 = mock_qr.show('Start Time', 'SOTDetector')
+    allcols = {'Start Time', 'End Time', 'Instrument', 'SOTDetector', 'Level', 'Source', 'Provider', 'url'}
+    assert not allcols.difference(qrshow0.colnames)
+    assert qrshow1.colnames == ['Start Time', 'SOTDetector']
+    assert qrshow0['Instrument'][0] == 'SOT'


### PR DESCRIPTION
## PR Description

I was told that via the VSO they only have level 0 data access for SOT FG and SP data.
So I decided to add scraper clients for both data sources.

The unit tests are a lot, but they are mostly offline and do cover all the combos for these files.

The other choice for the client is to download daily genx files to search and construct the urls and I thought that won't be accepted as a client.

TODO:

- [ ] Is this plugged into the error catching that Clients can now do?
- [x] Changelog
- [ ] Whatsnew?

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
