### PR TITLE
Mask occulting added back to METISMap

### DIFF
--- a/changelog/8658.feature.rst
+++ b/changelog/8658.feature.rst
@@ -1,1 +1,1 @@
-Added a default `mask` property to `~sunpy.map.sources.METISMap` and a gallery example demonstrating how to download, load, and plot METIS observations.
+Added a default `~sunpy.map.sources.METISMap.mask` property to `~sunpy.map.sources.METISMap` and a gallery example demonstrating how to download, load, and plot METIS observations.

--- a/changelog/8658.feature.rst
+++ b/changelog/8658.feature.rst
@@ -1,0 +1,1 @@
+Added a default `mask` property to `~sunpy.map.sources.METISMap` and a gallery example demonstrating how to download, load, and plot METIS observations.

--- a/examples/map/metis_mask.py
+++ b/examples/map/metis_mask.py
@@ -1,0 +1,78 @@
+"""
+==============
+Plotting METIS
+==============
+
+In this example, we plot the VL total brightness data product from METIS with the recommended contrast cutoffs.
+"""
+# sphinx_gallery_tags = ["Map", "METIS"]
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import colors
+
+import sunpy.map
+from sunpy.net import Fido
+from sunpy.net import attrs as a
+
+###############################################################################
+# First, download some METIS data with `~sunpy.net.Fido`.
+
+result = Fido.search(a.Time("2022-03-22 21:00", "2022-03-22 22:50"),
+                     a.Instrument.metis, a.Level(2), a.Provider.soar,
+                     a.soar.Product.metis_vl_tb)
+metis_data_product = Fido.fetch(result)
+
+###############################################################################
+# Then we use one of the data products to create a simple map.
+# A `~sunpy.map.sources.METISMap` is created with a default mask property that
+# excludes pixels inside the inner occulter and outside the outer field of view
+
+vl_maps = sunpy.map.Map(metis_data_product[0])
+vl_tb_list = [m for m in vl_maps if m.measurement == "VL-TB"]
+vl_tb_example = vl_tb_list[0]
+
+fig = plt.figure()
+ax = fig.add_subplot(projection=vl_tb_example)
+norm = vl_tb_example.plot_settings["norm"]
+vl_tb_example.plot(axes=ax, cmap=vl_tb_example.plot_settings["cmap"])
+plt.show()
+
+
+
+##############################################################################
+# In this example, we also know there is a related event. To get a better idea
+# of what the event looks like we need to create a running difference.
+# To do this we need to create a list of maps and filter for the VL-TB.
+
+
+vl_tb_maps = sunpy.map.Map(metis_data_product,sequence=True)
+m_seq_vltb = [m for m in vl_tb_maps if m.measurement == "VL-TB"]
+
+
+###############################################################################
+# Now we calculate the running difference.
+
+m_seq_running = sunpy.map.Map(
+    [m - prev_m.quantity for m, prev_m in zip(m_seq_vltb[1:], m_seq_vltb[:-1])],
+    sequence=True
+)
+
+
+###############################################################################
+# Now we can normalise the values from all the maps
+# and create a running difference animation
+
+all_diff_data = np.concatenate([m.data for m in m_seq_running])
+vmin, vmax = np.percentile(all_diff_data, [1, 99])
+norm = colors.Normalize(vmin=vmin, vmax=vmax)
+
+fig = plt.figure()
+ax = fig.add_subplot(projection=m_seq_running.maps[0])
+ani_running = m_seq_running.plot(
+    axes=ax,
+    title='VL-TB Running Difference',
+    norm=norm
+)
+plt.colorbar(extend='both', label=m_seq_running[0].unit.to_string())
+plt.show()

