### PR TITLE
Add propagate_to_threads option to coordinate screens

### DIFF
--- a/changelog/8700.feature.rst
+++ b/changelog/8700.feature.rst
@@ -1,5 +1,6 @@
-Added the ``propagate_to_threads`` keyword to `~sunpy.coordinates.SphericalScreen` and
-`~sunpy.coordinates.PlanarScreen`, which makes the screen assumption also apply to
-calculations in other threads. This is necessary for the screen to have an effect when
-work is dispatched to worker threads while the context manager is active, e.g., when
+Added the ``propagate_to_threads`` keyword to `~sunpy.coordinates.SphericalScreen`,
+`~sunpy.coordinates.PlanarScreen`, :func:`~sunpy.coordinates.transform_with_sun_center`,
+and :func:`~sunpy.coordinates.propagate_with_solar_surface`, which makes the assumption
+also apply to calculations in other threads. This is necessary for the context manager to
+have an effect when work is dispatched to worker threads while it is active, e.g., when
 reprojecting a map with ``parallel=True``.

--- a/changelog/8700.feature.rst
+++ b/changelog/8700.feature.rst
@@ -1,0 +1,5 @@
+Added the ``propagate_to_threads`` keyword to `~sunpy.coordinates.SphericalScreen` and
+`~sunpy.coordinates.PlanarScreen`, which makes the screen assumption also apply to
+calculations in other threads. This is necessary for the screen to have an effect when
+work is dispatched to worker threads while the context manager is active, e.g., when
+reprojecting a map with ``parallel=True``.

--- a/sunpy/coordinates/_transformations.py
+++ b/sunpy/coordinates/_transformations.py
@@ -83,8 +83,32 @@ class TransformationOptions(threading.local):
 _transformation_options = TransformationOptions()
 
 
+# Storage of transformation options that have opted in to being visible to all threads (see
+# the ``propagate_to_threads`` keyword of the context managers), which is necessary for an
+# option to apply in worker threads spawned while the context manager is active (e.g., by
+# specifying ``parallel=True`` for a reprojection). An option enabled by the current thread
+# takes precedence over any shared option.
+_shared_options_lock = threading.Lock()
+_shared_ignore_sun_motion = 0  # the number of active contexts shared across threads
+_shared_autoapply_diffrot = []  # stack of rotation-model names shared across threads
+
+
+def _active_ignore_sun_motion():
+    if _transformation_options.ignore_sun_motion:
+        return True
+    with _shared_options_lock:
+        return _shared_ignore_sun_motion > 0
+
+
+def _active_autoapply_diffrot():
+    if _transformation_options.autoapply_diffrot is not None:
+        return _transformation_options.autoapply_diffrot
+    with _shared_options_lock:
+        return _shared_autoapply_diffrot[-1] if _shared_autoapply_diffrot else None
+
+
 @sunpycontextmanager
-def transform_with_sun_center():
+def transform_with_sun_center(propagate_to_threads=False):
     """
     Context manager for coordinate transformations to ignore the motion of the center of the Sun.
 
@@ -98,6 +122,16 @@ def transform_with_sun_center():
     Under this context manager, transformations will instead move the coordinate over time to
     "follow" the translational motion of the center of Sun, thus maintaining the position of the
     coordinate relative to the center of the Sun.
+
+    Parameters
+    ----------
+    propagate_to_threads : `bool`, optional
+        If `True`, this option also applies to calculations in other threads, which is
+        necessary when work is dispatched to worker threads while this context manager is
+        active (e.g., when specifying ``parallel=True`` for a reprojection). An option
+        enabled by a given thread always takes precedence over an option propagated from a
+        different thread. Defaults to `False`, i.e., the option applies only to
+        calculations in the thread that entered the context manager.
 
     Notes
     -----
@@ -132,21 +166,28 @@ def transform_with_sun_center():
     <SkyCoord (HeliographicStonyhurst: obstime=2001-02-01T00:00:00.000, rsun=695700.0 km): (lon, lat, radius) in (deg, deg, AU)
         (0., 0., 0.)>
     """
