### PR TITLE
Fix issue with parser log records missing the origin attribute

### DIFF
--- a/changelog/8793.bugfix.rst
+++ b/changelog/8793.bugfix.rst
@@ -1,0 +1,1 @@
+Fix debug logging so enabling it does not cause an error from the `~sunpy.net.scraper.Scraper` due to ``parse`` using standard lib logging.

--- a/sunpy/util/logger.py
+++ b/sunpy/util/logger.py
@@ -56,10 +56,18 @@ class SunpyLogger(AstropyLogger):
         else:
             self.warning(message)
 
+class OriginFilter(logging.Filter):
+    """
+    Ensure any child record propagating to the Sunpy (Astropy) logger handlers has an origin.
+    """
+    def filter(self, record):
+        if not hasattr(record, "origin"):
+            record.origin = getattr(record, "name", "sunpy")
+        return True
 
 def _init_log(config=None):
     """
-    Initializes the SunPy log.
+    Initialises the SunPy log.
 
     In most circumstances this is called automatically when importing
     SunPy. This code is based on that provided by Astropy see
@@ -72,6 +80,11 @@ def _init_log(config=None):
         if config is not None:
             _config_to_loggerConf(config)
         log._set_defaults()
+
+        # Ensure records propagating to child loggers have .origin
+        origin_filter = OriginFilter()
+        for handler in log.handlers:
+            handler.addFilter(origin_filter)
     finally:
         logging.setLoggerClass(orig_logger_cls)
 


### PR DESCRIPTION


## PR Description

Closes #8790 by adding a filter to add `.origin` to all records so the astropy logger works

## AI Assistance Disclosure


AI tools were used for:
- [  ] Code generation (e.g., when writing an implementation or fixing a bug)
- [  ] Test/benchmark generation
- [  ] Documentation (including examples)
- [  ] Research and understanding
- [  ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
