### PR TITLE
Fix parameter name mismatches in docstrings

### DIFF
--- a/changelog/8705.doc.rst
+++ b/changelog/8705.doc.rst
@@ -1,0 +1,1 @@
+Corrected several docstring parameter names in `sunpy.map`, `sunpy.net.scraper` and `sunpy.visualization` that did not match their function signatures.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -532,7 +532,7 @@ def pixelate_coord_path(smap, coord_path, *, bresenham=False):
     ----------
     smap : `~sunpy.map.GenericMap`
         The sunpy map.
-    coord : `~astropy.coordinates.SkyCoord`
+    coord_path : `~astropy.coordinates.SkyCoord`
         The coordinate path.
     bresenham : `bool`
         If ``True``, use Bresenham's line algorithm instead of the default

--- a/sunpy/net/scraper_utils.py
+++ b/sunpy/net/scraper_utils.py
@@ -52,7 +52,7 @@ def date_floor(date, timestep):
 
     Parameters
     ----------
-    datetime : `datetime.datetime` or `astropy.time.Time`
+    date : `datetime.datetime` or `astropy.time.Time`
         The date to floor.
     timestep : `dateutil.relativedelta.relativedelta`
         The smallest timestep to floor.

--- a/sunpy/visualization/visualization.py
+++ b/sunpy/visualization/visualization.py
@@ -79,7 +79,7 @@ def show_hpr_impact_angle(declination_axis):
 
     Parameters
     ----------
-    coordinate_axis : `astropy.visualization.wcsaxes.CoordinateHelper`
+    declination_axis : `astropy.visualization.wcsaxes.CoordinateHelper`
         The coordinate axis for Helioprojective Radial declination (``delta``)
 
     See Also


### PR DESCRIPTION
### Description

Fixes three docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `sunpy/map/maputils.py` | `pixelate_coord_path` | `coord` | `coord_path` |
| `sunpy/net/scraper_utils.py` | `date_floor` | `datetime` | `date` |
| `sunpy/visualization/visualization.py` | `show_hpr_impact_angle` | `coordinate_axis` | `declination_axis` |

Doc-only change; no behavior modified. I believe this qualifies for the "No Changelog Entry Needed" label, but happy to add a `trivial` changelog entry if preferred.