+    global _shared_ignore_sun_motion
     try:
         old_ignore_sun_motion = _transformation_options.ignore_sun_motion  # nominally False
 
         if not old_ignore_sun_motion:
             log.debug("Ignoring the motion of the center of the Sun for transformations")
         _transformation_options.ignore_sun_motion = True
+        if propagate_to_threads:
+            with _shared_options_lock:
+                _shared_ignore_sun_motion += 1
         yield
     finally:
         if not old_ignore_sun_motion:
             log.debug("Stop ignoring the motion of the center of the Sun for transformations")
         _transformation_options.ignore_sun_motion = old_ignore_sun_motion
+        if propagate_to_threads:
+            with _shared_options_lock:
+                _shared_ignore_sun_motion -= 1
 
 
 @sunpycontextmanager
-def propagate_with_solar_surface(rotation_model='howard'):
+def propagate_with_solar_surface(rotation_model='howard', propagate_to_threads=False):
     """
     Context manager for coordinate transformations to automatically apply solar
     differential rotation for any change in observation time.
@@ -170,6 +211,13 @@ def propagate_with_solar_surface(rotation_model='howard'):
         ``'allen'``, and ``'rigid'``. See the documentation for
         :func:`~sunpy.sun.models.differential_rotation` for the differences
         between these models.
+    propagate_to_threads : `bool`, optional
+        If `True`, this option also applies to calculations in other threads, which is
+        necessary when work is dispatched to worker threads while this context manager is
+        active (e.g., when specifying ``parallel=True`` for a reprojection). An option
+        enabled by a given thread always takes precedence over an option propagated from a
+        different thread. Defaults to `False`, i.e., the option applies only to
+        calculations in the thread that entered the context manager.
 
     Notes
     -----
@@ -209,19 +257,30 @@ def propagate_with_solar_surface(rotation_model='howard'):
          (85.1064,   0., 1.), (85.1064,  30., 1.),
          (85.1064,  60., 1.)]>
     """
-    with transform_with_sun_center():
+    with transform_with_sun_center(propagate_to_threads=propagate_to_threads):
         try:
             old_autoapply_diffrot = _transformation_options.autoapply_diffrot  # nominally False
 
             log.debug("Enabling automatic solar differential rotation "
                       f"('{rotation_model}') for any changes in obstime")
             _transformation_options.autoapply_diffrot = rotation_model
+            if propagate_to_threads:
+                with _shared_options_lock:
+                    _shared_autoapply_diffrot.append(rotation_model)
             yield
         finally:
             if not old_autoapply_diffrot:
                 log.debug("Disabling automatic solar differential rotation "
                           "for any changes in obstime")
             _transformation_options.autoapply_diffrot = old_autoapply_diffrot
+            if propagate_to_threads:
+                with _shared_options_lock:
+                    # Remove the most recent matching entry so that concurrent contexts
+                    # in different threads cannot corrupt each other's state
+                    for i in reversed(range(len(_shared_autoapply_diffrot))):
+                        if _shared_autoapply_diffrot[i] == rotation_model:
+                            del _shared_autoapply_diffrot[i]
+                            break
 
 
 # Global counter to keep track of the layer of transformation
@@ -738,7 +797,7 @@ def _affine_params_hcrs_to_hgs(hcrs_time, hgs_time):
 
     # All of the above is calculated for the HGS observation time
     # If the HCRS observation time is different, calculate the translation in origin
-    if not _transformation_options.ignore_sun_motion and np.any(hcrs_time != hgs_time):
+    if not _active_ignore_sun_motion() and np.any(hcrs_time != hgs_time):
         sun_pos_old_icrs = get_body_barycentric('sun', hcrs_time)
         offset_icrf = sun_pos_old_icrs - sun_pos_icrs
     else:
@@ -807,9 +866,9 @@ def hgs_to_hgs(from_coo, to_frame):
     elif _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
