### PR TITLE
Handle empty timeseries when producing a summary

### DIFF
--- a/changelog/7914.bugfix.rst
+++ b/changelog/7914.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `~sunpy.timeseries.GenericTimeSeries` raising an error when it is printed or displayed after being truncated to a time range that contains no data. Summarising an empty timeseries now reports ``None`` for the start, end and center dates and for the resolution, instead of raising.

--- a/changelog/7914.bugfix.rst
+++ b/changelog/7914.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed `~sunpy.timeseries.GenericTimeSeries` raising an error when it is printed or displayed after being truncated to a time range that contains no data. Summarising an empty timeseries now reports ``None`` for the start, end and center dates and for the resolution, instead of raising.

--- a/changelog/8752.bugfix.rst
+++ b/changelog/8752.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `~sunpy.timeseries.GenericTimeSeries` raising an error when it is printed or displayed after being truncated to a time range that contains no data. Summarising an empty timeseries now reports ``None`` for the start, end and center dates and for the resolution, instead of raising.

--- a/sunpy/timeseries/sources/goes.py
+++ b/sunpy/timeseries/sources/goes.py
@@ -119,6 +119,11 @@ class XRSTimeSeries(GenericTimeSeries):
         # The ordering of where we get the metadata from is important.
         # We always want to check ID first as that will most likely have the correct information.
         # The other fields are fallback and sometimes have data in them that is "useless".
+        if not self.meta.metas:
+            # An empty timeseries (e.g. the result of a truncation that
+            # selected no rows) has no metadata to parse.
+            log.debug('No metadata available to parse a satellite number from')
+            return None
         id = (
             self.meta.metas[0].get("id", "").strip()
             or self.meta.metas[0].get("filename_id", "").strip()

--- a/sunpy/timeseries/tests/test_timeseriesbase.py
+++ b/sunpy/timeseries/tests/test_timeseriesbase.py
@@ -130,6 +130,29 @@ def test_truncation_dates(eve_test_ts):
             eve_test_ts.time_range.split(3)[1])
 
 
+def test_truncation_to_empty_summary(eve_test_ts):
+    # Truncating to a time range that contains no data should still produce a
+    # usable object rather than raising when it is summarised or displayed.
+    # See https://github.com/sunpy/sunpy/issues/7914
+    tr = TimeRange(eve_test_ts.time_range.end + TimeDelta(10*u.day),
+                   eve_test_ts.time_range.end + TimeDelta(11*u.day))
+    truncated = eve_test_ts.truncate(tr)
+
+    assert truncated.shape[0] == 0
+    assert truncated.time_range is None
+
+    summary = truncated._text_summary()
+    assert "Start Date:\t\t\tNone" in summary
+    assert "End Date:\t\t\tNone" in summary
+    assert "Center Date:\t\t\tNone" in summary
+    assert "Resolution:\t\t\tNone" in summary
+
+    # These must not raise for an empty timeseries.
+    str(truncated)
+    repr(truncated)
+    truncated._repr_html_()
+
+
 def test_truncated_none_ts(concatenate_multi_files_ts):
     # This timerange covers the whole range of metadata, so no change is expected
     a = concatenate_multi_files_ts.meta.metadata[0][0].start - TimeDelta(1*u.day)

--- a/sunpy/timeseries/timeseriesbase.py
+++ b/sunpy/timeseries/timeseriesbase.py
@@ -214,11 +214,11 @@ class GenericTimeSeries:
         if obs is None:
             try:
                 obs = self.meta.metadata[0][2]["telescop"]
-            except KeyError:
+            except (KeyError, IndexError):
                 obs = "Unknown"
         try:
             inst = self.meta.metadata[0][2]["instrume"]
-        except KeyError:
+        except (KeyError, IndexError):
             inst = "Unknown"
         try:
             link = f"""<a href={self.url} target="_blank">{inst}</a>"""
@@ -229,10 +229,18 @@ class GenericTimeSeries:
         drange = drange.to_string(float_format="{:.2E}".format)
         drange = drange.replace("\n", "<br>")
 
-        center = self.time_range.center.value.astype('datetime64[s]')
-        center = str(center).replace("T", " ")
-        resolution = round(self.time_range.seconds.value/self.shape[0], 3)
-        resolution = str(resolution)+" s"
+        time_range = self.time_range
+        if time_range is None:
+            # The timeseries holds no data, so there are no dates to report.
+            start_date = end_date = center = "None"
+            resolution = "None"
+        else:
+            start_date = dat.index.min().round('s')
+            end_date = dat.index.max().round('s')
+            center = time_range.center.value.astype('datetime64[s]')
+            center = str(center).replace("T", " ")
+            resolution = round(time_range.seconds.value/self.shape[0], 3)
+            resolution = str(resolution)+" s"
 
         channels = self.columns
         channels = "<br>".join(channels)
