### PR TITLE
Add on_disk_mask helper to sunpy.map.maputils

### DIFF
--- a/changelog/8782.feature.rst
+++ b/changelog/8782.feature.rst
@@ -1,0 +1,1 @@
+Added :func:`sunpy.map.on_disk_mask`, which returns a boolean array that is `True` for the pixels of a map that are on the solar disk.

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -16,7 +16,7 @@ __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'all_corner_coords_from_map',
            'map_edges', 'solar_angular_radius', 'sample_at_coords',
            'contains_full_disk', 'is_all_off_disk', 'is_all_on_disk',
-           'contains_limb', 'coordinate_is_on_solar_disk',
+           'contains_limb', 'coordinate_is_on_solar_disk', 'on_disk_mask',
            'on_disk_bounding_coordinates',
            'contains_coordinate', 'contains_solar_center',
            'pixelate_coord_path']
@@ -285,6 +285,29 @@ def coordinate_is_on_solar_disk(coordinates):
     # Calculate the radial angle from the center of the Sun (do not assume small angles)
     # and compare it to the angular radius of the Sun
     return np.arccos(np.cos(coordinates.Tx) * np.cos(coordinates.Ty)) <= solar_angular_radius(coordinates)
+
+
+def on_disk_mask(smap):
+    """
+    Returns a mask of the pixels of a map that are on the solar disk.
+
+    This combines `all_coordinates_from_map` and `coordinate_is_on_solar_disk`
+    into a single call. See `coordinate_is_on_solar_disk` for how the check is
+    made for each pixel.
+
+    Parameters
+    ----------
+    smap : `~sunpy.map.GenericMap`
+        The input map. The coordinate frame of the map must be
+        `~sunpy.coordinates.frames.Helioprojective`.
+
+    Returns
+    -------
+    `~numpy.ndarray`
+        A boolean array with the same shape as ``smap.data``. A value is
+        `True` if that pixel is on the solar disk, and `False` otherwise.
+    """
+    return coordinate_is_on_solar_disk(all_coordinates_from_map(smap))
 
 
 def is_all_off_disk(smap):

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -25,6 +25,7 @@ from sunpy.map.maputils import (
     is_all_on_disk,
     map_edges,
     on_disk_bounding_coordinates,
+    on_disk_mask,
     pixelate_coord_path,
     sample_at_coords,
     solar_angular_radius,
@@ -199,6 +200,22 @@ def test_coordinate_is_on_solar_disk(aia171_test_map, all_off_disk_map, all_on_d
     assert np.any(~coordinate_is_on_solar_disk(all_coordinates_from_map(straddles_limb_map)))
 
 
+def test_on_disk_mask(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map):
+    mask = on_disk_mask(aia171_test_map)
+    assert mask.shape == aia171_test_map.data.shape
+    assert mask.dtype == bool
+
+    # The result must match doing the same check by hand with the two
+    # underlying functions.
+    expected = coordinate_is_on_solar_disk(all_coordinates_from_map(aia171_test_map))
+    np.testing.assert_array_equal(mask, expected)
+
+    assert np.all(~on_disk_mask(all_off_disk_map))
+    assert np.all(on_disk_mask(all_on_disk_map))
+    assert np.any(on_disk_mask(straddles_limb_map))
+    assert np.any(~on_disk_mask(straddles_limb_map))
+
+
 # Testing values are derived from running the code, not from external sources
 def test_on_disk_bounding_coordinates(aia171_test_map):
     bl, tr = on_disk_bounding_coordinates(aia171_test_map)
@@ -266,6 +283,8 @@ def test_functions_raise_non_frame_map(non_helioprojective_map):
         contains_limb(non_helioprojective_map)
     with pytest.raises(ValueError, match=r"HeliographicCarrington, .* Helioprojective"):
         on_disk_bounding_coordinates(non_helioprojective_map)
+    with pytest.raises(ValueError, match=r"HeliographicCarrington, .* Helioprojective"):
+        on_disk_mask(non_helioprojective_map)
 
 
 def test_contains_coord(aia171_test_map):


### PR DESCRIPTION
This adds a single function that returns a boolean mask of the pixels of a map that are on the solar disk. Right now this currently needs two functions, `all_coordinates_from_map` followed by `coordinate_is_on_solar_disk`, and the same two lines are repeated in several examples. Closes #8778

## AI Assistance Disclosure

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
- [ ] No AI tools were used