-        if _transformation_options.autoapply_diffrot:
+        if (autoapply_diffrot := _active_autoapply_diffrot()) is not None:
             from_coo = from_coo._apply_diffrot((to_frame.obstime - from_coo.obstime).to('day'),
-                                               _transformation_options.autoapply_diffrot)
+                                               autoapply_diffrot)
         return from_coo.transform_to(HCRS(obstime=to_frame.obstime)).transform_to(to_frame)
 
 

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -583,6 +583,22 @@ class Helioprojective(SunPyBaseCoordinateFrame):
             self.screen = None
     _assumptions = _Assumptions()
 
+    # Storage of screens that have opted in to being visible to all threads (see the
+    # ``propagate_to_threads`` keyword of screen classes), which is necessary for a screen
+    # to apply in worker threads spawned while the context manager is active (e.g., by
+    # specifying ``parallel=True`` for a reprojection). A screen entered by the current
+    # thread takes precedence over any shared screen. Exits remove entries by identity,
+    # so concurrent contexts in different threads cannot corrupt each other's state.
+    _shared_screens = []
+    _shared_screens_lock = threading.Lock()
+
+    @classmethod
+    def _active_screen(cls):
+        if cls._assumptions.screen is not None:
+            return cls._assumptions.screen
+        with cls._shared_screens_lock:
+            return cls._shared_screens[-1] if cls._shared_screens else None
+
     @property
     def angular_radius(self):
         """
@@ -643,9 +659,9 @@ class Helioprojective(SunPyBaseCoordinateFrame):
         with np.errstate(invalid='ignore'):
             d = ((-1*b) - np.sqrt(b**2 - 4*c)) / 2  # use the "near" solution
 
-        if self._assumptions.screen:
-            d_screen = self._assumptions.screen.calculate_distance(self)
-            d = np.fmin(d, d_screen) if self._assumptions.screen.only_off_disk else d_screen
+        if (screen := self._active_screen()) is not None:
+            d_screen = screen.calculate_distance(self)
+            d = np.fmin(d, d_screen) if screen.only_off_disk else d_screen
 
         # This warning can be triggered in specific draw calls when plt.show() is called
         # we can not easily prevent this, so we check the specific function is being called

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -11,7 +11,7 @@ from astropy.coordinates.representation import CartesianRepresentation, UnitSphe
 
 from sunpy import log
 from sunpy.coordinates import HeliographicStonyhurst, Helioprojective
-from sunpy.coordinates._transformations import _transformation_options
+from sunpy.coordinates._transformations import _active_autoapply_diffrot
 from sunpy.util.decorators import _active_contexts
 from sunpy.util.exceptions import warn_user
 
@@ -222,7 +222,7 @@ class SphericalScreen(BaseScreen):
             distance = ((-1*b) + np.sqrt(b**2 - 4*c)) / 2  # use the "far" solution
 
         # Iterate the calculation if differential rotation is being applied
-        if _transformation_options.autoapply_diffrot is not None and np.any(frame.obstime != self._center.obstime):
+        if _active_autoapply_diffrot() is not None and np.any(frame.obstime != self._center.obstime):
             screen_frame = Helioprojective(observer=self._center, obstime=self._center.obstime)
             distance = self._iterate_calculate_distance(frame, distance, screen_frame)
 
@@ -315,7 +315,7 @@ class PlanarScreen(BaseScreen):
         distance = d_from_plane / rep.dot(direction)
 
         # Iterate the calculation if differential rotation is being applied
-        if _transformation_options.autoapply_diffrot is not None and np.any(frame.obstime != self._vantage_point.obstime):
+        if _active_autoapply_diffrot() is not None and np.any(frame.obstime != self._vantage_point.obstime):
             screen_frame = Helioprojective(observer=self._vantage_point, obstime=self._vantage_point.obstime)
             distance = self._iterate_calculate_distance(frame, distance, screen_frame)
 

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -20,8 +20,9 @@ __all__ = ['BaseScreen', 'SphericalScreen', 'PlanarScreen']
 
 class BaseScreen(abc.ABC):
 
-    def __init__(self, only_off_disk=False):
+    def __init__(self, only_off_disk=False, propagate_to_threads=False):
         self.only_off_disk = only_off_disk
+        self.propagate_to_threads = propagate_to_threads
 
     @property
     def _context_name(self):
@@ -37,11 +38,22 @@ class BaseScreen(abc.ABC):
         _active_contexts.stack.append(self._context_name)
         self._old_assumed_screen = Helioprojective._assumptions.screen  # nominally None
         Helioprojective._assumptions.screen = self
+        if self.propagate_to_threads:
+            with Helioprojective._shared_screens_lock:
+                Helioprojective._shared_screens.append(self)
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         if (removed := _active_contexts.stack.pop()) != self._context_name:
             raise RuntimeError(f"Cannot remove {self._context_name} from tracking stack because {removed} is last active.")
         Helioprojective._assumptions.screen = self._old_assumed_screen
+        if self.propagate_to_threads:
+            with Helioprojective._shared_screens_lock:
+                # Remove by identity rather than by position so that concurrent contexts
+                # in different threads cannot corrupt each other's state
+                for i in reversed(range(len(Helioprojective._shared_screens))):
+                    if Helioprojective._shared_screens[i] is self:
+                        del Helioprojective._shared_screens[i]
+                        break
 
     def _iterate_calculate_distance(self, coord, distance, screen_frame):
         """
