### PR TITLE
preserve masks when animating mapsequence

### DIFF
--- a/changelog/8617.bugfix.rst
+++ b/changelog/8617.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where :meth:`~sunpy.map.MapSequence.plot` did not respect the mask of individual maps when updating animation frames.

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -328,7 +328,12 @@ class MapSequence:
         def updatefig(i, im, annotate, ani_data, removes):
             while removes:
                 removes.pop(0).remove()
-            im.set_array(ani_data[i].data)
+            frame_data = np.asarray(ani_data[i].data)
+            if ani_data[i].mask is not None:
+                frame_data = np.ma.masked_array(frame_data,
+                                                mask=ani_data[i].mask,
+                                                copy=False)
+            im.set_array(frame_data)
             im.set_cmap(kwargs.get('cmap', ani_data[i].plot_settings.get('cmap')) or "grey")
             norm = deepcopy(kwargs.get('norm', ani_data[i].plot_settings.get('norm')))
             if clip_interval is not None:

--- a/sunpy/map/mapsequence.py
+++ b/sunpy/map/mapsequence.py
@@ -328,7 +328,7 @@ class MapSequence:
         def updatefig(i, im, annotate, ani_data, removes):
             while removes:
                 removes.pop(0).remove()
-            frame_data = np.asarray(ani_data[i].data)
+            frame_data = np.asanyarray(ani_data[i].data)
             if ani_data[i].mask is not None:
                 frame_data = np.ma.masked_array(frame_data,
                                                 mask=ani_data[i].mask,

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -156,6 +156,17 @@ def test_map_sequence_plot_custom_cmap_norm(aia171_test_map, hmi_test_map):
     animation._step()
 
 
+def test_map_sequence_plot_respects_masks(aia171_test_map, aia171_test_map_with_mask):
+    seq = sunpy.map.Map([aia171_test_map, aia171_test_map_with_mask], sequence=True)
+    animation = seq.plot()
+    image = animation._fig.axes[0].images[0]
+    animation._func(1, *animation._args)
+    rendered_data = image.get_array()
+
+    assert np.ma.isMaskedArray(rendered_data)
+    assert np.array_equal(np.ma.getmaskarray(rendered_data), aia171_test_map_with_mask.mask)
+
+
 def test_save(aia171_test_map, hmi_test_map, tmp_path):
     """
     Tests the MapSequence save function


### PR DESCRIPTION
closes #8610 

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used


