### PR TITLE
Adds typehints to `TimeRange` properties returning `astropy.time.Time`

### DIFF
--- a/sunpy/time/timerange.py
+++ b/sunpy/time/timerange.py
@@ -136,7 +136,7 @@ class TimeRange:
                 self._t2 = x
 
     @property
-    def start(self):
+    def start(self) -> Time:
         """
         Get the start time.
 
@@ -148,7 +148,7 @@ class TimeRange:
         return self._t1
 
     @property
-    def end(self):
+    def end(self) -> Time:
         """
         Get the end time.
 
@@ -172,7 +172,7 @@ class TimeRange:
         return self._t2 - self._t1
 
     @property
-    def center(self):
+    def center(self) -> Time:
         """
         Gets the center of the time range.
 


### PR DESCRIPTION
## PR Description

Adds return typehints for `TimeRange.start`, `TimeRange.end`, and `TimeRange.center`, which all return `astropy.time.Time`.

Due to the way the `__init__` method in `TimeRange` is structured, LSPs may interpret the output of the above properties as `None | Time`, which can show an error when accessing the attributes and methods within (however there are no issues at runtime).

e.g. for:

```python
from sunpy.time import TimeRange

time_range = TimeRange("2020-01-01", "2021-01-01")

time_range.start.to_datetime()
```

> error| "to_datetime" is not a known attribute of "None"
(pyright)

From my testing, `TimeRange.center` doesn't behave like this, however I added the hint for consistency with the `start` and `end` properties.

These changes don't affect runtime behaviour, but makes the package easier to work with in practice.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
