### PR TITLE
Fix SOLARNETClient to use unblocked host URL

### DIFF
--- a/changelog/8639.bugfix.rst
+++ b/changelog/8639.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the `sunpy.net.solarnet.SOLARNETClient` to use ``solarnet.oma.be`` instead of the blocked ``solarnet2.oma.be`` host.

--- a/docs/whatsnew/7.1.rst
+++ b/docs/whatsnew/7.1.rst
@@ -72,7 +72,7 @@ Added support for querying data from `solarnet API <https://solarnet.oma.be/>`__
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the SOLARNETClient:
-    Source: https://solarnet2.oma.be
+    Source: https://solarnet.oma.be
     <BLANKLINE>
            OID                 DATE_BEG                 DATE_END         WAVEMIN WAVEMAX         DATE_OBS
     ------------------ ------------------------ ------------------------ ------- ------- ------------------------

--- a/sunpy/net/solarnet/solarnet.py
+++ b/sunpy/net/solarnet/solarnet.py
@@ -10,7 +10,7 @@ from sunpy.net.attr import and_
 from sunpy.net.base_client import BaseClient, QueryResponseTable
 from sunpy.net.solarnet.attrs import Dataset, Tags, Target, walker
 
-_BASE_URL = "https://solarnet2.oma.be/service/api/svo/{}"
+_BASE_URL = "https://solarnet.oma.be/service/api/svo/{}"
 
 __all__ = ["SOLARNETClient"]
 
@@ -49,7 +49,7 @@ class SOLARNETClient(BaseClient):
     Results from 1 Provider:
     <BLANKLINE>
     2 Results from the SOLARNETClient:
-    Source: https://solarnet2.oma.be
+    Source: https://solarnet.oma.be
     <BLANKLINE>
          OID               DATE_BEG                 DATE_END          WAVEMIN   WAVEMAX          DATE_OBS         EXPTIME MEASURE STEPS WAVELENG
     -------------- ------------------------ ------------------------ --------- --------- ------------------------ ------- ------- ----- --------
@@ -61,7 +61,7 @@ class SOLARNETClient(BaseClient):
 
     @property
     def info_url(self):
-        return 'https://solarnet2.oma.be'
+        return 'https://solarnet.oma.be'
 
     def search(self, *query):
         """

--- a/sunpy/net/solarnet/tests/test_solarnet.py
+++ b/sunpy/net/solarnet/tests/test_solarnet.py
@@ -17,7 +17,7 @@ def client():
 
 
 def test_info_url(client):
-    assert client.info_url == 'https://solarnet2.oma.be'
+    assert client.info_url == 'https://solarnet.oma.be'
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
I mean there is a chance they will also block this host? But it is the one listed in theor documentation:

https://solarnet.oma.be/svo_restful_api_user_manual.html

if it works then closes #8638 