### PR TITLE
Document magnitude of eccentricity effect on synodic differential rotation

### DIFF
--- a/changelog/8720.doc.rst
+++ b/changelog/8720.doc.rst
@@ -1,0 +1,1 @@
+Documented the approximate seasonal magnitude (+0.034/-0.032 deg/day near perihelion/aphelion) of the circular-orbit assumption in the synodic differential rotation correction in :func:`sunpy.sun.models.differential_rotation`.

--- a/sunpy/sun/models.py
+++ b/sunpy/sun/models.py
@@ -140,6 +140,17 @@ def differential_rotation(duration: u.s, latitude: u.deg, *, model='howard', fra
     1 microrad/s is approximately 4.95 deg/day.
     See also the comparisons in :cite:t:`beck_comparison_2000`.
 
+    Note that the synodic correction assumes a circular Earth orbit.
+    Because Earth's orbital eccentricity is :math:`e \approx 0.0167`, the
+    true rate varies over the year by about :math:`+0.034` deg/day near
+    perihelion (early January) and :math:`-0.032` deg/day near aphelion
+    (early July), following
+    :math:`\dot\nu = n(1+e\cos\nu)^2/(1-e^2)^{3/2}` from two-body Kepler
+    orbital mechanics. This seasonal variation is not accounted for and is
+    generally negligible, but for precise differential-rotation
+    calculations, use the ``sunpy.coordinates`` framework directly rather
+    than this function.
+
     Examples
     --------
     .. minigallery:: sunpy.sun.models.differential_rotation


### PR DESCRIPTION
Closes #8718 

## Description

Per feedback on #8718 : the docstring already notes that `frame_time='synodic'` uses Earth's average orbital motion, so this PR adds the missing piece, the approximate magnitude of the resulting inaccuracy from Earth's orbital eccentricity, plus a pointer to the `sunpy.coordinates` framework for anyone needing precise calculations.

## Derivation

dν/dt = n(1 + e cos ν)² / (1 - e²)^(3/2) (Kepler's second law + conic section relation). With e = 0.0167086 (JPL/J2000) and n = 0.9856 deg/day: +0.0338 deg/day at perihelion (~Jan 3), -0.0323 deg/day at aphelion (~Jul 4-5).

Documentation-only, no test changes.

AI tools were used for calculating the orbital mechanics