@@ -248,8 +256,8 @@ class GenericTimeSeries:
                    Observatory:\t\t\t{obs}
                    Instrument:\t\t\t{link}
                    Channel(s):\t\t\t{channels}
-                   Start Date:\t\t\t{dat.index.min().round('s')}
-                   End Date:\t\t\t{dat.index.max().round('s')}
+                   Start Date:\t\t\t{start_date}
+                   End Date:\t\t\t{end_date}
                    Center Date:\t\t\t{center}
                    Resolution:\t\t\t{resolution}
                    Samples per Channel:\t\t{self.shape[0]}
@@ -342,6 +350,17 @@ class GenericTimeSeries:
         # conflict in a single notebook.
         source = str(self.source) + str(time.perf_counter_ns())
 
+        # When the timeseries holds no (finite) data no histograms are
+        # produced, so fall back to a blank cell rather than indexing an
+        # empty list.
+        if hlist2:
+            hist_cell = (
+                f"""<img src="{hlist2[0]}" alt="Click here for histograms" """
+                f"""onclick="{source}.next(this)"/>"""
+            )
+        else:
+            hist_cell = "No data to histogram"
+
         return textwrap.dedent(f"""\
             <pre>{html.escape(object.__repr__(self))}</pre>
             <script type="text/javascript">
@@ -368,8 +387,7 @@ class GenericTimeSeries:
                 </tr>
                 <tr>
                     <td>
-                    <img src="{hlist2[0]}" alt="Click here for histograms"
-                         onclick="{source}.next(this)"/>
+                    {hist_cell}
                     </td>
                 </tr>
             </table>""")


### PR DESCRIPTION
Truncating a `TimeSeries` to a time range that contains no data leaves an object that blows up as soon as you try to look at it. This is easy to hit from the docs — the [truncation example](https://docs.sunpy.org/en/stable/tutorial/timeseries.html#truncating-a-timeseries) uses a 2012 `TimeRange` against the GOES sample data, which is from 2011, so it silently selects zero rows and then raises when the result is displayed.

Reproducer:

```python
import sunpy.timeseries, sunpy.data.sample
from sunpy.time import TimeRange

ts = sunpy.timeseries.TimeSeries(sunpy.data.sample.GOES_XRS_TIMESERIES)
print(ts.truncate(TimeRange('2012-06-07 05:00', '2012-06-07 06:30')))
```

There turned out to be three separate failures on that path, all from the same root cause — the summary code assumes there is at least one row:

- `GenericTimeSeries._text_summary` indexes `self.meta.metadata[0]`, which is empty after a truncation that kept nothing. The `except KeyError` around it doesn't catch the resulting `IndexError`.
- The same method dereferences `self.time_range`, but that property already returns `None` when there is no data, so it raises `AttributeError`. It also divides by `self.shape[0]` for the resolution, which is zero.
- `_repr_html_` indexes `hlist2[0]`, but no histograms are generated when there are no finite values, so it raises `IndexError`.

`XRSTimeSeries.observatory` had the same problem independently — it reads `self.meta.metas[0]` unguarded, so it raised before the base class ever got a chance to fall back to `"Unknown"`.

This fixes all four sites so an empty timeseries summarises rather than raising: the dates and resolution report `None`, the metadata lookups fall back to `"Unknown"`, and the histogram cell degrades to a short placeholder. Non-empty timeseries are unaffected — that path is unchanged.

I deliberately did not change `truncate` itself to reject empty results. Returning an empty timeseries seems reasonable, and there are existing tests that truncate down to nothing and expect an object back; the bug is purely that the object couldn't be displayed.

### Testing

Added `test_truncation_to_empty_summary`, which truncates past the end of the data and asserts `str()`, `repr()` and `_repr_html_()` all work. Confirmed it's a genuine regression test — with the fix stashed it fails with the original `IndexError: list index out of range`, and passes with the fix applied.

```
$ python -m pytest sunpy/timeseries/ -q
205 passed, 5 skipped, 12 deselected in 21.87s

$ python -m pytest sunpy/timeseries/ sunpy/util/ sunpy/time/ -q
469 passed, 8 skipped, 12 deselected in 23.66s

$ ruff check sunpy/timeseries/
All checks passed!
```

Fixes #7914

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