--- a/examples/map/metis_mask.py
+++ b/examples/map/metis_mask.py
@@ -5,7 +5,8 @@ Plotting METIS
 
 In this example, we plot the VL total brightness data product from METIS with the recommended contrast cutoffs.
 """
-# sphinx_gallery_tags = ["Map", "METIS"]
+# sphinx_gallery_tags = ["Map", "METIS", "SOAR", "Solar Orbiter", "Visualization"]
+# sphinx_gallery_thumbnail_number = -1
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -34,37 +35,35 @@ vl_tb_example = vl_tb_list[0]
 
 fig = plt.figure()
 ax = fig.add_subplot(projection=vl_tb_example)
-norm = vl_tb_example.plot_settings["norm"]
-vl_tb_example.plot(axes=ax, cmap=vl_tb_example.plot_settings["cmap"])
-plt.show()
-
-
+im = vl_tb_example.plot(axes=ax)
+fig.colorbar(im)
 
 ##############################################################################
-# In this example, we also know there is a related event. To get a better idea
-# of what the event looks like we need to create a running difference.
-# To do this we need to create a list of maps and filter for the VL-TB.
+# In this example, we also know there is an eruption event.
+# We start by animating this time series.
+# To do this we load all the HDUs of all the files and filter down to
+# just the "VL-TB" HDUs and make a `~sunpy.map.MapSequence`.
 
-
-vl_tb_maps = sunpy.map.Map(metis_data_product,sequence=True)
-m_seq_vltb = [m for m in vl_tb_maps if m.measurement == "VL-TB"]
-
+vl_tb_maps = sunpy.map.Map(metis_data_product)
+m_seq_vltb = sunpy.map.Map([m for m in vl_tb_maps if m.measurement == "VL-TB"], sequence=True)
+fig = plt.figure()
+m_seq_vltb.plot()
 
 ###############################################################################
-# Now we calculate the running difference.
+# To get a better idea of what the event looks like we need to create
+# a running difference.
 
 m_seq_running = sunpy.map.Map(
     [m - prev_m.quantity for m, prev_m in zip(m_seq_vltb[1:], m_seq_vltb[:-1])],
     sequence=True
 )
 
-
 ###############################################################################
 # Now we can normalise the values from all the maps
 # and create a running difference animation
 
 all_diff_data = np.concatenate([m.data for m in m_seq_running])
-vmin, vmax = np.percentile(all_diff_data, [1, 99])
+vmin, vmax = np.percentile(all_diff_data, [0.05, 99.95])
 norm = colors.Normalize(vmin=vmin, vmax=vmax)
 
 fig = plt.figure()

--- a/examples/map/plotting_metis_data.py
+++ b/examples/map/plotting_metis_data.py
@@ -18,17 +18,26 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import colors
 
+import astropy.units as u
+
 import sunpy.map
 from sunpy.net import Fido
 from sunpy.net import attrs as a
 
 ###############################################################################
+# The METIS instrument mainly provides VL and UV data products. In the first
+# example we will demonstrate the plotting of the VL data product.
+# In the second example we will showcase the UV data and helpful operations
+# you can do with `sunpy.map`.
+
+
+###############################################################################
 # First, download some METIS data with `~sunpy.net.Fido`.
 
-result = Fido.search(a.Time("2022-03-22 21:00", "2022-03-22 22:50"),
+vl_result = Fido.search(a.Time("2022-03-22 21:00", "2022-03-22 22:50"),
                      a.Instrument.metis, a.Level(2), a.Provider.soar,
                      a.soar.Product.metis_vl_tb)
-metis_data_product = Fido.fetch(result)
+metis_data_product = Fido.fetch(vl_result)
 
 ###############################################################################
 # The downloaded METIS FITS file contains multiple image header data units (HDUs).
@@ -58,8 +67,6 @@ fig.colorbar(im)
 
 vl_tb_maps = sunpy.map.Map(metis_data_product)
 m_seq_vltb = sunpy.map.Map([m for m in vl_tb_maps if m.measurement == "VL-TB"], sequence=True)
-fig = plt.figure()
-m_seq_vltb.plot()
 
 ###############################################################################
 # To get a better idea of what the event looks like we need to create
@@ -86,4 +93,70 @@ ani_running = m_seq_running.plot(
     norm=norm
 )
 plt.colorbar(extend='both', label=m_seq_running[0].unit.to_string())
+plt.show()
+
+
+###############################################################################
+# Now we move on to the UV data product.
+# First, let's search for and download a METIS UV observation.
+
+uv_result = Fido.search(
+    a.Time("2024-12-09 00:36", "2024-12-09 00:38"),
+    a.Instrument.metis,
+    a.Level(2),
+    a.Provider.soar,
+    a.soar.Product.metis_uv_image,
+)
+metis_data_product = Fido.fetch(uv_result)
+
+###############################################################################
+# Like the VL product, the UV fits file contains multiple HDUs. Passing the
+# file to `sunpy.map.Map` returns a `~sunpy.map.MapSequence`, where each entry
+# corresponds to one HDU. Here we inspect what's available and select the
+# first map.
+
+metis_uv_data = sunpy.map.Map(metis_data_product[0])
+metis_map = metis_uv_data[0]
+
+###############################################################################
+# By default, `~sunpy.map.sources.METISMap` sets a norm using
+# `~astropy.visualization.PercentileInterval` at 99.5 %. For data with
+# a wide dynamic range this is often a good starting point, but you can tighten
+# or loosen it by updating the norm's interval directly, or by passing
+# ``norm=None`` and using ``clip_interval`` to build a fresh norm
+# from a chosen percentile range.
+
+
+fig, axes = plt.subplots(1, 2, subplot_kw={"projection": metis_map},
+                         figsize=(12, 5))
+
+# Left panel: default plot_settings norm
+metis_map.plot(axes=axes[0], cmap=metis_map.plot_settings["cmap"])
+axes[0].set_title("Default norm (PercentileInterval 99.5 %)")
+
+# Right panel: norm=None lets clip_interval take over
+metis_map.plot(
+    axes=axes[1],
+    cmap=metis_map.plot_settings["cmap"],
+    norm=None,
+    clip_interval=(0.05, 99.95) * u.percent,
+)
+axes[1].set_title("Custom clip_interval (0.05-99.95 %)")
+
+plt.tight_layout()
+plt.show()
+
+
+###############################################################################
+# The UV data can contain a small number of very bright outlier pixels.
+# We can flag them by building a quality mask from the 99.99th percentile of
+# the data and merging it with the map's existing occulter mask.
+
+qmat = metis_map.data > np.percentile(metis_map.data, 99.99)
+metis_map.mask = metis_map.mask | qmat
+
+fig = plt.figure()
+ax = fig.add_subplot(projection=metis_map)
+im = metis_map.plot(axes=ax)
+ax.set_title("METIS UV with quality mask")
 plt.show()

--- a/examples/map/plotting_metis_data.py
+++ b/examples/map/plotting_metis_data.py
@@ -155,12 +155,12 @@ plt.show()
 
 
 ###############################################################################
-# The UV data can contain a small number of very bright outlier pixels.
-# We can flag them by building a quality mask from the 99.99th percentile of
-# the data and merging it with the map's existing occulter mask.
+# The UV data can contain a small number of very bright outlier pixels. We can
+# flag them by using the quality mask from Metis file that is provided in the
+# second map of the HDUs and merge it with the map's existing occulter mask.
 
-qmat = metis_map.data > np.percentile(metis_map.data, 99.99)
-metis_map.mask = metis_map.mask | qmat
+qmat = metis_uv_data[1].data
+metis_map.mask = metis_map.mask | ~qmat.astype(bool)
 
 fig = plt.figure()
 ax = fig.add_subplot(projection=metis_map)

--- a/examples/map/plotting_metis_data.py
+++ b/examples/map/plotting_metis_data.py
@@ -28,7 +28,7 @@ from sunpy.net import attrs as a
 # The Metis instrument provides visible-light (VL) and ultraviolet (UV) data
 # products.  In this example we will demonstrate the plotting of the VL
 # total-brightness data product. We first plot a single map, and then build
-# a `MapSequence` to animate a coronal eruption as a running-difference movie.
+# a `~sunpy.map.MapSequence` to animate a coronal eruption as a running-difference movie.
 # In the second example we will showcase the UV data and helpful operations
 
 
@@ -44,9 +44,9 @@ vl_result = Fido.search(a.Time("2022-03-22 21:00", "2022-03-22 22:50"),
 metis_files = Fido.fetch(vl_result)
 
 ###############################################################################
-# The downloaded Metis fits file contains multiple image header data units (HDUs).
-# When passed to `sunpy.map.Map`, SunPy creates a MapSequence containing one map
-# for each HDU.
+# The downloaded Metis fits file contains multiple image header data units
+# (HDUs). When passed to `~sunpy.map.Map`, SunPy creates a
+# `~sunpy.map.MapSequence` containing one map for each HDU.
 # We then filter the sequence to obtain only the VL total-brightness maps.
 # Finally, we select the first VL total-brightness map.
 
@@ -55,7 +55,7 @@ vl_tb_list = [m for m in vl_maps if m.measurement == "VL-TB"]
 vl_tb_example = vl_tb_list[0]
 
 ###############################################################################
-# A `~sunpy.map.sources.METISMap` is created with a default ``mask ``property
+# A `~sunpy.map.sources.METISMap` is created with a default ``mask`` property
 # that # flags pixels inside the inner occulter and outside the outer field of
 # view. When the `~sunpy.map.sources.METISMap` is plotted, the masked # pixels
 # are not shown, so only the annular region observed by the coronagraph is
@@ -119,14 +119,14 @@ metis_uv_file = Fido.fetch(uv_result)
 
 ###############################################################################
 # As with the VL product, the UV file stores several products as separate image
-# HDUs, so `sunpy.map.Map` again returns a list of maps. We keep just the UV
+# HDUs, so `~sunpy.map.Map` again returns a list of maps. We keep just the UV
 # intensity maps (``measurement == "UV"``) and select the first one.
 
 metis_uv_data = sunpy.map.Map(metis_uv_file[0])
 metis_map = metis_uv_data[0]
 
 ###############################################################################
-# By default, `~sunpy.map.sources.MetisMap` sets a norm using
+# By default, `~sunpy.map.sources.METISMap` sets a norm using
 # `~astropy.visualization.PercentileInterval` at 99.5 %. For data with
 # a wide dynamic range this is often a good starting point, but you can tighten
 # or loosen it by updating the norm's interval directly, or by passing

--- a/examples/map/plotting_metis_data.py
+++ b/examples/map/plotting_metis_data.py
@@ -1,17 +1,17 @@
 """
