### PR TITLE
Add support and CI runs for free-threaded Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,11 @@ jobs:
         - linux: py314
           name: py314 (parallel threads)
           posargs: --parallel-threads=auto --color=yes
+        - linux: py314t-devdeps-minimal
+          name: py314t-devdeps
+        - linux: py314t-devdeps-minimal
+          name: py314t-devdeps (parallel threads)
+          posargs: --parallel-threads=auto --color=yes
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
       anaconda_user: scientific-python-nightly-wheels
       anaconda_package: sunpy
       anaconda_keep_n_latest: 1
+      env: |
+        EXTENSION_HELPERS_PY_LIMITED_API: 'cp312'
     secrets:
       anaconda_token: ${{ secrets.anaconda_org_upload_token }}
 

--- a/changelog/8653.bugfix.rst
+++ b/changelog/8653.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the potential sharing of metadata when using a `~sunpy.timeseries.TimeSeries` method to create a new instance base on an existing instance.

--- a/changelog/8653.feature.rst
+++ b/changelog/8653.feature.rst
@@ -1,0 +1,1 @@
+``sunpy`` can now be built for use with free-threaded Python, although some certain optional dependencies (e.g., OpenCV) are not yet compatible with free threading.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools>=62.1",
   "setuptools_scm[toml]>=8.0.1",
   "wheel",
-  "extension-helpers>=1.3.0,<2",
+  "extension-helpers>=1.4,<2",
   "numpy>=2.0.0rc1",
 ]
 build-backend = "setuptools.build_meta"
@@ -183,8 +183,8 @@ sunpy = "sunpy.io.special.asdf.entry_points:get_resource_mappings"
 [project.entry-points."asdf.extensions"]
 sunpy = "sunpy.io.special.asdf.entry_points:get_extensions"
 
-[tool.distutils.bdist_wheel]
-py-limited-api = "cp312"
+[tool.cibuildwheel]
+environment-pass = ["EXTENSION_HELPERS_PY_LIMITED_API"]
 
 [tool.extension-helpers]
 use_extension_helpers = "true"

--- a/sunpy/map/sources/tests/test_asos_hxi_source.py
+++ b/sunpy/map/sources/tests/test_asos_hxi_source.py
@@ -1,6 +1,8 @@
 """
 Test cases for ASO-S HXIMap subclass.
 """
+from copy import deepcopy
+
 import pytest
 
 import astropy.units as u
@@ -45,6 +47,8 @@ def test_unit(hxi_map):
 
 
 def test_broken_units(hxi_map):
+    hxi_map = deepcopy(hxi_map)  # for thread safety
+
     # Check that no unit or bunit leads to no unit
     hxi_map.meta["unit"] = None
     assert hxi_map.unit is None

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -1376,9 +1376,11 @@ def test_missing_metadata_warnings():
         'ctype1': 'HPLN-TAN',
         'ctype2': 'HPLT-TAN',
     }
+    fig = Figure()
     with pytest.warns(Warning) as record:  # NOQA: PT030,PT031
         array_map = sunpy.map.Map(np.random.rand(20, 15), header)
-        array_map.peek()
+        ax = fig.add_subplot(projection=array_map)
+        array_map.plot(axes=ax)
     # There should be 2 warnings for missing metadata (obstime and observer location)
     assert len([w for w in record if w.category in (SunpyMetadataWarning, SunpyUserWarning)]) == 2
 

--- a/sunpy/map/tests/test_plotting.py
+++ b/sunpy/map/tests/test_plotting.py
@@ -470,7 +470,9 @@ def test_plot_autoalign_image_fail(aia171_test_map):
         aia.plot(axes=ax, autoalign='image')
 
 
-def test_plot_unit8(aia171_test_map):
+def test_plot_uint8(aia171_test_map):
     # Check that plotting a map with uint8 data does not raise an error
-    aia171_unit8 = sunpy.map.Map(aia171_test_map.data.astype('uint8'), aia171_test_map.meta)
-    aia171_unit8.plot()
+    aia171_uint8 = sunpy.map.Map(aia171_test_map.data.astype('uint8'), aia171_test_map.meta)
+    fig = Figure()
+    ax = fig.add_subplot(projection=aia171_uint8)
+    aia171_uint8.plot(axes=ax)

--- a/sunpy/net/hek/tests/test_utils.py
+++ b/sunpy/net/hek/tests/test_utils.py
@@ -25,6 +25,8 @@ from sunpy.net.hek.utils import (
     _parse_unit,
 )
 
