### PR TITLE
Fix AttributeError in GenericTimeSeries._text_summary for Time-indexed data (#7932)

### DIFF
--- a/changelog/8701.bugfix.rst
+++ b/changelog/8701.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an `AttributeError` when printing or displaying a `~sunpy.timeseries.GenericTimeSeries` built from a `~pandas.DataFrame` indexed by an `~astropy.time.Time` array.

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -520,6 +520,25 @@ def test_repr_html_(generic_ts):
     assert isinstance(html_string, str)
 
 
+def test_text_summary_time_index():
+    # Regression test for https://github.com/sunpy/sunpy/issues/7932
+    # A TimeSeries built from a DataFrame indexed by an astropy Time array used
+    # to raise ``AttributeError: 'datetime.datetime' object has no attribute
+    # 'astype'`` in ``_text_summary`` because ``Time.value`` is format-dependent
+    # and is not always a NumPy ``datetime64``.
+    times = parse_time("2020-01-01") + TimeDelta(np.arange(60) * u.minute)
+    intensity = np.sin(np.linspace(0, 2 * np.pi, 60))
+    df = pd.DataFrame(intensity, index=times, columns=["intensity"])
+    ts = sunpy.timeseries.TimeSeries(df, {}, {"intensity": u.W / u.m**2})
+
+    summary = ts._text_summary()
+    assert "Start Date:\t\t\t2020-01-01 00:00:00" in summary
+    assert "End Date:\t\t\t2020-01-01 00:59:00" in summary
+    assert "Center Date:\t\t\t2020-01-01 00:29:30" in summary
+    # The full string representation must not raise either.
+    assert isinstance(str(ts), str)
+
+
 @pytest.mark.thread_unsafe(reason="mocks web browser")
 def test_quicklook(mocker, generic_ts):
     mockwbopen = mocker.patch('webbrowser.open_new_tab')

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -229,8 +229,15 @@ class GenericTimeSeries:
         drange = drange.to_string(float_format="{:.2E}".format)
         drange = drange.replace("\n", "<br>")
 
-        center = self.time_range.center.value.astype('datetime64[s]')
-        center = str(center).replace("T", " ")
+        def _format_date(time):
+            # ``Time.value`` is format-dependent (it can be a ``datetime`` or a
+            # ``str``), neither of which supports ``.astype``. ``datetime64`` is
+            # always a NumPy ``datetime64`` regardless of the ``Time`` format.
+            return str(time.datetime64.astype('datetime64[s]')).replace("T", " ")
+
+        start = _format_date(self.time_range.start)
+        end = _format_date(self.time_range.end)
+        center = _format_date(self.time_range.center)
         resolution = round(self.time_range.seconds.value/self.shape[0], 3)
         resolution = str(resolution)+" s"
 
@@ -248,8 +255,8 @@ class GenericTimeSeries:
                    Observatory:\t\t\t{obs}
                    Instrument:\t\t\t{link}
                    Channel(s):\t\t\t{channels}
-                   Start Date:\t\t\t{dat.index.min().round('s')}
-                   End Date:\t\t\t{dat.index.max().round('s')}
+                   Start Date:\t\t\t{start}
+                   End Date:\t\t\t{end}
                    Center Date:\t\t\t{center}
                    Resolution:\t\t\t{resolution}
                    Samples per Channel:\t\t{self.shape[0]}

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -230,10 +230,11 @@ class GenericTimeSeries:
         drange = drange.replace("\n", "<br>")
 
         def _format_date(time):
-            # ``Time.value`` is format-dependent (it can be a ``datetime`` or a
-            # ``str``), neither of which supports ``.astype``. ``datetime64`` is
-            # always a NumPy ``datetime64`` regardless of the ``Time`` format.
-            return str(time.datetime64.astype('datetime64[s]')).replace("T", " ")
+            # ``time`` is an astropy ``Time``; ``.iso`` yields a
+            # ``YYYY-MM-DD HH:MM:SS.sss`` string regardless of the underlying
+            # ``Time.format`` (which ``.value`` is sensitive to). Slice to the
+            # seconds field to keep the previous second-resolution output.
+            return time.iso[:19]
 
         start = _format_date(self.time_range.start)
         end = _format_date(self.time_range.end)


### PR DESCRIPTION
Fixes #7932

### The problem

Printing a `TimeSeries` that was built from a `DataFrame` indexed by an astropy
`Time` array raises:

```
AttributeError: 'datetime.datetime' object has no attribute 'astype'
```

Minimal reproduction (from the issue):

```python
from sunpy.timeseries import TimeSeries
from sunpy.time import parse_time
from astropy.time import TimeDelta
import astropy.units as u
import numpy as np
import pandas as pd

times = parse_time("now") - TimeDelta(np.arange(24 * 60) * u.minute)
intensity = np.sin(np.arange(0, 12 * np.pi, step=(12 * np.pi) / (24 * 60)))
df = pd.DataFrame(intensity, index=times, columns=['intensity'])
ts = TimeSeries(df, {}, {'intensity': u.W / u.m**2})
print(ts)   # AttributeError
```

### Root cause

`_text_summary` computed the center date with
`self.time_range.center.value.astype('datetime64[s]')`. `Time.value` is
*format-dependent*: for a `Time` in `datetime` format it returns a
`datetime.datetime`, and for a `Time` in `isot` format it returns a `str` —
neither of which has an `.astype` method. The code implicitly assumed `.value`
would always be a NumPy `datetime64`, which only happens to be true for some
`Time` formats.

While fixing this I found the same class of bug two lines below: the Start/End
dates were rendered with `dat.index.min().round('s')` /
`dat.index.max().round('s')`. When the frame is indexed by a `Time` array those
reductions return a `Time`, which has no `.round`, so the very same repro fails
again on the next line once the center line is fixed.

### The fix

Derive all three dates (start, end, center) from `Time.datetime64`, which is
always a NumPy `datetime64` regardless of the `Time` format, and route them
through one small helper so the three fields stay consistent. This addresses the
whole bug class rather than just the single reported line.

Output after the fix (same repro):

```
SunPy TimeSeries
----------------
...
Start Date:         2026-07-01 06:09:45
End Date:           2026-07-02 06:08:45
Center Date:        2026-07-01 18:09:15
Resolution:         59.958 s
...
```

### Testing

- Added `test_text_summary_time_index`, a regression test that builds a
  `TimeSeries` from a `Time`-indexed `DataFrame` and asserts the summary renders
  the expected Start/End/Center dates. It fails on `main` with the original
  `AttributeError` and passes with this change (verified by reverting the fix in
  the working tree).
- `pytest sunpy/timeseries/tests/test_timeseriesbase.py` — 69 passed, 2 deselected.
- `ruff==0.15.15` (the pinned pre-commit version) and `isort` both clean on the
  changed files.

### Note (out of scope for this PR)

`_repr_html_` has a separate, unrelated bug for **single-column** timeseries:
`fig.subplots(nrows=1, ncols=1)` returns a single `Axes`, so `zip(axs, ...)`
raises `TypeError: 'Axes' object is not iterable`. That is independent of #7932
and not touched here; happy to open a follow-up issue/PR if useful.
