### PR TITLE
Fix segfault from pandas==3.0.4

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - pip
   - openjpeg
   - graphviz!=2.42.*,!=2.43.*
+  # Avoid native crashes in pandas 3.0.4 with Python 3.13 when handling TimeSeries data.
   - pandas!=3.0.4
   - pycairo

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -6,4 +6,5 @@ dependencies:
   - pip
   - openjpeg
   - graphviz!=2.42.*,!=2.43.*
+  - pandas!=3.0.4
   - pycairo

--- a/changelog/8691.bugfix.rst
+++ b/changelog/8691.bugfix.rst
@@ -1,0 +1,1 @@
+Excluded pandas 3.0.4 from SunPy's dependencies because it can cause native crashes when handling `~sunpy.timeseries.TimeSeries` data with Python 3.13.

--- a/changelog/8691.bugfix.rst
+++ b/changelog/8691.bugfix.rst
@@ -1,1 +1,1 @@
-Excluded pandas 3.0.4 from SunPy's dependencies because it can cause native crashes when handling `~sunpy.timeseries.TimeSeries` data with Python 3.13.
+Excluded pandas 3.0.4 from dependencies because it causes segfaults when handling `~sunpy.timeseries.TimeSeries` data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ timeseries = [
   # We need to raise this to ensure the goes netcdf files open.
   "h5py>=3.12.0",
   "matplotlib>=3.10.0",
+  # Avoid native crashes in pandas 3.0.4 with Python 3.13 when handling TimeSeries data.
   "pandas>=2.3.0,!=3.0.4",
 ]
 visualization = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ timeseries = [
   # We need to raise this to ensure the goes netcdf files open.
   "h5py>=3.12.0",
   "matplotlib>=3.10.0",
-  "pandas>=2.3.0",
+  "pandas>=2.3.0,!=3.0.4",
 ]
 visualization = [
   "matplotlib>=3.10.0",

--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -15,7 +15,7 @@ dependencies:
   - mpl_animators
   - numpy
   - packaging
-  - pandas
+  - pandas!=3.0.4
   - parfive
   - pyerfa
   # - python  # Commented out to avoid triggering an upgrade

--- a/sunpy-dev-env.yml
+++ b/sunpy-dev-env.yml
@@ -15,6 +15,7 @@ dependencies:
   - mpl_animators
   - numpy
   - packaging
+  # Avoid native crashes in pandas 3.0.4 with Python 3.13 when handling TimeSeries data.
   - pandas!=3.0.4
   - parfive
   - pyerfa


### PR DESCRIPTION
Encountered 2 different segfaults from 3,0.4 pandas, after fixing them i Found a 3rd so just decided to  undo the fixes and dodge the release.The 3.0.4 release must be borked in some way and needs to be excluded from all our envs.