-==================================================
-Example showcase obtaining and plotting METIS data
-==================================================
+===============================================
+Downloading and plotting Metis coronagraph data
+===============================================
 
 This example demonstrates how to download, load, and visualize visible-light
-total brightness observations from the METIS coronagraph aboard
+total brightness observations from the Metis coronagraph aboard
 the Solar Orbiter mission.
 
-METIS observes the solar corona by occulting the bright solar disk,
+Metis observes the solar corona by occulting the bright solar disk,
 allowing faint coronal structures to be imaged in visible light and
 ultraviolet wavelengths.
 """
-# sphinx_gallery_tags = ["Map", "METIS", "SOAR", "Solar Orbiter", "Visualization"]
+# sphinx_gallery_tags = ["Map", "Metis", "SOAR", "Solar Orbiter", "Visualization"]
 # sphinx_gallery_thumbnail_number = -1
 
 import matplotlib.pyplot as plt
@@ -25,14 +25,18 @@ from sunpy.net import Fido
 from sunpy.net import attrs as a
 
 ###############################################################################
-# The METIS instrument mainly provides VL and UV data products. In the first
-# example we will demonstrate the plotting of the VL data product.
+# The Metis instrument provides visible-light (VL) and ultraviolet (UV) data
+# products.  In this example we will demonstrate the plotting of the VL
+# total-brightness data product. We first plot a single map, and then build
+# a `MapSequence` to animate a coronal eruption as a running-difference movie.
 # In the second example we will showcase the UV data and helpful operations
-# you can do with `sunpy.map`.
 
 
 ###############################################################################
-# First, download some METIS data with `~sunpy.net.Fido`.
+# The data is served by the Solar Orbiter Archive (SOAR),
+# so we set ``a.Provider.soar``.
+# Here we query for the Level 2, visible-light total-brightness product
+# (``a.soar.Product.metis_vl_tb``) over a time range covering an eruption event.
 
 vl_result = Fido.search(a.Time("2022-03-22 21:00", "2022-03-22 22:50"),
                      a.Instrument.metis, a.Level(2), a.Provider.soar,
@@ -40,7 +44,7 @@ vl_result = Fido.search(a.Time("2022-03-22 21:00", "2022-03-22 22:50"),
 metis_data_product = Fido.fetch(vl_result)
 
 ###############################################################################
-# The downloaded METIS FITS file contains multiple image header data units (HDUs).
+# The downloaded Metis fits file contains multiple image header data units (HDUs).
 # When passed to `sunpy.map.Map`, SunPy creates a MapSequence containing one map
 # for each HDU.
 # We then filter the sequence to obtain only the VL total-brightness maps.
@@ -51,8 +55,11 @@ vl_tb_list = [m for m in vl_maps if m.measurement == "VL-TB"]
 vl_tb_example = vl_tb_list[0]
 
 ###############################################################################
-# A `~sunpy.map.sources.METISMap` is created with a default mask property that
-# excludes pixels inside the inner occulter and outside the outer field of view
+# A `~sunpy.map.sources.METISMap` is created with a default ``mask ``property
+# that # flags pixels inside the inner occulter and outside the outer field of
+# view. When the `~sunpy.map.sources.METISMap` is plotted, the masked # pixels
+# are not shown, so only the annular region observed by the coronagraph is
+# visible.
 
 fig = plt.figure()
 ax = fig.add_subplot(projection=vl_tb_example)
@@ -60,10 +67,11 @@ im = vl_tb_example.plot(axes=ax)
 fig.colorbar(im)
 
 ##############################################################################
-# In this example, we also know there is an eruption event.
-# We start by animating this time series.
-# To do this we load all the HDUs of all the files and filter down to
-# just the "VL-TB" HDUs and make a `~sunpy.map.MapSequence`.
+# In this example, the observation captured an eruption event.
+# To visualise this, we build a time series sequence of maps and animate it.
+# We load all of the downloaded files at once (again getting a list of maps),
+# keep just the VL-TB maps, and combine them into a
+# `~sunpy.map.MapSequence` by passing ``sequence=True``
 
 vl_tb_maps = sunpy.map.Map(metis_data_product)
 m_seq_vltb = sunpy.map.Map([m for m in vl_tb_maps if m.measurement == "VL-TB"], sequence=True)
@@ -98,7 +106,7 @@ plt.show()
 
 ###############################################################################
 # Now we move on to the UV data product.
-# First, let's search for and download a METIS UV observation.
+# First, let's search for and download a Metis UV observation from SOAR.
 
 uv_result = Fido.search(
     a.Time("2024-12-09 00:36", "2024-12-09 00:38"),
@@ -107,19 +115,18 @@ uv_result = Fido.search(
     a.Provider.soar,
     a.soar.Product.metis_uv_image,
 )
-metis_data_product = Fido.fetch(uv_result)
+metis_uv_file = Fido.fetch(uv_result)
 
 ###############################################################################
-# Like the VL product, the UV fits file contains multiple HDUs. Passing the
-# file to `sunpy.map.Map` returns a `~sunpy.map.MapSequence`, where each entry
-# corresponds to one HDU. Here we inspect what's available and select the
-# first map.
+# As with the VL product, the UV file stores several products as separate image
+# HDUs, so `sunpy.map.Map` again returns a list of maps. We keep just the UV
+# intensity maps (``measurement == "UV"``) and select the first one.
 
-metis_uv_data = sunpy.map.Map(metis_data_product[0])
+metis_uv_data = sunpy.map.Map(metis_uv_file[0])
 metis_map = metis_uv_data[0]
 
 ###############################################################################
-# By default, `~sunpy.map.sources.METISMap` sets a norm using
+# By default, `~sunpy.map.sources.MetisMap` sets a norm using
 # `~astropy.visualization.PercentileInterval` at 99.5 %. For data with
 # a wide dynamic range this is often a good starting point, but you can tighten
 # or loosen it by updating the norm's interval directly, or by passing

--- a/examples/map/plotting_metis_data.py
+++ b/examples/map/plotting_metis_data.py
@@ -41,7 +41,7 @@ from sunpy.net import attrs as a
 vl_result = Fido.search(a.Time("2022-03-22 21:00", "2022-03-22 22:50"),
                      a.Instrument.metis, a.Level(2), a.Provider.soar,
                      a.soar.Product.metis_vl_tb)
-metis_data_product = Fido.fetch(vl_result)
+metis_files = Fido.fetch(vl_result)
 
 ###############################################################################
 # The downloaded Metis fits file contains multiple image header data units (HDUs).
@@ -50,7 +50,7 @@ metis_data_product = Fido.fetch(vl_result)
 # We then filter the sequence to obtain only the VL total-brightness maps.
 # Finally, we select the first VL total-brightness map.
 
-vl_maps = sunpy.map.Map(metis_data_product[0])
+vl_maps = sunpy.map.Map(metis_files[0])
 vl_tb_list = [m for m in vl_maps if m.measurement == "VL-TB"]
 vl_tb_example = vl_tb_list[0]
 

--- a/examples/map/plotting_metis_data.py
+++ b/examples/map/plotting_metis_data.py
@@ -55,7 +55,7 @@ vl_tb_list = [m for m in vl_maps if m.measurement == "VL-TB"]
 vl_tb_example = vl_tb_list[0]
 
 ###############################################################################
-# A `~sunpy.map.sources.METISMap` is created with a default ``mask`` property
+# A `~sunpy.map.sources.METISMap` is created with a default `~sunpy.map.sources.METISMap.mask` property
 # that # flags pixels inside the inner occulter and outside the outer field of
 # view. When the `~sunpy.map.sources.METISMap` is plotted, the masked # pixels
 # are not shown, so only the annular region observed by the coronagraph is

--- a/examples/map/plotting_metis_data.py
+++ b/examples/map/plotting_metis_data.py
@@ -73,7 +73,7 @@ fig.colorbar(im)
 # keep just the VL-TB maps, and combine them into a
 # `~sunpy.map.MapSequence` by passing ``sequence=True``
 
-vl_tb_maps = sunpy.map.Map(metis_data_product)
+vl_tb_maps = sunpy.map.Map(metis_files)
 m_seq_vltb = sunpy.map.Map([m for m in vl_tb_maps if m.measurement == "VL-TB"], sequence=True)
 
 ###############################################################################

--- a/examples/map/plotting_metis_data.py
+++ b/examples/map/plotting_metis_data.py
@@ -1,9 +1,15 @@
 """
