### PR TITLE
Add decorator for assuming frame attributes

### DIFF
--- a/changelog/8753.feature.rst
+++ b/changelog/8753.feature.rst
@@ -1,0 +1,1 @@
+Add two new context managers `~sunpy.coordinates.assume_observer` and `~sunpy.coordinates.assume_frame_attributes` which can be used for assuming the position of the observer (or obstime) during coordinate operations. This can be particularly applicable when doing operations on two frames with the same observer but only a small difference in position / time between frames.

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -21,7 +21,7 @@ below (see `astropy.coordinates.builtin_frames`).
 from . import sun
 from ._transformations import _make_sunpy_graph, propagate_with_solar_surface, transform_with_sun_center
 from .ephemeris import *
-from .frameattributes import assume_frame_attributes
+from .frameattributes import assume_frame_attributes, assume_observer
 from .frames import *
 from .metaframes import *
 from .screens import PlanarScreen, SphericalScreen

--- a/sunpy/coordinates/__init__.py
+++ b/sunpy/coordinates/__init__.py
@@ -21,6 +21,7 @@ below (see `astropy.coordinates.builtin_frames`).
 from . import sun
 from ._transformations import _make_sunpy_graph, propagate_with_solar_surface, transform_with_sun_center
 from .ephemeris import *
+from .frameattributes import assume_frame_attributes
 from .frames import *
 from .metaframes import *
 from .screens import PlanarScreen, SphericalScreen

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -14,18 +14,30 @@ from sunpy.time import parse_time
 
 __all__ = ['TimeFrameAttributeSunPy', 'ObserverCoordinateAttribute']
 
-
-# TODO: I have no idea if sticking a dict in here makes it actually threadsafe, I assume not as it's mutable
 _assumed_attributes = ContextVar('_assumed_attributes', default=defaultdict(lambda: None))
 
 
 @contextmanager
 def assume_frame_attributes(**kwargs):
     """
-    Assume a value of a given frame attribute.
+    Assume a value of one or more frame attributes.
+
+    Parameters
+    ----------
+    kwargs
+        This function accepts any keyword arguments and will override
+        any frame attribute with a name matching that of the keyword
+        name.
     """
-    with _assumed_attributes.set(kwargs):
-        yield
+    # Get the current assumed attributes
+    current_attrs = _assumed_attributes.get()
+    # Build the new set, overriding current with kwargs
+    new_attrs = {**current_attrs, **kwargs}
+    # Set the new assumed attrs, but make sure it's still a defaultdict
+    token = _assumed_attributes.set(defaultdict(lambda: None, new_attrs))
+    yield
+    # Reset to previous value using token
+    _assumed_attributes.reset(token)
 
 
 class _AssumedAttributeMixin(Attribute):  # Inherit for type checking mainly

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -1,12 +1,22 @@
 import datetime
+from typing import Any
+from collections import defaultdict
+from contextvars import ContextVar
+
+import numpy as np
 
 import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, CoordinateAttribute, SkyCoord, TimeAttribute
 from astropy.time import Time
+from astropy.utils import ShapedLikeNDArray
 
 from sunpy.time import parse_time
 
 __all__ = ['TimeFrameAttributeSunPy', 'ObserverCoordinateAttribute']
+
+
+# TODO: I have no idea if sticking a dict in here makes it actually threadsafe, I assume not as it's mutable
+_assumed_attributes = ContextVar('_assumed_attributes', default=defaultdict(lambda: None))
 
 
 class TimeFrameAttributeSunPy(TimeAttribute):
@@ -28,6 +38,10 @@ class TimeFrameAttributeSunPy(TimeAttribute):
     frame_attr : descriptor
         A new data descriptor to hold a frame attribute
     """
+    def __get__(self, instance, frame_cls=None):
+        if (assumed_value := _assumed_attributes.get()[self.name]) is not None:
+            return assumed_value
+        return super().__get__(instance, frame_cls=frame_cls)
 
     def convert_input(self, value):
         """
@@ -141,7 +155,11 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
     def __get__(self, instance, frame_cls=None):
         # If instance is None then we can't get obstime so it doesn't matter.
         if instance is not None:
-            observer = getattr(instance, '_' + self.name)
+            assumed_observer = True
+            observer: Any | None = _assumed_attributes.get()[self.name]
+            if observer is None:
+                assumed_observer = False
+                observer = getattr(instance, '_' + self.name)
             obstime = getattr(instance, 'obstime', None)  # TODO: Why is this `None` needed?
 
             # If the observer is a string and we have obstime then calculate
