### PR TITLE
Fixed `NOAAPredictIndicesTimeSeries.plot()` not plotting on the specified axes

### DIFF
--- a/changelog/8600.bugfix.rst
+++ b/changelog/8600.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where `~sunpy.timeseries.sources.NOAAPredictIndicesTimeSeries` would always plot to the current pyplot-managed axes even when a different axes was specified.

--- a/sunpy/timeseries/sources/noaa.py
+++ b/sunpy/timeseries/sources/noaa.py
@@ -249,9 +249,9 @@ class NOAAPredictIndicesTimeSeries(GenericTimeSeries):
         axes, columns = self._setup_axes_columns(axes, columns)
 
         dataframe = self.to_dataframe()
-        dataframe['sunspot'].plot(color='b', **plot_args)
-        dataframe['sunspot high'].plot(linestyle='--', color='b', **plot_args)
-        dataframe['sunspot low'].plot(linestyle='--', color='b', **plot_args)
+        dataframe['sunspot'].plot(ax=axes, color='b', **plot_args)
+        dataframe['sunspot high'].plot(ax=axes, linestyle='--', color='b', **plot_args)
+        dataframe['sunspot low'].plot(ax=axes, linestyle='--', color='b', **plot_args)
         axes.set_ylim(0)
         axes.set_ylabel('Sunspot Number')
         axes.yaxis.grid(True, 'major')


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

`NOAAPredictIndicesTimeSeries.plot()` accepts an `axes` argument to plot to a specific axes, but neglects to pass it on to `DataFrame.plot()`, and thus can only plot to the current pyplot-managed axes.  This PR fixes the bug.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- - [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- - [ ] Test/benchmark generation
- - [ ] Documentation (including examples)
- - [ ] Research and understanding
- - [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