-==============
-Plotting METIS
-==============
+==================================================
+Example showcase obtaining and plotting METIS data
+==================================================
 
-In this example, we plot the VL total brightness data product from METIS with the recommended contrast cutoffs.
+This example demonstrates how to download, load, and visualize visible-light
+total brightness observations from the METIS coronagraph aboard
+the Solar Orbiter mission.
+
+METIS observes the solar corona by occulting the bright solar disk,
+allowing faint coronal structures to be imaged in visible light and
+ultraviolet wavelengths.
 """
 # sphinx_gallery_tags = ["Map", "METIS", "SOAR", "Solar Orbiter", "Visualization"]
 # sphinx_gallery_thumbnail_number = -1
@@ -25,13 +31,19 @@ result = Fido.search(a.Time("2022-03-22 21:00", "2022-03-22 22:50"),
 metis_data_product = Fido.fetch(result)
 
 ###############################################################################
-# Then we use one of the data products to create a simple map.
-# A `~sunpy.map.sources.METISMap` is created with a default mask property that
-# excludes pixels inside the inner occulter and outside the outer field of view
+# The downloaded METIS FITS file contains multiple image header data units (HDUs).
+# When passed to `sunpy.map.Map`, SunPy creates a MapSequence containing one map
+# for each HDU.
+# We then filter the sequence to obtain only the VL total-brightness maps.
+# Finally, we select the first VL total-brightness map.
 
 vl_maps = sunpy.map.Map(metis_data_product[0])
 vl_tb_list = [m for m in vl_maps if m.measurement == "VL-TB"]
 vl_tb_example = vl_tb_list[0]
+
+###############################################################################
+# A `~sunpy.map.sources.METISMap` is created with a default mask property that
+# excludes pixels inside the inner occulter and outside the outer field of view
 
 fig = plt.figure()
 ax = fig.add_subplot(projection=vl_tb_example)

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -234,7 +234,6 @@ class METISMap(GenericMap):
     -----
 
     This map source clips out the upper and lower :math:`0.5\%` of the pixels as many Metis files have some extreme spikes.
-    These clipped pixels are shown in red by default.
 
     References
     ----------
@@ -377,11 +376,10 @@ class METISMap(GenericMap):
     def mask(self, value):
         self._mask = value
 
-
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):
         """
