### PR TITLE
Fix all_colnames only returning columns from the first table

### DIFF
--- a/changelog/8714.bugfix.rst
+++ b/changelog/8714.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `~sunpy.net.fido_factory.UnifiedResponse.all_colnames` only returning column names from the first table in the response instead of all tables.

--- a/sunpy/net/fido_factory.py
+++ b/sunpy/net/fido_factory.py
@@ -295,7 +295,7 @@ class UnifiedResponse(Sequence):
         """
         colnames = set(self[0].colnames)
         for resp in self[1:]:
-            colnames.union(resp.colnames)
+            colnames.update(resp.colnames)
         return sorted(list(colnames))
 
 

--- a/sunpy/net/tests/test_fido.py
+++ b/sunpy/net/tests/test_fido.py
@@ -221,6 +221,17 @@ def test_vso_unifiedresponse(mock_build_client):
     assert isinstance(uresp, UnifiedResponse)
 
 
+def test_all_colnames_multiple_tables():
+    # Regression test: all_colnames must collect columns from every table
+    # in the response, not just the first one.
+    table_one = QueryResponseTable({"Start Time": [1, 2], "Instrument": ["a", "b"]})
+    table_one.client = GenericClient()
+    table_two = QueryResponseTable({"Start Time": [3], "Provider": ["c"]})
+    table_two.client = GenericClient()
+    uresp = UnifiedResponse(table_one, table_two)
+    assert uresp.all_colnames == ["Instrument", "Provider", "Start Time"]
+
+
 @pytest.mark.remote_data
 def test_responses():
     results = Fido.search(


### PR DESCRIPTION
`UnifiedResponse.all_colnames` only ever returned the column names from the first table in the response.

```python
colnames = set(self[0].colnames)
for resp in self[1:]:
    colnames.union(resp.colnames)
return sorted(list(colnames))
```

`set.union()` returns a new set rather than mutating in place, so the result of `colnames.union(resp.colnames)` was discarded every loop iteration. `colnames` never picked up columns from any table after the first.

Fix is a one-line swap to `colnames.update(resp.colnames)`, which mutates in place.

Verified by reading the current source on `main` and reproducing the bug directly: building a `UnifiedResponse` from two `QueryResponseTable` objects with different columns, `all_colnames` dropped the second table's columns before the fix and returns both sets of columns after. Added a regression test (`test_all_colnames_multiple_tables` in `sunpy/net/tests/test_fido.py`) that fails against the old code and passes against the fix. Full `sunpy/net/tests/test_fido.py` non-remote-data suite passes (15 passed).

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.