@@ -153,5 +171,31 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
                     setattr(instance, '_' + self.name, new_observer)
                 else:
                     return observer
+
+            if assumed_observer:
+                # This is horrible but super.__get__ can't be used (for now)
+                out, converted = self.convert_input(observer)
+                if instance is not None:
+                    # None if instance (frame) has no data!
+                    instance_shape = getattr(instance, "shape", None)
+                    if instance_shape is not None and (
+                        getattr(out, "shape", ()) and out.shape != instance_shape
+                    ):
+                        # If the shapes do not match, try broadcasting.
+                        try:
+                            if isinstance(out, ShapedLikeNDArray):
+                                out = out._apply(
+                                    np.broadcast_to, shape=instance_shape, subok=True
+                                )
+                            else:
+                                out = np.broadcast_to(out, instance_shape, subok=True)
+                        except ValueError:
+                            # raise more informative exception.
+                            raise ValueError(
+                                f"attribute {self.name} should be scalar or have shape"
+                                f" {instance_shape}, but it has shape {out.shape} and could not"
+                                " be broadcast."
+                            )
+                return out
 
         return super().__get__(instance, frame_cls=frame_cls)

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -1,12 +1,11 @@
 import datetime
-from typing import Any
 from collections import defaultdict
 from contextvars import ContextVar
 
 import numpy as np
 
 import astropy.units as u
-from astropy.coordinates import BaseCoordinateFrame, CoordinateAttribute, SkyCoord, TimeAttribute
+from astropy.coordinates import Attribute, BaseCoordinateFrame, CoordinateAttribute, SkyCoord, TimeAttribute
 from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
 
@@ -18,8 +17,53 @@ __all__ = ['TimeFrameAttributeSunPy', 'ObserverCoordinateAttribute']
 # TODO: I have no idea if sticking a dict in here makes it actually threadsafe, I assume not as it's mutable
 _assumed_attributes = ContextVar('_assumed_attributes', default=defaultdict(lambda: None))
 
+class _AssumedAttributeMixin(Attribute):  # Inherit for type checking mainly
+    # This class re-implements the astropy.coordinates.attributes.Attribute.__get__ method
+    # to support assumed attributes, maybe this will be upstreamed at somepoint
+    def __get__(self, instance, frame_cls=None):
+        if instance is None:
+            # Return the descriptor instance to enable the retrieval of the docstring
+            return self
 
-class TimeFrameAttributeSunPy(TimeAttribute):
+        if (assumed_value := _assumed_attributes.get().get(self.name)) is not None:
+            out = assumed_value
+        else:
+            out = getattr(instance, "_" + self.name, self.default)
+
+        if out is None:
+            out = getattr(instance, self.secondary_attribute, self.default)
+
+        out, converted = self.convert_input(out)
+        if instance is not None:
+            # None if instance (frame) has no data!
+            instance_shape = getattr(instance, "shape", None)
+            if instance_shape is not None and (
+                getattr(out, "shape", ()) and out.shape != instance_shape
+            ):
+                # If the shapes do not match, try broadcasting.
+                try:
+                    if isinstance(out, ShapedLikeNDArray):
+                        out = out._apply(
+                            np.broadcast_to, shape=instance_shape, subok=True
+                        )
+                    else:
+                        out = np.broadcast_to(out, instance_shape, subok=True)
+                except ValueError:
+                    # raise more informative exception.
+                    raise ValueError(
+                        f"attribute {self.name} should be scalar or have shape"
+                        f" {instance_shape}, but it has shape {out.shape} and could not"
+                        " be broadcast."
+                    )
+
+                converted = True
+
+            if converted:
+                setattr(instance, "_" + self.name, out)
+
+        return out
+
+class TimeFrameAttributeSunPy(_AssumedAttributeMixin, TimeAttribute):
     """
     Frame attribute descriptor for quantities that are Time objects.
     See the `~astropy.coordinates.Attribute` API doc for further
@@ -38,11 +82,6 @@ class TimeFrameAttributeSunPy(TimeAttribute):
     frame_attr : descriptor
         A new data descriptor to hold a frame attribute
     """
