### PR TITLE
TST: fixup astropy 8+ conftest settings

### DIFF
--- a/sunpy/conftest.py
+++ b/sunpy/conftest.py
@@ -53,18 +53,17 @@ def no_download_iers(request):
 
 
 @pytest.fixture(scope='session', autouse=True)
-def tmp_config_dir(request):
+def tmp_config_dir(request, tmp_path):
     """
     Globally set the default config for all tests.
     """
-    tmpdir = tempfile.TemporaryDirectory()
-    os.environ["SUNPY_CONFIGDIR"] = str(tmpdir.name)
+    os.environ["SUNPY_CONFIGDIR"] = str(tmp_path)
     if minversion(astropy, "8.0.0"):
-        os.environ["ASTROPY_CACHE_DIR"] = str(tmpdir)
-        os.environ["ASTROPY_CONFIG_DIR"] = str(tmpdir)
+        os.environ["ASTROPY_CACHE_DIR"] = str(tmp_path)
+        os.environ["ASTROPY_CONFIG_DIR"] = str(tmp_path)
     else:
-        astropy.config.paths.set_temp_cache._temp_path = pathlib.Path(tmpdir.name)
-        astropy.config.paths.set_temp_config._temp_path = pathlib.Path(tmpdir.name)
+        astropy.config.paths.set_temp_cache._temp_path = tmp_path
+        astropy.config.paths.set_temp_config._temp_path = tmp_path
 
     yield
 
@@ -75,7 +74,6 @@ def tmp_config_dir(request):
         astropy.config.paths.set_temp_cache._temp_path = None
         astropy.config.paths.set_temp_config._temp_path = None
     del os.environ["SUNPY_CONFIGDIR"]
-    tmpdir.cleanup()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## PR Description
Follow up to #8616
Started as a pure fix from https://github.com/sunpy/sunpy/pull/8616#discussion_r3218104257, then I just refactored the fixture to extend `tmp_path`, removing cruft

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
