### PR TITLE
Fix bug with our coordinates context managers no longer working if threads are spawned within them

### DIFF
--- a/changelog/8707.bugfix.rst
+++ b/changelog/8707.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that prevented our coordinates context managers from applying to threads spawned within them (e.g., for parallel processing).

--- a/sunpy/coordinates/_transformations.py
+++ b/sunpy/coordinates/_transformations.py
@@ -13,9 +13,9 @@ This module contains the functions for converting one
 
 """
 import logging
-import threading
 from copy import deepcopy
 from functools import wraps
+from contextvars import ContextVar
 
 import erfa
 import numpy as np
@@ -74,13 +74,8 @@ __all__ = ['transform_with_sun_center',
 # Thread-safe storage of the current states of the transformation options
 # Otherwise, enabling an option on one thread can affect the calculations on another thread
 # Furthermore, context exits may restore a state that was supposed to have ended
-class TransformationOptions(threading.local):
-    def __init__(self):
-        # Boolean flag for whether to ignore the motion of the center of the Sun in inertial space
-        self.ignore_sun_motion = False
-        # If not None, the name of the differential-rotation model to use for any obstime change
-        self.autoapply_diffrot = None
-_transformation_options = TransformationOptions()
+_ignore_sun_motion = ContextVar('_ignore_sun_motion', default=False)
+_autoapply_diffrot = ContextVar('_autoapply_diffrot', default=False)
 
 
 @sunpycontextmanager
@@ -133,16 +128,16 @@ def transform_with_sun_center():
         (0., 0., 0.)>
     """
     try:
-        old_ignore_sun_motion = _transformation_options.ignore_sun_motion  # nominally False
+        old_ignore_sun_motion = _ignore_sun_motion.get()  # nominally False
 
         if not old_ignore_sun_motion:
             log.debug("Ignoring the motion of the center of the Sun for transformations")
-        _transformation_options.ignore_sun_motion = True
+        token = _ignore_sun_motion.set(True)
         yield
     finally:
         if not old_ignore_sun_motion:
             log.debug("Stop ignoring the motion of the center of the Sun for transformations")
-        _transformation_options.ignore_sun_motion = old_ignore_sun_motion
+        _ignore_sun_motion.reset(token)
 
 
 @sunpycontextmanager
@@ -211,17 +206,17 @@ def propagate_with_solar_surface(rotation_model='howard'):
     """
     with transform_with_sun_center():
         try:
-            old_autoapply_diffrot = _transformation_options.autoapply_diffrot  # nominally False
+            old_autoapply_diffrot = _autoapply_diffrot.get()  # nominally False
 
             log.debug("Enabling automatic solar differential rotation "
                       f"('{rotation_model}') for any changes in obstime")
-            _transformation_options.autoapply_diffrot = rotation_model
+            token = _autoapply_diffrot.set(rotation_model)
             yield
         finally:
             if not old_autoapply_diffrot:
                 log.debug("Disabling automatic solar differential rotation "
                           "for any changes in obstime")
-            _transformation_options.autoapply_diffrot = old_autoapply_diffrot
+            _autoapply_diffrot.reset(token)
 
 
 # Global counter to keep track of the layer of transformation
@@ -738,7 +733,7 @@ def _affine_params_hcrs_to_hgs(hcrs_time, hgs_time):
 
     # All of the above is calculated for the HGS observation time
     # If the HCRS observation time is different, calculate the translation in origin
-    if not _transformation_options.ignore_sun_motion and np.any(hcrs_time != hgs_time):
+    if not _ignore_sun_motion.get() and np.any(hcrs_time != hgs_time):
         sun_pos_old_icrs = get_body_barycentric('sun', hcrs_time)
         offset_icrf = sun_pos_old_icrs - sun_pos_icrs
     else:
@@ -807,9 +802,9 @@ def hgs_to_hgs(from_coo, to_frame):
     elif _times_are_equal(from_coo.obstime, to_frame.obstime):
         return to_frame.realize_frame(from_coo.data)
     else:
-        if _transformation_options.autoapply_diffrot:
+        if _autoapply_diffrot.get():
             from_coo = from_coo._apply_diffrot((to_frame.obstime - from_coo.obstime).to('day'),
-                                               _transformation_options.autoapply_diffrot)
+                                               _autoapply_diffrot.get())
         return from_coo.transform_to(HCRS(obstime=to_frame.obstime)).transform_to(to_frame)
 
 

--- a/sunpy/coordinates/_transformations.py
+++ b/sunpy/coordinates/_transformations.py
@@ -74,8 +74,11 @@ __all__ = ['transform_with_sun_center',
 # Thread-safe storage of the current states of the transformation options
 # Otherwise, enabling an option on one thread can affect the calculations on another thread
 # Furthermore, context exits may restore a state that was supposed to have ended
+
+# Boolean flag for whether to ignore the motion of the center of the Sun in inertial space
 _ignore_sun_motion = ContextVar('_ignore_sun_motion', default=False)
-_autoapply_diffrot = ContextVar('_autoapply_diffrot', default=False)
+# If not None, the name of the differential-rotation model to use for any obstime change
+_autoapply_diffrot = ContextVar('_autoapply_diffrot', default=None)
 
 
 @sunpycontextmanager

--- a/sunpy/coordinates/frames.py
+++ b/sunpy/coordinates/frames.py
@@ -6,8 +6,8 @@ the `astropy.coordinates` module.
 """
 import os
 import re
