### PR TITLE
Add support for extracting SIP from headers

### DIFF
--- a/changelog/8573.bugfix.rst
+++ b/changelog/8573.bugfix.rst
@@ -1,1 +1,1 @@
-Add support for SIP distortion in Map WCS.
+Fixed a bug where SIP distortion information in a Map WCS was ignored.

--- a/changelog/8573.bugfix.rst
+++ b/changelog/8573.bugfix.rst
@@ -1,0 +1,1 @@
+Add support for SIP distortion in Map WCS.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -674,6 +674,10 @@ class GenericMap(NDData):
         # Set the shape of the data array
         w2.array_shape = self.data.shape
 
+        if any(t.endswith("-SIP") for t in self.coordinate_system):
+            sip_wcs = astropy.wcs.WCS(header=self.meta)
+            w2.sip = sip_wcs.sip
+
         # Validate the WCS here.
         w2.wcs.set()
         return w2

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -674,6 +674,7 @@ class GenericMap(NDData):
         # Set the shape of the data array
         w2.array_shape = self.data.shape
 
+        # Unlike Astropy we only use SIP distortions if it is in the CTYPE.
         if any(t.endswith("-SIP") for t in self.coordinate_system):
             sip_wcs = astropy.wcs.WCS(header=self.meta)
             w2.sip = sip_wcs.sip

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -107,6 +107,41 @@ def test_wcs_pv():
     assert pv_values[6] == (2, 10, 0.1)
 
 
+def test_wcs_sip(aia171_test_map):
+    wcs1 = aia171_test_map.wcs
+    header_sip = wcs1.to_header()
+    k1 = -7e-12
+
+    header_sip["CTYPE1"] = header_sip["CTYPE1"] + "-SIP"
+    header_sip["CTYPE2"] = header_sip["CTYPE2"] + "-SIP"
+    header_sip['A_ORDER'] = 3
+    header_sip['B_ORDER'] = 3
+    header_sip['A_3_0'] = -k1
+    header_sip['A_1_2'] = -k1
+    header_sip['B_0_3'] = -k1
+    header_sip['B_2_1'] = -k1
+    header_sip['A_DMAX'] = 1.0
+    header_sip['B_DMAX'] = 1.0
+
+    sip_map = sunpy.map.Map(aia171_test_map.data, header_sip)
+
+    sip_wcs = sip_map.wcs
+    assert sip_wcs.sip is not None
+
+    # The SIP distortion shouldn't affect the ref pixel
+    ref1 = aia171_test_map.wcs.pixel_to_world(*aia171_test_map.reference_pixel)
+    ref2 = sip_map.wcs.pixel_to_world(*aia171_test_map.reference_pixel)
+
+    assert u.allclose(ref1.Tx, ref2.Tx)
+    assert u.allclose(ref1.Ty, ref2.Ty)
+
+    # Pixels away from the ref should be distorted
+    edge1 = aia171_test_map.wcs.pixel_to_world(1020, 1020)
+    edge2 = sip_map.wcs.pixel_to_world(1020, 1020)
+
+    assert not u.allclose(edge1.Tx, edge2.Tx)
+    assert not u.allclose(edge1.Ty, edge2.Ty)
+
 def test_wcs_cache(aia171_test_map):
     wcs1 = aia171_test_map.wcs
     wcs2 = aia171_test_map.wcs


### PR DESCRIPTION
Add support for [SIP distortions](https://fits.gsfc.nasa.gov/registry/sip/SIP_distortion_v1_0.pdf) in Map.