-    def __get__(self, instance, frame_cls=None):
-        if instance is not None and (assumed_value := _assumed_attributes.get()[self.name]) is not None:
-            return assumed_value
-        return super().__get__(instance, frame_cls=frame_cls)
-
     def convert_input(self, value):
         """
         Convert input value to a Time object and validate by running through the
@@ -90,7 +129,7 @@ class TimeFrameAttributeSunPy(TimeAttribute):
         return out, converted
 
 
-class ObserverCoordinateAttribute(CoordinateAttribute):
+class ObserverCoordinateAttribute(_AssumedAttributeMixin, CoordinateAttribute):
     """
     An Attribute to describe the location of the observer in the solar system.
     The observer location can be given as a string of a known observer, which
@@ -155,11 +194,7 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
     def __get__(self, instance, frame_cls=None):
         # If instance is None then we can't get obstime so it doesn't matter.
         if instance is not None:
-            assumed_observer = True
-            observer: Any | None = _assumed_attributes.get()[self.name]
-            if observer is None:
-                assumed_observer = False
-                observer = getattr(instance, '_' + self.name)
+            observer = getattr(instance, '_' + self.name)
             obstime = getattr(instance, 'obstime', None)  # TODO: Why is this `None` needed?
 
             # If the observer is a string and we have obstime then calculate
@@ -171,31 +206,5 @@ class ObserverCoordinateAttribute(CoordinateAttribute):
                     setattr(instance, '_' + self.name, new_observer)
                 else:
                     return observer
-
-            if assumed_observer:
-                # This is horrible but super.__get__ can't be used (for now)
-                out, converted = self.convert_input(observer)
-                if instance is not None:
-                    # None if instance (frame) has no data!
-                    instance_shape = getattr(instance, "shape", None)
-                    if instance_shape is not None and (
-                        getattr(out, "shape", ()) and out.shape != instance_shape
-                    ):
-                        # If the shapes do not match, try broadcasting.
-                        try:
-                            if isinstance(out, ShapedLikeNDArray):
-                                out = out._apply(
-                                    np.broadcast_to, shape=instance_shape, subok=True
-                                )
-                            else:
-                                out = np.broadcast_to(out, instance_shape, subok=True)
-                        except ValueError:
-                            # raise more informative exception.
-                            raise ValueError(
-                                f"attribute {self.name} should be scalar or have shape"
-                                f" {instance_shape}, but it has shape {out.shape} and could not"
-                                " be broadcast."
-                            )
-                return out
 
         return super().__get__(instance, frame_cls=frame_cls)

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -39,7 +39,7 @@ class TimeFrameAttributeSunPy(TimeAttribute):
         A new data descriptor to hold a frame attribute
     """
     def __get__(self, instance, frame_cls=None):
-        if (assumed_value := _assumed_attributes.get()[self.name]) is not None:
+        if instance is not None and (assumed_value := _assumed_attributes.get()[self.name]) is not None:
             return assumed_value
         return super().__get__(instance, frame_cls=frame_cls)
 

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -77,6 +77,20 @@ def assume_frame_attributes(**kwargs):
     _assumed_attributes.reset(token)
 
 
+@contextmanager
+def assume_observer(observer):
+    """
+    Assume the provided observer and it's obstime.
+
+    Parameters
+    ----------
+    observer: astropy.coordinates.SkyCoord
+        The observer to assume, should have an obstime which will also be assumed.
+    """
+    with assume_frame_attributes(observer=observer, obstime=observer.obstime):
+        yield
+
+
 class _AssumedAttributeMixin(Attribute):  # Inherit for type checking mainly
     # This class re-implements the astropy.coordinates.attributes.Attribute.__get__ method
     # to support assumed attributes, maybe this will be upstreamed at somepoint

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -88,6 +88,32 @@ def assume_observer(observer):
     ----------
     observer: astropy.coordinates.SkyCoord
         The observer to assume, should have an obstime which will also be assumed.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import SkyCoord
+    >>> import sunpy.coordinates
+    >>> from sunpy.coordinates import Helioprojective
+    >>> import astropy.units as u
+    >>> sc = SkyCoord(0*u.deg, 0*u.deg, 5*u.km,
+    ...               obstime="2010/01/01T00:00:00", observer="earth", frame="helioprojective")
+    >>> sc
+    <SkyCoord (Helioprojective: obstime=2010-01-01T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
+        (0., 0., 5.)>
+
+    This transformation does an observer shift and round trip through Heliographic coordinates:
+
+    >>> target_frame = Helioprojective(observer="mars", obstime=sc.obstime)
+    >>> sc.transform_to(target_frame)
+    <SkyCoord (Helioprojective: obstime=2010-01-01T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'mars'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
+        (-79535.05476998, -424.5843386, 1.105226e+08)>
+
+    This transformation does not, because the observer of the input and output coordinates are the same, so in this case the transform does nothing.
+
+    >>> with assume_observer(target_frame.observer):
+    ...     sc.transform_to(Helioprojective(obstime="2010/01/02T00:00:00"))
+    <SkyCoord (Helioprojective: obstime=2010-01-01T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'mars'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
+        (0., 0., 5.)>
     """
     with assume_frame_attributes(observer=observer, obstime=observer.obstime):
         yield