-        Return ``True`` if ``header`` corresponds to a METIS L2 product.
+        Return ``True`` if ``header`` corresponds to a Metis L2 product.
 
         Parameters
         ----------

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -1,6 +1,7 @@
 """
 Solar Orbiter Map subclass definitions.
 """
+import numpy as np
 from matplotlib.colors import CenteredNorm
 
 import astropy.units as u
@@ -293,6 +294,69 @@ class METISMap(GenericMap):
 
         suff, _ = METISMap._BTYPE_SUFF_DICT.get(btype, ("", None))
         return prodtype + suff
+
+
+    @property
+    def mask(self):
+        """
+        Mask pixels obscured by the internal and external occulters.
+
+        Returns a mask set to ``True`` for pixels inside the inner occulter
+        and outside the outer field of view. Computed lazily on first access
+        and cached thereafter.
+
+        Warnings
+        --------
+        If CDELT1 and CDELT2 are not equal (non-square pixels), this method
+        will warn and return ``None`` without computing a mask, as the
+        circular mask calculation assumes square pixels.
+        """
+        if self._mask is None:
+            if self.scale[0] != self.scale[1]:
+                warn_user(
+                    f"Warning: CDELT1 != CDELT2 for {self.name}. Exiting mask_occs method..."
+                )
+                return None
+
+            # Calculate occulter radii in pixels
+            inn_fov = (self.meta["inn_fov"] * u.deg / self.scale[0]).decompose()
+            out_fov = (self.meta["out_fov"] * u.deg / self.scale[1]).decompose()
+
+            # Create coordinate grids
+            x = np.arange(0, self.meta["naxis1"], 1)
+            y = np.arange(0, self.meta["naxis2"], 1)
+            xx, yy = np.meshgrid(x, y, sparse=True)
+
+            # Calculate distance from internal occulter center
+            in_xcen = (self.meta["io_xcen"] - 1) * u.pix
+            in_ycen = (self.meta["io_ycen"] - 1) * u.pix
+            dist_inncen = np.sqrt((xx * u.pix - in_xcen) ** 2 + (yy * u.pix - in_ycen) ** 2)
+
+            # Calculate distance from external occulter/field stop center
+            # NOTE: Workaround for DR1 data where fs_*cen keywords are not correctly defined.
+            # In DR1, fs_xcen and fs_ycen are not available and as consequence the corresponding keywords in a FITS file are assigned to crpix1 and crpix2, respectively.
+            # When this occurs, sun_xcen and sun_ycen should be used as approximate coordinates of the field stop center.
+            # This problem is solved in DR2.
+            if self.meta["fs_xcen"] == self.meta["crpix1"] and self.meta["fs_ycen"] == self.meta["crpix2"]:
+                # DR1 workaround: use sun center instead; For the DR1 data fs_*cen keywords are not defined correctly in a FITS file header
+                out_xcen = (self.meta["sun_xcen"] - 1) * u.pix
+                out_ycen = (self.meta["sun_ycen"] - 1) * u.pix
+            else:
+                # Normal case: use field stop center
+                out_xcen = (self.meta["fs_xcen"] - 1) * u.pix
+                out_ycen = (self.meta["fs_ycen"] - 1) * u.pix
+
+            dist_outcen = np.sqrt((xx * u.pix - out_xcen) ** 2 + (yy * u.pix - out_ycen) ** 2)
+
+            mask_inner = dist_inncen <= inn_fov
+            mask_outer = dist_outcen >= out_fov
+            self._mask = mask_inner | mask_outer
+
+        return self._mask
+
+    @mask.setter
+    def mask(self, value):
+        self._mask = value
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -2,7 +2,6 @@
 Solar Orbiter Map subclass definitions.
 """
 import numpy as np
-from matplotlib import cm
 from matplotlib.colors import CenteredNorm
 
 import astropy.units as u
@@ -264,16 +263,13 @@ class METISMap(GenericMap):
         if btype in METISMap._BTYPE_SUFF_DICT:
             _, nickname_add = METISMap._BTYPE_SUFF_DICT[btype]
         self._nickname = f"{self.instrument}/{self.meta['filter']}{nickname_add}"
-        cmap = cm.get_cmap(f"solo{self.instrument}{self.measurement}".lower())
+        self.plot_settings["cmap"] = f"solo{self.instrument}{self.measurement}".lower()
 
         self.plot_settings["norm"] = ImageNormalize(
             self.data,
             interval=PercentileInterval(99.5),
             clip=False,
         )
-        # Set the under and over value for the colormap to be red, this will highlight pixels where the value is clipped
-        cmap = cmap.with_extremes(under="red", over="red")
-        self.plot_settings["cmap"] = cmap
 
     @property
     def rsun_obs(self):

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -8,6 +8,7 @@ import astropy.units as u
 from astropy.coordinates import CartesianRepresentation
 from astropy.visualization import AsinhStretch, ImageNormalize
 
+from sunpy import log
 from sunpy.coordinates import HeliocentricInertial
 from sunpy.map import GenericMap
 from sunpy.map.sources.source_type import source_stretch
@@ -296,7 +297,7 @@ class METISMap(GenericMap):
         return prodtype + suff
 
 
-    @property
+    @GenericMap.mask.getter
     def mask(self):
         """
         Mask pixels obscured by the internal and external occulters.