-import threading
 import traceback
+from contextvars import ContextVar
 
 import numpy as np
 
@@ -578,10 +578,7 @@ class Helioprojective(SunPyBaseCoordinateFrame):
     # Thread-safe storage of the currently active screen assumption, if any
     # Otherwise, the screen on one thread can affect calculations on another thread
     # Furthermore, context exits may restore a state that was supposed to have ended
-    class _Assumptions(threading.local):
-        def __init__(self):
-            self.screen = None
-    _assumptions = _Assumptions()
+    _assumed_screen = ContextVar('_assumed_screen', default=None)
 
     @property
     def angular_radius(self):
@@ -643,9 +640,9 @@ class Helioprojective(SunPyBaseCoordinateFrame):
         with np.errstate(invalid='ignore'):
             d = ((-1*b) - np.sqrt(b**2 - 4*c)) / 2  # use the "near" solution
 
-        if self._assumptions.screen:
-            d_screen = self._assumptions.screen.calculate_distance(self)
-            d = np.fmin(d, d_screen) if self._assumptions.screen.only_off_disk else d_screen
+        if self._assumed_screen.get():
+            d_screen = self._assumed_screen.get().calculate_distance(self)
+            d = np.fmin(d, d_screen) if self._assumed_screen.get().only_off_disk else d_screen
 
         # This warning can be triggered in specific draw calls when plt.show() is called
         # we can not easily prevent this, so we check the specific function is being called

--- a/sunpy/coordinates/screens.py
+++ b/sunpy/coordinates/screens.py
@@ -11,7 +11,7 @@ from astropy.coordinates.representation import CartesianRepresentation, UnitSphe
 
 from sunpy import log
 from sunpy.coordinates import HeliographicStonyhurst, Helioprojective
-from sunpy.coordinates._transformations import _transformation_options
+from sunpy.coordinates._transformations import _autoapply_diffrot
 from sunpy.util.decorators import _active_contexts
 from sunpy.util.exceptions import warn_user
 
@@ -34,14 +34,16 @@ class BaseScreen(abc.ABC):
         ...
 
     def __enter__(self):
-        _active_contexts.stack.append(self._context_name)
-        self._old_assumed_screen = Helioprojective._assumptions.screen  # nominally None
-        Helioprojective._assumptions.screen = self
+        active_contexts_copy = _active_contexts.get().copy()
+        active_contexts_copy.append(self._context_name)
+        self._active_contexts_token = _active_contexts.set(active_contexts_copy)
+        self._assumed_screen_token = Helioprojective._assumed_screen.set(self)
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        if (removed := _active_contexts.stack.pop()) != self._context_name:
+        if (removed := _active_contexts.get()[-1]) != self._context_name:
             raise RuntimeError(f"Cannot remove {self._context_name} from tracking stack because {removed} is last active.")
