### PR TITLE
Fix: Apply standard plot formatting on draw_* methods (#8331)

### DIFF
--- a/changelog/8331.bugfix.rst
+++ b/changelog/8331.bugfix.rst
@@ -1,0 +1,1 @@
+Added standard plot formatting (title and axis labels) to the ``draw_contours``, ``draw_grid``, ``draw_limb``, ``draw_quadrangle``, and ``draw_extent`` methods on `~sunpy.map.GenericMap`.

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2352,6 +2352,8 @@ class GenericMap(NDData):
         Keyword arguments are passed onto the `sunpy.visualization.wcsaxes_compat.wcsaxes_heliographic_overlay` function.
         """
         axes = self._check_axes(axes)
+        if annotate:
+            self._auto_format_plot(axes)
         return wcsaxes_compat.wcsaxes_heliographic_overlay(axes,
                                                            grid_spacing=grid_spacing,
                                                            annotate=annotate,
@@ -2406,6 +2408,7 @@ class GenericMap(NDData):
         import sunpy.visualization.drawing
 
         axes = self._check_axes(axes)
+        self._auto_format_plot(axes)
         return sunpy.visualization.drawing.limb(
             axes,
             self.observer_coordinate,
@@ -2434,6 +2437,7 @@ class GenericMap(NDData):
         import sunpy.visualization.drawing
 
         axes = self._check_axes(axes)
+        self._auto_format_plot(axes)
         return sunpy.visualization.drawing.extent(
             axes,
             self.wcs,
@@ -2488,6 +2492,7 @@ class GenericMap(NDData):
         .. minigallery:: sunpy.map.GenericMap.draw_quadrangle
         """
         axes = self._check_axes(axes)
+        self._auto_format_plot(axes)
 
         if isinstance(bottom_left, u.Quantity):
             anchor, _, top_right, _ = self._parse_submap_quantity_input(bottom_left, top_right, width, height)
@@ -2619,6 +2624,7 @@ class GenericMap(NDData):
         contour_args = self._update_contour_args(contour_args)
 
         axes = self._check_axes(axes)
+        self._auto_format_plot(axes)
         levels = self._process_levels_arg(levels)
 
         # Pixel indices
@@ -2713,6 +2719,21 @@ class GenericMap(NDData):
 
         return figure
 
+    def _auto_format_plot(self, axes):
+        """
+        Apply default title and axis labels.
+        """
+        # Apply the default title if one is not already set
+        if axes.get_title() == "":
+            axes.set_title(self.plot_settings.get('title', self.latex_name))
+
+        # Apply the default axis label if one is not already set
+        for coord, ctype in zip(axes.coords, axes.wcs.wcs.ctype):
+            if coord.get_axislabel() == coord.default_label:
+                # WCSAxes has unit identifiers on the tick labels, so no need
+                # to add unit information to the label
+                coord.set_axislabel(axis_labels_from_ctype(ctype, None))
+
     @u.quantity_input
     def plot(self, *, annotate=True, axes=None, title=True, autoalign=True,
              clip_interval: u.percent = None, **imshow_kwargs):
@@ -2789,27 +2810,18 @@ class GenericMap(NDData):
 
         axes = self._check_axes(axes, warn_different_wcs=autoalign is False)
 
-        # Normal plot
-        plot_settings = copy.deepcopy(self.plot_settings)
-        if 'title' in plot_settings:
-            plot_settings_title = plot_settings.pop('title')
-        else:
-            plot_settings_title = self.latex_name
-
-        # Anything left in plot_settings is given to imshow
-        imshow_args = plot_settings
         if annotate:
-            if title is True:
-                title = plot_settings_title
+            self._auto_format_plot(axes)
 
-            if title:
-                axes.set_title(title)
+        if title is False:
+            title = ""
 
-            # WCSAxes has unit identifiers on the tick labels, so no need
-            # to add unit information to the label
-            ctype = axes.wcs.wcs.ctype
-            axes.coords[0].set_axislabel(axis_labels_from_ctype(ctype[0], None))
-            axes.coords[1].set_axislabel(axis_labels_from_ctype(ctype[1], None))
+        if isinstance(title, str):
+            axes.set_title(title)
+
+        # Remove any title from plot settings since it has already been used
+        imshow_args = copy.deepcopy(self.plot_settings)
+        imshow_args.pop('title', None)
 
         # Take a deep copy here so that a norm in imshow_kwargs doesn't get modified
         # by setting it's vmin and vmax

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -477,7 +477,7 @@ def test_plot_unit8(aia171_test_map):
 
 
 @figure_test
-@pytest.mark.parametrize("method, kwargs", [
+@pytest.mark.parametrize(("method", "kwargs"), [
     ("draw_grid", {"grid_spacing": (5, 5) * u.deg}),
     ("draw_limb", {}),
     ("draw_extent", {}),

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -474,3 +474,25 @@ def test_plot_unit8(aia171_test_map):
     # Check that plotting a map with uint8 data does not raise an error
     aia171_unit8 = sunpy.map.Map(aia171_test_map.data.astype('uint8'), aia171_test_map.meta)
     aia171_unit8.plot()
+
+
+@figure_test
+@pytest.mark.parametrize("method, kwargs", [
+    ("draw_grid", {"grid_spacing": (5, 5) * u.deg}),
+    ("draw_limb", {}),
+    ("draw_extent", {}),
+    ("draw_quadrangle", {
+        "bottom_left": (50, 50) * u.pix,
+        "width": 30 * u.pix,
+        "height": 50 * u.pix
+    }),
+    ("draw_contours", {"levels": u.Quantity(np.arange(1, 100, 10), 'percent')}),
+])
+def test_auto_format_plot_methods(aia171_test_map, method, kwargs):
+    fig = Figure()
+    ax = fig.add_subplot(projection=aia171_test_map)
+    with sunpy.coordinates.SphericalScreen(aia171_test_map.observer_coordinate):
+        getattr(aia171_test_map, method)(axes=ax, **kwargs)
+    ax.set_xlim(0, aia171_test_map.data.shape[1] - 1)
+    ax.set_ylim(0, aia171_test_map.data.shape[0] - 1)
+    return fig

--- a/sunpy/tests/figure_hashes_mpl_382_astropy_702_animators_121.json
+++ b/sunpy/tests/figure_hashes_mpl_382_astropy_702_animators_121.json
@@ -90,5 +90,10 @@
   "sunpy.visualization.tests.test_drawing.test_heliographic_equator_prime_meridian": "3cb195a44e899ef46de7365bd0a0c580b7ea69662bdc560a1bbb1686c2ad48cf",
   "sunpy.visualization.tests.test_drawing.test_draw_extent": "d9e5182e20feff6257c3209c2202727a8e628842ca3c0c80fd1cafbc64376388",
   "sunpy.visualization.tests.test_drawing.test_draw_extent_3d": "1d329ecd0e31f4d4ecfb3b75e255c117dc631bd39be9a8a862fb7974004ff07c",
-  "sunpy.visualization.tests.test_visualization.test_show_hpr_impact_angle": "43f6c3fea4238064ce503d699cba6457b3eb07ee58ea2a52f43556f42ee7efc8"
+  "sunpy.visualization.tests.test_visualization.test_show_hpr_impact_angle": "43f6c3fea4238064ce503d699cba6457b3eb07ee58ea2a52f43556f42ee7efc8",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_grid-kwargs0]": "0a9fbe1581d78ad093d975ae675632a0acf4cf7ce58634f33759a9c93c8778e0",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_limb-kwargs1]": "53559fd44b08efb73a50169aa1eea6c72501f31aa5bad1085103feedcc641ce3",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_extent-kwargs2]": "53559fd44b08efb73a50169aa1eea6c72501f31aa5bad1085103feedcc641ce3",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_quadrangle-kwargs3]": "53559fd44b08efb73a50169aa1eea6c72501f31aa5bad1085103feedcc641ce3",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_contours-kwargs4]": "ca1b53cbff90b255b68f10a523ec5fa1a58e09c236541c095242048d48365999"
 }

--- a/sunpy/tests/figure_hashes_mpl_dev_astropy_dev_animators_dev.json
+++ b/sunpy/tests/figure_hashes_mpl_dev_astropy_dev_animators_dev.json
@@ -90,5 +90,10 @@
   "sunpy.visualization.tests.test_drawing.test_draw_extent_3d": "4ce066dbbc0b9134dcdb87691888375bbfef3cf56e252917ce89138837412131",
   "sunpy.visualization.tests.test_drawing.test_draw_prime_meridian_aia171": "ee1ca9019c8873bd631ebea6e791792c6179f8f6436f9fa8bcf7ed4859ba09c3",
   "sunpy.visualization.tests.test_drawing.test_heliographic_equator_prime_meridian": "22a628bc8e1b644511f2e720d3fbf3252dd3c920c24cf2220ff6c58ec4818f01",
-  "sunpy.visualization.tests.test_visualization.test_show_hpr_impact_angle": "c5963b0e9a17c4a1ed592d99d7f0979073ecaaa5d2eed766d1a2d8ccd9c7a4f5"
+  "sunpy.visualization.tests.test_visualization.test_show_hpr_impact_angle": "c5963b0e9a17c4a1ed592d99d7f0979073ecaaa5d2eed766d1a2d8ccd9c7a4f5",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_grid-kwargs0]": "0a9fbe1581d78ad093d975ae675632a0acf4cf7ce58634f33759a9c93c8778e0",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_limb-kwargs1]": "53559fd44b08efb73a50169aa1eea6c72501f31aa5bad1085103feedcc641ce3",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_extent-kwargs2]": "53559fd44b08efb73a50169aa1eea6c72501f31aa5bad1085103feedcc641ce3",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_quadrangle-kwargs3]": "53559fd44b08efb73a50169aa1eea6c72501f31aa5bad1085103feedcc641ce3",
+  "sunpy.map.tests.test_plotting.test_auto_format_plot_methods[draw_contours-kwargs4]": "ca1b53cbff90b255b68f10a523ec5fa1a58e09c236541c095242048d48365999"
 }


### PR DESCRIPTION
Supersedes and closes #8332. Fixes #8331.

This PR implements the `_auto_format_plot` functionality originally suggested by @ayshih and partially implemented in #8332. It also fixes the parameterized figure tests by drawing directly onto a bare WCSAxes with `SphericalScreen`, resolving the NaN warnings that stalled the previous PR.