### PR TITLE
Update is_url to use urlparse instead of urlopen.

### DIFF
--- a/changelog/8679.feature.rst
+++ b/changelog/8679.feature.rst
@@ -1,1 +1,1 @@
-Update :func:`~sunpy.util.io.is_url` to use `urllib.parse.urlparse` instead of `urllib.request.urlopen` so no network requests are made or needed.
+Update ``sunpy.util.io.is_url()`` to use `urllib.parse.urlparse` instead of `urllib.request.urlopen` so no network requests are made or needed.

--- a/changelog/8679.feature.rst
+++ b/changelog/8679.feature.rst
@@ -1,1 +1,2 @@
 Update ``sunpy.util.io.is_url()`` to use `urllib.parse.urlparse` instead of `urllib.request.urlopen` so no network requests are made or needed.
+This may result in different exceptions being raised if URLs are unreachable, from multiple places in ``sunpy`` such as ``Map`` and ``Timeseries``.

--- a/changelog/8679.feature.rst
+++ b/changelog/8679.feature.rst
@@ -1,0 +1,1 @@
+Update :func:`~sunpy.util.io.is_url` to use `urllib.parse.urlparse` instead of `urllib.request.urlopen` so no network requests are made or needed.

--- a/sunpy/util/io.py
+++ b/sunpy/util/io.py
@@ -3,7 +3,7 @@ import re
 import glob
 import pathlib
 import collections
-import urllib.request
+from urllib.parse import urlparse
 
 import fsspec
 
@@ -108,9 +108,10 @@ def is_url(obj):
         True if the object is a valid URL, False otherwise.
     """
     try:
-        urllib.request.urlopen(obj)
-        return True
-    except Exception:
+        result = urlparse(obj)
+        # Make sure scheme is http/https/fpt and has a non-empty netloc
+        return all([result.scheme in ("http", "https", "ftp"), result.netloc])
+    except (ValueError, AttributeError):
         return False
 
 

--- a/sunpy/util/io.py
+++ b/sunpy/util/io.py
@@ -109,7 +109,7 @@ def is_url(obj):
     """
     try:
         result = urlparse(obj)
-        # Make sure scheme is http/https/fpt and has a non-empty netloc
+        # Make sure scheme is http/https/ftp and has a non-empty netloc
         return all([result.scheme in ("http", "https", "ftp"), result.netloc])
     except (ValueError, AttributeError):
         return False


### PR DESCRIPTION
## PR Description

Update `is_url` to use urlparse instead of urlopen so don't need to make any network requests. 

The only side effect I can see is that if the string is a URL but that URL doesn't exist this will probably end up raising a different error than before e.g.

main
```
m = Map("http://aaa.bbb.ccc.com")
ValueError: Did not find any files at http:/aaa.bbb.ccc.com
m = Map("http://aaa.bbb.cccg.com")
ValueError: Did not find any files at http:/aaa.bbb.ccc.com
```

vs 
this PR 
```
m = Map("http://aaa.bbb.ccc.com") # not real URL
...
HTTPError: HTTP Error 404: Not Found

#or

m = Map("http://aaa.bbb.cccg.com") # domain doesn't exist
...
gaierror: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

URLError                                  Traceback (most recent call last)

```

Closes #8678 

## AI Assistance Disclosure

AI tools were used for:
- [  ] Code generation (e.g., when writing an implementation or fixing a bug)
- [  ] Test/benchmark generation
- [  ] Documentation (including examples)
- [  ] Research and understanding
- [x ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