@@ -158,6 +184,7 @@ class TimeFrameAttributeSunPy(_AssumedAttributeMixin, TimeAttribute):
     frame_attr : descriptor
         A new data descriptor to hold a frame attribute
     """
+
     def convert_input(self, value):
         """
         Convert input value to a Time object and validate by running through the

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -1,4 +1,5 @@
 import datetime
+from contextlib import contextmanager
 from collections import defaultdict
 from contextvars import ContextVar
 
@@ -16,6 +17,16 @@ __all__ = ['TimeFrameAttributeSunPy', 'ObserverCoordinateAttribute']
 
 # TODO: I have no idea if sticking a dict in here makes it actually threadsafe, I assume not as it's mutable
 _assumed_attributes = ContextVar('_assumed_attributes', default=defaultdict(lambda: None))
+
+
+@contextmanager
+def assume_frame_attributes(**kwargs):
+    """
+    Assume a value of a given frame attribute.
+    """
+    with _assumed_attributes.set(kwargs):
+        yield
+
 
 class _AssumedAttributeMixin(Attribute):  # Inherit for type checking mainly
     # This class re-implements the astropy.coordinates.attributes.Attribute.__get__ method

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -72,9 +72,11 @@ def assume_frame_attributes(**kwargs):
     new_attrs = {**current_attrs, **kwargs}
     # Set the new assumed attrs, but make sure it's still a defaultdict
     token = _assumed_attributes.set(defaultdict(lambda: None, new_attrs))
-    yield
-    # Reset to previous value using token
-    _assumed_attributes.reset(token)
+    try:
+        yield
+    finally:
+        # Reset to previous value using token
+        _assumed_attributes.reset(token)
 
 
 @contextmanager

--- a/sunpy/coordinates/frameattributes.py
+++ b/sunpy/coordinates/frameattributes.py
@@ -14,7 +14,12 @@ from sunpy.time import parse_time
 
 __all__ = ['TimeFrameAttributeSunPy', 'ObserverCoordinateAttribute']
 
-_assumed_attributes = ContextVar('_assumed_attributes', default=defaultdict(lambda: None))
+_assumed_attributes: ContextVar[defaultdict | None] = ContextVar('_assumed_attributes', default=None)
+
+
+def _get_assumed_attributes():
+    """A helper function so that we don't have a mutable default in ContextVar."""
+    return _assumed_attributes.get() or {}
 
 
 @contextmanager
@@ -22,15 +27,47 @@ def assume_frame_attributes(**kwargs):
     """
     Assume a value of one or more frame attributes.
 
+    .. note::
+
+        This currently applies only to sunpy frames for observer
+        coordinates and times (``obstime`` and ``observer`` attributes by
+        convention).
+
     Parameters
     ----------
     kwargs
         This function accepts any keyword arguments and will override
         any frame attribute with a name matching that of the keyword
         name.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import SkyCoord
+    >>> import sunpy.coordinates
+    >>> from sunpy.coordinates import Helioprojective
+    >>> import astropy.units as u
+    >>> sc = SkyCoord(0*u.deg, 0*u.deg, 5*u.km,
+    ...               obstime="2010/01/01T00:00:00", observer="earth", frame="helioprojective")
+    >>> sc
+    <SkyCoord (Helioprojective: obstime=2010-01-01T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
+        (0., 0., 5.)>
+
+    This transformation does an observer shift and round trip through Heliographic coordinates:
+
+    >>> sc.transform_to(Helioprojective(obstime="2010/01/02T00:00:00"))
+    <SkyCoord (Helioprojective: obstime=2010-01-02T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
+        (-0.82228008, 0.08095055, 4.99999994)>
+
+    This transformation does not, because the input obstime is assumed to be the same as the output obstime
+
+    >>> with assume_frame_attributes(obstime="2010/01/02T00:00:00"):
+    ...     sc.transform_to(Helioprojective(obstime="2010/01/02T00:00:00"))
+    <SkyCoord (Helioprojective: obstime=2010-01-02T00:00:00.000, rsun=695700.0 km, observer=<HeliographicStonyhurst Coordinate for 'earth'>): (Tx, Ty, distance) in (arcsec, arcsec, km)
+        (0., 0., 5.)>
+
     """
     # Get the current assumed attributes