@@ -138,6 +150,13 @@ class SphericalScreen(BaseScreen):
     only_off_disk : `bool`, optional
         If `True`, apply this assumption only to off-disk coordinates, with on-disk coordinates
         still mapped onto the surface of the Sun. Defaults to `False`.
+    propagate_to_threads : `bool`, optional
+        If `True`, this screen also applies to calculations in other threads, which is
+        necessary when work is dispatched to worker threads while this context manager is
+        active (e.g., when specifying ``parallel=True`` for a reprojection). A screen
+        entered by a given thread always takes precedence over a screen propagated from a
+        different thread. Defaults to `False`, i.e., the screen applies only to
+        calculations in the thread that entered the context manager.
 
     See Also
     --------
@@ -231,6 +250,13 @@ class PlanarScreen(BaseScreen):
     only_off_disk : `bool`, optional
         If `True`, apply this assumption only to off-disk coordinates, with on-disk coordinates
         still mapped onto the surface of the Sun. Defaults to `False`.
+    propagate_to_threads : `bool`, optional
+        If `True`, this screen also applies to calculations in other threads, which is
+        necessary when work is dispatched to worker threads while this context manager is
+        active (e.g., when specifying ``parallel=True`` for a reprojection). A screen
+        entered by a given thread always takes precedence over a screen propagated from a
+        different thread. Defaults to `False`, i.e., the screen applies only to
+        calculations in the thread that entered the context manager.
 
     See Also
     --------