@@ -311,16 +312,22 @@ class METISMap(GenericMap):
         will warn and return ``None`` without computing a mask, as the
         circular mask calculation assumes square pixels.
         """
+        if missing_keys := {"inn_fov", "out_fov",
+                            "io_xcen", "io_ycen",
+                            "fs_xcen", "fs_ycen"}.difference(self.meta.keys()):
+            warn_user(f"Missing {', '.join(missing_keys)} keys required to calculate occulter mask")
+            return super().mask
+
         if self._mask is None:
             if self.scale[0] != self.scale[1]:
-                warn_user(
-                    f"Warning: CDELT1 != CDELT2 for {self.name}. Exiting mask_occs method..."
+                log.warning(
+                    "CDELT1 != CDELT2, can not automatically compute the occulter mask."
                 )
                 return None
 
             # Calculate occulter radii in pixels
-            inn_fov = (self.meta["inn_fov"] * u.deg / self.scale[0]).decompose()
-            out_fov = (self.meta["out_fov"] * u.deg / self.scale[1]).decompose()
+            inn_fov = (self.meta["inn_fov"] * u.deg / self.scale[0])
+            out_fov = (self.meta["out_fov"] * u.deg / self.scale[1])
 
             # Create coordinate grids
             x = np.arange(0, self.meta["naxis1"], 1)
@@ -354,9 +361,6 @@ class METISMap(GenericMap):
 
         return self._mask
 
-    @mask.setter
-    def mask(self, value):
-        self._mask = value
 
     @classmethod
     def is_datasource_for(cls, data, header, **kwargs):

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -2,11 +2,12 @@
 Solar Orbiter Map subclass definitions.
 """
 import numpy as np
+from matplotlib import cm
 from matplotlib.colors import CenteredNorm
 
 import astropy.units as u
 from astropy.coordinates import CartesianRepresentation
-from astropy.visualization import AsinhStretch, AsymmetricPercentileInterval, ImageNormalize
+from astropy.visualization import AsinhStretch, ImageNormalize, PercentileInterval
 
 from sunpy import log
 from sunpy.coordinates import HeliocentricInertial
@@ -210,7 +211,7 @@ class PHIMap(GenericMap):
         return is_solo and is_phi and is_not_phi_stokes
 
 class METISMap(GenericMap):
-    """
+    r"""
     Metis Map.
 
     Metis is the multi-wavelength coronagraph on board the Solar Orbiter mission,
@@ -229,6 +230,12 @@ class METISMap(GenericMap):
     disk center.
 
     Solar Orbiter was successfully launched on February 10th, 2020.
+
+    Notes
+    -----
+
+    This map source clips out the upper and lower :math:`0.5\%` of the pixels as many Metis files have some extreme spikes.
+    These clipped pixels are shown in red by default.
 
     References
     ----------
@@ -249,22 +256,6 @@ class METISMap(GenericMap):
         "Relative error":                   ("-RE",  "-Rel. err."),
         "UV Lyman-alpha intensity":         ("",     ""),
     }
-    _METIS_CONTRAST_CUTS = {
-        "VL-TB": 0.05,
-        "VL-PB": 0.005,
-        "VL-FP": 0.01,
-        "VL-PA": 0.01,
-        "VL-SQ": 0.01,
-        "VL-SU": 0.01,
-        "UV":    0.05,
-        "VL-PQ": 0.0,
-        "VL-AE": 0.1,
-        "VL-RE": 0.02,
-    }
-    _METIS_CONTRAST_CUTS["VL-SI"] = _METIS_CONTRAST_CUTS["VL-TB"]
-    _METIS_CONTRAST_CUTS["UV-PQ"] = _METIS_CONTRAST_CUTS["VL-PQ"]
-    _METIS_CONTRAST_CUTS["UV-AE"] = _METIS_CONTRAST_CUTS["VL-AE"]
-    _METIS_CONTRAST_CUTS["UV-RE"] = _METIS_CONTRAST_CUTS["VL-RE"]
 
     def __init__(self, data, header, **kwargs):
         super().__init__(data, header, **kwargs)
@@ -273,17 +264,16 @@ class METISMap(GenericMap):
         if btype in METISMap._BTYPE_SUFF_DICT:
             _, nickname_add = METISMap._BTYPE_SUFF_DICT[btype]
         self._nickname = f"{self.instrument}/{self.meta['filter']}{nickname_add}"
-        self.plot_settings["cmap"] = f"solo{self.instrument}{self.measurement}".lower()
+        cmap = cm.get_cmap(f"solo{self.instrument}{self.measurement}".lower())
 
-        contr_cut = METISMap._METIS_CONTRAST_CUTS.get(self.measurement, 0.0) if "L2" in self.meta["level"] else 0.0
-        if contr_cut:
-            self.plot_settings["norm"] = ImageNormalize(
-                data=self.data,
-                interval=AsymmetricPercentileInterval(
-                    contr_cut * 100,
-                    (1 - contr_cut) * 100,
-                ),
-                clip=False)
+        self.plot_settings["norm"] = ImageNormalize(
+            self.data,
+            interval=PercentileInterval(99.5),
+            clip=False,
+        )
+        # Set the under and over value for the colormap to be red, this will highlight pixels where the value is clipped
+        cmap = cmap.with_extremes(under="red", over="red")
+        self.plot_settings["cmap"] = cmap
 
     @property
     def rsun_obs(self):

--- a/sunpy/map/sources/solo.py
+++ b/sunpy/map/sources/solo.py
@@ -6,7 +6,7 @@ from matplotlib.colors import CenteredNorm
 
 import astropy.units as u
 from astropy.coordinates import CartesianRepresentation
-from astropy.visualization import AsinhStretch, ImageNormalize
+from astropy.visualization import AsinhStretch, AsymmetricPercentileInterval, ImageNormalize
 
 from sunpy import log
 from sunpy.coordinates import HeliocentricInertial
@@ -249,6 +249,22 @@ class METISMap(GenericMap):
         "Relative error":                   ("-RE",  "-Rel. err."),
         "UV Lyman-alpha intensity":         ("",     ""),
     }