-    current_attrs = _assumed_attributes.get()
+    current_attrs = _get_assumed_attributes()
     # Build the new set, overriding current with kwargs
     new_attrs = {**current_attrs, **kwargs}
     # Set the new assumed attrs, but make sure it's still a defaultdict
@@ -48,7 +85,7 @@ class _AssumedAttributeMixin(Attribute):  # Inherit for type checking mainly
             # Return the descriptor instance to enable the retrieval of the docstring
             return self
 
-        if (assumed_value := _assumed_attributes.get().get(self.name)) is not None:
+        if (assumed_value := _get_assumed_attributes().get(self.name)) is not None:
             out = assumed_value
         else:
             out = getattr(instance, "_" + self.name, self.default)

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -249,7 +249,7 @@ def test_assume_observer():
     # This errors as the frames aren't compatible
     # assert hpc1.observer != assumed_observer
 
-    with _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer}): 
+    with _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer}):
         assert hpc1.obstime == assumed_obstime
         assert hpc1.observer == assumed_observer
 
@@ -270,7 +270,7 @@ def test_transform_assume_observerd():
     assert not u.allclose(original_transform.Tx, 0*u.arcsec)
     assert not u.allclose(original_transform.Ty, 0*u.arcsec)
 
-    with _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer}):   
+    with _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer}):
         assumed_transform = hpc1.transform_to(hpc2)
         assert u.allclose(assumed_transform.Tx, 0*u.arcsec)
         assert u.allclose(assumed_transform.Ty, 0*u.arcsec)

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 
 import pytest
 
@@ -7,7 +8,11 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 
 from sunpy.coordinates import frames, get_earth
-from sunpy.coordinates.frameattributes import ObserverCoordinateAttribute, TimeFrameAttributeSunPy
+from sunpy.coordinates.frameattributes import (
+    ObserverCoordinateAttribute,
+    TimeFrameAttributeSunPy,
+    _assumed_attributes,
+)
 from sunpy.coordinates.frames import (
     Heliocentric,
     HeliocentricInertial,
@@ -214,3 +219,64 @@ def test_observer_in_heeq(frame_class):
     frame = frame_class(observer=obs_heeq)
     assert issubclass(frame.observer.representation_type, SphericalRepresentation)
     assert_quantity_allclose(frame.observer.radius, 13*u.AU)
+
+
+def test_assume_obstime():
+    assumed_obstime = Time('2012-01-01 00:00:00')
+
+    hpc1 = Helioprojective()
+
+    assert hpc1.obstime != assumed_obstime
+
+    from sunpy.coordinates.frameattributes import _assumed_attributes
+    _assumed_attributes.set({"obstime": assumed_obstime})
+
+    assert hpc1.obstime == assumed_obstime
+
+
+def test_assume_observer():
+    original_obstime = Time('2026-08-12 19:09:00')
+    out_icrs = ICRS(get_body_barycentric("mars", original_obstime))
+    original_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=original_obstime))
+
+    assumed_obstime = Time('2012-01-01 00:00:00')
+    out_icrs = ICRS(get_body_barycentric("mars", assumed_obstime))
+    assumed_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=assumed_obstime))
+
+    hpc1 = Helioprojective(observer=original_observer, obstime=original_obstime)
+
+    assert hpc1.obstime != assumed_obstime
+    # This errors as the frames aren't compatible
+    # assert hpc1.observer != assumed_observer
+
+    _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer})
+
+    assert hpc1.obstime == assumed_obstime
+    assert hpc1.observer == assumed_observer
+
+    _assumed_attributes.set(defaultdict(lambda: None))
+
+
+def test_transform_assume_observer():
+    original_obstime = Time('2026-08-12 19:09:00')
+    out_icrs = ICRS(get_body_barycentric("mars", original_obstime))
+    original_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=original_obstime))
+
+    assumed_obstime = Time('2012-01-01 00:00:00')
+    out_icrs = ICRS(get_body_barycentric("mars", assumed_obstime))
+    assumed_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=assumed_obstime))
+
+    hpc1 = Helioprojective(0*u.arcsec, 0*u.arcsec, observer=original_observer, obstime=original_obstime)
+    hpc2 = Helioprojective(observer=assumed_observer, obstime=assumed_obstime)
+
+    original_transform = hpc1.transform_to(hpc2)
+    assert not u.allclose(original_transform.Tx, 0*u.arcsec)
+    assert not u.allclose(original_transform.Ty, 0*u.arcsec)
+
+    _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer})
+
+    assumed_transform = hpc1.transform_to(hpc2)
+    assert u.allclose(assumed_transform.Tx, 0*u.arcsec)
+    assert u.allclose(assumed_transform.Ty, 0*u.arcsec)
+
+    _assumed_attributes.set(defaultdict(lambda: None))

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -228,10 +228,8 @@ def test_assume_obstime():
 
     assert hpc1.obstime != assumed_obstime
 