-        Helioprojective._assumptions.screen = self._old_assumed_screen
+        _active_contexts.reset(self._active_contexts_token)
+        Helioprojective._assumed_screen.reset(self._assumed_screen_token)
 
     def _iterate_calculate_distance(self, coord, distance, screen_frame):
         """
@@ -203,7 +205,7 @@ class SphericalScreen(BaseScreen):
             distance = ((-1*b) + np.sqrt(b**2 - 4*c)) / 2  # use the "far" solution
 
         # Iterate the calculation if differential rotation is being applied
-        if _transformation_options.autoapply_diffrot is not None and np.any(frame.obstime != self._center.obstime):
+        if _autoapply_diffrot.get() is not None and np.any(frame.obstime != self._center.obstime):
             screen_frame = Helioprojective(observer=self._center, obstime=self._center.obstime)
             distance = self._iterate_calculate_distance(frame, distance, screen_frame)
 
@@ -289,7 +291,7 @@ class PlanarScreen(BaseScreen):
         distance = d_from_plane / rep.dot(direction)
 
         # Iterate the calculation if differential rotation is being applied
-        if _transformation_options.autoapply_diffrot is not None and np.any(frame.obstime != self._vantage_point.obstime):
+        if _autoapply_diffrot.get() is not None and np.any(frame.obstime != self._vantage_point.obstime):
             screen_frame = Helioprojective(observer=self._vantage_point, obstime=self._vantage_point.obstime)
             distance = self._iterate_calculate_distance(frame, distance, screen_frame)
 

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -57,8 +57,6 @@ Examples
 #   ICRS. ICRS is a safe frame to use because the SPICE built-in inertial
 #   frame 'J2000' is ICRS, despite its name.
 
-import threading
-
 import numpy as np
 
 try:
@@ -88,12 +86,9 @@ _ET_REF_EPOCH = Time('J2000', scale='tdb')
 _CLASS_TYPES = {1: 'inertial', 2: 'PCK', 3: 'CK', 4: 'TK', 5: 'dynamic', 6: 'switch'}
 
 
-# Thread-safe registry of the generated frame classes and center classes
-class _Registry(threading.local):
-    def __init__(self):
-        self.frames = {}
-        self.centers = {'SOLAR SYSTEM BARYCENTER': ICRS}
-_registry = _Registry()
+# Registry of the generated frame classes and center classes
+_frame_registry = {}
+_center_registry = {'SOLAR SYSTEM BARYCENTER': ICRS}
 
 
 @add_common_docstring(**_variables_for_parse_time_docstring())
@@ -186,7 +181,7 @@ def _is_2d(data):
 
 def _install_center_by_id(center_id):
     center_name = spiceypy.bodc2n(center_id)
-    if center_name in _registry.centers.keys():
+    if center_name in _center_registry.keys():
         return
 
     log.info(f"Creating ICRF frame with {center_name} ({center_id}) origin")
@@ -216,7 +211,7 @@ def _install_center_by_id(center_id):
 
     frame_transform_graph._add_merged_transform(center_cls, ICRS, center_cls)
 
-    _registry.centers[center_name] = center_cls
+    _center_registry[center_name] = center_cls
 
 
 def _install_frame_by_id(frame_id):
@@ -230,7 +225,7 @@ def _install_frame_by_id(frame_id):
 
     # Create a center class (if needed)
     _install_center_by_id(center_id)
-    center_cls = _registry.centers[center_name]
+    center_cls = _center_registry[center_name]
 
     frame_cls = type(astropy_frame_name, (SpiceBaseCoordinateFrame,), {},
                      frame_name=frame_name, center_name=center_name)
@@ -255,7 +250,7 @@ def _install_frame_by_id(frame_id):
 
     frame_transform_graph._add_merged_transform(frame_cls, center_cls, frame_cls)
 
-    _registry.frames[frame_name] = (frame_cls, center_cls)
+    _frame_registry[frame_name] = (frame_cls, center_cls)
 
 
 def _uninstall_frame_by_class(target_class, from_class):
@@ -294,20 +289,22 @@ def initialize(kernels):
     spiceypy.furnsh([str(kernel) for kernel in kernels])
 
     # Remove all existing SPICE frame classes
-    if _registry.frames:
-        log.info(f"Removing {len(_registry.frames)} existing SPICE frame classes")
-        for spice_frame_name in _registry.frames.keys():
-            frame_cls, center_cls = _registry.frames[spice_frame_name]
+    global _frame_registry
+    if _frame_registry:
+        log.info(f"Removing {len(_frame_registry)} existing SPICE frame classes")
+        for spice_frame_name in _frame_registry.keys():
+            frame_cls, center_cls = _frame_registry[spice_frame_name]
             _uninstall_frame_by_class(frame_cls, center_cls)
-        _registry.frames.clear()
+        _frame_registry.clear()
 
     # Remove all non-default SPICE center classes
-    if len(_registry.centers) > 1:
-        log.info(f"Removing {len(_registry.centers) - 1} existing SPICE origin classes")
-        for spice_center_name, center_cls in _registry.centers.items():
+    global _center_registry
+    if len(_center_registry) > 1:
+        log.info(f"Removing {len(_center_registry) - 1} existing SPICE origin classes")
+        for spice_center_name, center_cls in _center_registry.items():
             if center_cls != ICRS:
                 _uninstall_frame_by_class(center_cls, ICRS)
-        _registry.centers = {'SOLAR SYSTEM BARYCENTER': ICRS}
+        _center_registry = {'SOLAR SYSTEM BARYCENTER': ICRS}
 
     # Generate all SPICE frame classes
     for class_num in _CLASS_TYPES.keys():
@@ -346,7 +343,7 @@ def install_frame(spice_frame):
         if frame_name == '':
             raise ValueError(f"{frame_id} is not a valid SPICE frame ID.")
 
-    if frame_name in _registry.frames:
+    if frame_name in _frame_registry:
         log.info(f"{frame_name} (frame_id) has already been installed.")
     else:
         _install_frame_by_id(frame_id)
@@ -466,7 +463,7 @@ def get_fov(instrument, time, *, resolution=100):
         obstime = Time(np.tile(obstime, num_vectors)).reshape((num_vectors, *obstime.shape)).T
 
     fov = SkyCoord(CartesianRepresentation(vectors.T),
-                   frame=_registry.frames[spice_frame][0],
+                   frame=_frame_registry[spice_frame][0],
                    obstime=obstime,
                    representation_type='unitspherical')
     return fov

--- a/sunpy/coordinates/spice.py
+++ b/sunpy/coordinates/spice.py
@@ -28,6 +28,11 @@ Be aware that when converting a SPICE-based coordinate to/from a built-in frame,
 there can be small inconsistencies due to differing planetary ephemerides and
 models for various orientations.
 
+.. warning::
+    This module is not thread-safe: it relies on global state because the
+    wrapped SPICE code also relies on global state.  When parallel processing,
+    use multiple processes rather than multiple threads.
+
 Notes
 -----
 * 2D coordinates can be transformed only if the to/from frames have the same

--- a/sunpy/map/tests/test_reproject_to.py
+++ b/sunpy/map/tests/test_reproject_to.py
@@ -3,10 +3,12 @@ Test the `GenericMap.reproject_to()` method
 """
 import warnings
 
