### PR TITLE
Fix peculiar test failure related to Animation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -81,5 +81,3 @@ filterwarnings =
     ignore:The \'generic\' unit for NumPy timedelta is deprecated.*:DeprecationWarning
     # oldest deps - unclear what's causing this
     ignore:Passing \(type, 1\) or \'1type\' as a synonym of type is deprecated:FutureWarning
-    # oldest deps
-    ignore:Animation was deleted without rendering anything:UserWarning

--- a/sunpy/map/tests/test_mapsequence.py
+++ b/sunpy/map/tests/test_mapsequence.py
@@ -165,6 +165,7 @@ def test_map_sequence_plot_respects_masks(aia171_test_map, aia171_test_map_with_
     ax = fig.add_subplot(projection=seq.maps[0])
 
     animation = seq.plot(axes=ax)
+    animation._init_draw()  # prevent warning upon cleanup of no drawing
     image = animation._fig.axes[0].images[0]
     animation._func(1, *animation._args)
     rendered_data = image.get_array()
@@ -228,6 +229,7 @@ def test_mapsequence_plot_uint8_norm():
     ax = fig.add_subplot(projection=coconuts[0])
 
     moving_coconut = coconuts.plot(axes=ax)
+    moving_coconut._init_draw()  # prevent warning upon cleanup of no drawing
     moving_coconut._step()
 
 
@@ -241,10 +243,10 @@ def test_mapsequence_plot_uint8_norm_clip_interval():
     ax = fig.add_subplot(projection=coconuts[0])
 
     moving_coconut = coconuts.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
+    moving_coconut._init_draw()  # prevent warning upon cleanup of no drawing
     moving_coconut._step()
 
 
-@skip_glymur
 def test_mapsequence_plot_set_norm_pass_vmin_vmax(aia171_test_map):
     # Checking that passing in interval values works if the map has a norm
     coconuts = sunpy.map.Map([aia171_test_map]*10,sequence=True)
@@ -253,6 +255,8 @@ def test_mapsequence_plot_set_norm_pass_vmin_vmax(aia171_test_map):
     ax = fig.add_subplot(projection=coconuts[0])
 
     moving_coconut = coconuts.plot(axes=ax, clip_interval=(1, 99.99)*u.percent)
+    moving_coconut._init_draw()  # prevent warning upon cleanup of no drawing
     moving_coconut._step()
     moving_coconut = coconuts.plot(axes=ax, vmin=100, vmax=1000)
+    moving_coconut._init_draw()  # prevent warning upon cleanup of no drawing
     moving_coconut._step()

--- a/sunpy/physics/tests/test_differential_rotation.py
+++ b/sunpy/physics/tests/test_differential_rotation.py
@@ -1,3 +1,4 @@
+import warnings
 
 import numpy as np
 import pytest
@@ -394,7 +395,12 @@ def test_warp_sun_coordinates(all_on_disk_map):
 @pytest.mark.array_compare
 def test_differential_rotation(aia171_test_map):
     pytest.importorskip("skimage")
-    with pytest.warns(UserWarning, match="Using 'time' assumes an Earth-based observer"):
+    # pytest-run-parallel will run this test in parallel because pytest-arraydiff currently blocks
+    # the ability of pytest-run-parallel to recognize known thread-unsafe calls such as catching
+    # warnings.  So, we intentionally ignore warnings instead of checking what warnings were
+    # actually caught.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
         rot_map = differential_rotate(aia171_test_map, time=2*u.day)
     return rot_map.data
 


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

#8667 papered over an puzzling test failure that started on the `py312-oldestdeps` CI build after #8658 added a whole bunch of tests.  Example:

> FAILED ../../.tox/py312-oldestdeps/lib/python3.12/site-packages/sunpy/map/tests/test_plotting.py::test_different_wcs_plot_warning - UserWarning: Animation was deleted without rendering anything. This is most likely not intended. To prevent deletion, assign the Animation to a variable, e.g. `anim`, that exists until you output the Animation using `plt.show()` or `anim.save()`.

This test failure was especially puzzling because the identified test did not involve animations, the failure appeared on only one CI build, the failure could not be straightforwardly reproduced on local machines, and the failure could go away if (1) the number of tests was reduced or (2) the test were not run using parallel workers (pytest-xdist).

Ultimately, it turns out that the non-figure-tests in `test_mapsequence.py` need to initialize the animation instance so that a warning is not emitted when the animation instance is eventually deleted.  The deletion of the animation instance is up to the whims of Python garbage collection and delayed from the original test, which made the test failure confusing and difficult to reproduce (including being affected by exactly how tests were farmed out to parallel workers).

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- - [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- - [ ] Test/benchmark generation
- - [ ] Documentation (including examples)
- - [ ] Research and understanding
- - [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