-    from sunpy.coordinates.frameattributes import _assumed_attributes
-    _assumed_attributes.set({"obstime": assumed_obstime})
-
-    assert hpc1.obstime == assumed_obstime
+    with _assumed_attributes.set({"obstime": assumed_obstime}):
+        assert hpc1.obstime == assumed_obstime
 
 
 def test_assume_observer():
@@ -244,20 +242,19 @@ def test_assume_observer():
     assumed_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=assumed_obstime))
 
     hpc1 = Helioprojective(observer=original_observer, obstime=original_obstime)
+    _assumed_attributes.set(defaultdict(lambda: None))
+
 
     assert hpc1.obstime != assumed_obstime
     # This errors as the frames aren't compatible
     # assert hpc1.observer != assumed_observer
 
-    _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer})
-
-    assert hpc1.obstime == assumed_obstime
-    assert hpc1.observer == assumed_observer
-
-    _assumed_attributes.set(defaultdict(lambda: None))
+    with _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer}): 
+        assert hpc1.obstime == assumed_obstime
+        assert hpc1.observer == assumed_observer
 
 
-def test_transform_assume_observer():
+def test_transform_assume_observerd():
     original_obstime = Time('2026-08-12 19:09:00')
     out_icrs = ICRS(get_body_barycentric("mars", original_obstime))
     original_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=original_obstime))
@@ -273,10 +270,7 @@ def test_transform_assume_observer():
     assert not u.allclose(original_transform.Tx, 0*u.arcsec)
     assert not u.allclose(original_transform.Ty, 0*u.arcsec)
 
-    _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer})
-
-    assumed_transform = hpc1.transform_to(hpc2)
-    assert u.allclose(assumed_transform.Tx, 0*u.arcsec)
-    assert u.allclose(assumed_transform.Ty, 0*u.arcsec)
-
-    _assumed_attributes.set(defaultdict(lambda: None))
+    with _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer}):   
+        assumed_transform = hpc1.transform_to(hpc2)
+        assert u.allclose(assumed_transform.Tx, 0*u.arcsec)
+        assert u.allclose(assumed_transform.Ty, 0*u.arcsec)

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -271,3 +271,13 @@ def test_transform_assume_observerd():
         assumed_transform = hpc1.transform_to(hpc2)
         assert u.allclose(assumed_transform.Tx, 0*u.arcsec)
         assert u.allclose(assumed_transform.Ty, 0*u.arcsec)
+
+    # Test that nesting works
+    with assume_frame_attributes(obstime=assumed_obstime):
+        with assume_frame_attributes(observer=assumed_observer):
+            assumed_transform = hpc1.transform_to(hpc2)
+            assert u.allclose(assumed_transform.Tx, 0*u.arcsec)
+            assert u.allclose(assumed_transform.Ty, 0*u.arcsec)
+
+        # Test that exiting the inner context manager only reset the observer.
+        assert hpc1.obstime == assumed_obstime

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 
 import pytest
 
@@ -11,7 +10,7 @@ from sunpy.coordinates import frames, get_earth
 from sunpy.coordinates.frameattributes import (
     ObserverCoordinateAttribute,
     TimeFrameAttributeSunPy,
-    _assumed_attributes,
+    assume_frame_attributes,
 )
 from sunpy.coordinates.frames import (
     Heliocentric,
@@ -228,7 +227,7 @@ def test_assume_obstime():
 
     assert hpc1.obstime != assumed_obstime
 
-    with _assumed_attributes.set({"obstime": assumed_obstime}):
+    with assume_frame_attributes(obstime=assumed_obstime):
         assert hpc1.obstime == assumed_obstime
 
 
@@ -242,14 +241,12 @@ def test_assume_observer():
     assumed_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=assumed_obstime))
 
     hpc1 = Helioprojective(observer=original_observer, obstime=original_obstime)
