### PR TITLE
Fix preservation of SIP information when using a WCS instance with SIP

### DIFF
--- a/changelog/8586.bugfix.rst
+++ b/changelog/8586.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bugs where SIP distortion information was ignored when creating a `~sunpy.map.Map` using a `~astropy.wcs.WCS` instance with SIP information.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -236,7 +236,7 @@ class MapFactory(BasicRegistrationFactory):
         # Data-header or data-WCS pair
         data, header = arg
         if isinstance(header, WCS):
-            header = header.to_header()
+            header = header.to_header(relax=True)
 
         pair = data, header
         if self._validate_meta(header):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -3134,7 +3134,7 @@ class GenericMap(NDData):
         if return_footprint:
             output_array, footprint = output_array
 
-        target_header = target_wcs.to_header()
+        target_header = target_wcs.to_header(relax=True)
         if preserve_date_obs:
             # Explicitly not using _set_date or _set_reference_date. We do not know whether
             # target_header has a DATE-AVG key and if it does not, we would inadvertently

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -142,6 +142,17 @@ def test_wcs_sip(aia171_test_map):
     assert not u.allclose(edge1.Tx, edge2.Tx)
     assert not u.allclose(edge1.Ty, edge2.Ty)
 
+    # Check that a Map instantiated with a SIP WCS retains the SIP information
+    instantiated_map = sunpy.map.Map(sip_map.data, sip_map.wcs)
+    np.testing.assert_allclose(instantiated_map.wcs.sip.a, sip_wcs.sip.a)
+    np.testing.assert_allclose(instantiated_map.wcs.sip.b, sip_wcs.sip.b)
+
+    # Check that a Map reprojected to a SIP WCS retains the SIP information
+    reprojected_map = sip_map.reproject_to(sip_map.wcs)
+    np.testing.assert_allclose(reprojected_map.wcs.sip.a, sip_wcs.sip.a)
+    np.testing.assert_allclose(reprojected_map.wcs.sip.b, sip_wcs.sip.b)
+
+
 def test_wcs_cache(aia171_test_map):
     wcs1 = aia171_test_map.wcs
     wcs2 = aia171_test_map.wcs


### PR DESCRIPTION
# PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

Follow-on to #8573.  Basically, calling `WCS.to_header()` requires `relax=True` if there is the possibility that the `WCS` instance has SIP distortion information.  The two places in the library that need to be fixed are:

* Instantiation of a `Map` using a `WCS` instance
* Reprojection of a `Map` by calling `reproject_to()` on a `WCS` instance

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- - [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- - [ ] Test/benchmark generation
- - [ ] Documentation (including examples)
- - [ ] Research and understanding
- - [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
