### PR TITLE
FIX: Support slicedLowLevelWCS in GenericMap.plot

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -2805,14 +2805,15 @@ class GenericMap(NDData):
             if title:
                 axes.set_title(title)
 
-            # WCSAxes has unit identifiers on the tick labels, so no need
-            # to add unit information to the label
+                    # WCSAxes has unit identifiers on the tick labels, so no need
+        # to add unit information to the label
+        if hasattr(axes.wcs, 'wcs'):
             ctype = axes.wcs.wcs.ctype
-            axes.coords[0].set_axislabel(axis_labels_from_ctype(ctype[0], None))
-            axes.coords[1].set_axislabel(axis_labels_from_ctype(ctype[1], None))
-
-        # Take a deep copy here so that a norm in imshow_kwargs doesn't get modified
-        # by setting it's vmin and vmax
+        else:
+            # For slicedLowLevelWCS, we need to get ctype differently
+            ctype = axes.wcs.world_axis_names
+        axes.coords[0].set_axislabel(axis_labels_from_ctype(ctype[0], None))
+        axes.coords[1].set_axislabel(axis_labels_from_ctype(ctype[1], None))
         imshow_args.update(copy.deepcopy(imshow_kwargs))
 
         if clip_interval is not None:
@@ -2828,10 +2829,14 @@ class GenericMap(NDData):
         else:
             data = np.ma.array(np.asarray(self.data), mask=self.mask)
 
-        # Disable autoalignment if it is not necessary
+                # Disable autoalignment if it is not necessary
         # TODO: revisit tolerance value
-        if autoalign is True and axes.wcs.wcs.compare(self.wcs.wcs, tolerance=0.01):
-            autoalign = False
+        if autoalign is True:
+            # Safely get the WCS objects
+            axes_wcs = axes.wcs.wcs if hasattr(axes.wcs, 'wcs') else axes.wcs
+            self_wcs = self.wcs.wcs if hasattr(self.wcs, 'wcs') else self.wcs
+            if axes_wcs.compare(self_wcs, tolerance=0.01):
+                autoalign = False
 
         if autoalign in {True, 'image'}:
             ny, nx = self.data.shape


### PR DESCRIPTION
# Thank you for contributing to SunPy

## 🚨 IMPORTANT 🚨

We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

[Please be aware that everyone has to follow our code of conduct](https://sunpy.org/coc)

[Furthermore, you might need to check with your work place if you are allowed to contribute code](https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html)

- Please try to create an issue _before_ creating a Pull Request.
- Please use the following Git commit message style
  - Use the future tense ("Adds feature" not "Added feature")
  - Limit the first line to 72 characters or less
- **Do not post the output from Large Language Models or similar generative AI as code or comments on GitHub or any other platform.**
  If you use generative AI tools as an aid in developing code or documentation changes, ensure that you fully understand the proposed changes and can explain why they are the correct approach and an improvement to the current state.
  See our documentation on fair and appropriate [AI usage](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
[This a brief explanation of them.](https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration)

## ↑👆 DELETE above _before_ submitting 👆↑

## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Fixes #8416

## Summary
This PR fixes an AttributeError when calling GenericMap.plot on a WCSAxes created from a sliced ndcube object.

## Changes Made
- Added fallback for when axes.wcs doesn't have a .wcs attribute
- Uses world_axis_names for slicedLowLevelWCS objects
- Safely handles WCS comparison in autoalignment block

## Testing
- Successfully ran reproduction script from issue #8416
- Plot renders without errors
Please also include relevant motivation and context.
-->

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