+    _METIS_CONTRAST_CUTS = {
+        "VL-TB": 0.05,
+        "VL-PB": 0.005,
+        "VL-FP": 0.01,
+        "VL-PA": 0.01,
+        "VL-SQ": 0.01,
+        "VL-SU": 0.01,
+        "UV":    0.05,
+        "VL-PQ": 0.0,
+        "VL-AE": 0.1,
+        "VL-RE": 0.02,
+    }
+    _METIS_CONTRAST_CUTS["VL-SI"] = _METIS_CONTRAST_CUTS["VL-TB"]
+    _METIS_CONTRAST_CUTS["UV-PQ"] = _METIS_CONTRAST_CUTS["VL-PQ"]
+    _METIS_CONTRAST_CUTS["UV-AE"] = _METIS_CONTRAST_CUTS["VL-AE"]
+    _METIS_CONTRAST_CUTS["UV-RE"] = _METIS_CONTRAST_CUTS["VL-RE"]
 
     def __init__(self, data, header, **kwargs):
         super().__init__(data, header, **kwargs)
@@ -258,6 +274,16 @@ class METISMap(GenericMap):
             _, nickname_add = METISMap._BTYPE_SUFF_DICT[btype]
         self._nickname = f"{self.instrument}/{self.meta['filter']}{nickname_add}"
         self.plot_settings["cmap"] = f"solo{self.instrument}{self.measurement}".lower()
+
+        contr_cut = METISMap._METIS_CONTRAST_CUTS.get(self.measurement, 0.0) if "L2" in self.meta["level"] else 0.0
+        if contr_cut:
+            self.plot_settings["norm"] = ImageNormalize(
+                data=self.data,
+                interval=AsymmetricPercentileInterval(
+                    contr_cut * 100,
+                    (1 - contr_cut) * 100,
+                ),
+                clip=False)
 
     @property
     def rsun_obs(self):
@@ -297,14 +323,13 @@ class METISMap(GenericMap):
         return prodtype + suff
 
 