+pytestmark = pytest.mark.thread_unsafe(reason="unit parsing temporarily modifies the global unit registry")
+
 
 @pytest.mark.parametrize(('input_unit', 'expected_unit'), [
     ('DN/sec/pixel', u.DN/(u.pix*u.s)),

--- a/sunpy/net/jsoc/tests/test_jsoc.py
+++ b/sunpy/net/jsoc/tests/test_jsoc.py
@@ -309,6 +309,7 @@ def test_jsoc_cutout_attrs(client, jsoc_test_email, aia171_test_map):
     assert m.data.shape == (1085, 1085, 6)
 
 
+@pytest.mark.thread_unsafe(reason="mocks a method")
 def test_row_and_warning(mocker, client, jsoc_response_double):
     mocker.patch("sunpy.net.jsoc.jsoc.JSOCClient.get_request")
     request_data = mocker.patch("sunpy.net.jsoc.jsoc.JSOCClient.request_data")

--- a/sunpy/net/tests/test_attrs.py
+++ b/sunpy/net/tests/test_attrs.py
@@ -30,6 +30,7 @@ def test_wavelength_attr():
     assert wave.unconverted_value == (1*u.Mm, 2*u.Mm)
 
 
+@pytest.mark.thread_unsafe(reason="mocks a function")
 def test_instrument_show_in_notebook(mocker):
     pytest.importorskip("itables")
     mock_datagrid =  mocker.patch("itables.show")

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -186,6 +186,7 @@ def test_unifiedresponse_slicing():
     assert isinstance(results[0], QueryResponseTable)
 
 
+@pytest.mark.thread_unsafe(reason="mocks a function")
 def test_show_in_notebook(mocker):
     pytest.importorskip("itables")
     mock_datagrid =  mocker.patch("itables.show")

--- a/sunpy/physics/tests/test_differential_rotation.py
+++ b/sunpy/physics/tests/test_differential_rotation.py
@@ -1,4 +1,5 @@
 import warnings
+from copy import deepcopy
 
 import numpy as np
 import pytest
@@ -406,6 +407,8 @@ def test_differential_rotation(aia171_test_map):
 
 
 def test_rsun_fallback(aia171_test_map):
+    aia171_test_map = deepcopy(aia171_test_map)  # for thread safety
+
     pytest.importorskip("skimage")
     # Remove the AIA-specific value of the solar radius
     assert_quantity_allclose(aia171_test_map.rsun_meters, 696 * u.Mm)

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -443,7 +443,7 @@ class GenericTimeSeries:
 
         # Make a copy of all the TimeSeries components.
         data = copy.copy(self._data)
-        meta = TimeSeriesMetaData(copy.copy(self.meta.metadata))
+        meta = TimeSeriesMetaData(copy.deepcopy(self.meta.metadata))
         units = copy.copy(self.units)
 
         # Add the unit to the units dictionary if already there.
@@ -481,7 +481,7 @@ class GenericTimeSeries:
         data = self._data.drop(colname, axis='columns')
         units = self.units.copy()
         units.pop(colname)
-        return self.__class__(data, self.meta, units)
+        return self.__class__(data, copy.deepcopy(self.meta), units)
 
     def sort_index(self, **kwargs):
         """
@@ -496,7 +496,7 @@ class GenericTimeSeries:
             A new `~sunpy.timeseries.TimeSeries` in ascending chronological order.
         """
         return GenericTimeSeries(self._data.sort_index(**kwargs),
-                                 TimeSeriesMetaData(copy.copy(self.meta.metadata)),
+                                 TimeSeriesMetaData(copy.deepcopy(self.meta.metadata)),
                                  copy.copy(self.units))
 
     def truncate(self, a, b=None, int=None):
@@ -576,7 +576,7 @@ class GenericTimeSeries:
 
         # Build generic TimeSeries object and sanatise metadata and units.
         object = GenericTimeSeries(data.sort_index(),
-                                   TimeSeriesMetaData(copy.copy(self.meta.metadata)),
+                                   TimeSeriesMetaData(copy.deepcopy(self.meta.metadata)),
                                    units)
         object._sanitize_metadata()
         return object

--- a/sunpy/util/tests/test_logger.py
+++ b/sunpy/util/tests/test_logger.py
@@ -85,6 +85,7 @@ def send_to_log(message, kind='INFO'):
 
 # Most of the logging functionality is tested in Astropy's tests for AstropyLogger
 
+@pytest.mark.thread_unsafe(reason="overrides warning.showwarning")
 def test_sunpy_warnings_logging():
     # Test that our logger intercepts our warnings but not Astropy warnings
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ requires =
 envlist =
     py{312,313,314}{,-online,-minimal}
     py313-minimal-noana
-    py314-devdeps
+    py{314,314t}-devdeps{,-minimal}
     py312-oldestdeps
     codestyle
     build_docs{,-gallery}
@@ -45,6 +45,7 @@ setenv =
     PARFIVE_HIDE_PROGRESS = True
     NO_VERIFY_HELIO_SSL = 1
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/liberfa/simple
+    py314t: PYTHON_GIL = 0
 deps =
     # Avoid adding this to the pyproject.toml as a dependency
     pytest-xdist
@@ -75,7 +76,16 @@ deps =
     reportlog: pytest-reportlog
 extras =
     !minimal: tests
-    minimal: core,tests-only
+    minimal: core
+    minimal: tests-only
+    py314t: asdf
+    # py314t: jpeg2000
+    # py314t: opencv
+    py314t: spice
+    py314t: scikit-image
+    py314t: s3
+    py314t: asdf-tests
+    py314t: jupyter
 commands_pre =
     oldestdeps: minimum_dependencies sunpy --extras asdf dask image jpeg2000 map opencv net scikit-image spice timeseries visualization tests-only --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

* Allow the library to be built for freethreaded Python (approach copied from astropy/reproject#600)
* Add CI runs using freethreaded Python (py314t) with the GIL explicitly disabled (PYTHON_GIL=0).
  * Start with `devdeps` because reproject has not had a release yet that is compatible with a freethreaded build
  * OpenCV is omitted from the environment because it is not currently compatible with a freethreaded build.
  * Glymur+libopenjp2 is omitted from the environment because libopenjp2 does not appear to be thread safe.
  * ~We cannot currently use the OpenAstronomy workflow to set up Python because – at the time of this writing – that workflow installs Python 3.14.3 instead of something newer, and a bug affecting our logger (and Astropy's logger) is fixed in Python 3.14.4.~ Fixed by OpenAstronomy/github-actions-workflows#396
 * Fix a bug where most `TimeSeries` methods to create a new instance from an existing instance were not deepcopying the metadata

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- - [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- - [ ] Test/benchmark generation
- - [ ] Documentation (including examples)
- - [ ] Research and understanding
- - [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