--- a/sunpy/coordinates/tests/test_frames.py
+++ b/sunpy/coordinates/tests/test_frames.py
@@ -655,6 +655,43 @@ def test_spherical_screen_askew(off_limb_coord, only_off_disk, distance, non_ear
     assert u.quantity.allclose(olc_3d.distance, distance)
 
 
+@pytest.mark.parametrize('screen_class', [
+    SphericalScreen,
+    PlanarScreen,
+])
+def test_screen_propagate_to_threads(off_limb_coord, screen_class):
+    from concurrent.futures import ThreadPoolExecutor
+
+    def distance_in_other_thread():
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(lambda: off_limb_coord.make_3d().spherical.distance).result()
+
+    # By default, a screen does not apply to calculations in other threads
+    with screen_class(off_limb_coord.observer):
+        assert np.isnan(distance_in_other_thread()).any()
+
+    # With propagate_to_threads, the screen applies to calculations in other threads
+    with screen_class(off_limb_coord.observer, propagate_to_threads=True):
+        assert not np.isnan(distance_in_other_thread()).any()
+
+    # The shared screen no longer applies after the context manager exits
+    assert np.isnan(distance_in_other_thread()).any()
+
+    # A screen entered by a thread takes precedence over a propagated screen
+    with screen_class(off_limb_coord.observer, propagate_to_threads=True):
+        shared_distance = off_limb_coord.make_3d().spherical.distance
+
+        def with_local_screen():
+            with SphericalScreen(off_limb_coord.observer, radius=2*u.AU):
+                return off_limb_coord.make_3d().spherical.distance
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            local_distance = executor.submit(with_local_screen).result()
+        assert not u.quantity.allclose(local_distance, shared_distance)
+
+
 @pytest.mark.parametrize(('screen', 'only_off_disk', 'distance'), [
     (SphericalScreen, False, [0.98405002, 0.98306592, 0.98253594]*u.AU),
     (SphericalScreen, True, [0.98405002, 0.97910333, 0.98253594]*u.AU),

--- a/sunpy/coordinates/tests/test_transformations.py
+++ b/sunpy/coordinates/tests/test_transformations.py
@@ -1234,3 +1234,52 @@ def test_propagate_with_solar_surface():
     assert_quantity_allclose(result4.lon, result1.lon)
     assert_quantity_allclose(result4.lat, result1.lat)
     assert_quantity_allclose(result4.distance, result1.distance)
+
+
+def test_context_managers_propagate_to_threads():
+    from concurrent.futures import ThreadPoolExecutor
+
+    sun_center = HeliographicStonyhurst(0*u.deg, 0*u.deg, 0*u.AU, obstime="2001-01-01")
+    hgs_end_frame = HeliographicStonyhurst(obstime="2001-02-01")
+
+    def sun_center_lon_in_other_thread():
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: sun_center.transform_to(hgs_end_frame).lon).result()
+
+    # By default, the option does not apply to calculations in other threads
+    with transform_with_sun_center():
+        assert not u.allclose(sun_center_lon_in_other_thread(), sun_center.lon)
+
+    # With propagate_to_threads, the option applies to calculations in other threads
+    with transform_with_sun_center(propagate_to_threads=True):
+        assert_quantity_allclose(sun_center_lon_in_other_thread(), sun_center.lon)
+
+    # The shared option no longer applies after the context manager exits
+    assert not u.allclose(sun_center_lon_in_other_thread(), sun_center.lon)
+
+    meridian = HeliocentricInertial(0*u.deg, np.arange(0, 90, 10)*u.deg, 1*u.AU,
+                                    obstime='2001-01-01')
+    dt = 6*u.day
+    hci_end_frame = HeliocentricInertial(obstime=meridian.obstime + dt)
+
+    def meridian_lon_in_other_thread():
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: meridian.transform_to(hci_end_frame).lon).result()
+
+    # With propagate_to_threads, differential rotation applies to calculations in other threads
+    with propagate_with_solar_surface(propagate_to_threads=True):
+        assert u.allclose(meridian_lon_in_other_thread(),
+                          differential_rotation(dt, meridian.lat, model='howard'))
+
+    # An option enabled by a thread takes precedence over a propagated option
+    with propagate_with_solar_surface('howard', propagate_to_threads=True):
+        def with_local_context():
+            with propagate_with_solar_surface('rigid'):
+                return meridian.transform_to(hci_end_frame).lon
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            local_lon = executor.submit(with_local_context).result()
+        assert u.allclose(local_lon, differential_rotation(dt, meridian.lat, model='rigid'))
+
+    # The shared option no longer applies after the context manager exits
+    assert u.allclose(meridian_lon_in_other_thread(), 0*u.deg, atol=1e-1*u.deg)


### PR DESCRIPTION
## PR Description

Making the screen state thread-local (#8500) means a screen entered in
one thread is invisible to worker threads spawned while the context
manager is active, e.g. by reproject with parallel=True. Off-disk
coordinates then silently come back as all NaNs in those workers.

Add an opt-in propagate_to_threads keyword to SphericalScreen and
PlanarScreen that additionally registers the screen in shared storage
visible to all threads. A screen entered by a given thread still takes
precedence over a propagated screen, and exits remove entries by
identity, preserving the thread-safety guarantees of #8500 for the
default case.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

# Thank you for contributing to SunPy

It is my pleasure. 

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation
- [X] Documentation (including examples)
- [X] Research and understanding
- [X] No human was used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.