### PR TITLE
Fix where RUSTUP_TOOLCHAIN is defined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
           - openjpeg
         apt:
           - libopenjp2-7
+      setenv: |
+        RUSTUP_TOOLCHAIN: stable  # needed for building mocpy (a dependency of reproject)
       envs: |
         - linux: py314
           name: py314 (parallel threads)

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,8 @@ pass_env =
     LOCALE_ARCHIVE
     # If the user has set a LC override we should follow it
     LC_ALL
+    # Needed for building Rust-based dependencies
+    RUSTUP_TOOLCHAIN
 setenv =
     MPLBACKEND = agg
     SUNPY_SAMPLEDIR = {env:SUNPY_SAMPLEDIR:{toxinidir}/.tox/sample_data/}
@@ -46,8 +48,6 @@ setenv =
     NO_VERIFY_HELIO_SSL = 1
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/liberfa/simple
     py314t: PYTHON_GIL = 0
-    # Needed to build mocpy (a dependency of reproject) since there is no wheel
-    py314t: RUSTUP_TOOLCHAIN = stable
 deps =
     # Avoid adding this to the pyproject.toml as a dependency
     pytest-xdist


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

A follow-up to #8703 so that `RUSTUP_TOOLCHAIN` is defined in the GitHub workflow and passed on to the build by tox, instead of being defined in `tox.ini`.  In principle, someone might want to run tox locally with a different value for `RUSTUP_TOOLCHAIN`.  When I attempted this approach for #8703, I was so certain that the associated `pass_env` had to be in `[testenv:.pkg]` (which doesn't work) that I neglected to try putting it in `[testenv]` (which works).

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- - [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- - [ ] Test/benchmark generation
- - [ ] Documentation (including examples)
- - [ ] Research and understanding
- - [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
