### PR TITLE
Fix bug in VSOClient where ill formatted times would cause a crash

### DIFF
--- a/changelog/8702.bugfix.rst
+++ b/changelog/8702.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in `~sunpy.net.vso.vso.VSOClient` where unparsable times would cause a crash. Now unparsable times are replaced with a dummy value and the entry is masked, similar to how missing values are already treated.

--- a/sunpy/net/vso/table_response.py
+++ b/sunpy/net/vso/table_response.py
@@ -102,7 +102,11 @@ class VSOQueryResponseTable(QueryResponseTable):
                     mask = []
                     for i, t in enumerate(data[col]):
                         if t is not None:
-                            times.append(parse_time(t))
+                            try:
+                              times.append(parse_time(t))
+                            except ValueError:
+                                mask.append(i)
+                                times.append(Time(val=0, format='mjd'))
                         else:
                             # Create a dummy time and mask it later
                             times.append(Time(val=0, format='mjd'))

--- a/sunpy/net/vso/table_response.py
+++ b/sunpy/net/vso/table_response.py
@@ -103,7 +103,7 @@ class VSOQueryResponseTable(QueryResponseTable):
                     for i, t in enumerate(data[col]):
                         if t is not None:
                             try:
-                              times.append(parse_time(t))
+                                times.append(parse_time(t))
                             except ValueError:
                                 mask.append(i)
                                 times.append(Time(val=0, format='mjd'))

--- a/sunpy/net/vso/tests/test_vso.py
+++ b/sunpy/net/vso/tests/test_vso.py
@@ -239,6 +239,12 @@ def test_QueryResponse_build_table_with_no_end_time(mocker):
     assert start_time_[0].value == '2016-02-14 08:08:12.000'
 
 
+def test_QueryResponse_build_table_bad_time_format(mocker):
+    mocker.patch("sunpy.net.vso.vso.build_client", return_value=True)
+    records = (MockQRRecord(start_time="20220102030462"),)
+    table = VSOQueryResponseTable.from_zeep_response(MockQRResponse(records), client=None)
+    assert table['Start Time'].masked
+
 
 @pytest.mark.remote_data
 def test_vso_hmi(client, tmpdir):


### PR DESCRIPTION


## PR Description

Closes #8687 by treating dates which can't be parsed in a similar way to missing dates, use a dummy value and mask the corresponding entry in the table.

## AI Assistance Disclosure

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
