### PR TITLE
Improved error handling in map factory

### DIFF
--- a/changelog/8589.bugfix.rst
+++ b/changelog/8589.bugfix.rst
@@ -1,0 +1,1 @@
+Improved `sunpy.map.Map` error messages when NumPy array inputs are missing metadata or WCS information or are passed in place of python lists.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -54,14 +54,16 @@ class MapFactory(BasicRegistrationFactory):
     \\*inputs
         Inputs to parse for map objects. This can be one or more of the following:
 
-        - A string or `~pathlib.Path` object pointing to a FITS file.
-        - A directory containing FITS files (if there is more than one FITS file in the directory, it will return a list of Map objects).
-        - A tuple containing a data array and a header (for modifying the data or header).
-        - A `~sunpy.util.metadata.MetaDict` object, which includes data and metadata as a dictionary-like object.
-        - An `astropy.wcs.WCS` object, which represents the World Coordinate System for the data.
-        - A glob pattern to match multiple FITS files (e.g., ``eit_*.fits``).
-        - A URL pointing to a FITS file (can be remote).
-        - A combination of any of the above inputs.
+        - A string or `~pathlib.Path` object pointing to a file.
+        - A directory containing files.
+        - A glob pattern matching multiple files (for example, ``eit_*.fits``).
+        - A URL or URI pointing to a file (can be remote).
+        - An existing `~sunpy.map.GenericMap`.
+        - A tuple of ``(data, metadata)`` or ``(data, wcs)``, where metadata is a `dict` (including `~sunpy.util.metadata.MetaDict`) or an `astropy.io.fits.Header`, and ``wcs`` is an `astropy.wcs.WCS`.
+        - A data array followed immediately by that same metadata or `astropy.wcs.WCS`.
+
+        These inputs can be mixed in one call, but any data array must be
+        immediately followed by its metadata or WCS.
 
     sequence : `bool`, optional
         Return a `sunpy.map.MapSequence` object comprised of all the parsed maps.
@@ -188,8 +190,20 @@ class MapFactory(BasicRegistrationFactory):
                 continue
 
             if isinstance(arg, SUPPORTED_ARRAY_TYPES):
+                if i + 1 >= len(args):
+                    raise ValueError(
+                        "Array inputs to sunpy.map.Map must be followed by a header-like "
+                        "object or an astropy.wcs.WCS instance. If you meant to pass "
+                        "multiple filenames, use a Python list rather than a NumPy array."
+                    )
+
                 # The next two items are data and a header
                 data, header = args[i:i+2]
+                if not isinstance(header, WCS) and not self._validate_meta(header):
+                    raise ValueError(
+                        "Array inputs to sunpy.map.Map must be followed by a header-like "
+                        f"object or an astropy.wcs.WCS instance, but got {type(header).__name__}."
+                    )
                 parsed_args.append((data, header))
                 skip_next = True
             elif isinstance(arg, str) and is_url(arg):

--- a/sunpy/map/tests/test_map_factory.py
+++ b/sunpy/map/tests/test_map_factory.py
@@ -228,6 +228,22 @@ def test_errors(tmpdir):
         sunpy.map.Map(files)
 
 
+def test_array_of_filenames_error():
+    files = np.array([AIA_171_IMAGE, RHESSI_IMAGE])
+    with pytest.raises(ValueError, match="use a Python list rather than a NumPy array"):
+        sunpy.map.Map(files)
+
+
+def test_array_missing_header_error():
+    with pytest.raises(ValueError, match="must be followed by a header-like object or an astropy.wcs.WCS instance"):
+        sunpy.map.Map(AIA_MAP.data)
+
+
+def test_array_invalid_second_argument_error():
+    with pytest.raises(ValueError, match="but got int"):
+        sunpy.map.Map(AIA_MAP.data, 42)
+
+
 @pytest.mark.filterwarnings("ignore:One of the data, header pairs failed to validate")
 @pytest.mark.parametrize(('allow_errors', 'error', 'match'),
                          [(True, RuntimeError, 'No maps loaded'),


### PR DESCRIPTION
It now should informatively error on passing np.array or  if array inputs are not correctly pair with wcs/metadata

## PR Description

this closes #8044, there was a partial fix in #8052 but it did not improvbe error handling and, tbh, the docstring was still not the clearest.

## AI Assistance Disclosure


AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