-    _assumed_attributes.set(defaultdict(lambda: None))
-
 
     assert hpc1.obstime != assumed_obstime
     # This errors as the frames aren't compatible
     # assert hpc1.observer != assumed_observer
 
-    with _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer}):
+    with assume_frame_attributes(obstime=assumed_obstime, observer=assumed_observer):
         assert hpc1.obstime == assumed_obstime
         assert hpc1.observer == assumed_observer
 
@@ -270,7 +267,7 @@ def test_transform_assume_observerd():
     assert not u.allclose(original_transform.Tx, 0*u.arcsec)
     assert not u.allclose(original_transform.Ty, 0*u.arcsec)
 
-    with _assumed_attributes.set({"obstime": assumed_obstime, "observer": assumed_observer}):
+    with assume_frame_attributes(obstime=assumed_obstime, observer=assumed_observer):
         assumed_transform = hpc1.transform_to(hpc2)
         assert u.allclose(assumed_transform.Tx, 0*u.arcsec)
         assert u.allclose(assumed_transform.Ty, 0*u.arcsec)

--- a/sunpy/coordinates/tests/test_frameattributes.py
+++ b/sunpy/coordinates/tests/test_frameattributes.py
@@ -11,6 +11,7 @@ from sunpy.coordinates.frameattributes import (
     ObserverCoordinateAttribute,
     TimeFrameAttributeSunPy,
     assume_frame_attributes,
+    assume_observer,
 )
 from sunpy.coordinates.frames import (
     Heliocentric,
@@ -251,7 +252,7 @@ def test_assume_observer():
         assert hpc1.observer == assumed_observer
 
 
-def test_transform_assume_observerd():
+def test_transform_assume_attributes():
     original_obstime = Time('2026-08-12 19:09:00')
     out_icrs = ICRS(get_body_barycentric("mars", original_obstime))
     original_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=original_obstime))
@@ -281,3 +282,25 @@ def test_transform_assume_observerd():
 
         # Test that exiting the inner context manager only reset the observer.
         assert hpc1.obstime == assumed_obstime
+
+
+def test_transform_assume_observer():
+    original_obstime = Time('2026-08-12 19:09:00')
+    out_icrs = ICRS(get_body_barycentric("mars", original_obstime))
+    original_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=original_obstime))
+
+    assumed_obstime = Time('2012-01-01 00:00:00')
+    out_icrs = ICRS(get_body_barycentric("mars", assumed_obstime))
+    assumed_observer = out_icrs.transform_to(HeliographicStonyhurst(obstime=assumed_obstime))
+
+    hpc1 = Helioprojective(0*u.arcsec, 0*u.arcsec, observer=original_observer, obstime=original_obstime)
+    hpc2 = Helioprojective(observer=assumed_observer, obstime=assumed_obstime)
+
+    original_transform = hpc1.transform_to(hpc2)
+    assert not u.allclose(original_transform.Tx, 0*u.arcsec)
+    assert not u.allclose(original_transform.Ty, 0*u.arcsec)
+
+    with assume_observer(assumed_observer):
+        assumed_transform = hpc1.transform_to(hpc2)
+        assert u.allclose(assumed_transform.Tx, 0*u.arcsec)
+        assert u.allclose(assumed_transform.Ty, 0*u.arcsec)


### PR DESCRIPTION
This is still WIP, but I thought I'd open the PR for visibility and comment.

Also I'm going to PR this up to Astropy given it really needs to live in [`Attribute.__get__`](https://github.com/astropy/astropy/blob/7556e8eb6c1a80dc694bb30fd87d6773457b037c/astropy/coordinates/attributes.py#L122).

I tested the performance of this out with VBI data and reproject: https://gist.github.com/Cadair/3d4438623ade65d2ee975d8eba4afc92 it get's a nice marginal gain and the output seems the same as before lol

fixes #8289 

---
## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request.
Your pull request will not be reviewed until you have completed this checklist.
Removing this checklist may result in your pull request being automatically closed without a review.
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.