-    @GenericMap.mask.getter
+    @property
     def mask(self):
         """
         Mask pixels obscured by the internal and external occulters.
 
         Returns a mask set to ``True`` for pixels inside the inner occulter
-        and outside the outer field of view. Computed lazily on first access
-        and cached thereafter.
+        and outside the outer field of view.
 
         Warnings
         --------
@@ -320,7 +345,7 @@ class METISMap(GenericMap):
 
         if self._mask is None:
             if self.scale[0] != self.scale[1]:
-                log.warning(
+                log.info(
                     "CDELT1 != CDELT2, can not automatically compute the occulter mask."
                 )
                 return None
@@ -360,6 +385,11 @@ class METISMap(GenericMap):
             self._mask = mask_inner | mask_outer
 
         return self._mask
+
+
+    @mask.setter
+    def mask(self, value):
+        self._mask = value
 
 
     @classmethod

--- a/sunpy/map/sources/tests/test_metis_source.py
+++ b/sunpy/map/sources/tests/test_metis_source.py
@@ -14,10 +14,7 @@ from astropy.coordinates import SkyCoord
 
 from sunpy.map import Map
 from sunpy.map.sources.solo import METISMap
-
-# ============================================================================
-# FIXTURES - Test data and metadata configuration
-# ============================================================================
+from sunpy.util.exceptions import SunpyUserWarning
 
 METIS_HEADER_VARIANTS = [
     pytest.param({}, id="baseline-VL"),
@@ -72,11 +69,13 @@ def minimal_metis_header():
     return _BASE_METIS_HEADER.copy()
 
 
+@pytest.fixture
+def metis_non_square_header():
+    return {**_BASE_METIS_HEADER, "CDELT1": 512.0, "CDELT2": 256.0}
+
 @pytest.fixture(scope="module")
 def metis_test_data():
-    """
-    Generates synthetic 1024x1024 image data with a radial gradient.
-    """
+    """Generates synthetic 1024x1024 image data with a radial gradient."""
     size = 1024
     y, x = np.ogrid[-size / 2 : size / 2, -size / 2 : size / 2]
     r = np.sqrt(x**2 + y**2)
@@ -95,9 +94,7 @@ def test_coordinate_frame( metis_map):
 
 
 def test_colormaps_by_filter( metis_map):
-    """
-    Verify that the default colormap is assigned based on the FILTER keyword.
-    """
+    """Verify that the default colormap is assigned based on the FILTER keyword."""
     expected = {
         "VL": "solometisvl-tb",
         "UV": "solometisuv",
@@ -106,9 +103,7 @@ def test_colormaps_by_filter( metis_map):
 
 
 def test_wcs_conversion( metis_test_data, minimal_metis_header):
-    """
-    Test that pixel coordinates correctly transform to world coordinates (Arcsecs).
-    """
+    """Test that pixel coordinates correctly transform to world coordinates (Arcsecs)."""
     metis_map = Map(metis_test_data,minimal_metis_header)
     # Center of the image (0-indexed 511.5) should be close to CRVAL (0,0)
     center_coord = metis_map.pixel_to_world(511 * u.pix, 511 * u.pix)
@@ -116,20 +111,13 @@ def test_wcs_conversion( metis_test_data, minimal_metis_header):
     assert u.allclose(center_coord.Tx, 0 * u.arcsec, atol=1e-2 * u.arcsec)
 
 
-"""
-Tests for proper object instantiation.
-"""
-
 def test_basic_initialization( metis_map):
     assert isinstance(metis_map, METISMap)
     assert metis_map.instrument == "METIS"
 
 
 def test_rsun_fallback_logic( metis_test_data, minimal_metis_header):
-    """
-    Verify the hierarchical search for solar radius keywords
-    (RSUN_ARC vs RSUN_OBS).
-    """
+    """Verify the hierarchical search for solar radius keywords(RSUN_ARC vs RSUN_OBS)."""
     header = minimal_metis_header.copy()
     del header["RSUN_ARC"]
     header["RSUN_OBS"] = 950.0
@@ -145,26 +133,43 @@ def test_prodtype_property(metis_test_data, minimal_metis_header):
 
 
 def test_rsun_obs_uses_super(metis_test_data, minimal_metis_header):
-    """
-    Verify rsun_obs uses GenericMap when RSUN_OBS exists.
-    """
+    """Verify rsun_obs uses GenericMap when RSUN_OBS exists."""
     header = minimal_metis_header.copy()
     header["RSUN_OBS"] = 950.0
-
     metis_map = Map(metis_test_data, header)
-
     assert metis_map.rsun_obs == 950.0 * u.arcsec
 
+
 def test_fall_back_to_rsun_arc(metis_test_data, minimal_metis_header):
-    """
-    Verify rsun_obs falls back to RSUN_ARC when no other solar radius keywords exist.
-    """
+    """Verify rsun_obs falls back to RSUN_ARC when no other solar radius keywords exist."""
     header = minimal_metis_header.copy()
-
-    header.pop("RSUN_OBS", None)
-    header.pop("SOLAR_R", None)
-    header.pop("RADIUS", None)
-
     metis_map = Map(metis_test_data, header)
-
     assert metis_map.rsun_obs == 960.0 * u.arcsec
+
+
+def test_mask_is_set(metis_map):
+    """Verify mask property before and after mask_occ() is called."""
+    assert metis_map.mask is not None
+
+
+def test_mask_values_are_bool(metis_map):
+    """Verify mask was created."""
+    assert metis_map.mask.dtype == bool
+
+
+def test_mask_occ_does_not_mask_entire_image(metis_map):
+    """Verify that mask_occ does not occult the entire image"""
+    assert not metis_map.mask.all()
+
+
+def test_mask_occ_center_occulted(metis_map):
+    """Verify that the center is masked"""
+    assert metis_map.mask[512,512]
+
+
+@pytest.fixture
+def metis_map_non_square(metis_test_data, metis_non_square_header):
+    """Verify that the mask correctly warns users when CDELT shape is unequal"""
+    with pytest.warns(SunpyUserWarning):
+        metis_map_no_mask =  Map(metis_test_data, metis_non_square_header)
+    assert metis_map_no_mask.mask is None

--- a/sunpy/map/sources/tests/test_metis_source.py
+++ b/sunpy/map/sources/tests/test_metis_source.py
@@ -73,6 +73,12 @@ def minimal_metis_header():
 def metis_non_square_header():
     return {**_BASE_METIS_HEADER, "CDELT1": 512.0, "CDELT2": 256.0}
 
+
+@pytest.fixture
+def metis_map_non_square(metis_test_data, metis_non_square_header):
+    return Map(metis_test_data, metis_non_square_header)
+
+
 @pytest.fixture(scope="module")
 def metis_test_data():
     """Generates synthetic 1024x1024 image data with a radial gradient."""
@@ -167,9 +173,8 @@ def test_mask_occ_center_occulted(metis_map):
     assert metis_map.mask[512,512]
 
 
-@pytest.fixture
-def metis_map_non_square(metis_test_data, metis_non_square_header):
-    """Verify that the mask correctly warns users when CDELT shape is unequal"""
-    with pytest.warns(SunpyUserWarning):
-        metis_map_no_mask =  Map(metis_test_data, metis_non_square_header)
-    assert metis_map_no_mask.mask is None
+def test_mask_warns_non_square(metis_map_non_square):
+    """Verify that the mask property warns when CDELT1 != CDELT2"""
+    with pytest.warns(SunpyUserWarning, match="CDELT1 != CDELT2"):
+        result = metis_map_non_square.mask
+    assert result is None

--- a/sunpy/map/sources/tests/test_metis_source.py
+++ b/sunpy/map/sources/tests/test_metis_source.py
@@ -14,7 +14,6 @@ from astropy.coordinates import SkyCoord
 
 from sunpy.map import Map
 from sunpy.map.sources.solo import METISMap
-from sunpy.util.exceptions import SunpyUserWarning
 
 METIS_HEADER_VARIANTS = [
     pytest.param({}, id="baseline-VL"),
@@ -175,6 +174,5 @@ def test_mask_occ_center_occulted(metis_map):
 
 def test_mask_warns_non_square(metis_map_non_square):
     """Verify that the mask property warns when CDELT1 != CDELT2"""
-    with pytest.warns(SunpyUserWarning, match="CDELT1 != CDELT2"):
-        result = metis_map_non_square.mask
+    result = metis_map_non_square.mask
     assert result is None

--- a/sunpy/map/sources/tests/test_metis_source.py
+++ b/sunpy/map/sources/tests/test_metis_source.py
@@ -14,6 +14,7 @@ from astropy.coordinates import SkyCoord
 
 from sunpy.map import Map
 from sunpy.map.sources.solo import METISMap
+from sunpy.util.exceptions import SunpyUserWarning
 
 METIS_HEADER_VARIANTS = [
     pytest.param({}, id="baseline-VL"),
@@ -176,3 +177,26 @@ def test_mask_warns_non_square(metis_map_non_square):
     """Verify that the mask property warns when CDELT1 != CDELT2"""
     result = metis_map_non_square.mask
     assert result is None
+
+
+def test_mask_missing_keys_falls_back_to_super(metis_test_data, minimal_metis_header):
+    """Verify that mask falls back to super().mask when occulter keys are missing."""
+    header = minimal_metis_header.copy()
+    del header["INN_FOV"]  # Remove one required key to trigger missing_keys
+    metis_map = Map(metis_test_data, header)
+    with pytest.warns(SunpyUserWarning, match="Missing.*keys required to calculate occulter mask"):
+        result = metis_map.mask
+    # GenericMap.mask returns None by default when no mask is set
+    assert result is None
+
+
+def test_mask_uses_field_stop_center_dr2(metis_test_data, minimal_metis_header):
+    """Verify the normal (DR2) mask path where fs_xcen != crpix1 or fs_ycen != crpix2."""
+    header = minimal_metis_header.copy()
+    # Shift the field stop center away from crpix so the DR1 workaround is NOT triggered
+    header["FS_XCEN"] = 514.0
+    header["FS_YCEN"] = 514.0
+    metis_map = Map(metis_test_data, header)
+    assert metis_map.mask is not None
+    assert metis_map.mask.dtype == bool
+    assert not metis_map.mask.all()


### PR DESCRIPTION
## PR Description

Adding the `mask_occ` method back to METISMap based on #8650

The PR includes some tests for the method as well.

If everyone is happy with this functionality then I can add an example to this PR as well. 

Should any data samples be uploaded to sunpy/data first? I saw some of the example gallery docs use fido to pull the data.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
