### PR TITLE
Backport PR #8586 on branch 7.0 (Fix preservation of SIP information when using a WCS instance with SIP)

### DIFF
--- a/changelog/8586.bugfix.rst
+++ b/changelog/8586.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bugs where SIP distortion information was ignored when creating a `~sunpy.map.Map` using a `~astropy.wcs.WCS` instance with SIP information.

--- a/sunpy/map/map_factory.py
+++ b/sunpy/map/map_factory.py
@@ -237,7 +237,7 @@ class MapFactory(BasicRegistrationFactory):
         # Data-header or data-WCS pair
         data, header = arg
         if isinstance(header, WCS):
-            header = header.to_header()
+            header = header.to_header(relax=True)
 
         pair = data, header
         if self._validate_meta(header):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -3194,7 +3194,7 @@ class GenericMap(NDData):
             output_array, footprint = output_array
 
         # Create and return a new GenericMap
-        outmap = GenericMap(output_array, target_wcs.to_header(),
+        outmap = GenericMap(output_array, target_wcs.to_header(relax=True),
                             plot_settings=self.plot_settings)
 
         # Check rsun mismatch

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -142,6 +142,17 @@ def test_wcs_sip(aia171_test_map):
     assert not u.allclose(edge1.Tx, edge2.Tx)
     assert not u.allclose(edge1.Ty, edge2.Ty)
 
+    # Check that a Map instantiated with a SIP WCS retains the SIP information
+    instantiated_map = sunpy.map.Map(sip_map.data, sip_map.wcs)
+    np.testing.assert_allclose(instantiated_map.wcs.sip.a, sip_wcs.sip.a)
+    np.testing.assert_allclose(instantiated_map.wcs.sip.b, sip_wcs.sip.b)
+
+    # Check that a Map reprojected to a SIP WCS retains the SIP information
+    reprojected_map = sip_map.reproject_to(sip_map.wcs)
+    np.testing.assert_allclose(reprojected_map.wcs.sip.a, sip_wcs.sip.a)
+    np.testing.assert_allclose(reprojected_map.wcs.sip.b, sip_wcs.sip.b)
+
+
 def test_wcs_cache(aia171_test_map):
     wcs1 = aia171_test_map.wcs
     wcs2 = aia171_test_map.wcs


### PR DESCRIPTION
(cherry picked from commit 08040f551c9177e639fbc7475ca08074be5bbd89)
