### PR TITLE
Transition from extras to dependency groups for developer dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         - cp3{12,13,14}-win_amd64
         - target: cp3{12,13,14}-manylinux_aarch64
           runs-on: ubuntu-24.04-arm
-      test_extras: 'tests'
+      test_groups: 'tests'
       test_command: 'pytest -p no:warnings --doctest-rst --pyargs sunpy'
       submodules: false
       save_artifacts: true
@@ -153,7 +153,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v2  # zizmor: ignore[unpinned-uses]
     with:
       python-version: "3.13"
-      test_extras: 'tests'
+      test_groups: 'tests'
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunpy'
       submodules: false
       env: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,9 +23,9 @@ formats:
 
 python:
   install:
-    - method: pip
-      extra_requirements:
-        - all
+    - method: uv
+      command: sync
+      groups:
         - docs
         - docs-gallery
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ build:
       - git fetch --unshallow || true
     pre_install:
       - git update-index --assume-unchanged .rtd-environment.yml docs/conf.py
+      - pip install --group docs --group docs-gallery .
 
 conda:
   environment: .rtd-environment.yml
@@ -23,9 +24,7 @@ formats:
 
 python:
   install:
-    - method: uv
-      command: sync
-      groups:
-        - docs
-        - docs-gallery
+    - method: pip
+      extra_requirements:
+        - all
       path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,17 +23,7 @@ if on_rtd:
     os.environ['LC_ALL'] = 'C'
     os.environ['PARFIVE_HIDE_PROGRESS'] = 'True'
 
-# -- Check for dependencies ----------------------------------------------------
-
-from sunpy.util import missing_dependencies_by_extra
-
-missing_requirements = missing_dependencies_by_extra("sunpy")["docs"]
-if missing_requirements:
-    print(
-        f"The {' '.join(missing_requirements.keys())} package(s) could not be found and "
-        "is needed to build the documentation, please install the 'docs' requirements."
-    )
-    sys.exit(1)
+# -- Other imports ----------------------------------------------------
 
 from matplotlib import MatplotlibDeprecationWarning
 from ruamel.yaml import YAML

--- a/docs/dev_guide/contents/dependencies.rst
+++ b/docs/dev_guide/contents/dependencies.rst
@@ -14,4 +14,5 @@ We have three categories of extras:
   Subpackages will emit a clear import error message if the needed package is not installed.
 * groupings : These are the groups that are used to install multiple optional dependencies at once.
   These range from "all" which includes every optional dependency to "core" which only includes the dependencies that are needed to run the core functionality of sunpy.
-  This also includes the "test", "docs" and "dev" groups.
+
+In addition to this, developer specific dependencies are specified in `dependency groups <https://packaging.python.org/en/latest/specifications/dependency-groups>`__ including the "test", "docs" and "dev" groups.

--- a/docs/dev_guide/contents/newcomers.rst
+++ b/docs/dev_guide/contents/newcomers.rst
@@ -175,7 +175,7 @@ This will make submitting changes easier in the long term for you:
     $ git remote add upstream https://github.com/sunpy/sunpy.git
     # This retrieves the tags from the main sunpy repository, which are used for determining the version of your fork.
     $ git fetch --tags upstream