+import dask
 import numpy as np
 import pytest
 from matplotlib.figure import Figure
 from matplotlib.testing.decorators import check_figures_equal
+from packaging.version import Version
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
@@ -48,6 +50,31 @@ def hpc_header(aia171_test_map):
         scale=u.Quantity(aia171_test_map.scale),
         projection_code='TAN'
     )
+
+
+@pytest.fixture
+def diffrot_header(aia171_test_map):
+    new_time = aia171_test_map.date + 5*u.day
+    return {
+        'naxis1': 150,
+        'naxis2': 150,
+        'crpix1': 75.5,
+        'crpix2': 75.5,
+        'crval1': 0,
+        'crval2': 0,
+        'cdelt1': 20,
+        'cdelt2': 20,
+        'cunit1': 'arcsec',
+        'cunit2': 'arcsec',
+        'ctype1': 'HPLN-TAN',
+        'ctype2': 'HPLT-TAN',
+        'hgln_obs': 0,
+        'hglt_obs': 30,
+        'rsun_ref': aia171_test_map.rsun_meters.value,
+        'dsun_obs': aia171_test_map.dsun.value,
+        'date-obs': new_time.isot,
+        'mjd-obs': new_time.mjd,
+    }
 
 
 @figure_test
@@ -228,33 +255,11 @@ def test_reproject_to_auto_extent_wcs(aia171_test_map, auto_extent, crpix, pixel
 
 @figure_test
 @pytest.mark.parametrize("screen", [sunpy.coordinates.SphericalScreen, sunpy.coordinates.PlanarScreen])
-def test_reproject_to_screen_plus_diffrot(aia171_test_map, screen):
-    new_time = aia171_test_map.date + 5*u.day
-    header = {
-        'naxis1': 150,
-        'naxis2': 150,
-        'crpix1': 75.5,
-        'crpix2': 75.5,
-        'crval1': 0,
-        'crval2': 0,
-        'cdelt1': 20,
-        'cdelt2': 20,
-        'cunit1': 'arcsec',
-        'cunit2': 'arcsec',
-        'ctype1': 'HPLN-TAN',
-        'ctype2': 'HPLT-TAN',
-        'hgln_obs': 0,
-        'hglt_obs': 30,
-        'rsun_ref': aia171_test_map.rsun_meters.value,
-        'dsun_obs': aia171_test_map.dsun.value,
-        'date-obs': new_time.isot,
-        'mjd-obs': new_time.mjd,
-    }
-
+def test_reproject_to_screen_plus_diffrot(aia171_test_map, diffrot_header, screen):
     with sunpy.coordinates.transform_with_sun_center(), screen(aia171_test_map.observer_coordinate, only_off_disk=True):
-        without_diffrot = aia171_test_map.reproject_to(header)
+        without_diffrot = aia171_test_map.reproject_to(diffrot_header)
         with sunpy.coordinates.propagate_with_solar_surface():
-            with_diffrot = aia171_test_map.reproject_to(header)
+            with_diffrot = aia171_test_map.reproject_to(diffrot_header)
 
     fig = Figure(figsize=(11, 4))
     ax1 = fig.add_subplot(121, projection=without_diffrot)
@@ -310,3 +315,21 @@ def test_reproject_to_preserve_date_obs_raises_exception_missing_date_obs_avg(m_
     target_header.set('NAXIS2', value=m_eit_1.data.shape[0])
     with pytest.raises(ValueError, match="The target_wcs has neither a DATE-AVG or DATE-OBS."):
         m_eit_2.reproject_to(target_header, preserve_date_obs=True)
+
+
+@pytest.mark.skipif(Version(dask.__version__) < Version("2026.3.0"),
+                    reason="dask>=2026.3.0 is required for threads to inherit context variables")
+def test_reproject_to_screen_parallel(aia171_test_map, hpc_header):
+    with sunpy.coordinates.SphericalScreen(aia171_test_map.observer_coordinate):
+        serial = aia171_test_map.reproject_to(hpc_header)
+        parallel = aia171_test_map.reproject_to(hpc_header, parallel=True)
+    assert_quantity_allclose(serial.data, parallel.data)
+
+
+@pytest.mark.skipif(Version(dask.__version__) < Version("2026.3.0"),
+                    reason="dask>=2026.3.0 is required for threads to inherit context variables")
+def test_reproject_to_diffrot_parallel(aia171_test_map, diffrot_header):
+    with sunpy.coordinates.propagate_with_solar_surface():
+        serial = aia171_test_map.reproject_to(diffrot_header)
+        parallel = aia171_test_map.reproject_to(diffrot_header, parallel=True)
+    assert_quantity_allclose(serial.data, parallel.data)

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -1,7 +1,7 @@
 """
 This module provides sunpy specific decorators.
 """
-import threading
+import contextvars
 from inspect import cleandoc
 from functools import wraps
 from contextlib import contextmanager
@@ -26,10 +26,7 @@ _NOT_FOUND = object()
 
 
 # Thread-safe stack (i.e., LIFO) of active contexts as a list of fully qualified name strings
-class _ActiveContexts(threading.local):
-    def __init__(self):
-        self.stack = []
-_active_contexts = _ActiveContexts()
+_active_contexts = contextvars.ContextVar('_active_contexts', default=[])
 
 
 def deprecated(
@@ -260,7 +257,9 @@ def sunpycontextmanager(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         func_name = f"{func.__module__}.{func.__qualname__}"
-        _active_contexts.stack.append(func_name)
+        active_contexts_copy = _active_contexts.get().copy()
+        active_contexts_copy.append(func_name)
+        token = _active_contexts.set(active_contexts_copy)
         gen = func(*args, **kwargs)
         value = next(gen)
         try:
@@ -269,8 +268,9 @@ def sunpycontextmanager(func):
             gen.throw(e)
         else:
             next(gen, None)
-            if (removed := _active_contexts.stack.pop()) != func_name:
+            if (removed := _active_contexts.get()[-1]) != func_name:
                 raise RuntimeError(f"Cannot remove {func_name} from tracking stack because {removed} is last active.")
+            _active_contexts.reset(token)
     return contextmanager(wrapper)
 
 

--- a/sunpy/util/decorators.py
+++ b/sunpy/util/decorators.py
@@ -26,6 +26,8 @@ _NOT_FOUND = object()
 
 
 # Thread-safe stack (i.e., LIFO) of active contexts as a list of fully qualified name strings
+# It is not thread-safe to modify the list directly
+# Instead, the list should be copied and then the context variable set with the modified copy
 _active_contexts = contextvars.ContextVar('_active_contexts', default=[])
 
 

--- a/sunpy/util/tests/test_decorators.py
+++ b/sunpy/util/tests/test_decorators.py
@@ -41,23 +41,23 @@ def test_context_tracking():
     ctx2_name = f"{ctx2.__module__}.{ctx2.__qualname__}"
 
     # Check that no sunpy contexts are active before entering
-    assert _active_contexts.stack == []
+    assert _active_contexts.get() == []
 
     with ctx1():
         # Check that the context is active while inside
-        assert _active_contexts.stack == [ctx1_name]
+        assert _active_contexts.get() == [ctx1_name]
 
         with ctx2():
             # Check nesting of contexts
-            assert _active_contexts.stack == [ctx1_name, ctx2_name]
+            assert _active_contexts.get() == [ctx1_name, ctx2_name]
 
             with ctx1():
                 # Check a repeated context in the nesting
-                assert _active_contexts.stack == [ctx1_name, ctx2_name, ctx1_name]
+                assert _active_contexts.get() == [ctx1_name, ctx2_name, ctx1_name]
 
             # Check that only the last context is removed and not its duplicate
-            assert _active_contexts.stack == [ctx1_name, ctx2_name]
+            assert _active_contexts.get() == [ctx1_name, ctx2_name]
 
-        assert _active_contexts.stack == [ctx1_name]
+        assert _active_contexts.get() == [ctx1_name]
 
-    assert _active_contexts.stack == []
+    assert _active_contexts.get() == []


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

#8500 used `threading.local()` to provide thread-specific (and hence thread-safe) state, but `threading.local()` state does not get passed on to (a.k.a. inherited by) threads that are spawned by that thread.  For example, this means a coordinate context manager does not work if dask parallel processing by threads is invoked within it (see #8704).  The appropriate approach for thread-safe storage that can be passed on to spawned threads is through `contextvars`.  This PR makes the switch to `contextvars`.

Be aware that the passing on of `contextvars` happens by default only on free-threaded builds of Python (cf. [`thread_inherit_context`](https://docs.python.org/3/library/sys.html#sys.flags.thread_inherit_context)).  For normal builts of Python, the code that spawns threads needs to call `contextvars.copy_context()` and manually it on.  For dask thread-based parallel processing, this requires dask >= 2026.3.0.  Thus, this PR fixes #8704 if dask >= 2026.3.0 is installed.

This PR also reverts the intended thread-safety changes in #8500 to `sunpy.coordinates.spice`.  Upon review, having thread-specific state makes no sense because `spiceypy`/`CSPICE` rely on global state.  Instead, I have added a thread-safety warning note to the module docstring.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- - [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- - [ ] Test/benchmark generation
- - [ ] Documentation (including examples)
- - [ ] Research and understanding
- - [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
