### PR TITLE
Refactor: Move coordinate-only functions from maputils to coordinates…

### DIFF
--- a/changelog/8455.refactor.rst
+++ b/changelog/8455.refactor.rst
@@ -1,0 +1,1 @@
+Moved coordinate-only functions solar_angular_radius and coordinate_is_on_solar_disk from maputils to coordinates.utils.

--- a/changelog/8455.refactor.rst
+++ b/changelog/8455.refactor.rst
@@ -1,1 +1,0 @@
-Moved coordinate-only functions solar_angular_radius and coordinate_is_on_solar_disk from maputils to coordinates.utils.

--- a/changelog/8800.breaking.rst
+++ b/changelog/8800.breaking.rst
@@ -1,0 +1,1 @@
+Moved coordinate-only functions solar_angular_radius and coordinate_is_on_solar_disk from sunpy.map.maputils to sunpy.coordinates.utils.

--- a/examples/computer_vision_techniques/mask_disk.py
+++ b/examples/computer_vision_techniques/mask_disk.py
@@ -10,9 +10,9 @@ How to mask out all emission from the solar disk.
 import matplotlib.pyplot as plt
 
 import sunpy.map
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 from sunpy.data.sample import AIA_171_IMAGE
 from sunpy.map.maputils import all_coordinates_from_map
-from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # We start with the sample data.

--- a/examples/computer_vision_techniques/mask_disk.py
+++ b/examples/computer_vision_techniques/mask_disk.py
@@ -11,7 +11,8 @@ import matplotlib.pyplot as plt
 
 import sunpy.map
 from sunpy.data.sample import AIA_171_IMAGE
-from sunpy.map.maputils import all_coordinates_from_map, coordinate_is_on_solar_disk
+from sunpy.map.maputils import all_coordinates_from_map
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # We start with the sample data.

--- a/examples/plotting/masked_composite_plot.py
+++ b/examples/plotting/masked_composite_plot.py
@@ -17,7 +17,8 @@ import astropy.units as u
 
 import sunpy.data.sample
 from sunpy.map import Map
-from sunpy.map.maputils import all_coordinates_from_map, coordinate_is_on_solar_disk
+from sunpy.map.maputils import all_coordinates_from_map
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # Let's import sample data representing the three types of data we want to

--- a/examples/plotting/masked_composite_plot.py
+++ b/examples/plotting/masked_composite_plot.py
@@ -16,9 +16,9 @@ import matplotlib.pyplot as plt
 import astropy.units as u
 
 import sunpy.data.sample
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 from sunpy.map import Map
 from sunpy.map.maputils import all_coordinates_from_map
-from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # Let's import sample data representing the three types of data we want to

--- a/examples/plotting/phi_example.py
+++ b/examples/plotting/phi_example.py
@@ -15,9 +15,9 @@ for instrument details.
 import matplotlib.pyplot as plt
 
 import sunpy.map
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 from sunpy.net import Fido
 from sunpy.net import attrs as a
-from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # Searching for PHI-HRT Data

--- a/examples/plotting/phi_example.py
+++ b/examples/plotting/phi_example.py
@@ -17,6 +17,7 @@ import matplotlib.pyplot as plt
 import sunpy.map
 from sunpy.net import Fido
 from sunpy.net import attrs as a
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 
 ###############################################################################
 # Searching for PHI-HRT Data
@@ -117,7 +118,7 @@ phi_fdt_icnt_map = sunpy.map.Map(files_phi_fdt_all[5]).rotate(recenter=True)
 # Make a mask to mask out off-disc pixels and make new maps
 # ---------------------------------------------------------------
 hpc_coords = sunpy.map.all_coordinates_from_map(phi_fdt_blos_map)
-mask = ~sunpy.map.coordinate_is_on_solar_disk(hpc_coords)
+mask = ~coordinate_is_on_solar_disk(hpc_coords)
 
 phi_fdt_blos_map = sunpy.map.Map(phi_fdt_blos_map.data, phi_fdt_blos_map.meta, mask=mask)
 phi_fdt_bmag_map = sunpy.map.Map(phi_fdt_bmag_map.data, phi_fdt_bmag_map.meta, mask=mask)