-    $ pip install -e ".[dev]"
+    $ pip install --group dev -e .
 
 .. note::
     If this does not work, it could be due to a missing C compiler (e.g., ``gcc``, ``clang`` or ``msvc``) that is required to build sunpy at install.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ docs = [
   "sphinx-autodoc-typehints",
 ]
 docs-gallery = [
-  {include-group = "docs"},
   "astroquery>=0.4.6",
   "jplephem>=2.19",
   "pillow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "astropy>=6.1.0",
   "fsspec>=2023.6.0",
   "numpy>=1.26.0",
-  "numpy>=2.3.0;python_version=='3.14'",
+  "numpy>=2.3.0;python_version>='3.14'",
   "packaging>=23.2",
   "parfive[ftp]>=2.1.0",
   "pyerfa>=2.0.1.1",
@@ -107,6 +107,8 @@ jupyter = [
   "itables>=2.2.4",
   "ipywidgets>=8.1.0",
 ]
+
+[dependency-groups]
 # These dependencies are required to run the tests
 tests-only = [
   "hvpy>=1.1.0",
@@ -123,7 +125,9 @@ asdf-tests = [
 ]
 # This extra allows you to run all tests
 tests = [
-  "sunpy[all,s3,tests-only,asdf-tests,jupyter]",
+  "sunpy[all,s3,jupyter]",
+  {include-group = "tests-only"},
+  {include-group = "asdf-tests"},
 ]
 docs = [
   "sunpy[all]",
@@ -142,14 +146,19 @@ docs = [
   "sphinx-autodoc-typehints",
 ]
 docs-gallery = [
-  "sunpy[docs]",
+  {include-group = "docs"},
   "astroquery>=0.4.6",
   "jplephem>=2.19",
   "pillow",
   "sunpy-soar",
   "exifread",
 ]
-dev = ["sunpy[docs,tests]"]
+dev = [
+  {include-group = "tests"},
+  {include-group = "docs"},
+  {include-group = "docs-gallery"},
+  "setuptools-scm>=8.0.1",  # For sunpy._dev dynamic version
+]
 
 [project.urls]
 Homepage = "https://sunpy.org"

--- a/sunpy/tests/self_test.py
+++ b/sunpy/tests/self_test.py
@@ -48,21 +48,10 @@ def self_test(*, package=None, online=False, online_only=False, figure_only=Fals
     print("Starting sunpy self test...")
     print()
     print("Checking for packages needed to run sunpy:")
-    missing_deps = missing_dependencies_by_extra(exclude_extras=["asdf", "dask", "dev", "all", "docs"])
-    missing_tests = {**missing_deps.pop("core"), **missing_deps.pop("tests-only")}
+    missing_deps = missing_dependencies_by_extra(exclude_extras=["asdf", "s3", "dask", "all"])
     printed = print_missing_dependencies_report(missing_deps)
     if not printed:
         print("All required and optional sunpy dependencies are installed.")
-    if missing_tests:
-        print("You do not have all the required dependencies installed to run the sunpy test suite.")
-        print()
-        for dep in missing_tests:
-            print(f"  * {dep}")
-        print()
-        print("If are using conda, you will want to run conda install <package name>")
-        print('Otherwise you will want run pip install "sunpy[tests]"')
-        print()
-        return 1
     print()
     print("Starting the sunpy test suite:")
     test_args = _self_test_args(

--- a/sunpy/util/tests/test_sysinfo.py
+++ b/sunpy/util/tests/test_sysinfo.py
@@ -32,9 +32,6 @@ EXTRA_DEPS = [
 EXTRA_ALL_GROUPS = [
     "all",
     "asdf",
-    "dev",
-    "docs-gallery",
-    "docs",
     "image",
     "jpeg2000",
     "map",
@@ -42,7 +39,6 @@ EXTRA_ALL_GROUPS = [
     "opencv",
     "required",
     "spice",
-    "tests",
     "timeseries",
     "visualization",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -108,8 +108,7 @@ commands =
 [testenv:build_docs{,-gallery}]
 changedir = docs
 description = Invoke sphinx-build to build the HTML docs
-extras =
-    all
+dependency_groups =
     docs
     gallery: docs-gallery
 commands =
@@ -130,8 +129,7 @@ commands =
 [testenv:linkcheck]
 changedir = docs
 description = Invoke sphinx-build to check the URLS within the docs
-extras =
-    all
+dependency_groups =
     docs
 commands =
     pip freeze --all --no-input

--- a/tox.ini
+++ b/tox.ini
@@ -73,8 +73,10 @@ deps =
     # Use pytest-reportlog
     reportlog: pytest-reportlog
 extras =
+    core
+dependency_groups =
     !minimal: tests
-    minimal: core,tests-only
+    minimal: tests-only
 commands_pre =
     oldestdeps: minimum_dependencies sunpy --extras asdf dask image jpeg2000 map opencv net scikit-image spice timeseries visualization tests-only --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt


### PR DESCRIPTION
[Dependency Groups](https://packaging.python.org/en/latest/specifications/dependency-groups/) are a reasonably new feature of Python packaging (introduced in [PEP 735](https://peps.python.org/pep-0735/) in Oct 2024).

As of pip 25.1 (released April 2025, bundled in Python >= 3.13.4) both pip and uv have support for installing them. This effectively requires developers to have pip >= 25.1 to install developer dependencies.