### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,19 +1,30 @@
 # Exclude specific files
 # All files which are tracked by git and not explicitly excluded here are included by setuptools_scm
 exclude .codecov.yaml
+exclude .coveragerc
+exclude .cruft.json
+exclude .flake8
 exclude .editorconfig
 exclude .gitattributes
 exclude .gitignore
+exclude .isort.cfg
 exclude .mailmap
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yaml
 exclude .rtd-environment.yml
+exclude .ruff.toml
 exclude .test_package_pins.txt
 exclude .zenodo.json
+exclude _typos.toml
 exclude asv.conf.json
 exclude CITATION.cff
 exclude sunpy-dev-env.yml
 exclude tox.ini
+
+exclude docs/Makefile
+exclude docs/conf.py
+exclude docs/make.bat
+exclude docs/nitpick-exceptions
 
 # Prune folders
 prune .circleci

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,11 +21,6 @@ exclude CITATION.cff
 exclude sunpy-dev-env.yml
 exclude tox.ini
 
-exclude docs/Makefile
-exclude docs/conf.py
-exclude docs/make.bat
-exclude docs/nitpick-exceptions
-
 # Prune folders
 prune .circleci
 prune .github


### PR DESCRIPTION
Add some more config file to the excludes.

We currently include the source rst for our doc which isn't very useful? Should it either be removed or the html/text build?

```
tar -tf dist/sunpy-8.0.dev145+g6626a2290.d20260421.tar.gz
...
sunpy-8.0.dev145+g6626a2290.d20260421/
sunpy-8.0.dev145+g6626a2290.d20260421/CHANGELOG.rst
sunpy-8.0.dev145+g6626a2290.d20260421/CITATION.rst
sunpy-8.0.dev145+g6626a2290.d20260421/LICENSE.rst
sunpy-8.0.dev145+g6626a2290.d20260421/MANIFEST.in
sunpy-8.0.dev145+g6626a2290.d20260421/PKG-INFO
sunpy-8.0.dev145+g6626a2290.d20260421/README.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/citation.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/ai_usage.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/backports.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/ci_jobs.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/code_standards.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/conda_for_dependencies.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/dependencies.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/documentation.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/example_gallery.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/funding.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/images/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/images/actions_check_pr.png
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/images/actions_summary_check.png
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/images/checks.png
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/images/checks_pr.png
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/logger.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/maintainer_workflow.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/newcomers.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/pr_checklist.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/pr_review_procedure.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/public_api.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/remote_data_manager.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/tests.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/contents/units_quantities.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/dev_guide/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/coord_components.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/create_a_map.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/create_coords.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/create_custom_map.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/create_custom_timeseries.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/create_rectangle_on_map.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/fix_map_metadata.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/manipulate_grid_lines.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/observer_by_coordinate.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/parse_time.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/read_asdf_file.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/remote_data_manager.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/search_multiple_wavelengths.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/search_vso.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/how_to/transform_coords.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/bibliography.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/coordinates/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/coordinates/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/customization.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/data.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/image.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/internal_api.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/io.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/known_issues.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/map.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/net.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/physics.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/ssw.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/stability.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/sun.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/sunpy.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/sunpy_stability.yaml
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/time.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/timeseries.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/troubleshooting.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/util.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/reference/visualization.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/references.bib
sunpy-8.0.dev145+g6626a2290.d20260421/docs/robots.txt
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/coordinates/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/coordinates/carrington.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/coordinates/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/coordinates/rotatedsunframe.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/coordinates/rsun.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/coordinates/velocities.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/coordinates/wcs.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/custom_map_rotate.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/deprecation.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/extending_fido.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/history_comments.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/installation.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/logger.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/new_map_class.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/rsun.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/scraper_migration.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/topic_guide/timeseries_metadata.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/acquiring_data/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/acquiring_data/hek.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/acquiring_data/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/acquiring_data/jsoc.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/coordinates.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/index.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/installation.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/maps.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/time.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/timeseries.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/tutorial/units.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/0.8.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/0.9.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/1.0.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/1.1-wispr.png
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/1.1.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/2.0.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/2.1.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/3.0.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/3.1.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/4.0.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/4.1.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/5.0.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/5.1.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/6.0.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/6.1.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/7.0-punch.png
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/7.0-suit.png
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/7.0.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/7.1-demo-asos_hxi.png
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/7.1.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/changelog.rst
sunpy-8.0.dev145+g6626a2290.d20260421/docs/whatsnew/index.rst
```