--- a/examples/showcase/hmi_cutout.py
+++ b/examples/showcase/hmi_cutout.py
@@ -20,6 +20,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 import sunpy.map
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
 from sunpy.data.sample import HMI_LOS_IMAGE
 
 ##############################################################################
@@ -35,7 +36,7 @@ right_corner = SkyCoord(Tx=158*u.arcsec, Ty=350*u.arcsec, frame=magnetogram.coor
 # limb.
 
 hpc_coords = sunpy.map.all_coordinates_from_map(magnetogram)
-mask = ~sunpy.map.coordinate_is_on_solar_disk(hpc_coords)
+mask = ~coordinate_is_on_solar_disk(hpc_coords)
 magnetogram_big = sunpy.map.Map(magnetogram.data, magnetogram.meta, mask=mask)
 
 ##############################################################################

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -11,16 +11,14 @@ from sunpy.coordinates import frames, get_earth, sun
 from sunpy.coordinates.screens import SphericalScreen
 from sunpy.coordinates.utils import (
     GreatArc,
+    _verify_coordinate_helioprojective,
+    coordinate_is_on_solar_disk,
     get_heliocentric_angle,
     get_limb_coordinates,
     get_rectangle_coordinates,
     solar_angle_equivalency,
     solar_angular_radius,
-    coordinate_is_on_solar_disk,
-    _verify_coordinate_helioprojective
 )
-
-from sunpy.coordinates.frames import HeliographicStonyhurst, Helioprojective
 from sunpy.sun import constants
 from sunpy.util.exceptions import SunpyUserWarning
 
@@ -437,22 +435,21 @@ def test_solar_angular_radius():
     np.testing.assert_almost_equal(sar.to(u.arcsec).value, 959.6, decimal=1)
 
 import numpy as np
-import astropy.units as u
-from astropy.coordinates import SkyCoord
+
 
 def test_coordinate_is_on_solar_disk():
     # 1. Test a coordinate directly on the disk (center of the Sun)
-    coord_on = SkyCoord(0*u.arcsec, 0*u.arcsec, 
+    coord_on = SkyCoord(0*u.arcsec, 0*u.arcsec,
                         frame='helioprojective', observer='earth', obstime='2020-01-01')
     assert coordinate_is_on_solar_disk(coord_on)
 
     # 2. Test a coordinate well off the disk (solar radius is ~960 arcsec)
-    coord_off = SkyCoord(1500*u.arcsec, 0*u.arcsec, 
+    coord_off = SkyCoord(1500*u.arcsec, 0*u.arcsec,
                          frame='helioprojective', observer='earth', obstime='2020-01-01')
     assert not coordinate_is_on_solar_disk(coord_off)
 
     # 3. Test an array of coordinates simultaneously
-    coords = SkyCoord([0, 1500]*u.arcsec, [0, 0]*u.arcsec, 
+    coords = SkyCoord([0, 1500]*u.arcsec, [0, 0]*u.arcsec,
                       frame='helioprojective', observer='earth', obstime='2020-01-01')
     result = coordinate_is_on_solar_disk(coords)
     assert np.array_equal(result, [True, False])
@@ -465,7 +462,7 @@ def test_verify_coordinate_helioprojective():
     # 1. Valid frame should pass silently without raising an error
     hpc = SkyCoord(0*u.arcsec, 0*u.arcsec, frame='helioprojective', observer='earth', obstime='2020-01-01')
     _verify_coordinate_helioprojective(hpc)
-    
+
     # 2. Invalid frame should raise the expected ValueError
     icrs = SkyCoord(1*u.deg, 2*u.deg, frame="icrs")
     with pytest.raises(ValueError, match="must be in the Helioprojective frame"):

--- a/sunpy/coordinates/tests/test_utils.py
+++ b/sunpy/coordinates/tests/test_utils.py
@@ -15,7 +15,12 @@ from sunpy.coordinates.utils import (
     get_limb_coordinates,
     get_rectangle_coordinates,
     solar_angle_equivalency,
+    solar_angular_radius,
+    coordinate_is_on_solar_disk,
+    _verify_coordinate_helioprojective
 )
+
+from sunpy.coordinates.frames import HeliographicStonyhurst, Helioprojective
 from sunpy.sun import constants
 from sunpy.util.exceptions import SunpyUserWarning
 
@@ -418,3 +423,50 @@ def test_get_heliocentric_angle_errors():
     bad_skycoord = SkyCoord(0*u.arcsec, 0*u.arcsec, frame='heliographic_stonyhurst', observer="earth")
     with pytest.raises(ConvertError, match="frame needs a specified obstime"):
         get_heliocentric_angle(bad_skycoord)
+
+
+def test_solar_angular_radius():
+    # Define a coordinate with a standard 1 AU observer distance
+    observer = SkyCoord(0*u.deg, 0*u.deg, radius=1*u.AU, frame='heliographic_stonyhurst', obstime="2020-01-01")
+    on_disk = SkyCoord(0*u.arcsec, 0*u.arcsec, frame='helioprojective', observer=observer, obstime="2020-01-01")
+
+    sar = solar_angular_radius(on_disk)
+
+    assert isinstance(sar, u.Quantity)
+    # The solar radius at 1 AU is approximately 959.6 arcsec
+    np.testing.assert_almost_equal(sar.to(u.arcsec).value, 959.6, decimal=1)
+
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+def test_coordinate_is_on_solar_disk():
+    # 1. Test a coordinate directly on the disk (center of the Sun)
+    coord_on = SkyCoord(0*u.arcsec, 0*u.arcsec, 
+                        frame='helioprojective', observer='earth', obstime='2020-01-01')
+    assert coordinate_is_on_solar_disk(coord_on)
+
+    # 2. Test a coordinate well off the disk (solar radius is ~960 arcsec)
+    coord_off = SkyCoord(1500*u.arcsec, 0*u.arcsec, 
+                         frame='helioprojective', observer='earth', obstime='2020-01-01')
+    assert not coordinate_is_on_solar_disk(coord_off)
+
+    # 3. Test an array of coordinates simultaneously
+    coords = SkyCoord([0, 1500]*u.arcsec, [0, 0]*u.arcsec, 
+                      frame='helioprojective', observer='earth', obstime='2020-01-01')
+    result = coordinate_is_on_solar_disk(coords)
+    assert np.array_equal(result, [True, False])
+
+@pytest.fixture
+def non_helioprojective_skycoord():
+    return SkyCoord(0 * u.rad, 0 * u.rad, frame="icrs")
+
+def test_verify_coordinate_helioprojective():
+    # 1. Valid frame should pass silently without raising an error
+    hpc = SkyCoord(0*u.arcsec, 0*u.arcsec, frame='helioprojective', observer='earth', obstime='2020-01-01')
+    _verify_coordinate_helioprojective(hpc)
+    
+    # 2. Invalid frame should raise the expected ValueError
+    icrs = SkyCoord(1*u.deg, 2*u.deg, frame="icrs")
+    with pytest.raises(ValueError, match="must be in the Helioprojective frame"):
+        _verify_coordinate_helioprojective(icrs)

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -8,9 +8,8 @@ import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 from astropy.coordinates.representation import CartesianRepresentation
 
-from sunpy.coordinates import sun
+from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, get_body_heliographic_stonyhurst, sun
 from sunpy.coordinates.frames import Helioprojective
-from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, get_body_heliographic_stonyhurst
 from sunpy.sun import constants
 
 __all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates', 'get_heliocentric_angle','solar_angular_radius','coordinate_is_on_solar_disk']
@@ -602,4 +601,3 @@ def coordinate_is_on_solar_disk(coordinates):
     return np.arccos(
         np.cos(coordinates.Tx) * np.cos(coordinates.Ty)
     ) <= solar_angular_radius(coordinates)
-

--- a/sunpy/coordinates/utils.py
+++ b/sunpy/coordinates/utils.py
@@ -8,10 +8,12 @@ import astropy.units as u
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 from astropy.coordinates.representation import CartesianRepresentation
 
+from sunpy.coordinates import sun
+from sunpy.coordinates.frames import Helioprojective
 from sunpy.coordinates import Heliocentric, HeliographicStonyhurst, get_body_heliographic_stonyhurst
 from sunpy.sun import constants
 
-__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates', 'get_heliocentric_angle']
+__all__ = ['GreatArc', 'get_rectangle_coordinates', 'solar_angle_equivalency', 'get_limb_coordinates', 'get_heliocentric_angle','solar_angular_radius','coordinate_is_on_solar_disk']
 
 
 class GreatArc:
@@ -530,3 +532,74 @@ def get_heliocentric_angle(coordinate_on_solar_disk):
     to_observer = CartesianRepresentation(0, 0, 1) * hcc.observer.radius - normal
     heliocentric_angle = np.arctan2(normal.cross(to_observer).norm(), normal.dot(to_observer))
     return heliocentric_angle.to(u.deg)
+
+
+
+def _verify_coordinate_helioprojective(coordinates):
+    """
+    Raises an error if the coordinate is not in the
+    `~sunpy.coordinates.frames.Helioprojective` frame.
+
+    Parameters
+    ----------
+    coordinates : `~astropy.coordinates.SkyCoord`, `~astropy.coordinates.BaseCoordinateFrame`
+    """
+
+    frame = coordinates.frame if hasattr(coordinates,'frame') else coordinates
+    if not isinstance(frame,Helioprojective):
+        raise ValueError(
+            f"The input coordinate(s) is of type {type(frame).__name__}, "
+            "but must be in the Helioprojective frame."
+        )
+
+def solar_angular_radius(coordinates):
+    """
+    Calculates the solar angular radius as seen by the observer.
+
+    The tangent vector from the observer to the edge of the Sun forms a
+    right-angle triangle with the radius of the Sun as the far side and the
+    Sun-observer distance as the hypotenuse. Thus, the sine of the angular
+    radius of the Sun is ratio of these two distances.
+
+    Parameters
+    ----------
+    coordinates : `~astropy.coordinates.SkyCoord`, `~sunpy.coordinates.frames.Helioprojective`
+        The input coordinate. The coordinate frame must be
+        `~sunpy.coordinates.Helioprojective`.
+
+    Returns
+    -------
+    angle : `~astropy.units.Quantity`
+        The solar angular radius.
+    """
+
+    _verify_coordinate_helioprojective(coordinates)
+    return sun._angular_radius(coordinates.rsun,coordinates.observer.radius)
+
+@u.quantity_input
+def coordinate_is_on_solar_disk(coordinates):
+    """
+    Checks if the helioprojective Cartesian coordinates are on the solar disk.
+
+    The check is performed by comparing the coordinate's angular distance
+    to the angular size of the solar radius. The solar disk is assumed to be
+    a circle i.e., solar oblateness and other effects that cause the solar disk to
+    be non-circular are not taken in to account.
+
+    Parameters
+    ----------
+    coordinates : `~astropy.coordinates.SkyCoord`, `~sunpy.coordinates.frames.Helioprojective`
+        The input coordinate. The coordinate frame must be
+        `~sunpy.coordinates.Helioprojective`.
+
+    Returns
+    -------
+    `~bool`
+        Returns `True` if the coordinate is on disk, `False` otherwise.
+    """
+
+    _verify_coordinate_helioprojective(coordinates)
+    return np.arccos(
+        np.cos(coordinates.Tx) * np.cos(coordinates.Ty)
+    ) <= solar_angular_radius(coordinates)
+

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -10,11 +10,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.visualization import AsymmetricPercentileInterval
 
-from sunpy.coordinates import Helioprojective, sun
-from sunpy.coordinates.utils import (
-    _verify_coordinate_helioprojective,
-    coordinate_is_on_solar_disk
-)
+from sunpy.coordinates.utils import _verify_coordinate_helioprojective, coordinate_is_on_solar_disk
 
 __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'all_corner_coords_from_map',

--- a/sunpy/map/maputils.py
+++ b/sunpy/map/maputils.py
@@ -11,12 +11,16 @@ from astropy.coordinates import SkyCoord
 from astropy.visualization import AsymmetricPercentileInterval
 
 from sunpy.coordinates import Helioprojective, sun
+from sunpy.coordinates.utils import (
+    _verify_coordinate_helioprojective,
+    coordinate_is_on_solar_disk
+)
 
 __all__ = ['all_pixel_indices_from_map', 'all_coordinates_from_map',
            'all_corner_coords_from_map',
-           'map_edges', 'solar_angular_radius', 'sample_at_coords',
+           'map_edges', 'sample_at_coords',
            'contains_full_disk', 'is_all_off_disk', 'is_all_on_disk',
-           'contains_limb', 'coordinate_is_on_solar_disk',
+           'contains_limb',
            'on_disk_bounding_coordinates',
            'contains_coordinate', 'contains_solar_center',
            'pixelate_coord_path']
@@ -125,43 +129,6 @@ def map_edges(smap):
     return top, bottom, left_hand_side, right_hand_side
 
 
-def _verify_coordinate_helioprojective(coordinates):
-    """
-    Raises an error if the coordinate is not in the
-    `~sunpy.coordinates.frames.Helioprojective` frame.
-
-    Parameters
-    ----------
-    coordinates : `~astropy.coordinates.SkyCoord`, `~astropy.coordinates.BaseCoordinateFrame`
-    """
-    frame = coordinates.frame if hasattr(coordinates, 'frame') else coordinates
-    if not isinstance(frame, Helioprojective):
-        raise ValueError(f"The input coordinate(s) is of type {type(frame).__name__}, "
-                         "but must be in the Helioprojective frame.")
-
-
-def solar_angular_radius(coordinates):
-    """
-    Calculates the solar angular radius as seen by the observer.
-
-    The tangent vector from the observer to the edge of the Sun forms a
-    right-angle triangle with the radius of the Sun as the far side and the
-    Sun-observer distance as the hypotenuse. Thus, the sine of the angular
-    radius of the Sun is ratio of these two distances.
-
-    Parameters
-    ----------
-    coordinates : `~astropy.coordinates.SkyCoord`, `~sunpy.coordinates.frames.Helioprojective`
-        The input coordinate. The coordinate frame must be
-        `~sunpy.coordinates.Helioprojective`.
-
-    Returns
-    -------
-    angle : `~astropy.units.Quantity`
-        The solar angular radius.
-    """
-    _verify_coordinate_helioprojective(coordinates)
-    return sun._angular_radius(coordinates.rsun, coordinates.observer.radius)
 
 
 def sample_at_coords(smap, coordinates):
@@ -259,32 +226,6 @@ def contains_solar_center(smap):
     _verify_coordinate_helioprojective(smap.coordinate_frame)
     return contains_coordinate(smap, SkyCoord(0*u.arcsec, 0*u.arcsec, frame=smap.coordinate_frame))
 
-
-@u.quantity_input
-def coordinate_is_on_solar_disk(coordinates):
-    """
-    Checks if the helioprojective Cartesian coordinates are on the solar disk.
-
-    The check is performed by comparing the coordinate's angular distance
-    to the angular size of the solar radius. The solar disk is assumed to be
-    a circle i.e., solar oblateness and other effects that cause the solar disk to
-    be non-circular are not taken in to account.
-
-    Parameters
-    ----------
-    coordinates : `~astropy.coordinates.SkyCoord`, `~sunpy.coordinates.frames.Helioprojective`
-        The input coordinate. The coordinate frame must be
-        `~sunpy.coordinates.Helioprojective`.
-
-    Returns
-    -------
-    `~bool`
-        Returns `True` if the coordinate is on disk, `False` otherwise.
-    """
-    _verify_coordinate_helioprojective(coordinates)
-    # Calculate the radial angle from the center of the Sun (do not assume small angles)
-    # and compare it to the angular radius of the Sun
-    return np.arccos(np.cos(coordinates.Tx) * np.cos(coordinates.Ty)) <= solar_angular_radius(coordinates)
 
 
 def is_all_off_disk(smap):

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -1,4 +1,3 @@
-import re
 
 import numpy as np
 import pytest
@@ -8,7 +7,6 @@ from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 
 import sunpy.map
-from sunpy.coordinates import HeliographicStonyhurst
 from sunpy.coordinates.frames import HeliographicCarrington
 from sunpy.coordinates.utils import GreatArc
 from sunpy.map.maputils import (

--- a/sunpy/map/tests/test_maputils.py
+++ b/sunpy/map/tests/test_maputils.py
@@ -12,7 +12,6 @@ from sunpy.coordinates import HeliographicStonyhurst
 from sunpy.coordinates.frames import HeliographicCarrington
 from sunpy.coordinates.utils import GreatArc
 from sunpy.map.maputils import (
-    _verify_coordinate_helioprojective,
     all_coordinates_from_map,
     all_corner_coords_from_map,
     all_pixel_indices_from_map,
@@ -20,14 +19,12 @@ from sunpy.map.maputils import (
     contains_full_disk,
     contains_limb,
     contains_solar_center,
-    coordinate_is_on_solar_disk,
     is_all_off_disk,
     is_all_on_disk,
     map_edges,
     on_disk_bounding_coordinates,
     pixelate_coord_path,
     sample_at_coords,
-    solar_angular_radius,
 )
 
 
@@ -143,11 +140,6 @@ def test_map_edges(all_off_disk_map):
     assert np.all(edges[0][10] == [10, 11] * u.pix)
 
 
-def test_solar_angular_radius(aia171_test_map):
-    on_disk = aia171_test_map.center
-    sar = solar_angular_radius(on_disk)
-    assert isinstance(sar, u.Quantity)
-    np.testing.assert_almost_equal(sar.to(u.arcsec).value, 971.80181131, decimal=1)
 
 
 def test_contains_full_disk(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map):
@@ -177,26 +169,6 @@ def test_contains_limb(aia171_test_map, all_off_disk_map, all_on_disk_map, strad
     assert ~contains_limb(all_on_disk_map)
     assert contains_limb(straddles_limb_map)
 
-
-def test_coordinate_is_on_solar_disk(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map):
-    off_disk = aia171_test_map.bottom_left_coord
-    on_disk = aia171_test_map.center
-
-    # Check for individual coordinates
-    assert coordinate_is_on_solar_disk(on_disk)
-    assert ~coordinate_is_on_solar_disk(off_disk)
-
-    # Raise the error
-    with pytest.raises(ValueError, match=re.escape("The input coordinate(s) is of type HeliographicStonyhurst, but must be in the Helioprojective frame.")):
-        coordinate_is_on_solar_disk(on_disk.transform_to(HeliographicStonyhurst))
-
-    # Check for sets of coordinates
-    assert np.any(coordinate_is_on_solar_disk(all_coordinates_from_map(aia171_test_map)))
-    assert np.any(~coordinate_is_on_solar_disk(all_coordinates_from_map(aia171_test_map)))
-    assert np.all(~coordinate_is_on_solar_disk(all_coordinates_from_map(all_off_disk_map)))
-    assert np.all(coordinate_is_on_solar_disk(all_coordinates_from_map(all_on_disk_map)))
-    assert np.any(coordinate_is_on_solar_disk(all_coordinates_from_map(straddles_limb_map)))
-    assert np.any(~coordinate_is_on_solar_disk(all_coordinates_from_map(straddles_limb_map)))
 
 
 # Testing values are derived from running the code, not from external sources
@@ -232,27 +204,6 @@ def test_contains_solar_center(aia171_test_map, all_off_disk_map, all_on_disk_ma
     assert not contains_solar_center(straddles_limb_map)
     assert not contains_solar_center(sub_smap)
 
-
-def test_verify_coordinate_helioprojective(aia171_test_map, all_off_disk_map, all_on_disk_map, straddles_limb_map,
-                                           sub_smap, non_helioprojective_map, non_helioprojective_skycoord):
-    # These should be helioprojective.
-    _verify_coordinate_helioprojective(aia171_test_map.coordinate_frame)
-    _verify_coordinate_helioprojective(all_off_disk_map.coordinate_frame)
-    _verify_coordinate_helioprojective(all_on_disk_map.coordinate_frame)
-    _verify_coordinate_helioprojective(straddles_limb_map.coordinate_frame)
-    _verify_coordinate_helioprojective(sub_smap.coordinate_frame)
-    # These are not.
-    with pytest.raises(ValueError, match=r"HeliographicCarrington, .* Helioprojective"):
-        _verify_coordinate_helioprojective(non_helioprojective_map.coordinate_frame)
-    with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
-        _verify_coordinate_helioprojective(non_helioprojective_skycoord)
-
-
-def test_functions_raise_non_frame_coords(non_helioprojective_skycoord):
-    with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
-        solar_angular_radius(non_helioprojective_skycoord)
-    with pytest.raises(ValueError, match=r"ICRS, .* Helioprojective"):
-        coordinate_is_on_solar_disk(non_helioprojective_skycoord)
 
 
 def test_functions_raise_non_frame_map(non_helioprojective_map):

--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -177,8 +177,7 @@ class Cutout(DataAttr):
         center_y = (bl.Ty + tr.Ty) / 2
         center = SkyCoord(center_x, center_y, frame=bottom_left.frame)
         if tracking:
-            # import here so net won't depend on map
-            from sunpy.map.maputils import coordinate_is_on_solar_disk
+            from sunpy.coordinates.utils import coordinate_is_on_solar_disk
             if not coordinate_is_on_solar_disk(center):
                 raise ValueError("Tracking is enabled, but the center of the cutout "
                                  f"(Tx={center_x}, Ty={center_y}) is not on the solar disk.")

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -14,9 +14,7 @@ from sunpy.coordinates import (
     get_earth,
     transform_with_sun_center,
 )
-
 from sunpy.coordinates.utils import coordinate_is_on_solar_disk
-
 from sunpy.map import (
     contains_full_disk,
     is_all_off_disk,

--- a/sunpy/physics/differential_rotation.py
+++ b/sunpy/physics/differential_rotation.py
@@ -14,9 +14,11 @@ from sunpy.coordinates import (
     get_earth,
     transform_with_sun_center,
 )
+
+from sunpy.coordinates.utils import coordinate_is_on_solar_disk
+
 from sunpy.map import (
     contains_full_disk,
-    coordinate_is_on_solar_disk,
     is_all_off_disk,
     is_all_on_disk,
     map_edges,


### PR DESCRIPTION
## PR Description
Closes #8445

### Summary
This PR refactors `sunpy.map.maputils` by moving coordinate-only functions to `sunpy.coordinates.utils`. This establishes a cleaner, one-way dependency hierarchy where `maputils` depends on `coordinates`, but not the reverse.

### Changes Made
* Moved  the `solar_angular_radius` and `coordinate_is_on_solar_disk` functions  to `sunpy.coordinates.utils` file .
* Relocated the private validation helper `_verify_coordinate_helioprojective`.
* Updated the downstream usages across the library (examples, `net`, and `physics`).
* Migrated the corresponding tests to `sunpy/coordinates/tests/test_utils.py` from `sunpy/map/tests/test_maputils.py`. 
* **Crucially**: Refactored the migrated coordinates tests to use pure `SkyCoord` objects instead of `aia171_test_map` fixtures, completely severing the test-level dependency on `sunpy.map`.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request.
Your pull request will not be reviewed until you have completed this checklist.
Removing this checklist may result in your pull request being automatically closed without a review.
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation
- [ ] Documentation (including examples)
- [X] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
